### PR TITLE
Adding DAO for Comments in WPAndroid room database.

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -61,6 +61,11 @@ android {
             }
         }
     }
+
+    sourceSets {
+        // Adds exported schema location as test app assets.
+        getByName("androidTest").assets.srcDirs += "$projectDir/../fluxc/schemas"
+    }
 }
 
 if (["tests.properties", "tests.properties-extra"].any { file(it).exists() }) {
@@ -115,6 +120,7 @@ dependencies {
     implementation "androidx.room:room-runtime:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
     implementation "androidx.room:room-ktx:$roomVersion"
+    androidTestImplementation "androidx.room:room-testing:$roomVersion"
 
     // Dagger
     implementation "com.google.dagger:dagger:$daggerVersion"

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/CommentsDaoTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/CommentsDaoTest.kt
@@ -131,9 +131,14 @@ class CommentsDaoTest {
                     comments = commentList
             )
 
-            val result = commentsDao.getFilteredComments(commentList.first().localSiteId, listOf(APPROVED).map { it.toString() })
+            val result = commentsDao.getFilteredComments(
+                    commentList.first().localSiteId,
+                    listOf(APPROVED).map { it.toString() }
+            )
 
-            assertThat(result.sortedBy { it.remoteCommentId } ).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
+            assertThat(
+                    result.sortedBy { it.remoteCommentId }
+            ).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
         }
     }
 
@@ -198,7 +203,9 @@ class CommentsDaoTest {
                     orderAscending = false
             )
 
