### PR TITLE
Jetpack Scan: Support multisite not supported reason

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.Reason
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.ScanProgressStatus
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.State.IDLE
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.State.SCANNING
@@ -96,7 +97,8 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
         val model = ScanStateModel(
             state = IDLE,
             hasCloud = false,
-            mostRecentStatus = mostRecentStatus
+            mostRecentStatus = mostRecentStatus,
+            reason = Reason.NO_REASON
         )
 
         scanSqlUtils.replaceScanState(site, model)
@@ -129,7 +131,8 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
         val model = ScanStateModel(
             state = SCANNING,
             hasCloud = false,
-            currentStatus = currentStatus
+            currentStatus = currentStatus,
+            reason = Reason.NO_REASON
         )
 
         scanSqlUtils.replaceScanState(site, model)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.release
 
 import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -78,7 +77,7 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
         assertNotNull(scanStateForSite)
         scanStateForSite?.apply {
             assertNotNull(state)
-            Assert.assertTrue(listOf(IDLE, SCANNING).contains(state))
+            assertTrue(listOf(IDLE, SCANNING).contains(state))
         }
     }
 
@@ -204,7 +203,7 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
             }
             throw AssertionError("Unexpected error occurred with type: " + event.error.type)
         }
-        Assert.assertTrue(siteStore.hasSite())
+        assertTrue(siteStore.hasSite())
         assertEquals(TestEvents.SITE_CHANGED, nextEvent)
         mCountDownLatch.countDown()
     }
@@ -224,20 +223,20 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
         // Correct user we should get an OnAuthenticationChanged message
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload))
         // Wait for a network response / onChanged event
-        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         // Fetch account from REST API, and wait for OnAccountChanged event
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
-        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         // Fetch sites from REST API, and wait for onSiteChanged event
         mCountDownLatch = CountDownLatch(1)
         nextEvent = TestEvents.SITE_CHANGED
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(FetchSitesPayload()))
 
