### PR TITLE
WP-Android 14942 - Jetpack enable stats module

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
@@ -64,11 +64,11 @@ class JetpackRestClientTest {
         val jetpackInstalledPayload = jetpackRestClient.installJetpack(site)
 
         checkUrlAndLogin()
-        assertThat(jetpackInstalledPayload).isNotNull()
+        assertThat(jetpackInstalledPayload).isNotNull
         assertThat(jetpackInstalledPayload.success).isEqualTo(success)
     }
 
-    fun checkUrlAndLogin() {
+    private fun checkUrlAndLogin() {
         val url = "https://public-api.wordpress.com/rest/v1/jetpack-install/http%3A%2F%2Fwordpress.org/"
         assertThat(urlCaptor.lastValue).isEqualTo(url)
         assertThat(paramsCaptor.lastValue).containsEntry("user", username).containsEntry("password", password)
@@ -81,7 +81,7 @@ class JetpackRestClientTest {
         val jetpackErrorPayload = jetpackRestClient.installJetpack(site)
 
         checkUrlAndLogin()
-        assertThat(jetpackErrorPayload).isNotNull()
+        assertThat(jetpackErrorPayload).isNotNull
         assertThat(jetpackErrorPayload.success).isEqualTo(false)
         assertThat(jetpackErrorPayload.error?.type).isEqualTo(JetpackInstallErrorType.GENERIC_ERROR)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClientTest.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.test
 class JetpackRestClientTest {
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder
     @Mock private lateinit var site: SiteModel
     @Mock private lateinit var requestQueue: RequestQueue
     @Mock private lateinit var accessToken: AccessToken
@@ -51,7 +52,8 @@ class JetpackRestClientTest {
                 null,
                 requestQueue,
                 accessToken,
-                userAgent)
+                userAgent,
+                jetpackTunnelGsonRequestBuilder)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
@@ -12,10 +12,17 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.JetpackAction.ACTIVATE_STATS_MODULE
 import org.wordpress.android.fluxc.action.JetpackAction.INSTALL_JETPACK
 import org.wordpress.android.fluxc.generated.JetpackActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient
+import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModuleError
+import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModuleErrorType
+import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModuleErrorType.API_ERROR
+import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModuleErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModulePayload
+import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModuleResultPayload
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallError
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstallErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.JetpackStore.JetpackInstalledPayload
@@ -50,7 +57,7 @@ class JetpackStoreTest {
 
         jetpackStore.onSiteChanged(OnSiteChanged(1))
 
-        assertThat(result!!.success).isTrue()
+        assertThat(result!!.success).isTrue
         val expectedChangeEvent = OnJetpackInstalled(success, INSTALL_JETPACK)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))
     }
@@ -79,7 +86,7 @@ class JetpackStoreTest {
 
         jetpackStore.onSiteChanged(OnSiteChanged(1))
 
-        assertThat(result!!.success).isFalse()
+        assertThat(result!!.success).isFalse
         val expectedChangeEvent = OnJetpackInstalled(installError, INSTALL_JETPACK)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))
     }
