### PR TITLE
Add dont_change_homepage to activate theme API call

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.store.ThemeStore;
+import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched;
 import org.wordpress.android.fluxc.store.ThemeStore.OnSiteThemesChanged;
 import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated;
@@ -404,7 +405,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACTIVATED_THEME;
-        SiteThemePayload payload = new SiteThemePayload(jetpackSite, themeToActivate);
+        ActivateThemePayload payload = new ActivateThemePayload(jetpackSite, themeToActivate);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -128,7 +128,16 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         assertNotNull(themeToActivate);
 
         // activate it
-        ThemeModel activatedTheme = activateTheme(jetpackSite, themeToActivate);
+        ThemeModel activatedTheme = activateTheme(jetpackSite, themeToActivate, false);
+        assertNotNull(activatedTheme);
+        assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
+
+        // Select again
+        themeToActivate = getOtherTheme(themes, currentTheme.getThemeId());
+        assertNotNull(themeToActivate);
+
+        // activate it
+        activatedTheme = activateTheme(jetpackSite, themeToActivate, true);
         assertNotNull(activatedTheme);
         assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
 
@@ -401,7 +410,14 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         return mThemeStore.getActiveThemeForSite(jetpackSite);
     }
 
-    private ThemeModel activateTheme(@NonNull SiteModel jetpackSite, @NonNull ThemeModel themeToActivate)
+    private ThemeModel activateTheme(@NonNull SiteModel jetpackSite,
+                                     @NonNull ThemeModel themeToActivate) throws InterruptedException {
+        return activateTheme(jetpackSite, themeToActivate, true);
+    }
+
+    private ThemeModel activateTheme(@NonNull SiteModel jetpackSite,
+                                     @NonNull ThemeModel themeToActivate,
+                                     boolean dontChangeHomepage)
             throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACTIVATED_THEME;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -109,7 +109,34 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     }
 
     @Test
