### PR TITLE
Jetpack: Enhance Rewind Status Model with Reason Enum

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Reason
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.RUNNING
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State.ACTIVE
@@ -235,7 +236,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         val status = RUNNING
         val progress = 30
         val rewind = Rewind(rewindId, restoreId, status, progress, null, null, null)
-        val model = RewindStatusModel(ACTIVE, null, Date(), null, null, rewind)
+        val model = RewindStatusModel(ACTIVE, Reason.NO_REASON, Date(), null, null, rewind)
 
         activityLogSqlUtils.replaceRewindStatus(site, model)
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -20,9 +20,7 @@ import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Reason
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind
-import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.RUNNING
-import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State.ACTIVE
-import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State.UNAVAILABLE
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State
 import org.wordpress.android.fluxc.persistence.ActivityLogSqlUtils
 import org.wordpress.android.fluxc.release.ReleaseStack_ActivityLogTestJetpack.Sites.CompleteJetpackSite
 import org.wordpress.android.fluxc.release.ReleaseStack_ActivityLogTestJetpack.Sites.FreeJetpackSite
@@ -142,7 +140,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         assertNotNull(rewindStatusForSite)
         rewindStatusForSite?.apply {
             assertNotNull(this.state)
-            assertEquals(this.state, UNAVAILABLE)
+            assertEquals(this.state, State.UNAVAILABLE)
         }
     }
 
@@ -233,10 +231,10 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
 
         val rewindId = "rewindId"
         val restoreId: Long = 123
-        val status = RUNNING
+        val status = Rewind.Status.RUNNING
         val progress = 30
         val rewind = Rewind(rewindId, restoreId, status, progress, null, null, null)
-        val model = RewindStatusModel(ACTIVE, Reason.NO_REASON, Date(), null, null, rewind)
+        val model = RewindStatusModel(State.ACTIVE, Reason.NO_REASON, Date(), null, null, rewind)
 
         activityLogSqlUtils.replaceRewindStatus(site, model)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -21,8 +21,8 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityTypeModel
