### PR TITLE
Block editor settings endpoint - Removes experimental namespace

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_EditorThemeStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_EditorThemeStoreTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.mocked
 
 import android.os.Bundle
 import com.google.gson.JsonArray
-import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/ResponseMockingInterceptor.kt
@@ -97,9 +97,10 @@ class ResponseMockingInterceptor @Inject constructor() : Interceptor {
     }
 
     @JvmOverloads
-    fun respondWithError(jsonResponse: JsonElement, errorCode: Int = 404) {
+    fun respondWithError(jsonResponse: JsonElement, errorCode: Int = 404, interceptorMode: InterceptorMode = ONE_TIME) {
         nextResponseJson = jsonResponse.toString()
         nextResponseCode = errorCode
+        mode = interceptorMode
     }
 
     @Throws(IOException::class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -24,7 +24,7 @@ import javax.inject.Singleton
 
 private const val THEME_REQUEST_PATH = "/wp/v2/themes?status=active"
 private const val EDITOR_SETTINGS_REQUEST_PATH = "wp-block-editor/v1/settings?context=mobile"
-private const val EDITOR_SETTINGS_EXPERIMENTAL_REQUEST_PATH = "__experimental/wp-block-editor/v1/settings?context=mobile"
+private const val EDITOR_SETTINGS_EXPERIMENTAL_REQUEST_PATH = "__experimental/$EDITOR_SETTINGS_REQUEST_PATH"
 private const val EDITOR_SETTINGS_LIMIT_VERSION = "5.8"
 
 @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -186,6 +186,7 @@ class ReactNativeStore
                 val url = path?.let {
                     val newPath = it
                             .replace("wp/v2".toRegex(), "wp/v2/sites/$wpComSiteId")
+                            .replace("wp-block-editor/v1".toRegex(), "wp-block-editor/v1/sites/$wpComSiteId")
                     slashJoin(WPCOM_ENDPOINT, newPath)
                 }
                 Pair(url, params)


### PR DESCRIPTION
## Description
* Aligns the api client with the [removal of the experimental namespace from the block editor settings endpoint](https://github.com/WordPress/gutenberg/pull/33128).
* Adds the site information in the wp-block-editor namespace for WP.com connected sites 
* It also [renames](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2049/commits/d35db4ef45705bc008966e7d81b603541f079f7c) functions and constants in the implementation to clarify that the block editor settings api call escapes the scope of the Global Styles feature.

## To test
Check [Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15002)

📓 Note that the Jetpack side is still dependent on some backend changes so this PR is still a draft.