### PR TITLE
Workaround for fast scrolling crash on screens using legacy paging

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datasource/InternalPagedListDataSource.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datasource/InternalPagedListDataSource.kt
@@ -63,7 +63,7 @@ class InternalPagedListDataSource<LIST_DESCRIPTOR : ListDescriptor, ITEM_IDENTIF
          * See https://github.com/wordpress-mobile/WordPress-Android/issues/14860.
          * A pattern was noticed: the crash occurred only on the last page where endPosition was set to
          * (startPosition + 20) > totalSize. This workaround fixes this problem by resetting
-         * endPosition to totalSize as tte crash occurred only on the last page.
+         * endPosition to totalSize as the crash occurred only on the last page.
          */
         var newEndPosition = endPosition
         if (endPosition > totalSize) newEndPosition = totalSize

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datasource/InternalPagedListDataSource.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/datasource/InternalPagedListDataSource.kt
@@ -58,10 +58,19 @@ class InternalPagedListDataSource<LIST_DESCRIPTOR : ListDescriptor, ITEM_IDENTIF
      * @param endPosition End position that's exclusive
      */
     private fun getItemIds(startPosition: Int, endPosition: Int): List<ITEM_IDENTIFIER> {
-        require(startPosition in 0 until endPosition && endPosition <= totalSize) {
+        /**
+         * After upgrading to Paging 3 in the client app, screens using legacy paging crashed on fast scrolling.
+         * See https://github.com/wordpress-mobile/WordPress-Android/issues/14860.
+         * A pattern was noticed: the crash occurred only on the last page where endPosition was set to
+         * (startPosition + 20) > totalSize. This workaround fixes this problem by resetting
+         * endPosition to totalSize as tte crash occurred only on the last page.
+         */
+        var newEndPosition = endPosition
+        if (endPosition > totalSize) newEndPosition = totalSize
+        require(startPosition in 0 until newEndPosition && newEndPosition <= totalSize) {
             "Illegal start($startPosition) or end($endPosition) position for totalSize($totalSize)"
         }
 
-        return itemIdentifiers.subList(startPosition, endPosition)
+        return itemIdentifiers.subList(startPosition, newEndPosition)
     }
 }


### PR DESCRIPTION
### Description

This PR adds a workaround to fix a crash on screens using legacy paging.
The crash occurs when `endPosition` is set to (`startPosition` + 20) > `totalSize`. This PR sets `endIndex = totalSize` whenever it goes beyond it.

See Sentry Crash Instances to see the pattern:
https://sentry.io/share/issue/09d3b8128d0e448abd3e8c3be693bcd9/
`IllegalArgumentException: Illegal start(20) or end(40) position for totalSize(30)`

https://sentry.io/share/issue/09d3b8128d0e448abd3e8c3be693bcd9/
`IllegalArgumentException: Illegal start(40) or end(60) position for totalSize(57)`

https://sentry.io/share/issue/09d3b8128d0e448abd3e8c3be693bcd9/
`IllegalArgumentException: Illegal start(80) or end(100) position for totalSize(92)`



### How to Test

https://github.com/wordpress-mobile/WordPress-Android/pull/14938