### PR TITLE
Add wepb mimetype

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
@@ -51,6 +51,7 @@ class MimeTypesTest {
                         "image/jpeg",
                         "image/png",
                         "image/gif",
+                        "image/webp",
                         "application/pdf",
                         "application/msword",
                         "application/doc",
@@ -89,7 +90,8 @@ class MimeTypesTest {
                         "video/3gpp2",
                         "image/jpeg",
                         "image/png",
-                        "image/gif"
+                        "image/gif",
+                        "image/webp"
                 )
         )
     }
@@ -102,7 +104,8 @@ class MimeTypesTest {
                 arrayOf(
                         "image/jpeg",
                         "image/png",
-                        "image/gif"
+                        "image/gif",
+                        "image/webp"
                 )
         )
     }
@@ -180,6 +183,7 @@ class MimeTypesTest {
             "image/jpeg",
             "image/png",
             "image/gif",
+            "image/webp",
             "application/pdf",
             "application/msword",
             "application/doc",

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeType.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeType.kt
@@ -28,6 +28,7 @@ data class MimeType(val type: Type, val subtypes: List<Subtype>, val extensions:
         JPEG("jpeg"),
         PNG("png"),
         GIF("gif"),
+        WEBP("webp"),
         PDF("pdf"),
         DOC("doc"),
         MSDOC("ms-doc"),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -71,7 +71,8 @@ class MimeTypes {
     private val imageTypes = listOf(
             MimeType(IMAGE, Subtype.JPEG, listOf("jpg", "jpeg")),
             MimeType(IMAGE, Subtype.PNG, listOf("png")),
-            MimeType(IMAGE, Subtype.GIF, listOf("gif"))
+            MimeType(IMAGE, Subtype.GIF, listOf("gif")),
+            MimeType(IMAGE, Subtype.WEBP, listOf("webp"))
     )
 
     /*

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -62,11 +62,12 @@ class MimeTypes {
 
     /*
      * The WordPress supported image types based on https://wordpress.com/support/accepted-filetypes/ are:
-     * .jpg, .jpeg, .png, .gif
+     * .jpg, .jpeg, .png, .gif, .webp
      * This translates (based on https://android.googlesource.com/platform/frameworks/base/+/cd92588/media/java/android/media/MediaFile.java) to:
      * .jpg, .jpeg - "image/jpeg"
      * .png - "image/png"
      * .gif - "image/gif"
+     * .webp - "image/webp"
      */
     private val imageTypes = listOf(
             MimeType(IMAGE, Subtype.JPEG, listOf("jpg", "jpeg")),


### PR DESCRIPTION
Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/2885

### Description

This PR enables `webp` mimetype in `FluxC`.

### How to test

See https://github.com/wordpress-mobile/WordPress-Android/issues/2885