### PR TITLE
Woo Shipping Labels: add support for printing multiple labels

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -173,22 +173,32 @@ class WooShippingLabelFragment : Fragment() {
         print_shipping_label.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
-                        activity, "Enter the remote shipping Label Id:", isNumeric = true
+                        activity, "Enter one or multiple shipping Label Ids (separated by commas):", isNumeric = false
                 ) { remoteIdEditText ->
                     if (remoteIdEditText.text.isEmpty()) {
                         prependToLog("Remote Id is null so doing nothing")
                         return@showSingleLineDialog
                     }
 
-                    val remoteId = remoteIdEditText.text.toString().toLong()
-                    prependToLog("Submitting request to print shipping label for id $remoteId")
+                    val remoteIds = try {
+                        remoteIdEditText.text.split(",").map { it.trim().toLong() }
+                    } catch (e: Exception) {
+                        prependToLog("please check that your input is valid")
+                        return@showSingleLineDialog
+                    }
+                    prependToLog(
+                            "Submitting request to print shipping label(s) ${remoteIds.joinToString(" and ")}"
+                    )
 
                     coroutineScope.launch {
                         try {
                             val response = withContext(Dispatchers.Default) {
-                                // the paper size can be label, legal, letter
-                                // For the example app, the default is set as label
-                                wcShippingLabelStore.printShippingLabel(site, "label", remoteId)
+                                if (remoteIds.size == 1) {
+                                    // Use the single label function here to confirm that it's working as well
+                                    wcShippingLabelStore.printShippingLabel(site, "label", remoteIds.first())
+                                } else {
+                                    wcShippingLabelStore.printShippingLabels(site, "label", remoteIds)
+                                }
                             }
                             response.error?.let {
                                 prependToLog("${it.type}: ${it.message}")
@@ -407,7 +417,8 @@ class WooShippingLabelFragment : Fragment() {
                             predefinedPackages = listOf(randomOption.predefinedPackages.random())
                     )
                     prependToLog(
-                            "Activating ${randomParam.predefinedPackages.first().id} from ${randomParam.carrier}...")
+                            "Activating ${randomParam.predefinedPackages.first().id} from ${randomParam.carrier}..."
+                    )
 
                     val result = withContext(Dispatchers.Default) {
                         wcShippingLabelStore.createPackages(

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -753,12 +753,12 @@ class WCShippingLabelStoreTest {
 
     private suspend fun printShippingLabelForOrder(): WooResult<String> {
         val printShippingLabelPayload = WooPayload(samplePrintShippingLabelApiResponse)
-        whenever(restClient.printShippingLabel(
-                site, printPaperSize, refundShippingLabelId
+        whenever(restClient.printShippingLabels(
+                site, printPaperSize, listOf(refundShippingLabelId)
         )).thenReturn(printShippingLabelPayload)
 
-        whenever(restClient.printShippingLabel(
-                errorSite, printPaperSize, refundShippingLabelId
+        whenever(restClient.printShippingLabels(
+                errorSite, printPaperSize, listOf(refundShippingLabelId)
         )).thenReturn(WooPayload(error))
 
         return store.printShippingLabel(site, printPaperSize, refundShippingLabelId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -89,15 +89,15 @@ class ShippingLabelRestClient @Inject constructor(
         }
     }
 
-    suspend fun printShippingLabel(
+    suspend fun printShippingLabels(
         site: SiteModel,
         paperSize: String,
-        remoteShippingLabelId: Long
+        shippingLabelIds: List<Long>
     ): WooPayload<PrintShippingLabelApiResponse> {
         val url = WOOCOMMERCE.connect.label.print.pathV1
         val params = mapOf(
                 "paper_size" to paperSize,
-                "label_id_csv" to remoteShippingLabelId.toString(),
+                "label_id_csv" to shippingLabelIds.joinToString(","),
                 "caption_csv" to "",
                 "json" to "true"
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -109,10 +109,17 @@ class WCShippingLabelStore @Inject constructor(
     suspend fun printShippingLabel(
         site: SiteModel,
         paperSize: String,
-        remoteShippingLabelId: Long
+        shippingLabelId: Long
+    ): WooResult<String> = printShippingLabels(site, paperSize, listOf(shippingLabelId))
+
+    suspend fun printShippingLabels(
+        site: SiteModel,
+        paperSize: String,
+        shippingLabelIds: List<Long>
     ): WooResult<String> {
-        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "printShippingLabel") {
-            val response = restClient.printShippingLabel(site, paperSize, remoteShippingLabelId)
+        require(shippingLabelIds.isNotEmpty())
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "printShippingLabels") {
+            val response = restClient.printShippingLabels(site, paperSize, shippingLabelIds)
             return@withDefaultContext when {
                 response.isError -> {
                     WooResult(response.error)


### PR DESCRIPTION
This PR just adds a second function to `WCShippingLabelStore` to allow retrieving the content of multiple shipping labels using the same API call.

This is needed for https://github.com/woocommerce/woocommerce-android/issues/4444

#### Testing
1. Grab multiple labels' ids from your store.
2. Open the example app.
3. Click on Woo.
4. Click on Shipping Labels.
5. Click on printing shipping labels.
6. Enter the labels' ids separated by commas.
7. Confirm that you can see the content of the labels.