@@ -96,5 +103,90 @@ class JetpackStoreTest {
 
         val expectedChangeEvent = OnJetpackInstalled(installError, INSTALL_JETPACK)
         verify(dispatcher).emitChange(eq(expectedChangeEvent))
+    }
+
+    @Test
+    fun `given activate stats request, then rest client is triggered`() = test {
+        val requestPayload = ActivateStatsModulePayload(site)
+        val successPayload = ActivateStatsModuleResultPayload(true, site)
+        val enabled = "stats,other"
+
+        whenever(jetpackRestClient.activateStatsModule(eq(requestPayload))).thenReturn(successPayload)
+        whenever(site.activeModules).thenReturn(enabled)
+
+        val action = JetpackActionBuilder.newActivateStatsModuleAction(requestPayload)
+        jetpackStore.onAction(action)
+        verify(jetpackRestClient).activateStatsModule(requestPayload)
+    }
+
+    @Test
+    fun `given activate stats request, when rest client is triggered successfully, then success is returned`() = test {
+        val requestPayload = ActivateStatsModulePayload(site)
+        val successPayload = ActivateStatsModuleResultPayload(true, site)
+        val enabled = "stats,other"
+        whenever(jetpackRestClient.activateStatsModule(eq(requestPayload))).thenReturn(successPayload)
+        whenever(site.activeModules).thenReturn(enabled)
+
+        val action = JetpackActionBuilder.newActivateStatsModuleAction(requestPayload)
+        jetpackStore.onAction(action)
+
+        val expected = JetpackStore.OnActivateStatsModule(ACTIVATE_STATS_MODULE)
+        verify(dispatcher).emitChange(expected)
+    }
+
+    @Test
+    fun `given activate stats request, when rest client triggers invalid response, then error is returned`() = test {
+        val error = ActivateStatsModuleError(INVALID_RESPONSE, "error")
+        val requestPayload = ActivateStatsModulePayload(site)
+        val resultPayload = ActivateStatsModuleResultPayload(error, site)
+        whenever(jetpackRestClient.activateStatsModule(eq(requestPayload))).thenReturn(resultPayload)
+
+        val action = JetpackActionBuilder.newActivateStatsModuleAction(requestPayload)
+        jetpackStore.onAction(action)
+
+        val expectedEventWithError = JetpackStore.OnActivateStatsModule(resultPayload.error, ACTIVATE_STATS_MODULE)
+        verify(dispatcher).emitChange(expectedEventWithError)
+    }
+
+    @Test
+    fun `given activate stats request, when rest client triggers api error, then error is returned`() = test {
+        val error = ActivateStatsModuleError(API_ERROR, "error")
+        val requestPayload = ActivateStatsModulePayload(site)
+        val resultPayload = ActivateStatsModuleResultPayload(error, site)
+        whenever(jetpackRestClient.activateStatsModule(eq(requestPayload))).thenReturn(resultPayload)
+
+        val action = JetpackActionBuilder.newActivateStatsModuleAction(requestPayload)
+        jetpackStore.onAction(action)
+
+        val expectedEventWithError = JetpackStore.OnActivateStatsModule(resultPayload.error, ACTIVATE_STATS_MODULE)
+        verify(dispatcher).emitChange(expectedEventWithError)
+    }
+
+    @Test
+    fun `given activate stats request, when rest client triggers generic error, then error is returned`() = test {
+        val error = ActivateStatsModuleError(ActivateStatsModuleErrorType.GENERIC_ERROR, "error")
+        val requestPayload = ActivateStatsModulePayload(site)
+        val resultPayload = ActivateStatsModuleResultPayload(error, site)
+        whenever(jetpackRestClient.activateStatsModule(eq(requestPayload))).thenReturn(resultPayload)
+
+        val action = JetpackActionBuilder.newActivateStatsModuleAction(requestPayload)
+        jetpackStore.onAction(action)
+
+        val expectedEventWithError = JetpackStore.OnActivateStatsModule(resultPayload.error, ACTIVATE_STATS_MODULE)
+        verify(dispatcher).emitChange(expectedEventWithError)
+    }
+
+    @Test
+    fun `given activate stats request, when rest client triggers auth error, then error is returned`() = test {
+        val error = ActivateStatsModuleError(ActivateStatsModuleErrorType.AUTHORIZATION_REQUIRED, "error")
+        val requestPayload = ActivateStatsModulePayload(site)
+        val resultPayload = ActivateStatsModuleResultPayload(error, site)
+        whenever(jetpackRestClient.activateStatsModule(eq(requestPayload))).thenReturn(resultPayload)
+
+        val action = JetpackActionBuilder.newActivateStatsModuleAction(requestPayload)
+        jetpackStore.onAction(action)
+
+        val expectedEventWithError = JetpackStore.OnActivateStatsModule(resultPayload.error, ACTIVATE_STATS_MODULE)
+        verify(dispatcher).emitChange(expectedEventWithError)
     }
 }

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/JPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/JPAPIEndpoint.java
@@ -1,0 +1,27 @@
+package org.wordpress.android.fluxc.annotations.endpoint;
+
+public class JPAPIEndpoint {
+    private static final String JP_PREFIX_V4 = "jetpack/v4";
+
+    private final String mEndpoint;
+
+    public JPAPIEndpoint(String endpoint) {
+        mEndpoint = endpoint;
+    }
+
+    public JPAPIEndpoint(String endpoint, long id) {
+        this(endpoint + id + "/");
+    }
+
+    public JPAPIEndpoint(String endpoint, String value) {
+        this(endpoint + value + "/");
+    }
+
+    public String getEndpoint() {
+        return mEndpoint;
+    }
+
+    public String getPathV4() {
+        return "/" + JP_PREFIX_V4 + mEndpoint;
+    }
+}

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -7,6 +7,7 @@ import com.squareup.javapoet.TypeSpec;
 import org.wordpress.android.fluxc.annotations.AnnotationConfig;
 import org.wordpress.android.fluxc.annotations.endpoint.EndpointNode;
 import org.wordpress.android.fluxc.annotations.endpoint.EndpointTreeGenerator;
+import org.wordpress.android.fluxc.annotations.endpoint.JPAPIEndpoint;
 import org.wordpress.android.fluxc.annotations.endpoint.WCWPAPIEndpoint;
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint;
 import org.wordpress.android.fluxc.annotations.endpoint.WPComEndpoint;
