### PR TITLE
Strips semantic version information in GSS version check

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -144,5 +144,24 @@ class EditorThemeStore
     }
 
     private fun globalStyleSettingsAvailable(site: SiteModel, gssEnabled: Boolean) =
-            gssEnabled && Version(site.softwareVersion) >= Version(GSS_LIMIT_VERSION)
+            gssEnabled && hasRequiredWordPressVersion(site.softwareVersion)
+
+    /**
+     * Checks if the [wordPressSoftwareVersion] is higher or equal to [GSS_LIMIT_VERSION]
+     *
+     * Note: At this point semantic version information (alpha, beta etc) is stripped since it
+     * is not supported by our [Version] utility
+     *
+     * @param wordPressSoftwareVersion the WordPress version
+     * @return true if the check is met
+     */
+    private fun hasRequiredWordPressVersion(wordPressSoftwareVersion: String) = try {
+        val version = if (wordPressSoftwareVersion.contains("-")) {
+            // strip semantic versioning information (alpha, beta etc)
+            wordPressSoftwareVersion.substringBefore("-")
+        } else wordPressSoftwareVersion
+        Version(version) >= Version(GSS_LIMIT_VERSION)
+    } catch (e: IllegalArgumentException) {
+        false // if version parsing fails return false
+    }
 }


### PR DESCRIPTION
`WordPress-Android` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/14963

## Description
This PR works around the limitation of our [Version](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/ceca58fa9ec642014a1f3b5d2396752fb619db72/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/Version.java#L16) utility in handling semantic versions (e.g. `5.8-beta4-51251`) by stripping the extra information and keeping only the numeric version string (e.g. `5.8`). This applies only in the specific use case of checking the WordPress software version number for enabling [GSS](https://github.com/WordPress/gutenberg/issues/29063). 

## To test
### Reproduce the crash
1. Use the app from the [GSS Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14597)
2. Turn on the GlobalStyleSupportFeatureConfig (Me > App Settings > Test feature configuration)
3. Select a WP.com (now at version`5.8-beta4`) site or a self-hosted site with beta WordPress version
4. Try to open the editor
5. **Notice** that the app crashes
### Verify the fix
1. Use the app from [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14963)
2. Turn on the GlobalStyleSupportFeatureConfig (Me > App Settings > Test feature configuration)
3. Select a WP.com (now at version`5.8-beta4`) site or a self-hosted site with beta WordPress version
4. Try to open the editor
5. **Verify** that the app does not crash