### PR TITLE
Making SiteSTore open to allow mocking in androidTest.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -109,9 +109,11 @@ import javax.inject.Singleton
 
 /**
  * SQLite based only. There is no in memory copy of mapped data, everything is queried from the DB.
+ *
+ * NOTE: This class needs to be open because it's mocked in android tests in the WPAndroid project.
  */
 @Singleton
-class SiteStore
+open class SiteStore
 @Inject constructor(
     dispatcher: Dispatcher?,
     private val postSqlUtils: PostSqlUtils,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -111,6 +111,7 @@ import javax.inject.Singleton
  * SQLite based only. There is no in memory copy of mapped data, everything is queried from the DB.
  *
  * NOTE: This class needs to be open because it's mocked in android tests in the WPAndroid project.
+ *       TODO: consider adding https://kotlinlang.org/docs/all-open-plugin.html
  */
 @Singleton
 open class SiteStore
@@ -940,8 +941,11 @@ open class SiteStore
 
     /**
      * Obtains the site with the given (local) id and returns it as a [SiteModel].
+     *
+     * NOTE: This method needs to be open because it's mocked in android tests in the WPAndroid project.
+     *       TODO: consider adding https://kotlinlang.org/docs/all-open-plugin.html
      */
-    fun getSiteByLocalId(id: Int): SiteModel? {
+    open fun getSiteByLocalId(id: Int): SiteModel? {
         val result = siteSqlUtils.getSitesWithLocalId(id)
         return if (result.isNotEmpty()) {
             result[0]


### PR DESCRIPTION
This PR makes the SiteStore open to allow for connected tests mocking in WPAndroid specifically (companion PR [here](https://github.com/wordpress-mobile/WordPress-Android/pull/14922)). 
The original SiteStore.java was not final as well, so in the end we are bringing back the original condition in my understanding.

I was looking for some annotation similar to VisibleForTesting, but could not find something suitable at hand (we can maybe evaluate the introduction of [all-open plugin](https://kotlinlang.org/docs/all-open-plugin.html) in fluxc). Placed a comment in the code to document the why the class was marked open.