### PR TITLE
Change type of currentDeadline field

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
@@ -100,4 +100,13 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         assertTrue(result.result?.status == WCPayAccountStatusEnum.NO_ACCOUNT)
     }
+
+    @Test
+    fun whenOverdueRequirementsThenCurrentDeadlineCorrectlyParsed() = runBlocking {
+        interceptor.respondWithError("wc-pay-load-account-response-current-deadline.json", 200)
+
+        val result = payRestClient.loadAccount(SiteModel().apply { siteId = 123L })
+
+        assertTrue(result.result?.currentDeadline == 1628258304L)
+    }
 }

--- a/example/src/androidTest/resources/wc-pay-load-account-response-current-deadline.json
+++ b/example/src/androidTest/resources/wc-pay-load-account-response-current-deadline.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "has_pending_requirements": false,
+    "has_overdue_requirements": true,
+    "current_deadline": 1628258304,
+    "status": "",
+    "statement_descriptor": "DO.WPMT.CO",
+    "store_currencies": {
+      "default": "usd",
+      "supported": ["usd"]
+    },
+    "country": "US",
+    "card_present_eligible": false
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
@@ -17,7 +17,7 @@ data class WCPaymentAccountResult(
     @SerializedName("has_overdue_requirements")
     val hasOverdueRequirements: Boolean,
     @SerializedName("current_deadline")
-    val currentDeadline: Date?,
+    val currentDeadline: Long?,
     /**
      * An alphanumeric string set by the merchant, e.g. `MYSTORE.COM`
      * See https://stripe.com/docs/statement-descriptors

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
@@ -7,7 +7,6 @@ import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.model.pay.WCPaymentAccountResult.WCPayAccountStatusEnum.StoreCurrencies
 import java.lang.reflect.Type
-import java.util.Date
 
 data class WCPaymentAccountResult(
     @SerializedName("status")


### PR DESCRIPTION
When we implemented `/payments/accounts` endpoint we thought the endpoint uses ISO8601 format. As it turned out it uses a timestamp instead. This PR fixes this issue to prevent parsing errors.

To test:
Test this in [WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/4532)