### PR TITLE
Adds back GSS configuration parameter

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -37,7 +37,7 @@ class EditorThemeStore
 ) : Store(dispatcher) {
     private val editorThemeSqlUtils = EditorThemeSqlUtils()
 
-    class FetchEditorThemePayload @JvmOverloads constructor(val site: SiteModel) :
+    class FetchEditorThemePayload @JvmOverloads constructor(val site: SiteModel, val gssEnabled: Boolean = false) :
             Payload<BaseNetworkError>()
 
     data class OnEditorThemeChanged(
@@ -74,7 +74,7 @@ class EditorThemeStore
                         EditorThemeStore::class.java.simpleName + ": On FETCH_EDITOR_THEME"
                 ) {
                     val payload = action.payload as FetchEditorThemePayload
-                    if (payload.site.hasRequiredWordPressVersion(EDITOR_SETTINGS_WP_VERSION)) {
+                    if (editorSettingsAvailable(payload.site, payload.gssEnabled)) {
                         fetchEditorSettings(payload.site, actionType)
                     } else {
                         fetchEditorTheme(payload.site, actionType)
@@ -179,6 +179,9 @@ class EditorThemeStore
         val onChanged = OnEditorThemeChanged(EditorThemeError(error.message), action, endpoint)
         emitChange(onChanged)
     }
+
+    private fun editorSettingsAvailable(site: SiteModel, gssEnabled: Boolean) =
+            gssEnabled && site.hasRequiredWordPressVersion(EDITOR_SETTINGS_WP_VERSION)
 
     /**
      * Checks if the [SiteModel.getSoftwareVersion] is higher or equal to the [requiredVersion]


### PR DESCRIPTION
## Description
This PR reverts the changes applied with https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2067 allowing to disable the Global Style Settings feature.
This is a temporary change to unblock `1.58` [gutenberg-mobile ](https://github.com/wordpress-mobile/WordPress-Android/pull/15054#issuecomment-884923645)release.

## To test
Check [Android PR](TODO)