### PR TITLE
Added timestamp to comment response from self hosted site.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -337,6 +337,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         comment.setStatus(getCommentStatusFromXMLRPCStatusString(stringStatus).toString());
         Date datePublished = XMLRPCUtils.safeGetMapValue(commentMap, "date_created_gmt", new Date());
         comment.setDatePublished(DateTimeUtils.iso8601UTCFromDate(datePublished));
+        comment.setPublishedTimestamp(DateTimeUtils.timestampFromIso8601(comment.getDatePublished()));
         comment.setContent(XMLRPCUtils.safeGetMapValue(commentMap, "content", ""));
         comment.setUrl(XMLRPCUtils.safeGetMapValue(commentMap, "link", ""));
 


### PR DESCRIPTION
This PR adds a timestamp to CommentModel retrieved from self hosted sites.

You can test the changes with [this](https://github.com/wordpress-mobile/WordPress-Android/pull/14767) client-side PR.