### PR TITLE
Woo: fetch and expose order's meta data

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 153
+        return 154
     }
 
     override fun getDbName(): String {
@@ -1772,6 +1772,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 152 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCShippingLabelModel ADD COMMERCIAL_INVOICE_URL TEXT")
+                }
+                153 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCOrderModel ADD META_DATA TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -66,6 +66,8 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
 
     @Column var feeLines = ""
 
+    @Column var metaData = ""
+
     companion object {
         private val gson by lazy { Gson() }
     }
@@ -196,6 +198,14 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     fun getFeeLineList(): List<FeeLine> {
         val responseType = object : TypeToken<List<FeeLine>>() {}.type
         return gson.fromJson(feeLines, responseType) as? List<FeeLine> ?: emptyList()
+    }
+
+    /**
+     * Deserializes the JSON contained in [metaData] into a list of [WCMetaData] objects.
+     */
+    fun getMetaDataList(): List<WCMetaData> {
+        val responseType = object : TypeToken<List<WCMetaData>>() {}.type
+        return gson.fromJson(metaData, responseType) as? List<WCMetaData> ?: emptyList()
     }
 
     fun isMultiShippingLinesAvailable() = getShippingLineList().size > 1

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -66,4 +66,5 @@ class OrderApiResponse : Response {
     val status: String? = null
     val total: String? = null
     val total_tax: String? = null
+    val meta_data: JsonElement? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -732,6 +732,7 @@ class OrderRestClient @Inject constructor(
             lineItems = response.line_items.toString()
             shippingLines = response.shipping_lines.toString()
             feeLines = response.fee_lines.toString()
+            metaData = response.meta_data.toString()
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -830,7 +830,8 @@ class OrderRestClient @Inject constructor(
                 "shipping_total",
                 "status",
                 "total",
-                "total_tax"
+                "total_tax",
+                "meta_data"
         ).joinToString(separator = ",")
 
         private val TRACKING_FIELDS = arrayOf(


### PR DESCRIPTION
This PR fetches and exposes the `meta_data` of the WC Orders, so that the client apps can read them.
This is based on the changes done in #2028 to have a common class representing the meta data, and it's needed to pre-fill the shipping address's phone number (issue https://github.com/woocommerce/woocommerce-android/issues/4195)

#### Testing
1. Create an order in your store.
2. Open the order details in the web client.
3. Go to the section "Custom Fields" and add some custom data.
5. Apply the patch from below and run the example app.
6. Go to Woo, then Orders.
7. Click on "Fetch single order"
8. Enter the order id.
9. Notice that the meta data of the order is printed, and that it includes the field you added.

#### Patch for testing
```
Index: example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt	(revision ef4072a5a419c779716589c5a23b621dff278644)
+++ example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt	(date 1623694920378)
@@ -401,6 +401,7 @@
                                     })
                             )?.let {
                                 prependToLog("Single order fetched successfully!")
+                                prependToLog(it.getMetaDataList().toString())
                             } ?: prependToLog("WARNING: Fetched order not found in the local database!")
                         }
                     }

```