### PR TITLE
Woo Shipping Labels: add support for commercial invoices

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -2,10 +2,7 @@ package org.wordpress.android.fluxc.example.ui.shippinglabels
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
-import android.os.Environment
 import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
@@ -15,7 +12,6 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.Spinner
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
@@ -45,6 +41,7 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCCustomsItem
 import org.wordpress.android.fluxc.model.shippinglabels.WCNonDeliveryOption
 import org.wordpress.android.fluxc.model.shippinglabels.WCRestrictionType
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
+import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPackageData
@@ -58,6 +55,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.math.BigDecimal
+import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -192,16 +190,61 @@ class WooShippingLabelFragment : Fragment() {
                                 prependToLog("${it.type}: ${it.message}")
                             }
                             response.model?.let { base64Content ->
-                                // Since this function is used only by Woo testers and the Woo app
-                                // only supports API > 21, it's fine to add a check here to support devices
-                                // above API 19
-                                if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-                                    writePDFToFile(base64Content)?.let { openWebView(it) }
-                                }
+                                writePDFToFile(base64Content)?.let { openPdfReader(it) }
                             }
                         } catch (e: Exception) {
                             prependToLog("Error: ${e.message}")
                         }
+                    }
+                }
+            }
+        }
+
+        print_commercial_invoice.setOnClickListener {
+            selectedSite?.let { site ->
+                coroutineScope.launch {
+                    val orderId = showSingleLineDialog(requireActivity(), "Enter the order ID", isNumeric = true)
+                            ?.toLong()
+
+                    val labelId = showSingleLineDialog(requireActivity(), "Enter the label ID", isNumeric = true)
+                            ?.toLong()
+
+                    if (orderId == null || labelId == null) {
+                        prependToLog(
+                                "One of the submitted parameters is null\n" +
+                                        "Order ID: $orderId\n" +
+                                        "Label ID: $labelId"
+                        )
+                        return@launch
+                    }
+
+                    val label: WCShippingLabelModel? = wcShippingLabelStore.getShippingLabelById(site, orderId, labelId)
+                            ?: suspend {
+                                prependToLog("Fetching label")
+                                wcShippingLabelStore.fetchShippingLabelsForOrder(site, orderId)
+                                wcShippingLabelStore.getShippingLabelById(site, orderId, labelId)
+                            }.invoke()
+
+                    if (label == null) {
+                        prependToLog("Couldn't find a label with the id $labelId")
+                        return@launch
+                    }
+
+                    if (label.commercialInvoiceUrl.isNullOrEmpty()) {
+                        prependToLog(
+                                "The label doesn't have a commercial invoice URL, " +
+                                        "please make sure to use a international label with a carrier that requires " +
+                                        "a commercial invoice URL (DHL for example)"
+                        )
+                        return@launch
+                    }
+
+                    prependToLog("Downloading the commercial invoice")
+                    val invoiceFile = withContext(Dispatchers.IO) {
+                        downloadUrl(label.commercialInvoiceUrl!!)
+                    }
+                    invoiceFile?.let {
+                        openPdfReader(it)
                     }
                 }
             }
@@ -640,10 +683,9 @@ class WooShippingLabelFragment : Fragment() {
     /**
      * Creates a temporary file for storing captured photos
      */
-    @RequiresApi(VERSION_CODES.KITKAT)
     private fun createTempPdfFile(context: Context): File? {
         val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
-        val storageDir = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)
+        val storageDir = context.externalCacheDir
         return try {
             File.createTempFile(
                     "PDF_${timeStamp}_",
@@ -657,12 +699,6 @@ class WooShippingLabelFragment : Fragment() {
         }
     }
 
-    /**
-     * Since this function is used only by Woo testers and the Woo app
-     * only supports API > 21, it's fine to leave this method to support only
-     * API 19 and above.
-     */
-    @RequiresApi(VERSION_CODES.KITKAT)
     private fun writePDFToFile(base64Content: String): File? {
         return try {
             createTempPdfFile(requireContext())?.let { file ->
@@ -680,7 +716,7 @@ class WooShippingLabelFragment : Fragment() {
         }
     }
 
-    private fun openWebView(file: File) {
+    private fun openPdfReader(file: File) {
         val authority = requireContext().applicationContext.packageName + ".provider"
         val fileUri = FileProvider.getUriForFile(
                 requireContext(),
@@ -693,5 +729,22 @@ class WooShippingLabelFragment : Fragment() {
         sendIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         sendIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         startActivity(sendIntent)
+    }
+
+    private fun downloadUrl(url: String): File? {
+        return try {
+            URL(url).openConnection().inputStream.use { inputStream ->
+                createTempPdfFile(requireContext())?.let { file ->
+                    file.outputStream().use { output ->
+                        inputStream.copyTo(output)
+                    }
+                    file
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            prependToLog("Error downloading the file: ${e.message}")
+            null
+        }
     }
 }

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -64,6 +64,13 @@
             android:text="Print Shipping Label" />
 
         <Button
+            android:id="@+id/print_commercial_invoice"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Print Commercial Invoice" />
+
+        <Button
             android:id="@+id/check_creation_eligibility"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/example/src/main/res/xml/provider_paths.xml
+++ b/example/src/main/res/xml/provider_paths.xml
@@ -3,4 +3,7 @@
     <external-path
         name="external_files"
         path="."/>
+    <external-cache-path
+        name="cache_files"
+        path="."/>
 </paths>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 152
+        return 153
     }
 
     override fun getDbName(): String {
@@ -1769,6 +1769,9 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("CREATE TABLE MediaUploadModel (_id INTEGER PRIMARY KEY,UPLOAD_STATE INTEGER," +
                             "PROGRESS REAL,ERROR_TYPE TEXT,ERROR_MESSAGE TEXT,ERROR_SUB_TYPE TEXT," +
                             "FOREIGN KEY(_id) REFERENCES MediaModel(_id) ON DELETE CASCADE)")
+                }
+                152 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCShippingLabelModel ADD COMMERCIAL_INVOICE_URL TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelMapper.kt
@@ -25,6 +25,7 @@ class WCShippingLabelMapper
                 productNames = labelItem.productNames.toString()
                 productIds = labelItem.productIds.toString()
                 refund = labelItem.refund.toString()
+                commercialInvoiceUrl = labelItem.commercialInvoiceUrl
                 dateCreated = labelItem.dateCreated
                 expiryDate = labelItem.expiryDate
                 remoteOrderId = response.orderId ?: 0L
@@ -57,6 +58,7 @@ class WCShippingLabelMapper
                 productNames = labelItem.productNames.toString()
                 productIds = labelItem.productIds.toString()
                 refund = labelItem.refund.toString()
+                commercialInvoiceUrl = labelItem.commercialInvoiceUrl
                 dateCreated = labelItem.dateCreated
                 expiryDate = labelItem.expiryDate
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -29,7 +29,7 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     @Column var productIds = "" // list of product ids the shipping label was purchased for
     @Column var formData = "" // map containing package and product details related to that shipping label
     @Column var refund = "" // map containing refund information for a shipping label
-    @Column var commercialInvoiceUrl: String? =  null // URL pointing to the international commercial URL
+    @Column var commercialInvoiceUrl: String? = null // URL pointing to the international commercial URL
 
     override fun getId() = id
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -27,10 +27,9 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
     @Column var currency = ""
     @Column var productNames = "" // list of product names the shipping label was purchased for
     @Column var productIds = "" // list of product ids the shipping label was purchased for
-
     @Column var formData = "" // map containing package and product details related to that shipping label
-
     @Column var refund = "" // map containing refund information for a shipping label
+    @Column var commercialInvoiceUrl: String? =  null // URL pointing to the international commercial URL
 
     override fun getId() = id
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelModel.kt
@@ -104,13 +104,6 @@ class WCShippingLabelModel(@PrimaryKey @Column private var id: Int = 0) : Identi
         return gson.fromJson(refund, responseType) as? WCShippingLabelRefundModel
     }
 
-    class StoreOptions {
-        @SerializedName("currency_symbol") val currencySymbol: String? = null
-        @SerializedName("dimension_unit") val dimensionUnit: String? = null
-        @SerializedName("weight_unit") val weightUnit: String? = null
-        @SerializedName("origin_country") val originCountry: String? = null
-    }
-
     /**
      * Model class corresponding to the [formData] map from the API response.
      * The [formData] contains the [origin] and [destination] address and the

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/LabelItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/LabelItem.kt
@@ -15,6 +15,7 @@ class LabelItem {
     @SerializedName("product_names") val productNames: List<String>? = emptyList()
     @SerializedName("product_ids") val productIds: List<Long>? = emptyList()
     @SerializedName("refundable_amount") val refundableAmount: BigDecimal? = null
+    @SerializedName("commercial_invoice_url") val commercialInvoiceUrl: String? = null
     val status: String? = null
     val rate: BigDecimal? = null
     val currency: String? = null


### PR DESCRIPTION
This PR is needed for https://github.com/woocommerce/woocommerce-android/issues/4119, it just adds a column to save the `commercial_invoice_url`, and updates the example app to test retrieving it.

#### Test
1. Open the example app.
2. Click on Woo.
3. Click on Shipping Labels.
4. Click on Print Commercial Invoice
5. Enter the order and label ids.
6. Confirm that the default PDF reader is opened with the invoice file.

Please note that you need an international shipping label using one of the carriers that require the commercial invoice (for example DHL)