### PR TITLE
Change custom's item quantity to Int

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -62,6 +62,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
+import kotlin.math.ceil
 
 class WooShippingLabelFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
@@ -572,7 +573,7 @@ class WooShippingLabelFragment : Fragment() {
                                             productId = it.productId!!,
                                             description = it.name.orEmpty(),
                                             value = (it.price?.toBigDecimal() ?: BigDecimal.ZERO),
-                                            quantity = quantity,
+                                            quantity = ceil(quantity).toInt(),
                                             weight = 1f,
                                             hsTariffNumber = null,
                                             originCountry = "US"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingPackageCustoms.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingPackageCustoms.kt
@@ -27,7 +27,7 @@ data class WCShippingPackageCustoms(
 data class WCCustomsItem(
     @SerializedName("product_id") val productId: Long,
     val description: String,
-    val quantity: Float,
+    val quantity: Int,
     val value: BigDecimal,
     val weight: Float,
     @SerializedName("hs_tariff_number") val hsTariffNumber: String?,


### PR DESCRIPTION
To align with the web client, and to avoid issues with the API, we need to change the type of item's quantity in the Custom's data to Integer.