### PR TITLE
RewindStatusModel.State: Fix awaiting credentials value

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
@@ -14,7 +14,7 @@ data class RewindStatusModel(
         ACTIVE("active"),
         INACTIVE("inactive"),
         UNAVAILABLE("unavailable"),
-        AWAITING_CREDENTIALS("awaitingCredentials"),
+        AWAITING_CREDENTIALS("awaiting_credentials"),
         PROVISIONING("provisioning"),
         UNKNOWN("unknown");
 


### PR DESCRIPTION
This PR fixes `RewindStatusModel.State.AWAITING_CREDENTIALS` value from `awaitingCredentials` to `awaiting_credentials` based on the value returned from the API:

<img width="592" alt="awaiting_creds" src="https://user-images.githubusercontent.com/1405144/120677521-c993dc00-c4b4-11eb-8f3b-f3ae6915c256.png">


### How To Test 
https://github.com/wordpress-mobile/WordPress-Android/pull/14772