-        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-        Assert.assertTrue(siteStore.sitesCount > 0)
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(siteStore.sitesCount > 0)
     }
 
     private sealed class Sites(val wpUserName: String, val wpPassword: String, val siteUrl: String) {

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.Credentials
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.Reason
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.State
 import org.wordpress.android.fluxc.model.scan.threat.ThreatMapper
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
@@ -104,7 +105,7 @@ class ScanRestClientTest {
                 assertEquals(state, State.fromValue(requireNotNull(scanResponse.state)))
                 assertEquals(hasCloud, requireNotNull(scanResponse.hasCloud))
                 assertEquals(hasValidCredentials, scanResponse.credentials?.firstOrNull()?.stillValid)
-                assertNull(reason)
+                assertEquals(reason, Reason.NO_REASON)
                 assertNotNull(credentials)
                 assertNotNull(threats)
                 mostRecentStatus?.apply {

--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/ScanStateSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/ScanStateSqlUtilsTest.kt
@@ -11,6 +11,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.Reason
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.ScanProgressStatus
 import java.util.Date
 
@@ -64,7 +65,7 @@ class ScanStateSqlUtilsTest {
     private fun getScanStateModel(state: ScanStateModel.State): ScanStateModel {
         var scanStateModel = ScanStateModel(
                 state = state,
-                reason = "reason",
+                reason = Reason.UNKNOWN,
                 hasCloud = true,
                 hasValidCredentials = true
         )

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ScanStoreTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.action.ScanAction
 import org.wordpress.android.fluxc.generated.ScanActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.Reason
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.State
 import org.wordpress.android.fluxc.model.scan.threat.BaseThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
@@ -159,7 +160,12 @@ class ScanStoreTest {
 
     @Test
     fun `get scan state returns state and threats from the db`() = test {
-        val scanStateModel = ScanStateModel(State.IDLE, hasCloud = true, threats = listOf(threatInCurrentState))
+        val scanStateModel = ScanStateModel(
+                state = State.IDLE,
+                hasCloud = true,
+                threats = listOf(threatInCurrentState),
+                reason = Reason.NO_REASON
+        )
         whenever(scanSqlUtils.getScanStateForSite(siteModel)).thenReturn(scanStateModel)
         whenever(threatSqlUtils.getThreats(siteModel, listOf(CURRENT))).thenReturn(listOf(threatInCurrentState))
 
@@ -173,7 +179,11 @@ class ScanStoreTest {
     @Test
     fun `get valid credentials status returns corresponding status from the db`() = test {
         val expectedHasValidCredentials = true
-        val scanStateModel = ScanStateModel(State.IDLE, hasValidCredentials = expectedHasValidCredentials)
+        val scanStateModel = ScanStateModel(
+                state = State.IDLE,
+                hasValidCredentials = expectedHasValidCredentials,
+                reason = Reason.NO_REASON
+        )
         whenever(scanSqlUtils.getScanStateForSite(siteModel)).thenReturn(scanStateModel)
 
         val hasValidCredentials = scanStore.hasValidCredentials(siteModel)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/ScanStateModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/ScanStateModel.kt
@@ -5,7 +5,7 @@ import java.util.Date
 
 data class ScanStateModel(
     val state: State,
-    val reason: String? = null,
+    val reason: Reason,
     val threats: List<ThreatModel>? = null,
     val credentials: List<Credentials>? = null,
     val hasCloud: Boolean = false,
@@ -44,4 +44,16 @@ data class ScanStateModel(
         val error: Boolean = false,
         val isInitial: Boolean = false
     )
+
+    enum class Reason(val value: String?) {
+        MULTISITE_NOT_SUPPORTED("multisite_not_supported"),
+        NO_REASON(null),
+        UNKNOWN("unknown");
+
+        companion object {
+            fun fromValue(value: String?): Reason {
+                return values().firstOrNull { it.value == value } ?: UNKNOWN
+            }
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClient.kt
@@ -211,7 +211,7 @@ class ScanRestClient @Inject constructor(
         }
         val scanStateModel = ScanStateModel(
             state = state,
-            reason = response.reason,
+            reason = ScanStateModel.Reason.fromValue(response.reason),
             threats = threatModels,
             hasCloud = response.hasCloud ?: false,
             credentials = response.credentials?.map {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
@@ -72,7 +72,7 @@ class ScanSqlUtils @Inject constructor() {
             startDate = startDate,
             duration = mostRecentStatus?.duration ?: 0,
             progress = progress,
-            reason = reason?.value,
+            reason = reason.value,
             error = mostRecentStatus?.error ?: false,
             initial = isInitial,
             hasCloud = hasCloud,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
@@ -8,6 +8,7 @@ import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.Reason
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.ScanProgressStatus
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.State
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.State.IDLE
@@ -71,7 +72,7 @@ class ScanSqlUtils @Inject constructor() {
             startDate = startDate,
             duration = mostRecentStatus?.duration ?: 0,
             progress = progress,
-            reason = reason,
+            reason = reason?.value,
             error = mostRecentStatus?.error ?: false,
             initial = isInitial,
             hasCloud = hasCloud,
@@ -135,7 +136,7 @@ class ScanSqlUtils @Inject constructor() {
                 hasCloud = hasCloud,
                 mostRecentStatus = mostRecentStatus,
                 currentStatus = currentStatus,
-                reason = reason,
+                reason = Reason.fromValue(reason),
                 hasValidCredentials = hasValidCredentials
             )
         }


### PR DESCRIPTION
### Description

This PR replaces string `reason` with enum for `ScanStateModel`, supporting `MULTISITE_NOT_SUPPORTED` reason needed to fix https://github.com/wordpress-mobile/WordPress-Android/issues/14946 issue.

### To Test

See https://github.com/wordpress-mobile/WordPress-Android/pull/15061