-    public void testActivateTheme() throws InterruptedException {
+    public void testActivateThemeByKeepingHomepage() throws InterruptedException {
+        final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
+
+        // fetch installed themes
+        fetchInstalledThemes(jetpackSite);
+
+        // make sure there are at least 2 themes, one that's active and one that will be activated
+        List<ThemeModel> themes = mThemeStore.getThemesForSite(jetpackSite);
+        assertTrue(themes.size() > 1);
+
+        // fetch active theme
+        ThemeModel currentTheme = fetchCurrentTheme(jetpackSite);
+        assertNotNull(currentTheme);
+
+        // select a different theme to activate
+        ThemeModel themeToActivate = getOtherTheme(themes, currentTheme.getThemeId());
+        assertNotNull(themeToActivate);
+
+        // activate it
+        ThemeModel activatedTheme = activateTheme(jetpackSite, themeToActivate, true);
+        assertNotNull(activatedTheme);
+        assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
+
+        signOutWPCom();
+    }
+
+    @Test
+    public void testActivateThemeByUsingThemeHomepage() throws InterruptedException {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
         // fetch installed themes
@@ -129,15 +156,6 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         // activate it
         ThemeModel activatedTheme = activateTheme(jetpackSite, themeToActivate, false);
-        assertNotNull(activatedTheme);
-        assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
-
-        // Select again
-        themeToActivate = getOtherTheme(themes, currentTheme.getThemeId());
-        assertNotNull(themeToActivate);
-
-        // activate it
-        activatedTheme = activateTheme(jetpackSite, themeToActivate, true);
         assertNotNull(activatedTheme);
         assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
 
@@ -421,7 +439,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACTIVATED_THEME;
-        ActivateThemePayload payload = new ActivateThemePayload(jetpackSite, themeToActivate);
+        ActivateThemePayload payload = new ActivateThemePayload(jetpackSite, themeToActivate, dontChangeHomepage);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -110,7 +110,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         ThemeModel themeToActivate = getTwentySomethingFreeTheme(currentTheme.getThemeId(),
                 mThemeStore.getWpComThemes());
         assertNotNull(themeToActivate);
-        activateTheme(themeToActivate, true);
+        activateTheme(themeToActivate, false);
 
         // Assert that the activation was successful
         ThemeModel activatedTheme = mThemeStore.getActiveThemeForSite(sSite);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.ThemeStore;
+import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched;
 import org.wordpress.android.fluxc.store.ThemeStore.OnStarterDesignsFetched;
 import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated;
@@ -213,7 +214,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
     private void activateTheme(ThemeModel themeToActivate) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACTIVATED_THEME;
-        SiteThemePayload payload = new SiteThemePayload(sSite, themeToActivate);
+        ActivateThemePayload payload = new ActivateThemePayload(sSite, themeToActivate);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -15,7 +15,6 @@ import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched;
 import org.wordpress.android.fluxc.store.ThemeStore.OnStarterDesignsFetched;
 import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated;
 import org.wordpress.android.fluxc.store.ThemeStore.OnWpComThemesChanged;
-import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -75,7 +75,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
     }
 
     @Test
-    public void testActivateTheme() throws InterruptedException {
+    public void testActivateThemeByKeepingHomepage() throws InterruptedException {
         // Make sure no theme is active at first
         assertNull(mThemeStore.getActiveThemeForSite(sSite));
         ThemeModel currentTheme = fetchCurrentTheme();
@@ -88,7 +88,29 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         ThemeModel themeToActivate = getTwentySomethingFreeTheme(currentTheme.getThemeId(),
                 mThemeStore.getWpComThemes());
         assertNotNull(themeToActivate);
-        activateTheme(themeToActivate);
+        activateTheme(themeToActivate, true);
+
+        // Assert that the activation was successful
+        ThemeModel activatedTheme = mThemeStore.getActiveThemeForSite(sSite);
+        assertNotNull(activatedTheme);
+        assertEquals(activatedTheme.getThemeId(), themeToActivate.getThemeId());
+    }
+
+    @Test
+    public void testActivateThemeByUsingThemeHomepage() throws InterruptedException {
+        // Make sure no theme is active at first
+        assertNull(mThemeStore.getActiveThemeForSite(sSite));
+        ThemeModel currentTheme = fetchCurrentTheme();
+        assertNotNull(currentTheme);
+
+        // Fetch wp.com themes to activate a different theme
+        fetchWpComThemes();
+
+        // activate a different "Twenty ..." theme
+        ThemeModel themeToActivate = getTwentySomethingFreeTheme(currentTheme.getThemeId(),
+                mThemeStore.getWpComThemes());
+        assertNotNull(themeToActivate);
+        activateTheme(themeToActivate, true);
 
         // Assert that the activation was successful
         ThemeModel activatedTheme = mThemeStore.getActiveThemeForSite(sSite);
@@ -210,10 +232,11 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
-    private void activateTheme(ThemeModel themeToActivate) throws InterruptedException {
+    private void activateTheme(ThemeModel themeToActivate,
+                               boolean dontChangeHomePage) throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.ACTIVATED_THEME;
-        ActivateThemePayload payload = new ActivateThemePayload(sSite, themeToActivate);
+        ActivateThemePayload payload = new ActivateThemePayload(sSite, themeToActivate, dontChangeHomePage);
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -64,7 +64,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.SiteThemePayload(site, theme)
+                    val payload = ThemeStore.ActivateThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload))
                 }
             }
@@ -82,7 +82,7 @@ class ThemeFragment : Fragment() {
                     val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
-                    val payload = ThemeStore.SiteThemePayload(site, theme)
+                    val payload = ThemeStore.ActivateThemePayload(site, theme)
                     dispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(payload))
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchStarterDesignsPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
@@ -22,7 +23,7 @@ public enum ThemeAction implements IAction {
     FETCH_INSTALLED_THEMES, // Jetpack only
     @Action(payloadType = SiteModel.class)
     FETCH_CURRENT_THEME,
-    @Action(payloadType = SiteThemePayload.class)
+    @Action(payloadType = ActivateThemePayload.class)
     ACTIVATE_THEME,
     @Action(payloadType = SiteThemePayload.class)
     INSTALL_THEME,
@@ -38,7 +39,7 @@ public enum ThemeAction implements IAction {
     FETCHED_INSTALLED_THEMES,
     @Action(payloadType = FetchedCurrentThemePayload.class)
     FETCHED_CURRENT_THEME,
-    @Action(payloadType = SiteThemePayload.class)
+    @Action(payloadType = ActivateThemePayload.class)
     ACTIVATED_THEME,
     @Action(payloadType = SiteThemePayload.class)
     INSTALLED_THEME,


### PR DESCRIPTION
## Part of: 
Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/15014
Main PR: https://github.com/wordpress-mobile/WordPress-Android/pull/15055

## Description:
This PR adds a parameter `dont_change_homepage` to `POST /sites/$site/themes/mine` which can be set to `true` if we dont want to use theme's homepage layout when activating the theme.

## API Specs
https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/themes/mine/

## To Test
It can be tested with https://github.com/wordpress-mobile/WordPress-Android/pull/15055. There is also this `testActivateTheme()` test which tests theme activation but it is  not specific to `dont_change_homepage` param.