-            assertThat(result.sortedBy { it.remoteCommentId }).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
+            assertThat(
+                    result.sortedBy { it.remoteCommentId }
+            ).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/CommentsDaoTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/CommentsDaoTest.kt
@@ -1,0 +1,463 @@
+package org.wordpress.android.fluxc.persistence.room
+
+import androidx.room.Room
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.SPAM
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus.TRASH
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class CommentsDaoTest {
+    private lateinit var commentsDao: CommentsDao
+    private lateinit var db: WPAndroidDatabase
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        db = Room.inMemoryDatabaseBuilder(
+                context, WPAndroidDatabase::class.java).allowMainThreadQueries().build()
+        commentsDao = db.commentsDao()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun commentIsInsertedWhenNotPresent() {
+        runBlocking {
+            val comment = getDefaultComment()
+
+            val entityId = commentsDao.insertOrUpdateComment(comment)
+
+            assertThat(entityId).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun commentIsUpdatedWhenPresent() {
+        runBlocking {
+            val comment = getDefaultComment()
+
+            var entityId = commentsDao.insertOrUpdateComment(comment)
+
+            assertThat(entityId).isEqualTo(1)
+
+            val updatedComment = comment.copy(
+                    id = entityId,
+                    authorUrl = "authorUrl",
+                    iLike = true
+            )
+
+            entityId = commentsDao.insertOrUpdateComment(updatedComment)
+
+            assertThat(entityId).isEqualTo(1)
+
+            assertThat(commentsDao.getCommentById(entityId).firstOrNull()).isEqualTo(updatedComment)
+        }
+    }
+
+    @Test
+    fun commentIsUpdatedWhenMatchedByRemoteCommentId() {
+        runBlocking {
+            val comment = getDefaultComment()
+
+            var entityId = commentsDao.insertOrUpdateComment(comment)
+
+            assertThat(entityId).isEqualTo(1)
+
+            val updatedComment = comment.copy(
+                    id = 20,
+                    authorUrl = "authorUrl",
+                    iLike = true
+            )
+
+            entityId = commentsDao.insertOrUpdateComment(updatedComment)
+
+            assertThat(entityId).isEqualTo(1)
+
+            assertThat(commentsDao.getCommentById(entityId).firstOrNull()).isEqualTo(updatedComment.copy(id = entityId))
+        }
+    }
+
+    @Test
+    fun insertOrUpdateCanReturnUpdatedComment() {
+        runBlocking {
+            val comment = getDefaultComment()
+
+            val updatedComment = commentsDao.insertOrUpdateCommentForResult(comment).firstOrNull()
+
+            assertThat(updatedComment).isNotNull
+            assertThat(updatedComment?.id).isEqualTo(1)
+
+            assertThat(updatedComment).isEqualTo(comment)
+        }
+    }
+
+    @Test
+    fun getFilteredCommentsIsEmptyWhenFiltersDoNotMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(
+                    comments = commentList
+            )
+
+            val result = commentsDao.getFilteredComments(100, listOf(TRASH).map { it.toString() })
+
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun getFilteredCommentsIsNotEmptyWhenFiltersMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(
+                    comments = commentList
+            )
+
+            val result = commentsDao.getFilteredComments(commentList.first().localSiteId, listOf(APPROVED).map { it.toString() })
+
+            assertThat(result.sortedBy { it.remoteCommentId } ).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
+        }
+    }
+
+    @Test
+    fun getFilteredCommentsReturnAllCommentsWhenFiltersAreEmpty() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(
+                    comments = commentList
+            )
+
+            val result = commentsDao.getFilteredComments(commentList.first().localSiteId, listOf())
+
+            assertThat(result.sortedBy { it.remoteCommentId }).isEqualTo(commentList)
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteLimitsResults() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(),
+                    limit = commentList.size - 1,
+                    orderAscending = false
+            )
+
+            assertThat(result.size).isEqualTo(commentList.size - 1)
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteDoesNotLimitsResults() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(),
+                    limit = -1,
+                    orderAscending = false
+            )
+
+            assertThat(result.size).isEqualTo(commentList.size)
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteFilters() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(APPROVED).map { it.toString() },
+                    limit = -1,
+                    orderAscending = false
+            )
+
+            assertThat(result.sortedBy { it.remoteCommentId }).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteOrdersAscending() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(),
+                    limit = -1,
+                    orderAscending = true
+            )
+
+            assertThat(result).isEqualTo(commentList)
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteOrdersDescending() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(),
+                    limit = -1,
+                    orderAscending = false
+            )
+
+            assertThat(result).isEqualTo(commentList.reversed())
+        }
+    }
+
+    @Test
+    fun commentIsDeletedByDeleteComment() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToDelete = commentList.last()
+
+            val result = commentsDao.deleteComment(commentToDelete)
+
+            assertThat(result).isEqualTo(1)
+            val comments = commentsDao.getFilteredComments(
+                    localSiteId = commentToDelete.localSiteId,
+                    statuses = listOf()
+            )
+
+            assertThat(comments.size).isEqualTo(commentList.size - 1)
+            assertThat(comments.filter { it.remoteCommentId == commentToDelete.remoteCommentId }).isEmpty()
+        }
+    }
+
+    @Test
+    fun commentIsDeletedByRemoteCommentId() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            val notPresentId = commentList.map { it.id }.maxOrNull()!! * 10
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToDelete = commentList.last().copy(id = notPresentId)
+
+            val result = commentsDao.deleteComment(commentToDelete)
+
+            assertThat(result).isEqualTo(1)
+            val comments = commentsDao.getFilteredComments(
+                    localSiteId = commentToDelete.localSiteId,
+                    statuses = listOf()
+            )
+
+            assertThat(comments.size).isEqualTo(commentList.size - 1)
+            assertThat(comments.filter { it.remoteCommentId == commentToDelete.remoteCommentId }).isEmpty()
+        }
+    }
+
+    @Test
+    fun getCommentByIdReturnsComment() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToFind = commentList[commentList.size / 2]
+
+            val result = commentsDao.getCommentById(commentToFind.id).first()
+
+            assertThat(result).isEqualTo(commentToFind)
+        }
+    }
+
+    @Test
+    fun getCommentByIdReturnsNothingWhenNoMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            val notPresentId = commentList.map { it.id }.maxOrNull()!! * 10
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentById(notPresentId)
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun getCommentsByLocalSiteAndRemoteCommentIdReturnsComment() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToFind = commentList[commentList.size / 2]
+
+            val result = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                    commentToFind.localSiteId,
+                    commentToFind.remoteCommentId
+            ).first()
+
+            assertThat(result).isEqualTo(commentToFind)
+        }
+    }
+
+    @Test
+    fun getCommentsByLocalSiteAndRemoteCommentIdReturnsNothingWhenNoMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            val notPresentId = commentList.map { it.remoteCommentId }.maxOrNull()!! * 10
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                    commentList.first().localSiteId,
+                    notPresentId
+            )
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun getCommentsByLocalSiteIdAndRemoteCommentIdReturnsComment() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToFind = commentList[commentList.size / 2]
+
+            val result = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                    commentToFind.localSiteId,
+                    commentToFind.remoteCommentId
+            ).first()
+
+            assertThat(result).isEqualTo(commentToFind)
+        }
+    }
+
+    @Test
+    fun getCommentsByLocalSiteIdAndRemoteCommentIdReturnsNothingWhenNoMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            val notPresentId = commentList.map { it.remoteCommentId }.maxOrNull()!! * 10
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                    commentList.first().localSiteId,
+                    notPresentId
+            )
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun clearAllBySiteIdAndFiltersRemovesBySite() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.clearAllBySiteIdAndFilters(
+                    commentList.first().localSiteId,
+                    listOf()
+            )
+
+            assertThat(result).isEqualTo(commentList.size)
+        }
+    }
+
+    @Test
+    fun clearAllBySiteIdAndFiltersRemovesByFilters() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.clearAllBySiteIdAndFilters(
+                    commentList.first().localSiteId,
+                    listOf(SPAM.toString())
+            )
+
+            assertThat(result).isEqualTo(commentList.filter { it.status == SPAM.toString() }.size)
+        }
+    }
+
+    @Test
+    fun clearAllBySiteIdAndFiltersCanRemoveNothing() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.clearAllBySiteIdAndFilters(
+                    commentList.first().localSiteId,
+                    listOf(TRASH.toString())
+            )
+
+            assertThat(result).isEqualTo(0)
+        }
+    }
+
+    private fun getDefaultComment() = CommentEntity(
+            id = 1,
+            remoteCommentId = 10,
+            remotePostId = 100,
+            remoteParentCommentId = 1_000,
+            localSiteId = 10_000,
+            remoteSiteId = 100_000,
+            authorUrl = null,
+            authorName = null,
+            authorEmail = null,
+            authorProfileImageUrl = null,
+            postTitle = null,
+            status = APPROVED.toString(),
+            datePublished = null,
+            publishedTimestamp = 1_000_000,
+            content = null,
+            url = null,
+            hasParent = false,
+            parentId = 10_000_000,
+            iLike = false
+    )
+
+    private fun getDefaultCommentList(): CommentEntityList {
+        val comment = getDefaultComment()
+        return listOf(
+                comment.copy(
+                        id = 1,
+                        remoteCommentId = 10,
+                        datePublished = "2021-07-24T00:51:43+02:00",
+                        status = APPROVED.toString()
+                ),
+                comment.copy(
+                        id = 2,
+                        remoteCommentId = 20,
+                        datePublished = "2021-07-24T00:52:43+02:00",
+                        status = UNAPPROVED.toString()
+                ),
+                comment.copy(
+                        id = 3,
+                        remoteCommentId = 30,
+                        datePublished = "2021-07-24T00:53:43+02:00",
+                        status = APPROVED.toString()
+                ),
+                comment.copy(
+                        id = 4,
+                        remoteCommentId = 40,
+                        datePublished = "2021-07-24T00:54:43+02:00",
+                        status = SPAM.toString()
+                )
+        )
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/WPAndroidDatabaseMigrationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/WPAndroidDatabaseMigrationTest.kt
@@ -1,0 +1,85 @@
+package org.wordpress.android.fluxc.persistence.room
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.MIGRATION_1_2
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.MIGRATION_2_3
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.WP_DB_NAME
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class WPAndroidDatabaseMigrationTest {
+    @Rule
+    @JvmField
+    val helper: MigrationTestHelper = MigrationTestHelper(
+            InstrumentationRegistry.getInstrumentation(),
+            WPAndroidDatabase::class.java.canonicalName,
+            FrameworkSQLiteOpenHelperFactory()
+    )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate1To2() {
+        helper.createDatabase(WP_DB_NAME, 1).apply {
+            // populate BloggingReminders with some data
+            execSQL("""
+                INSERT INTO BloggingReminders 
+                (localSiteId, monday, tuesday, wednesday, thursday, friday, saturday, sunday) 
+                VALUES (1000,1, 1, 0, 0, 1, 0, 1) 
+                 """
+            )
+            close()
+        }
+
+        // Re-open the database with version 3 and provide migration to check against.
+        // Ask MigrationTestHelper to verify the schema changes
+        val db = helper.runMigrationsAndValidate(WP_DB_NAME, 2, true, MIGRATION_1_2)
+
+        // Validate that the data was migrated properly.
+        val cursor = db.query("SELECT * FROM BloggingReminders")
+
+        assertThat(cursor.count).isEqualTo(1)
+        cursor.moveToFirst()
+        assertThat(cursor.getInt(0)).isEqualTo(1000)
+        assertThat(cursor.getInt(2)).isEqualTo(1)
+        assertThat(cursor.getInt(4)).isEqualTo(0)
+        cursor.close()
+        db.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate2To3() {
+        helper.createDatabase(WP_DB_NAME, 2).apply {
+            // populate BloggingReminders with some data
+            execSQL(""" 
+                INSERT INTO BloggingReminders 
+                (localSiteId, monday, tuesday, wednesday, thursday, friday, saturday, sunday) 
+                VALUES (1000,1, 1, 0, 0, 1, 0, 1) 
+            """)
+            close()
+        }
+
+        // Re-open the database with version 3 and provide migration to check against.
+        // Ask MigrationTestHelper to verify the schema changes
+        val db = helper.runMigrationsAndValidate(WP_DB_NAME, 3, true, MIGRATION_2_3)
+
+        // Validate that the data was migrated properly.
+        val cursor = db.query("SELECT * FROM BloggingReminders")
+
+        assertThat(cursor.count).isEqualTo(1)
+        cursor.moveToFirst()
+        assertThat(cursor.getInt(0)).isEqualTo(1000)
+        assertThat(cursor.getInt(2)).isEqualTo(1)
+        assertThat(cursor.getInt(4)).isEqualTo(0)
+        cursor.close()
+        db.close()
+    }
+}

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/3.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/3.json
@@ -1,0 +1,369 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "264f8aa9a1fcd9a55dee7fb6aae8ef94",
+    "entities": [
+      {
+        "tableName": "BloggingReminders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `monday` INTEGER NOT NULL, `tuesday` INTEGER NOT NULL, `wednesday` INTEGER NOT NULL, `thursday` INTEGER NOT NULL, `friday` INTEGER NOT NULL, `saturday` INTEGER NOT NULL, `sunday` INTEGER NOT NULL, PRIMARY KEY(`localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monday",
+            "columnName": "monday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tuesday",
+            "columnName": "tuesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wednesday",
+            "columnName": "wednesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thursday",
+            "columnName": "thursday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friday",
+            "columnName": "friday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saturday",
+            "columnName": "saturday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sunday",
+            "columnName": "sunday",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOffers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `name` TEXT, `shortName` TEXT, `tagline` TEXT, `description` TEXT, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "shortName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_PlanOffers_internalPlanId",
+            "unique": true,
+            "columnNames": [
+              "internalPlanId"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_PlanOffers_internalPlanId` ON `${TABLE_NAME}` (`internalPlanId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOfferIds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `productId` INTEGER NOT NULL, `internalPlanId` INTEGER NOT NULL, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PlanOfferFeatures",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `stringId` TEXT, `name` TEXT, `description` TEXT, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringId",
+            "columnName": "stringId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Comments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remoteCommentId` INTEGER NOT NULL, `remotePostId` INTEGER NOT NULL, `remoteParentCommentId` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `remoteSiteId` INTEGER NOT NULL, `authorUrl` TEXT, `authorName` TEXT, `authorEmail` TEXT, `authorProfileImageUrl` TEXT, `postTitle` TEXT, `status` TEXT, `datePublished` TEXT, `publishedTimestamp` INTEGER NOT NULL, `content` TEXT, `url` TEXT, `hasParent` INTEGER NOT NULL, `parentId` INTEGER NOT NULL, `iLike` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteCommentId",
+            "columnName": "remoteCommentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePostId",
+            "columnName": "remotePostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteParentCommentId",
+            "columnName": "remoteParentCommentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteSiteId",
+            "columnName": "remoteSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorUrl",
+            "columnName": "authorUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorEmail",
+            "columnName": "authorEmail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorProfileImageUrl",
+            "columnName": "authorProfileImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "postTitle",
+            "columnName": "postTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "datePublished",
+            "columnName": "datePublished",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publishedTimestamp",
+            "columnName": "publishedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasParent",
+            "columnName": "hasParent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iLike",
+            "columnName": "iLike",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '264f8aa9a1fcd9a55dee7fb6aae8ef94')"
+    ]
+  }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.persistence.BloggingRemindersDao
 import org.wordpress.android.fluxc.persistence.PlanOffersDao
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.buildDb
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao
 import javax.inject.Singleton
 
 @Module
@@ -21,5 +22,9 @@ class DatabaseModule {
 
     @Singleton @Provides fun providePlanOffersDao(wpAndroidDatabase: WPAndroidDatabase): PlanOffersDao {
         return wpAndroidDatabase.planOffersDao()
+    }
+
+    @Singleton @Provides fun provideCommentsDao(wpAndroidDatabase: WPAndroidDatabase): CommentsDao {
+        return wpAndroidDatabase.commentsDao()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/comments/CommentsDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/comments/CommentsDao.kt
@@ -112,7 +112,6 @@ abstract class CommentsDao {
         )
     }
 
-
     @Query("SELECT * FROM Comments WHERE id = :localId LIMIT 1")
     abstract suspend fun getCommentById(localId: Long): CommentEntityList
 
@@ -184,7 +183,6 @@ abstract class CommentsDao {
         statuses: List<String>
     ): Int
 
-
     @Query("""
         DELETE FROM Comments 
         WHERE localSiteId = :localSiteId 
@@ -216,7 +214,6 @@ abstract class CommentsDao {
         remoteIds: List<Long>,
         endOfRange: Long
     ): Int
-
 
     @Query("""
         DELETE FROM Comments 
@@ -294,7 +291,7 @@ abstract class CommentsDao {
         val hasParent: Boolean,
         val parentId: Long,
         val iLike: Boolean
-    ){
+    ) {
         @Ignore
         var level: Int = 0
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/comments/CommentsDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/comments/CommentsDao.kt
@@ -1,0 +1,305 @@
+package org.wordpress.android.fluxc.persistence.comments
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Ignore
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+
+typealias CommentEntityList = List<CommentEntity>
+
+@Dao
+abstract class CommentsDao {
+    // Public methods
+    @Transaction
+    open suspend fun insertOrUpdateComment(comment: CommentEntity): Long {
+        return insertOrUpdateCommentInternal(comment)
+    }
+
+    @Transaction
+    open suspend fun insertOrUpdateCommentForResult(comment: CommentEntity): CommentEntityList {
+        val entityId = insertOrUpdateCommentInternal(comment)
+        return getCommentById(entityId)
+    }
+
+    @Transaction
+    open suspend fun getFilteredComments(localSiteId: Int, statuses: List<String>): CommentEntityList {
+        return getFilteredCommentsInternal(localSiteId, statuses, statuses.isNotEmpty())
+    }
+
+    @Transaction
+    open suspend fun getCommentsByLocalSiteId(
+        localSiteId: Int,
+        statuses: List<String>,
+        limit: Int,
+        orderAscending: Boolean
+    ): CommentEntityList {
+        return getCommentsByLocalSiteIdInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses,
+                limit = limit,
+                orderAscending = orderAscending
+        )
+    }
+
+    @Transaction
+    open suspend fun deleteComment(comment: CommentEntity): Int {
+        val result = deleteById(comment.id)
+
+        return if (result > 0) {
+            result
+        } else {
+            deleteByLocalSiteAndRemoteIds(comment.localSiteId, comment.remoteCommentId)
+        }
+    }
+
+    @Transaction
+    open suspend fun removeGapsFromTheTop(
+        localSiteId: Int,
+        statuses: List<String>,
+        remoteIds: List<Long>,
+        startOfRange: Long
+    ): Int {
+        return removeGapsFromTheTopInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses,
+                filterByIds = remoteIds.isNotEmpty(),
+                remoteIds = remoteIds,
+                startOfRange = startOfRange
+        )
+    }
+
+    @Transaction
+    open suspend fun removeGapsFromTheBottom(
+        localSiteId: Int,
+        statuses: List<String>,
+        remoteIds: List<Long>,
+        endOfRange: Long
+    ): Int {
+        return removeGapsFromTheBottomInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses,
+                filterByIds = remoteIds.isNotEmpty(),
+                remoteIds = remoteIds,
+                endOfRange = endOfRange
+        )
+    }
+
+    @Transaction
+    open suspend fun removeGapsFromTheMiddle(
+        localSiteId: Int,
+        statuses: List<String>,
+        remoteIds: List<Long>,
+        startOfRange: Long,
+        endOfRange: Long
+    ): Int {
+        return removeGapsFromTheMiddleInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses,
+                filterByIds = remoteIds.isNotEmpty(),
+                remoteIds = remoteIds,
+                startOfRange = startOfRange,
+                endOfRange = endOfRange
+        )
+    }
+
+
+    @Query("SELECT * FROM Comments WHERE id = :localId LIMIT 1")
+    abstract suspend fun getCommentById(localId: Long): CommentEntityList
+
+    @Query("SELECT * FROM Comments WHERE localSiteId = :localSiteId AND remoteCommentId = :remoteCommentId")
+    abstract suspend fun getCommentsByLocalSiteAndRemoteCommentId(
+        localSiteId: Int,
+        remoteCommentId: Long
+    ): CommentEntityList
+
+    @Transaction
+    open suspend fun appendOrUpdateComments(comments: CommentEntityList): Int {
+        val affectedIdList = insertOrUpdateCommentsInternal(comments)
+        return affectedIdList.size
+    }
+
+    @Transaction
+    open suspend fun clearAllBySiteIdAndFilters(localSiteId: Int, statuses: List<String>): Int {
+        return clearAllBySiteIdAndFiltersInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses
+        )
+    }
+
+    // Protected methods
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    protected abstract fun insert(comment: CommentEntity): Long
+
+    @Update
+    protected abstract fun update(comment: CommentEntity): Int
+
+    @Query("""
+        SELECT * FROM Comments WHERE localSiteId = :localSiteId 
+        AND CASE WHEN :filterByStatuses = 1 THEN status IN (:statuses) ELSE 1 END 
+        ORDER BY datePublished DESC
+    """)
+    protected abstract fun getFilteredCommentsInternal(
+        localSiteId: Int,
+        statuses: List<String>,
+        filterByStatuses: Boolean
+    ): CommentEntityList
+
+    @Query("""
+        SELECT * FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+        ORDER BY 
+        CASE WHEN :orderAscending = 1 THEN datePublished END ASC,
+        CASE WHEN :orderAscending = 0 THEN datePublished END DESC
+        LIMIT CASE WHEN :limit > 0 THEN :limit ELSE -1 END
+    """)
+    protected abstract fun getCommentsByLocalSiteIdInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>,
+        limit: Int,
+        orderAscending: Boolean
+    ): CommentEntityList
+
+    @Query("""
+        DELETE FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+    """)
+    protected abstract fun clearAllBySiteIdAndFiltersInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>
+    ): Int
+
+
+    @Query("""
+        DELETE FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+        AND CASE WHEN (:filterByIds = 1) THEN (remoteCommentId NOT IN (:remoteIds)) ELSE 1 END
+        AND publishedTimestamp >= :startOfRange
+    """)
+    protected abstract fun removeGapsFromTheTopInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>,
+        filterByIds: Boolean,
+        remoteIds: List<Long>,
+        startOfRange: Long
+    ): Int
+
+    @Query("""
+        DELETE FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+        AND CASE WHEN (:filterByIds = 1) THEN (remoteCommentId NOT IN (:remoteIds)) ELSE 1 END
+        AND publishedTimestamp <= :endOfRange
+    """)
+    protected abstract fun removeGapsFromTheBottomInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>,
+        filterByIds: Boolean,
+        remoteIds: List<Long>,
+        endOfRange: Long
+    ): Int
+
+
+    @Query("""
+        DELETE FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+        AND CASE WHEN (:filterByIds = 1) THEN (remoteCommentId NOT IN (:remoteIds)) ELSE 1 END
+        AND publishedTimestamp <= :startOfRange
+        AND publishedTimestamp >= :endOfRange
+    """)
+    protected abstract fun removeGapsFromTheMiddleInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>,
+        filterByIds: Boolean,
+        remoteIds: List<Long>,
+        startOfRange: Long,
+        endOfRange: Long
+    ): Int
+
+    @Query("DELETE FROM Comments WHERE id = :commentId")
+    protected abstract fun deleteById(commentId: Long): Int
+
+    @Query("DELETE FROM Comments WHERE localSiteId = :localSiteId AND remoteCommentId = :remoteCommentId")
+    protected abstract fun deleteByLocalSiteAndRemoteIds(localSiteId: Int, remoteCommentId: Long): Int
+
+    // Private methods
+    private suspend fun insertOrUpdateCommentsInternal(comments: CommentEntityList): List<Long> {
+        return comments.map { comment ->
+            insertOrUpdateCommentInternal(comment)
+        }
+    }
+
+    private suspend fun insertOrUpdateCommentInternal(comment: CommentEntity): Long {
+        val commentByLocalId = getCommentById(comment.id)
+
+        val matchingComments = if (commentByLocalId.isEmpty()) {
+            getCommentsByLocalSiteAndRemoteCommentId(comment.localSiteId, comment.remoteCommentId)
+        } else {
+            commentByLocalId
+        }
+
+        return if (matchingComments.isEmpty()) {
+            insert(comment)
+        } else {
+            // We are forcing the id of the matching comment so the update can
+            // act on the expected entity
+            val matchingComment = matchingComments.first()
+
+            update(comment.copy(id = matchingComment.id))
+            matchingComment.id
+        }
+    }
+
+    @Entity(
+            tableName = "Comments"
+    )
+    data class CommentEntity(
+        @PrimaryKey(autoGenerate = true)
+        val id: Long = 0,
+        val remoteCommentId: Long,
+        val remotePostId: Long,
+        val remoteParentCommentId: Long,
+        val localSiteId: Int,
+        val remoteSiteId: Long,
+        val authorUrl: String?,
+        val authorName: String?,
+        val authorEmail: String?,
+        val authorProfileImageUrl: String?,
+        val postTitle: String?,
+        val status: String?,
+        val datePublished: String?,
+        val publishedTimestamp: Long,
+        val content: String?,
+        val url: String?,
+        val hasParent: Boolean,
+        val parentId: Long,
+        val iLike: Boolean
+    ){
+        @Ignore
+        var level: Int = 0
+    }
+
+    companion object {
+        const val EMPTY_ID = -1L
+    }
+}


### PR DESCRIPTION
This PR is part of the phase 1 of the Unified Comments project aiming to unify the commenting experience in the WP app. 

This PR introduces a room database that should replace the CommentModel SQLite db that is based on Well SQL. 
- We are introducing a CommentsDao to interact with the comment entities stored in the Comments table.
- We have included a migration from version 2 to the current version 3 of the database.
- We tried to cover the dao with some unit testing and a migration test. To do this we included a new dependency `room-testing` but only as an androidTestImplementation, so should not affect the main implementation tree dependency graph.

To review this PR you should review the code and check the tests are green.

