### PR TITLE
Check blogging reminders presence

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/BloggingRemindersStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/BloggingRemindersStoreTest.kt
@@ -34,7 +34,7 @@ class BloggingRemindersStoreTest {
     fun `maps items emitted from dao`() = test {
         val dbEntity = BloggingReminders(siteId, monday = true)
         val domainModel = BloggingRemindersModel(siteId, setOf(MONDAY))
-        whenever(bloggingRemindersDao.getBySiteId(siteId)).thenReturn(flowOf(dbEntity))
+        whenever(bloggingRemindersDao.liveGetBySiteId(siteId)).thenReturn(flowOf(dbEntity))
         whenever(mapper.toDomainModel(dbEntity)).thenReturn(domainModel)
 
         assertThat(store.bloggingRemindersModel(siteId).single()).isEqualTo(domainModel)
@@ -42,7 +42,7 @@ class BloggingRemindersStoreTest {
 
     @Test
     fun `maps null value to empty model emitted from dao`() = test {
-        whenever(bloggingRemindersDao.getBySiteId(siteId)).thenReturn(flowOf(null))
+        whenever(bloggingRemindersDao.liveGetBySiteId(siteId)).thenReturn(flowOf(null))
 
         assertThat(store.bloggingRemindersModel(siteId).single()).isEqualTo(BloggingRemindersModel(siteId))
     }
@@ -56,5 +56,20 @@ class BloggingRemindersStoreTest {
         store.updateBloggingReminders(domainModel)
 
         verify(bloggingRemindersDao).insert(dbEntity)
+    }
+
+    @Test
+    fun `has modified blogging reminders when DAO returns data`() = test {
+        val dbEntity = BloggingReminders(siteId, monday = true)
+        whenever(bloggingRemindersDao.getBySiteId(siteId)).thenReturn(listOf(dbEntity))
+
+        assertThat(store.hasModifiedBloggingReminders(siteId)).isTrue()
+    }
+
+    @Test
+    fun `does not have modified blogging reminders when DAO returns no data`() = test {
+        whenever(bloggingRemindersDao.getBySiteId(siteId)).thenReturn(listOf())
+
+        assertThat(store.hasModifiedBloggingReminders(siteId)).isFalse()
     }
 }

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/1.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/1.json
@@ -1,0 +1,76 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "4f29ca40a8cdc7081cbff3a88c7eaa87",
+    "entities": [
+      {
+        "tableName": "BloggingReminders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `monday` INTEGER NOT NULL, `tuesday` INTEGER NOT NULL, `wednesday` INTEGER NOT NULL, `thursday` INTEGER NOT NULL, `friday` INTEGER NOT NULL, `saturday` INTEGER NOT NULL, `sunday` INTEGER NOT NULL, PRIMARY KEY(`localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monday",
+            "columnName": "monday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tuesday",
+            "columnName": "tuesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wednesday",
+            "columnName": "wednesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thursday",
+            "columnName": "thursday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friday",
+            "columnName": "friday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saturday",
+            "columnName": "saturday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sunday",
+            "columnName": "sunday",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4f29ca40a8cdc7081cbff3a88c7eaa87')"
+    ]
+  }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/BloggingRemindersDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/BloggingRemindersDao.kt
@@ -17,10 +17,10 @@ abstract class BloggingRemindersDao {
     abstract fun liveGetBySiteId(siteId: Int): Flow<BloggingReminders?>
 
     @Query("SELECT * FROM BloggingReminders WHERE localSiteId = :siteId")
-    abstract fun getBySiteId(siteId: Int): List<BloggingReminders>
+    abstract suspend fun getBySiteId(siteId: Int): List<BloggingReminders>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract fun insert(type: BloggingReminders): Long
+    abstract suspend fun insert(type: BloggingReminders): Long
 
     @Entity(tableName = "BloggingReminders")
     data class BloggingReminders(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/BloggingRemindersDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/BloggingRemindersDao.kt
@@ -14,7 +14,10 @@ abstract class BloggingRemindersDao {
     abstract fun getAll(): Flow<List<BloggingReminders>>
 
     @Query("SELECT * FROM BloggingReminders WHERE localSiteId = :siteId")
-    abstract fun getBySiteId(siteId: Int): Flow<BloggingReminders?>
+    abstract fun liveGetBySiteId(siteId: Int): Flow<BloggingReminders?>
+
+    @Query("SELECT * FROM BloggingReminders WHERE localSiteId = :siteId")
+    abstract fun getBySiteId(siteId: Int): List<BloggingReminders>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract fun insert(type: BloggingReminders): Long

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/BloggingRemindersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/BloggingRemindersStore.kt
@@ -23,9 +23,10 @@ class BloggingRemindersStore
         }
     }
 
-    fun hasModifiedBloggingReminders(siteId: Int): Boolean {
-        return bloggingRemindersDao.getBySiteId(siteId).isNotEmpty()
-    }
+    suspend fun hasModifiedBloggingReminders(siteId: Int) =
+            coroutineEngine.withDefaultContext(T.SETTINGS, this, "Has blogging reminders") {
+                bloggingRemindersDao.getBySiteId(siteId).isNotEmpty()
+            }
 
     suspend fun updateBloggingReminders(model: BloggingRemindersModel) =
             coroutineEngine.withDefaultContext(T.SETTINGS, this, "Updating blogging reminders") {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/BloggingRemindersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/BloggingRemindersStore.kt
@@ -18,9 +18,13 @@ class BloggingRemindersStore
     private val coroutineEngine: CoroutineEngine
 ) {
     fun bloggingRemindersModel(siteId: Int): Flow<BloggingRemindersModel> {
-        return bloggingRemindersDao.getBySiteId(siteId).map {
+        return bloggingRemindersDao.liveGetBySiteId(siteId).map {
             it?.let { dbModel -> mapper.toDomainModel(dbModel) } ?: BloggingRemindersModel(siteId)
         }
+    }
+
+    fun hasModifiedBloggingReminders(siteId: Int): Boolean {
+        return bloggingRemindersDao.getBySiteId(siteId).isNotEmpty()
     }
 
     suspend fun updateBloggingReminders(model: BloggingRemindersModel) =


### PR DESCRIPTION
This PR adds a method to check whether any blogging reminders item has been already stored in order to find out whether to show the prologue screen from settings.