### PR TITLE
Shipping Labels: add "email_receipts" parameter to the purchase flow

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -430,9 +430,7 @@ class WooShippingLabelFragment : Fragment() {
                                     WCCustomsItem(
                                             productId = it.productId!!,
                                             description = it.name.orEmpty(),
-                                            value = (it.price?.toBigDecimal() ?: BigDecimal.ZERO).multiply(
-                                                    BigDecimal.valueOf(quantity.toDouble())
-                                            ),
+                                            value = (it.price?.toBigDecimal() ?: BigDecimal.ZERO),
                                             quantity = quantity,
                                             weight = 1f,
                                             hsTariffNumber = null,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -493,7 +493,8 @@ class WooShippingLabelFragment : Fragment() {
                             if (isInternational) origin.copy(phone = "0000000000") else origin,
                             destination,
                             listOf(packageData),
-                            customsData?.let { listOf(it) }
+                            customsData?.let { listOf(it) },
+                            emailReceipts = true
                     )
 
                     result.error?.let {

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -426,7 +426,7 @@ class WCShippingLabelStoreTest {
                 any(),
                 any(),
                 anyOrNull(),
-                emailReceipts
+                any()
         ))
                 .thenReturn(WooPayload(error))
 
@@ -452,7 +452,7 @@ class WCShippingLabelStoreTest {
                 any(),
                 any(),
                 anyOrNull(),
-                emailReceipts
+                any()
         )).thenReturn(response)
 
         val statusIntermediateResponse = WCShippingLabelTestUtils.generateSampleShippingLabelsStatusApiResponse(false)
@@ -485,7 +485,7 @@ class WCShippingLabelStoreTest {
                 any(),
                 any(),
                 anyOrNull(),
-                emailReceipts
+                any()
         )
         verify(restClient).fetchShippingLabelsStatus(
                 site,
@@ -518,7 +518,7 @@ class WCShippingLabelStoreTest {
                 any(),
                 any(),
                 anyOrNull(),
-                emailReceipts
+                any()
         )).thenReturn(response)
 
         whenever(restClient.fetchShippingLabelsStatus(any(), any(), any())).thenReturn(WooPayload(error))
@@ -539,7 +539,7 @@ class WCShippingLabelStoreTest {
                 any(),
                 any(),
                 anyOrNull(),
-                emailReceipts
+                any()
         )
         verify(restClient, times(3)).fetchShippingLabelsStatus(
                 site,
@@ -559,7 +559,7 @@ class WCShippingLabelStoreTest {
                 any(),
                 any(),
                 anyOrNull(),
-                emailReceipts
+                any()
         )).thenReturn(response)
 
         val statusIntermediateResponse = WCShippingLabelTestUtils.generateSampleShippingLabelsStatusApiResponse(false)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -419,7 +419,15 @@ class WCShippingLabelStoreTest {
 
     @Test
     fun `purchase shipping label error`() = test {
-        whenever(restClient.purchaseShippingLabels(any(), any(), any(), any(), any(), anyOrNull()))
+        whenever(restClient.purchaseShippingLabels(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyOrNull(),
+                emailReceipts
+        ))
                 .thenReturn(WooPayload(error))
 
         val invalidRequestResult = store.purchaseShippingLabels(
@@ -437,7 +445,15 @@ class WCShippingLabelStoreTest {
     @Test
     fun `purchase shipping labels with polling`() = test {
         val response = WooPayload(samplePurchaseShippingLabelsResponse)
-        whenever(restClient.purchaseShippingLabels(any(), any(), any(), any(), any(), anyOrNull())).thenReturn(response)
+        whenever(restClient.purchaseShippingLabels(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyOrNull(),
+                emailReceipts
+        )).thenReturn(response)
 
         val statusIntermediateResponse = WCShippingLabelTestUtils.generateSampleShippingLabelsStatusApiResponse(false)
         val statusDoneReponse = WCShippingLabelTestUtils.generateSampleShippingLabelsStatusApiResponse(true)
@@ -462,7 +478,15 @@ class WCShippingLabelStoreTest {
                 site
         )
 
-        verify(restClient).purchaseShippingLabels(any(), any(), any(), any(), any(), anyOrNull())
+        verify(restClient).purchaseShippingLabels(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyOrNull(),
+                emailReceipts
+        )
         verify(restClient).fetchShippingLabelsStatus(
                 site,
                 orderId,
@@ -487,7 +511,15 @@ class WCShippingLabelStoreTest {
     @Test
     fun `purchase shipping labels with polling fail after 3 retries`() = test {
         val response = WooPayload(samplePurchaseShippingLabelsResponse)
-        whenever(restClient.purchaseShippingLabels(any(), any(), any(), any(), any(), anyOrNull())).thenReturn(response)
+        whenever(restClient.purchaseShippingLabels(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyOrNull(),
+                emailReceipts
+        )).thenReturn(response)
 
         whenever(restClient.fetchShippingLabelsStatus(any(), any(), any())).thenReturn(WooPayload(error))
 
@@ -500,7 +532,15 @@ class WCShippingLabelStoreTest {
                 null
         )
 
-        verify(restClient).purchaseShippingLabels(any(), any(), any(), any(), any(), anyOrNull())
+        verify(restClient).purchaseShippingLabels(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyOrNull(),
+                emailReceipts
+        )
         verify(restClient, times(3)).fetchShippingLabelsStatus(
                 site,
                 orderId,
@@ -512,7 +552,15 @@ class WCShippingLabelStoreTest {
     @Test
     fun `purchase shipping labels with polling one label failed`() = test {
         val response = WooPayload(samplePurchaseShippingLabelsResponse)
-        whenever(restClient.purchaseShippingLabels(any(), any(), any(), any(), any(), anyOrNull())).thenReturn(response)
+        whenever(restClient.purchaseShippingLabels(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyOrNull(),
+                emailReceipts
+        )).thenReturn(response)
 
         val statusIntermediateResponse = WCShippingLabelTestUtils.generateSampleShippingLabelsStatusApiResponse(false)
         val statusErrorResponse = WCShippingLabelTestUtils.generateErrorShippingLabelsStatusApiResponse()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -280,7 +280,8 @@ class ShippingLabelRestClient @Inject constructor(
         origin: ShippingLabelAddress,
         destination: ShippingLabelAddress,
         packagesData: List<WCShippingLabelPackageData>,
-        customsData: List<WCShippingPackageCustoms>?
+        customsData: List<WCShippingPackageCustoms>?,
+        emailReceipts: Boolean = false
     ): WooPayload<ShippingLabelStatusApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).pathV1
 
@@ -291,7 +292,8 @@ class ShippingLabelRestClient @Inject constructor(
                 "packages" to packagesData.map { labelPackage ->
                     val customs = customsData?.first { it.id == labelPackage.id }
                     labelPackage.toMap() + (customs?.toMap() ?: emptyMap())
-                }
+                },
+                "email_receipt" to emailReceipts
         )
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -362,7 +362,8 @@ class WCShippingLabelStore @Inject constructor(
         origin: ShippingLabelAddress,
         destination: ShippingLabelAddress,
         packagesData: List<WCShippingLabelPackageData>,
-        customsData: List<WCShippingPackageCustoms>?
+        customsData: List<WCShippingPackageCustoms>?,
+        emailReceipts: Boolean = false
     ): WooResult<List<WCShippingLabelModel>> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "purchaseShippingLabels") {
             val response = restClient.purchaseShippingLabels(
@@ -371,7 +372,8 @@ class WCShippingLabelStore @Inject constructor(
                     origin,
                     destination,
                     packagesData,
-                    customsData
+                    customsData,
+                    emailReceipts
             )
             return@withDefaultContext when {
                 response.isError -> WooResult(response.error)


### PR DESCRIPTION
This PR adds an optional parameter to the `purchaseLabel` function to allow passing the `email_receipts` parameter.

#### Testing
To keep the example app simple, it's always sending `true` in the parameter.
1. Open the example app.
2. Click on Woo.
3. Click on Shipping Labels.
4. Click on Purchase shipping label.
5. Enter the orderId of an eligible order.
6. Enter the other details.
7. Finish the purchase.
8. Confirm that you receive the receipt by email. 