@@ -43,6 +44,7 @@ public class EndpointProcessor extends AbstractProcessor {
     private static final String XMLRPC_ENDPOINT_FILE = "xmlrpc-endpoints.txt";
     private static final String WPAPI_ENDPOINT_FILE = "wp-api-endpoints.txt";
     private static final String WPORG_API_ENDPOINT_FILE = "wporg-api-endpoints.txt";
+    private static final String JPAPI_ENDPOINT_FILE = "jp-api-endpoints.txt";
 
     // Plugin endpoints
     private static final String WPORG_API_WC_ENDPOINT_FILE = "wc-wp-api-endpoints.txt";
@@ -82,6 +84,7 @@ public class EndpointProcessor extends AbstractProcessor {
                 generateXMLRPCEndpointFile();
                 generateWPAPIEndpointFile();
                 generateWPORGAPIEndpointFile();
+                generateJPAPIEndpointFile();
             } else if (outputPath.contains(fs + "plugins" + fs + "woocommerce" + fs + "build" + fs)) {
                 generateWCWPAPIPluginEndpointFile();
             }
@@ -153,6 +156,15 @@ public class EndpointProcessor extends AbstractProcessor {
 
         TypeSpec endpointClass = RESTPoet.generate(rootNode, "WPORGAPI", WPOrgAPIEndpoint.class,
                 WPORG_API_VARIABLE_ENDPOINT_PATTERN);
+        writeEndpointClassToFile(endpointClass);
+    }
+
+    private void generateJPAPIEndpointFile() throws IOException {
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream(JPAPI_ENDPOINT_FILE);
+        EndpointNode rootNode = EndpointTreeGenerator.process(inputStream);
+
+        TypeSpec endpointClass = RESTPoet.generate(rootNode, "JPAPI", JPAPIEndpoint.class,
+                WPAPI_VARIABLE_ENDPOINT_PATTERN);
         writeEndpointClassToFile(endpointClass);
     }
 

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -148,7 +148,7 @@ public class EndpointProcessor extends AbstractProcessor {
         EndpointNode rootNode = EndpointTreeGenerator.process(inputStream);
 
         TypeSpec endpointClass = RESTPoet.generate(rootNode, "WOOCOMMERCE", WCWPAPIEndpoint.class,
-                WPAPI_VARIABLE_ENDPOINT_PATTERN);
+                WCAPI_VARIABLE_ENDPOINT_PATTERN);
         writeEndpointClassToFile(endpointClass);
     }
 
@@ -166,7 +166,7 @@ public class EndpointProcessor extends AbstractProcessor {
         EndpointNode rootNode = EndpointTreeGenerator.process(inputStream);
 
         TypeSpec endpointClass = RESTPoet.generate(rootNode, "JPAPI", JPAPIEndpoint.class,
-                WPAPI_VARIABLE_ENDPOINT_PATTERN);
+                JPAPI_VARIABLE_ENDPOINT_PATTERN);
         writeEndpointClassToFile(endpointClass);
     }
 

