### PR TITLE
Re-enable fetchstyle plugin and request it from s3 repository 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     // Those declarations are just a workaround for a false-positive Kotlin Gradle Plugin warning
     // https://youtrack.jetbrains.com/issue/KT-46200
@@ -8,7 +7,7 @@ plugins {
     id "org.jetbrains.kotlin.jvm" apply false
     id "org.jetbrains.kotlin.kapt" apply false
 
-//    id "com.automattic.android.fetchstyle"
+    id "com.automattic.android.fetchstyle"
     id "com.automattic.android.configure"
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
         jcenter()
-        maven { url "https://dl.bintray.com/automattic/maven/" }
     }
     resolutionStrategy {
         eachPlugin {

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,10 +9,15 @@ pluginManagement {
         id "org.jetbrains.kotlin.kapt" version gradle.ext.kotlinVersion
     }
     repositories {
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android' 
+            content {
+                includeGroup "com.automattic.android"
+            }
+        }
         gradlePluginPortal()
         google()
         jcenter()
-        maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
         maven { url "https://dl.bintray.com/automattic/maven/" }
     }
     resolutionStrategy {


### PR DESCRIPTION
Since the [source code for fetchstyle plugin](https://github.com/Automattic/style-config-android) is heavily outdated, I couldn't fully update it in the time I allotted for it. I actually successfully published the plugin to S3, but there was something wrong with the groovy dependency, so it didn't work when I tried to consume it. So, for now, I've manually ported the fetchstyle plugin from jcenter to our s3 repository.

I also took the opportunity to remove the Bintray repository which is not used (or even valid) anymore.

**To test:**
* Run `./gradlew tasks --all | grep downloadConfigs` to verify the fetchstyle plugin tasks are available. Or you can run the `downloadConfigs` with `./gradlew downloadConfigs`.
* Run `./gradlew --scan` and open the scan. In the `Build Dependencies section`, use the search functionality to find the `fetchstyle` dependency and verify it's repository is our s3 repo and not `jcenter`

![fluxc](https://user-images.githubusercontent.com/662023/121822195-b67acc00-cc6b-11eb-8e8b-c1e0b72d7c5b.png)
