### PR TITLE
Woo: fix NPE if shipping_lines is missing from refunds response

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
@@ -12,26 +12,26 @@ import javax.inject.Inject
 class RefundMapper @Inject constructor() {
     fun map(response: RefundResponse): WCRefundModel {
         return WCRefundModel(
-                response.refundId,
-                response.dateCreated?.let { fromFormattedDate(it) } ?: Date(),
-                response.amount?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
-                response.reason,
-                response.refundedPayment ?: false,
-                response.items.map {
+                id = response.refundId,
+                dateCreated = response.dateCreated?.let { fromFormattedDate(it) } ?: Date(),
+                amount = response.amount?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+                reason = response.reason,
+                automaticGatewayRefund = response.refundedPayment ?: false,
+                items = response.items?.map {
                     WCRefundItem(
-                            it.id ?: -1,
-                            it.quantity?.toInt() ?: 0,
-                            it.subtotal?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
-                            it.totalTax?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
-                            it.name,
-                            it.productId,
-                            it.variationId,
-                            it.total?.toBigDecimalOrNull(),
-                            it.sku,
-                            it.price?.toBigDecimalOrNull()
+                            itemId = it.id ?: -1,
+                            quantity = it.quantity?.toInt() ?: 0,
+                            subtotal = it.subtotal?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+                            totalTax = it.totalTax?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+                            name = it.name,
+                            productId = it.productId,
+                            variationId = it.variationId,
+                            total = it.total?.toBigDecimalOrNull(),
+                            sku = it.sku,
+                            price = it.price?.toBigDecimalOrNull()
                     )
-                },
-                response.shippingLineItems
+                } ?: emptyList(),
+                shippingLineItems = response.shippingLineItems ?: emptyList()
         )
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
@@ -145,7 +145,7 @@ class RefundRestClient @Inject constructor(
         @SerializedName("amount") val amount: String?,
         @SerializedName("reason") val reason: String?,
         @SerializedName("refunded_payment") val refundedPayment: Boolean?,
-        @SerializedName("line_items") val items: List<LineItem>,
-        @SerializedName("shipping_lines") val shippingLineItems: List<WCRefundShippingLine>
+        @SerializedName("line_items") val items: List<LineItem>?,
+        @SerializedName("shipping_lines") val shippingLineItems: List<WCRefundShippingLine>?
     )
 }


### PR DESCRIPTION
This is needed to fix the crash https://github.com/woocommerce/woocommerce-android/issues/4109, which is caused by a null pointer exception at the `shipping_lines` item.
I took the change to make `items` also nullable, the mapper will always convert null items to empty lists.

#### Testing
I wasn't able to reproduce the original issue, as `shipping_lines` is always present in the API response, which means it's probably a plugin that's messing with the response for the affected users.
So just confirming that the feature is not impacted is enough: load refunds of a refunded order in the example app.