--- a/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
+++ b/fluxc-processor/src/main/java/org/wordpress/android/fluxc/processor/EndpointProcessor.java
@@ -52,6 +52,8 @@ public class EndpointProcessor extends AbstractProcessor {
     private static final Pattern WPCOMREST_VARIABLE_ENDPOINT_PATTERN = Pattern.compile("\\$");
     private static final Pattern WPAPI_VARIABLE_ENDPOINT_PATTERN = Pattern.compile("^<.*>");
     private static final Pattern WPORG_API_VARIABLE_ENDPOINT_PATTERN = Pattern.compile("^\\{.*\\}");
+    private static final Pattern WCAPI_VARIABLE_ENDPOINT_PATTERN = WPAPI_VARIABLE_ENDPOINT_PATTERN;
+    private static final Pattern JPAPI_VARIABLE_ENDPOINT_PATTERN = WPAPI_VARIABLE_ENDPOINT_PATTERN;
 
     private static final Map<String, List<String>> XML_RPC_ALIASES;
     static {

--- a/fluxc-processor/src/main/resources/jp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/jp-api-endpoints.txt
@@ -1,0 +1,1 @@
+/module/stats/active

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/JetpackAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/JetpackAction.java
@@ -4,9 +4,12 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModulePayload;
 
 @ActionEnum
 public enum JetpackAction implements IAction {
     @Action(payloadType = SiteModel.class)
-    INSTALL_JETPACK
+    INSTALL_JETPACK,
+    @Action(payloadType = ActivateStatsModulePayload.class)
+    ACTIVATE_STATS_MODULE
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -34,7 +34,6 @@ import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
-@Suppress("LongParameterList")
 class JetpackRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
 
 import android.content.Context
-import android.util.Log
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.JPAPI
@@ -35,6 +34,7 @@ import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
+@Suppress("LongParameterList")
 class JetpackRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackRestClient.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
 
 import android.content.Context
+import android.util.Log
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest
@@ -85,7 +87,7 @@ class JetpackRestClient @Inject constructor(
      * @param [payload] The payload to activate the stats module
      */
     suspend fun activateStatsModule(payload: ActivateStatsModulePayload): ActivateStatsModuleResultPayload {
-        val url = "/jetpack/v4/module/stats/active/"
+        val url = JPAPI.module.stats.active.pathV4
         val params = mutableMapOf("active" to true)
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -7,12 +7,14 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.JetpackAction
+import org.wordpress.android.fluxc.action.JetpackAction.ACTIVATE_STATS_MODULE
 import org.wordpress.android.fluxc.action.JetpackAction.INSTALL_JETPACK
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient
+import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModuleErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
@@ -42,6 +44,11 @@ class JetpackStore
                             action.payload as SiteModel,
                             actionType
                     )
+                }
+            }
+            ACTIVATE_STATS_MODULE -> {
+                coroutineEngine.launch(T.SETTINGS, this, "JetpackAction.ACTIVATE_STATS_MODULE") {
+                    emitChange(activateStatsModule(action.payload as ActivateStatsModulePayload))
                 }
             }
         }
@@ -134,5 +141,61 @@ class JetpackStore
     }
 
     // Activate Jetpack Stats Module
+    suspend fun activateStatsModule(requestPayload: ActivateStatsModulePayload): OnActivateStatsModule {
+        val payload = jetpackRestClient.activateStatsModule(requestPayload)
+        if (payload.success) {
+            reloadSite(requestPayload.site)
+            val reloadedSite = siteStore.getSiteByLocalId(requestPayload.site.id)
+            val isStatsModuleActive = reloadedSite?.activeModules?.contains("stats") ?: false
+            return emitActivateStatsModuleResult(payload, isStatsModuleActive)
+        }
+        return emitActivateStatsModuleResult(payload, false)
+    }
+
+    private fun emitActivateStatsModuleResult(
+        payload: ActivateStatsModuleResultPayload,
+        isStatsModuleActive: Boolean
+    ): OnActivateStatsModule {
+        return if (!payload.isError && isStatsModuleActive) {
+            OnActivateStatsModule(ACTIVATE_STATS_MODULE)
+        } else {
+            OnActivateStatsModule(
+                    ActivateStatsModuleError(GENERIC_ERROR, "Unable to activate stats"),
+                    ACTIVATE_STATS_MODULE
+            )
+        }
+    }
+
     class ActivateStatsModulePayload(val site: SiteModel) : Payload<BaseNetworkError>()
+
+    data class ActivateStatsModuleResultPayload(
+        val success: Boolean,
+        val site: SiteModel
+    ) : Payload<ActivateStatsModuleError>() {
+        constructor(error: ActivateStatsModuleError, site: SiteModel) : this(success = false, site = site) {
+            this.error = error
+        }
+    }
+
+    enum class ActivateStatsModuleErrorType {
+        GENERIC_ERROR,
+        AUTHORIZATION_REQUIRED,
+        INVALID_RESPONSE,
+        API_ERROR
+    }
+
+    class ActivateStatsModuleError(
+        val type: ActivateStatsModuleErrorType,
+        val message: String? = null
+    ) : OnChangedError
+
+    // Actions
+    data class OnActivateStatsModule(var causeOfChange: JetpackAction) : Store.OnChanged<ActivateStatsModuleError>() {
+        constructor(
+            error: ActivateStatsModuleError,
+            causeOfChange: JetpackAction
+        ) : this(causeOfChange = causeOfChange) {
+            this.error = error
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.action.JetpackAction.INSTALL_JETPACK
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -131,4 +132,7 @@ class JetpackStore
             siteContinuation = null
         }
     }
+
+    // Activate Jetpack Stats Module
+    class ActivateStatsModulePayload(val site: SiteModel) : Payload<BaseNetworkError>()
 }


### PR DESCRIPTION
**Description**

This PR
- Adds support for enabling the Jetpack stats module to `JetpackStore` using `JetpackAction. ACTIVATE_STATS_MODULE`
- Adds new annotation and endpoint support for `jetpack\v4`
- Adds `activateStatsModule` to `JetpackRestClient` for handling the dispatching of the actual call via the JetpackTunnel 

**How to test**
- Check that tests cover important conditions
- For manual testing, see instructions in *COMING SHORTLY*