### PR TITLE
Refactor fetch plugin action

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -664,7 +664,7 @@ class WooShippingLabelFragment : Fragment() {
                     result.error?.let {
                         prependToLog("${it.type}: ${it.message}")
                     }
-                    val plugin = wooCommerceStore.getPluginInfo(site, WOO_SERVICES)
+                    val plugin = wooCommerceStore.getSitePlugin(site, WOO_SERVICES)
                     plugin?.let {
                         prependToLog("$it")
                     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersByIdsPayload
 import org.wordpress.android.fluxc.store.WCShippingLabelStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.WOO_SERVICES
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -663,7 +664,7 @@ class WooShippingLabelFragment : Fragment() {
                     result.error?.let {
                         prependToLog("${it.type}: ${it.message}")
                     }
-                    val plugin = wooCommerceStore.getWooCommerceServicesPluginInfo(site)
+                    val plugin = wooCommerceStore.getPluginInfo(site, WOO_SERVICES)
                     plugin?.let {
                         prependToLog("$it")
                     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -658,12 +658,13 @@ class WooShippingLabelFragment : Fragment() {
             selectedSite?.let { site ->
                 coroutineScope.launch {
                     val result = withContext(Dispatchers.Default) {
-                        wooCommerceStore.fetchWooCommerceServicesPluginInfo(site)
+                        wooCommerceStore.fetchSitePlugins(site)
                     }
                     result.error?.let {
                         prependToLog("${it.type}: ${it.message}")
                     }
-                    result.model?.let {
+                    val plugin = wooCommerceStore.getWooCommerceServicesPluginInfo(site)
+                    plugin?.let {
                         prependToLog("$it")
                     }
                 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -104,7 +104,8 @@ class WooCommerceStoreTest {
     fun `when fetching plugin succeeds, then success returned`() = test {
         val result = getPlugin(isError = false)
 
-        Assertions.assertThat(result.error).isEqualTo(error)
+        Assertions.assertThat(result.isError).isFalse
+        Assertions.assertThat(result.model).isNotNull
     }
 
     @Test
@@ -119,7 +120,7 @@ class WooCommerceStoreTest {
         Assertions.assertThat(result).isEqualTo(expectedModel)
     }
 
-    private suspend fun getPlugin(isError: Boolean = false): WooResult<Unit> {
+    private suspend fun getPlugin(isError: Boolean = false): WooResult<List<WCPluginModel>> {
         val payload = WooPayload(response)
         if (isError) {
             whenever(restClient.fetchInstalledPlugins(any())).thenReturn(WooPayload(error))

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -45,12 +45,14 @@ open class WooCommerceStore @Inject constructor(
     private val wcCoreRestClient: WooCommerceRestClient,
     private val siteSqlUtils: SiteSqlUtils
 ) : Store(dispatcher) {
+    enum class WooPlugin(val displayName: String) {
+        WOO_SERVICES("WooCommerce Shipping &amp; Tax"),
+        WOO_PAYMENTS("WooCommerce Payments");
+    }
     companion object {
         const val WOO_API_NAMESPACE_V1 = "wc/v1"
         const val WOO_API_NAMESPACE_V2 = "wc/v2"
         const val WOO_API_NAMESPACE_V3 = "wc/v3"
-
-        private const val WOO_SERVICES_PLUGIN_NAME = "WooCommerce Shipping &amp; Tax"
     }
 
     class FetchApiVersionResponsePayload(
@@ -156,8 +158,8 @@ open class WooCommerceStore @Inject constructor(
         return siteSettings?.countryCode
     }
 
-    fun getWooCommerceServicesPluginInfo(site: SiteModel): WCPluginModel? {
-        return WCPluginSqlUtils.selectSingle(site, WOO_SERVICES_PLUGIN_NAME)
+    fun getPluginInfo(site: SiteModel, plugin: WooPlugin): WCPluginModel? {
+        return WCPluginSqlUtils.selectSingle(site, plugin.displayName)
     }
 
     suspend fun getSitePlugins(site: SiteModel): List<WCPluginModel> {


### PR DESCRIPTION
Method `fetchWooCommerceServicesPluginInfo` used to fetch all plugins, store them into the database and filter out all plugins but "WooCommerceServices" plugin. This PR refactors the code so the method is a bit more reusable and doesn't cause side-effects.


WPAndroid is not affected
WCAndroid - PR [here](https://github.com/woocommerce/woocommerce-android/compare/update-fluxc-fetch-plugins?expand=1)

This PR
- renames `fetchWooCommerceServicesPluginInfo` to `fetchSitePlugins` - returns all fetched plugins instead of just the Service plugin (previously the method was causing a side-effect since it fetched all plugins and stored them into the database even though the name mentioned just the Service plugin).
- renames `getWooCommerceServicesPluginInfo` to `getSitePlugin` and introduces `WooPlugin` parameter to let the client filter - to make the method reusable and not tied just to the Service plugin.


To test:
1. Run the example app
2. Sign in and tap on "Woo"
3. Tap on Shipping labels
4. Select site
5. Tap on "Get Shipping plugin info"
6. Verify the log display the plugin info