-import org.wordpress.android.fluxc.model.activity.RewindStatusModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Reason
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.UserAgent
@@ -265,7 +265,7 @@ class ActivityLogRestClientTest {
 
     @Test
     fun fetchActivityRewind_dispatchesResponseOnSuccess() = test {
-        val state = RewindStatusModel.State.ACTIVE
+        val state = State.ACTIVE
         val rewindResponse = REWIND_STATUS_RESPONSE.copy(state = state.value)
         initFetchRewindStatus(rewindResponse)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityTypeModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Reason
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.UserAgent
@@ -275,7 +276,7 @@ class ActivityLogRestClientTest {
             assertNull(error)
             assertNotNull(rewindStatusModelResponse)
             rewindStatusModelResponse?.apply {
-                assertEquals(reason, REWIND_STATUS_RESPONSE.reason)
+                assertEquals(reason, Reason.UNKNOWN)
                 assertEquals(state, state)
                 assertNotNull(rewind)
                 rewind?.apply {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
@@ -20,7 +20,7 @@ data class RewindStatusModel(
 
         companion object {
             fun fromValue(value: String): State? {
-                return State.values().firstOrNull { it.value == value }
+                return values().firstOrNull { it.value == value }
             }
         }
     }
@@ -47,7 +47,7 @@ data class RewindStatusModel(
 
             companion object {
                 fun fromValue(value: String?): Status? {
-                    return value?.let { Status.values().firstOrNull { it.value == value } }
+                    return value?.let { values().firstOrNull { it.value == value } }
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
@@ -10,6 +10,7 @@ data class RewindStatusModel(
     val credentials: List<Credentials>?,
     val rewind: Rewind?
 ) {
+    @Suppress("unused")
     enum class State(val value: String) {
         ACTIVE("active"),
         INACTIVE("inactive"),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/activity/RewindStatusModel.kt
@@ -4,7 +4,7 @@ import java.util.Date
 
 data class RewindStatusModel(
     val state: State,
-    val reason: String?,
+    val reason: Reason,
     val lastUpdated: Date,
     val canAutoconfigure: Boolean?,
     val credentials: List<Credentials>?,
@@ -22,6 +22,18 @@ data class RewindStatusModel(
         companion object {
             fun fromValue(value: String): State? {
                 return values().firstOrNull { it.value == value }
+            }
+        }
+    }
+
+    enum class Reason(val value: String?) {
+        MULTISITE_NOT_SUPPORTED("multisite_not_supported"),
+        NO_REASON(null),
+        UNKNOWN("unknown");
+
+        companion object {
+            fun fromValue(value: String?): Reason {
+                return values().firstOrNull { it.value == value } ?: UNKNOWN
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -359,6 +359,7 @@ class ActivityLogRestClient @Inject constructor(
         val stateValue = response.state
         val state = RewindStatusModel.State.fromValue(stateValue)
                 ?: return buildErrorPayload(site, RewindStatusErrorType.INVALID_RESPONSE)
+        val reason = RewindStatusModel.Reason.fromValue(response.reason)
         val rewindModel = response.rewind?.let {
             val rewindId = it.rewind_id
                     ?: return buildErrorPayload(site, RewindStatusErrorType.MISSING_REWIND_ID)
@@ -380,7 +381,7 @@ class ActivityLogRestClient @Inject constructor(
 
         val rewindStatusModel = RewindStatusModel(
                 state = state,
-                reason = response.reason,
+                reason = reason,
                 lastUpdated = response.last_updated,
                 canAutoconfigure = response.can_autoconfigure,
                 credentials = response.credentials?.map {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -356,8 +356,7 @@ class ActivityLogRestClient @Inject constructor(
 
     private fun buildRewindStatusPayload(response: RewindStatusResponse, site: SiteModel):
             FetchedRewindStatePayload {
-        val stateValue = response.state
-        val state = RewindStatusModel.State.fromValue(stateValue)
+        val state = RewindStatusModel.State.fromValue(response.state)
                 ?: return buildErrorPayload(site, RewindStatusErrorType.INVALID_RESPONSE)
         val reason = RewindStatusModel.Reason.fromValue(response.reason)
         val rewindModel = response.rewind?.let {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ActivityLogSqlUtils.kt
@@ -207,7 +207,7 @@ class ActivityLogSqlUtils
                 remoteSiteId = site.siteId,
                 state = this.state.value,
                 lastUpdated = this.lastUpdated.time,
-                reason = this.reason,
+                reason = this.reason.value,
                 canAutoconfigure = this.canAutoconfigure,
                 rewindId = this.rewind?.rewindId,
                 restoreId = this.rewind?.restoreId,
@@ -338,11 +338,12 @@ class ActivityLogSqlUtils
             )
             return RewindStatusModel(
                     RewindStatusModel.State.fromValue(state) ?: RewindStatusModel.State.UNKNOWN,
-                    reason,
+                    RewindStatusModel.Reason.fromValue(reason),
                     Date(lastUpdated),
                     canAutoconfigure,
                     credentials,
-                    restoreStatus)
+                    restoreStatus
+            )
         }
     }
 


### PR DESCRIPTION
Related to: [WordPress-Android#14982](https://github.com/wordpress-mobile/WordPress-Android/pull/14982)

This PR is complimentary to its related PR since it helps with providing the new `Reason` enum to that use case that will utilise it to hide the restore option for an unavailable rewind state on multisites.

All this PR is doing is changing the `RewindStatusModel` type of its string `reason` field to a new `Reason` enum.

To test:
- Run the `ActivityLogRestClientTest.kt` unit test suite and verify all tests pass successfully.
- Run the `ReleaseStack_ActivityLogTestJetpack.kt` connected test suite and verify all tests pass successfully.