### PR TITLE
Block Editor Settings: Adds endpoint information to the editor theme change event

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -19,6 +19,7 @@ const val MAP_KEY_ELEMENT_COLORS: String = "colors"
 const val MAP_KEY_ELEMENT_GRADIENTS: String = "gradients"
 const val MAP_KEY_ELEMENT_STYLES: String = "rawStyles"
 const val MAP_KEY_ELEMENT_FEATURES: String = "rawFeatures"
+const val MAP_KEY_IS_FSETHEME: String = "isFSETheme"
 
 data class EditorTheme(
     @SerializedName("theme_supports") val themeSupport: EditorThemeSupport,
@@ -30,7 +31,8 @@ data class EditorTheme(
                     blockEditorSettings.colors,
                     blockEditorSettings.gradients,
                     blockEditorSettings.styles.toString(),
-                    blockEditorSettings.features.toString()
+                    blockEditorSettings.features.toString(),
+                    blockEditorSettings.isFSETheme
             ),
             stylesheet = null,
             version = null
@@ -72,7 +74,8 @@ data class EditorThemeSupport(
     @SerializedName("editor-gradient-presets")
     val gradients: List<EditorThemeElement>?,
     val rawStyles: String?,
-    val rawFeatures: String?
+    val rawFeatures: String?,
+    val isFSETheme: Boolean
 ) {
     fun toBundle(): Bundle {
         val bundle = Bundle()
@@ -92,6 +95,8 @@ data class EditorThemeSupport(
         rawFeatures?.let {
             bundle.putString(MAP_KEY_ELEMENT_FEATURES, it)
         }
+
+        bundle.putBoolean(MAP_KEY_IS_FSETHEME, isFSETheme)
 
         return bundle
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -86,6 +86,11 @@ class EditorThemeSqlUtils {
         @Column var version: String? = null
         @Column var rawStyles: String? = null
         @Column var rawFeatures: String? = null
+        @Column var isFSETheme: Boolean = false
+            @JvmName("isFSETheme")
+            get
+            @JvmName("setIsFSETheme")
+            set
 
         override fun setId(id: Int) {
             this.mId = id
@@ -107,7 +112,7 @@ class EditorThemeSqlUtils {
                 gradients = storedGradients.mapNotNull { it.toEditorThemeElement() }
             }
 
-            val editorThemeSupport = EditorThemeSupport(colors, gradients, rawStyles, rawFeatures)
+            val editorThemeSupport = EditorThemeSupport(colors, gradients, rawStyles, rawFeatures, isFSETheme)
 
             return EditorTheme(editorThemeSupport, stylesheet, version)
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 158
+        return 159
     }
 
     override fun getDbName(): String {
@@ -1801,6 +1801,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 157 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD ZENDESK_PLAN TEXT")
                     db.execSQL("ALTER TABLE SiteModel ADD ZENDESK_ADD_ONS TEXT")
+                }
+                158 -> migrate(version) {
+                    db.execSQL("ALTER TABLE EditorTheme ADD IS_FSETHEME BOOLEAN")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -14,6 +14,9 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
 import org.wordpress.android.fluxc.persistence.EditorThemeSqlUtils
+import org.wordpress.android.fluxc.store.EditorThemeStore.ThemeChangedEndpoint.BLOCK_EDITOR
+import org.wordpress.android.fluxc.store.EditorThemeStore.ThemeChangedEndpoint.EXPERIMENTAL_BLOCK_EDITOR
+import org.wordpress.android.fluxc.store.EditorThemeStore.ThemeChangedEndpoint.THEME_SUPPORTS
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -49,12 +52,19 @@ class EditorThemeStore
     data class OnEditorThemeChanged(
         val editorTheme: EditorTheme?,
         val siteId: Int,
-        val causeOfChange: EditorThemeAction
+        val causeOfChange: EditorThemeAction,
+        val endpoint: ThemeChangedEndpoint
     ) : Store.OnChanged<EditorThemeError>() {
-        constructor(error: EditorThemeError, causeOfChange: EditorThemeAction) :
-                this(editorTheme = null, siteId = -1, causeOfChange = causeOfChange) {
+        constructor(error: EditorThemeError, causeOfChange: EditorThemeAction, endpoint: ThemeChangedEndpoint) :
+                this(editorTheme = null, siteId = -1, causeOfChange = causeOfChange, endpoint = endpoint) {
             this.error = error
         }
+    }
+
+    enum class ThemeChangedEndpoint(val value: String) {
+        THEME_SUPPORTS("theme_supports"),
+        BLOCK_EDITOR("wp-block-editor"),
+        EXPERIMENTAL_BLOCK_EDITOR("experimental_wp-block-editor")
     }
 
     class EditorThemeError(var message: String? = null) : OnChangedError
@@ -93,7 +103,11 @@ class EditorThemeStore
 
         when (response) {
             is Success -> {
-                val noThemeError = OnEditorThemeChanged(EditorThemeError("Response does not contain a theme"), action)
+                val noThemeError = OnEditorThemeChanged(
+                        EditorThemeError("Response does not contain a theme"),
+                        action,
+                        THEME_SUPPORTS
+                )
                 if (response.result == null || !response.result.isJsonArray) {
                     emitChange(noThemeError)
                     return
@@ -109,12 +123,12 @@ class EditorThemeStore
                 val existingTheme = editorThemeSqlUtils.getEditorThemeForSite(site)
                 if (newTheme != existingTheme) {
                     editorThemeSqlUtils.replaceEditorThemeForSite(site, newTheme)
-                    val onChanged = OnEditorThemeChanged(newTheme, site.id, action)
+                    val onChanged = OnEditorThemeChanged(newTheme, site.id, action, THEME_SUPPORTS)
                     emitChange(onChanged)
                 }
             }
             is Error -> {
-                val onChanged = OnEditorThemeChanged(EditorThemeError(response.error.message), action)
+                val onChanged = OnEditorThemeChanged(EditorThemeError(response.error.message), action, THEME_SUPPORTS)
                 emitChange(onChanged)
             }
         }
@@ -125,7 +139,7 @@ class EditorThemeStore
 
         when (response) {
             is Success -> {
-                response.handleFetchEditorSettingsResponse(site, action)
+                response.handleFetchEditorSettingsResponse(site, action, BLOCK_EDITOR)
             }
             is Error -> {
                 if (response.error.type == NOT_FOUND && site.mayHaveExperimentalEndpoint) {
@@ -135,7 +149,7 @@ class EditorThemeStore
                      */
                     fetchExperimentalEditorSettings(site, action)
                 } else {
-                    response.handleFetchEditorSettingsResponse(action)
+                    response.handleFetchEditorSettingsResponse(action, BLOCK_EDITOR)
                 }
             }
         }
@@ -146,19 +160,20 @@ class EditorThemeStore
 
         when (response) {
             is Success -> {
-                response.handleFetchEditorSettingsResponse(site, action)
+                response.handleFetchEditorSettingsResponse(site, action, EXPERIMENTAL_BLOCK_EDITOR)
             }
             is Error -> {
-                response.handleFetchEditorSettingsResponse(action)
+                response.handleFetchEditorSettingsResponse(action, EXPERIMENTAL_BLOCK_EDITOR)
             }
         }
     }
 
     private fun ReactNativeFetchResponse.Success.handleFetchEditorSettingsResponse(
         site: SiteModel,
-        action: EditorThemeAction
+        action: EditorThemeAction,
+        endpoint: ThemeChangedEndpoint
     ) {
-        val noGssError = OnEditorThemeChanged(EditorThemeError("Response does not contain GSS"), action)
+        val noGssError = OnEditorThemeChanged(EditorThemeError("Response does not contain GSS"), action, endpoint)
         if (result == null || !result.isJsonObject) {
             emitChange(noGssError)
             return
@@ -175,13 +190,16 @@ class EditorThemeStore
         val existingTheme = editorThemeSqlUtils.getEditorThemeForSite(site)
         if (newTheme != existingTheme) {
             editorThemeSqlUtils.replaceEditorThemeForSite(site, newTheme)
-            val onChanged = OnEditorThemeChanged(newTheme, site.id, action)
+            val onChanged = OnEditorThemeChanged(newTheme, site.id, action, endpoint)
             emitChange(onChanged)
         }
     }
 
-    private fun ReactNativeFetchResponse.Error.handleFetchEditorSettingsResponse(action: EditorThemeAction) {
-        val onChanged = OnEditorThemeChanged(EditorThemeError(error.message), action)
+    private fun ReactNativeFetchResponse.Error.handleFetchEditorSettingsResponse(
+        action: EditorThemeAction,
+        endpoint: ThemeChangedEndpoint
+    ) {
+        val onChanged = OnEditorThemeChanged(EditorThemeError(error.message), action, endpoint)
         emitChange(onChanged)
     }
 


### PR DESCRIPTION
### Description
Collects the following information to be used for [analytics purposes](https://github.com/wordpress-mobile/WordPress-Android/pull/15009)
* [endpoint information to the editor theme change event](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2051/commits/5e176c5d847fda847e111957cf2b475d761c1fac)
* [full site editing flag to the editor theme payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2051/commits/7cc25c7e28bab21c777e15783716fab4b3f1ec21)

#### Depends on: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2049

### To test
Check [Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15009) to verify the collected data via the analytics event

📓  Note that the Jetpack side is still dependent on some backend changes so this PR is still a draft.