### PR TITLE
[Gutenberg] Add /oembed/1.0 endpoint support for wpcom API

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -186,6 +186,7 @@ class ReactNativeStore
                 val url = path?.let {
                     val newPath = it
                             .replace("wp/v2".toRegex(), "wp/v2/sites/$wpComSiteId")
+                            .replace("oembed/1.0".toRegex(), "oembed/1.0/sites/$wpComSiteId")
                     slashJoin(WPCOM_ENDPOINT, newPath)
                 }
                 Pair(url, params)


### PR DESCRIPTION
WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/14998

When we add a link to an Embed block in Gutenberg, it triggers a request to the path `/oembed/1.0/proxy` with a `url` parameter.
For example, if we enter `https://www.youtube.com/watch?v=hMMg37xEQpo` link, it triggers `/oembed/1.0/proxy?url=https://www.youtube.com/watch?v=hMMg37xEQpo` request.
For self-hosted sites this request works fine, but for sites where we use WPCom API, we need to add `sites/` and the site id to the path, so it becomes: `/oembed/1.0/sites/proxy/($wpComSiteId)?url=https://www.youtube.com/watch?v=hMMg37xEQpo`. 
This PR is introducing a change that modifies the path where necessary to achieve the desired one.