### PR TITLE
Porting network clients for comments to kotlin.

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
@@ -1,0 +1,351 @@
+package org.wordpress.android.fluxc.comments
+
+import com.android.volley.NetworkResponse
+import com.android.volley.RequestQueue
+import com.android.volley.Response
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.HTTPAuthManager
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequestBuilder
+import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentsXMLRPCClient
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
+import org.wordpress.android.fluxc.utils.DateTimeUtilsWrapper
+import java.util.concurrent.CountDownLatch
+
+@RunWith(RobolectricTestRunner::class)
+class CommentsXMLRPCClientTest {
+    private lateinit var dispatcher: Dispatcher
+    private lateinit var requestQueue: RequestQueue
+    private lateinit var accessToken: AccessToken
+    private lateinit var userAgent: UserAgent
+    private lateinit var httpAuthManager: HTTPAuthManager
+    private lateinit var commentsMapper: CommentsMapper
+    private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    private lateinit var commentErrorUtilsWrapper: CommentErrorUtilsWrapper
+    private lateinit var site: SiteModel
+
+    private lateinit var xmlRpcClient: CommentsXMLRPCClient
+    private var mockedResponse = ""
+    private var countDownLatch: CountDownLatch? = null
+
+    @Before
+    fun setUp() {
+        dispatcher = Mockito.mock(Dispatcher::class.java)
+        requestQueue = Mockito.mock(RequestQueue::class.java)
+        userAgent = Mockito.mock(UserAgent::class.java)
+        httpAuthManager = Mockito.mock(HTTPAuthManager::class.java)
+        commentErrorUtilsWrapper = Mockito.mock(CommentErrorUtilsWrapper::class.java)
+        commentsMapper = CommentsMapper(DateTimeUtilsWrapper())
+        site = Mockito.mock(SiteModel::class.java)
+
+        doAnswer { invocation ->
+            val request = invocation.arguments[0] as XMLRPCRequest
+            try {
+                val requestClass = Class.forName(
+                        "org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest"
+                ) as Class<XMLRPCRequest>
+                // Reflection code equivalent to:
+                // Object o = request.parseNetworkResponse(data)
+                val parseNetworkResponse = requestClass.getDeclaredMethod(
+                        "parseNetworkResponse",
+                        NetworkResponse::class.java
+                )
+                parseNetworkResponse.isAccessible = true
+                val nr = NetworkResponse(mockedResponse.toByteArray())
+                val o = parseNetworkResponse.invoke(request, nr) as Response<Any>
+                // Reflection code equivalent to:
+                // request.deliverResponse(o)
+                val deliverResponse = requestClass.getDeclaredMethod("deliverResponse", Any::class.java)
+                deliverResponse.isAccessible = true
+                deliverResponse.invoke(request, o.result)
+            } catch (e: Exception) {
+                Assert.assertTrue("Unexpected exception: $e", false)
+            }
+            countDownLatch?.countDown()
+            null
+        }.whenever(requestQueue).add<Any>(any())
+
+        xmlRpcClient = CommentsXMLRPCClient(
+                dispatcher = dispatcher,
+                requestQueue = requestQueue,
+                userAgent = userAgent,
+                httpAuthManager = httpAuthManager,
+                commentErrorUtilsWrapper = commentErrorUtilsWrapper,
+                xmlrpcRequestBuilder = XMLRPCRequestBuilder(),
+                commentsMapper = commentsMapper
+        )
+
+        whenever(site.selfHostedSiteId).thenReturn(SITE_ID)
+        whenever(site.username).thenReturn("username")
+        whenever(site.password).thenReturn("password")
+        whenever(site.xmlRpcUrl).thenReturn("https://self-hosted/xmlrpc.php")
+    }
+
+    @Test
+    fun `fetchCommentsPage returns fetched page`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?><methodResponse><params><param><value><array><data>
+            <value><struct><member><name>date_created_gmt</name><value><dateTime.iso8601>20210727T23:56:21
+            </dateTime.iso8601></value></member><member><name>user_id</name><value><string>1</string>
+            </value></member><member><name>comment_id</name><value><string>44</string></value></member>
+            <member><name>parent</name><value><string>41</string></value></member><member><name>status</name>
+            <value><string>hold</string></value></member><member><name>content</name><value><string>
+            this is a content example</string></value></member><member><name>link</name><value><string>
+            http://test-debug/index.php/2021/04/01/happy-monday/#comment-44</string></value>
+            </member><member><name>post_id</name><value><string>367</string></value></member>
+            <member><name>post_title</name><value><string>happy-monday</string></value></member>
+            <member><name>author</name><value><string>authorname</string></value></member><member>
+            <name>author_url</name><value><string></string></value></member><member><name>author_email</name>
+            <value><string>authorname@mydomain.com</string></value></member><member><name>author_ip
+            </name><value><string>111.222.333.444</string></value></member><member><name>type
+            </name><value><string></string></value></member></struct></value></data>
+            </array></value></param></params></methodResponse>
+        """
+
+        val payload = xmlRpcClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isNotEmpty
+    }
+
+    @Test
+    fun `fetchCommentsPage returns error on API fail`() = test {
+        mockedResponse = """<?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse><params><param><value>
+            <string>error</string>
+            </value></param></params></methodResponse>
+        """
+
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any())).thenReturn(CommentError(GENERIC_ERROR, ""))
+
+        val payload = xmlRpcClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isTrue
+    }
+
+    @Test
+    fun `pushComment returns pushed comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <boolean>1</boolean>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.pushComment(
+                site = site,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isEqualTo(comment)
+    }
+
+    @Test
+    fun `fetchComment returns fetched comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <struct>
+              <member><name>date_created_gmt</name><value><dateTime.iso8601>20210727T20:33:41</dateTime.iso8601></value></member>
+              <member><name>user_id</name><value><string>1</string></value></member>
+              <member><name>comment_id</name><value><string>34</string></value></member>
+              <member><name>parent</name><value><string>33</string></value></member>
+              <member><name>status</name><value><string>approve</string></value></member>
+              <member><name>content</name><value><string>test1000</string></value></member>
+              <member><name>link</name><value><string>http://test-debug.org/index.php/2021/04/01/no-jp/#comment-34</string></value></member>
+              <member><name>post_id</name><value><string>367</string></value></member>
+              <member><name>post_title</name><value><string>no jp</string></value></member>
+              <member><name>author</name><value><string>authorname</string></value></member>
+              <member><name>author_url</name><value><string></string></value></member>
+              <member><name>author_email</name><value><string>authorname@mydomain.com</string></value></member>
+              <member><name>author_ip</name><value><string>111.111.111.111</string></value></member>
+              <member><name>type</name><value><string></string></value></member>
+            </struct>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isEqualTo(comment)
+    }
+
+    @Test
+    fun `fetchComment returns error on API fail`() = test {
+        mockedResponse = """<?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse><params><param><value>
+            <string>error</string>
+            </value></param></params></methodResponse>
+        """
+
+        val comment = getDefaultComment()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any())).thenReturn(CommentError(GENERIC_ERROR, ""))
+
+        val payload = xmlRpcClient.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isTrue
+    }
+
+    @Test
+    fun `deleteComment returns no comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <boolean>1</boolean>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isNull()
+    }
+
+    @Test
+    fun `createNewReply returns udpated reply`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <int>56</int>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+        val reply = comment.copy(content = "new reply content")
+
+        val payload = xmlRpcClient.createNewReply(
+                site = site,
+                comment = comment,
+                reply = reply
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response is CommentEntity).isTrue
+        assertThat((payload.response as CommentEntity).remoteCommentId).isEqualTo(56)
+    }
+
+    @Test
+    fun `createNewComment returns udpated comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <int>56</int>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.createNewComment(
+                site = site,
+                remotePostId = 100,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response is CommentEntity).isTrue
+        assertThat((payload.response as CommentEntity).remoteCommentId).isEqualTo(56)
+    }
+
+    private fun getDefaultComment() = CommentEntity(
+            id = 0,
+            remoteCommentId = 34,
+            remotePostId = 367,
+            remoteParentCommentId = 33,
+            localSiteId = 0,
+            remoteSiteId = 200,
+            authorUrl = "",
+            authorName = "authorname",
+            authorEmail = "authorname@mydomain.com",
+            authorProfileImageUrl = null,
+            postTitle = "no jp",
+            status = "approved",
+            datePublished = "2021-07-27T20:33:41+00:00",
+            publishedTimestamp = 0,
+            content = "test1000",
+            url = "http://test-debug.org/index.php/2021/04/01/no-jp/#comment-34",
+            hasParent = true,
+            parentId = 33,
+            iLike = false
+    )
+
+    companion object {
+        private const val SITE_ID = 200L
+        private const val PAGE_LEN = 30
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
@@ -1,0 +1,220 @@
+package org.wordpress.android.fluxc.common
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentParent
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.utils.DateTimeUtilsWrapper
+import java.util.Date
+
+class CommentsMapperTest {
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper = mock()
+    private val mapper = CommentsMapper(dateTimeUtilsWrapper)
+
+    @Test
+    fun `xmlrpc dto is converted to entity`() {
+        val comment = getDefaultComment(false).copy(
+                authorProfileImageUrl = null,
+                datePublished = "2021-07-29T21:29:27+00:00"
+        )
+        val site = SiteModel().apply {
+            id = comment.localSiteId
+            selfHostedSiteId = comment.remoteSiteId
+        }
+        val xmlRpcDto = comment.toXmlRpcDto()
+
+        whenever(dateTimeUtilsWrapper.timestampFromIso8601(any())).thenReturn(comment.publishedTimestamp)
+        whenever(dateTimeUtilsWrapper.iso8601UTCFromDate(any())).thenReturn(comment.datePublished)
+        val mappedEntity = mapper.commentXmlRpcDTOToEntity(xmlRpcDto, site)
+
+        assertThat(mappedEntity).isEqualTo(comment)
+    }
+
+    @Test
+    fun `xmlrpc dto list is converted to entity list`() {
+        val commentList = getDefaultCommentList(false).map { it.copy(id = 0, authorProfileImageUrl = null) }
+        val site = SiteModel().apply {
+            id = commentList.first().localSiteId
+            selfHostedSiteId = commentList.first().remoteSiteId
+        }
+        val xmlRpcDtoList = commentList.map { it.toXmlRpcDto() }
+
+        whenever(dateTimeUtilsWrapper.timestampFromIso8601(any())).thenReturn(commentList.first().publishedTimestamp)
+        whenever(dateTimeUtilsWrapper.iso8601UTCFromDate(any())).thenReturn(commentList.first().datePublished)
+
+        val mappedEntityList = mapper.commentXmlRpcDTOToEntityList(xmlRpcDtoList.toTypedArray(), site)
+
+        assertThat(mappedEntityList).isEqualTo(commentList)
+    }
+
+    @Test
+    fun `dto is converted to entity`() {
+        val comment = getDefaultComment(true).copy(datePublished = "2021-07-29T21:29:27+00:00")
+        val site = SiteModel().apply {
+            id = comment.localSiteId
+            siteId = comment.remoteSiteId
+        }
+        val commentDto = comment.toDto()
+
+        whenever(dateTimeUtilsWrapper.timestampFromIso8601(any())).thenReturn(comment.publishedTimestamp)
+        val mappedEntity = mapper.commentDtoToEntity(commentDto, site)
+
+        assertThat(mappedEntity).isEqualTo(comment)
+    }
+
+    @Test
+    fun `entity is converted to model`() {
+        val comment = getDefaultComment(true).copy(datePublished = "2021-07-29T21:29:27+00:00")
+        val commentModel = comment.toModel()
+
+        val mappedModel = mapper.commentEntityToLegacyModel(comment)
+
+        assertModelsEqual(mappedModel, commentModel)
+    }
+
+    @Test
+    fun `model is converted to entity`() {
+        val comment = getDefaultComment(true).copy(datePublished = "2021-07-29T21:29:27+00:00")
+        val commentModel = comment.toModel()
+
+        val mappedEntity = mapper.commentLegacyModelToEntity(commentModel)
+
+        assertThat(mappedEntity).isEqualTo(comment)
+    }
+
+    private fun assertModelsEqual(mappedModel: CommentModel, commentModel: CommentModel): Boolean {
+        return mappedModel.id == commentModel.id &&
+        mappedModel.remoteCommentId == commentModel.remoteCommentId &&
+        mappedModel.remotePostId == commentModel.remotePostId &&
+        mappedModel.remoteParentCommentId == commentModel.remoteParentCommentId &&
+        mappedModel.localSiteId == commentModel.localSiteId &&
+        mappedModel.remoteSiteId == commentModel.remoteSiteId &&
+        mappedModel.authorUrl == commentModel.authorUrl &&
+        mappedModel.authorName == commentModel.authorName &&
+        mappedModel.authorEmail == commentModel.authorEmail &&
+        mappedModel.authorProfileImageUrl == commentModel.authorProfileImageUrl &&
+        mappedModel.postTitle == commentModel.postTitle &&
+        mappedModel.status == commentModel.status &&
+        mappedModel.datePublished == commentModel.datePublished &&
+        mappedModel.publishedTimestamp == commentModel.publishedTimestamp &&
+        mappedModel.content == commentModel.content &&
+        mappedModel.url == commentModel.url &&
+        mappedModel.hasParent == commentModel.hasParent &&
+        mappedModel.parentId == commentModel.parentId &&
+        mappedModel.iLike == commentModel.iLike
+    }
+
+    private fun CommentEntity.toDto(): CommentWPComRestResponse {
+        val entity = this
+        return CommentWPComRestResponse().apply {
+            ID = entity.remoteCommentId //137
+            URL = entity.url
+            author = Author().apply {
+                ID = entity.remoteParentCommentId
+                URL = entity.authorUrl
+                avatar_URL = entity.authorProfileImageUrl
+                email = entity.authorEmail
+                name = entity.authorName
+            }
+            content = entity.content
+            date = entity.datePublished
+            i_like = entity.iLike
+            parent = CommentParent().apply {
+                ID = entity.parentId
+            }
+            post = Post().apply {
+                type = "post"
+                title = entity.postTitle
+                link = "https://public-api.wordpress.com/rest/v1.1/sites/185464053/posts/85"
+                ID = entity.remotePostId
+            }
+            status = entity.status
+        }
+    }
+    
+    private fun CommentEntity.toModel(): CommentModel {
+        val entity = this
+        return CommentModel().apply {
+            id = entity.id.toInt()
+            remoteCommentId = entity.remoteCommentId
+            remotePostId = entity.remotePostId
+            remoteParentCommentId = entity.remoteParentCommentId
+            localSiteId = entity.localSiteId
+            remoteSiteId = entity.remoteSiteId
+            authorUrl = entity.authorUrl
+            authorName = entity.authorName
+            authorEmail = entity.authorEmail
+            authorProfileImageUrl = entity.authorProfileImageUrl
+            postTitle = entity.postTitle
+            status = entity.status
+            datePublished = entity.datePublished
+            publishedTimestamp = entity.publishedTimestamp
+            content = entity.content
+            url = entity.authorProfileImageUrl
+            hasParent = entity.hasParent
+            parentId = entity.parentId
+            iLike = entity.iLike
+        }
+    }
+
+    private fun CommentEntity.toXmlRpcDto(): HashMap<*, *> {
+        return hashMapOf<String, Any?>(
+                "parent" to this.remoteParentCommentId.toString(),
+                "post_title" to this.postTitle,
+                "author" to this.authorName,
+                "link" to this.url,
+                "date_created_gmt" to Date(),
+                "comment_id" to this.remoteCommentId.toString(),
+                "content" to this.content,
+                "author_url" to this.authorUrl,
+                "post_id" to this.remotePostId,
+                "user_id" to "1",
+                "author_email" to this.authorEmail,
+                "status" to this.status
+        )
+    }
+
+    private fun getDefaultComment(allowNulls: Boolean): CommentEntity {
+        val remoteParentCommentId = 1_000L
+        return CommentEntity(
+                id = 0,
+                remoteCommentId = 10,
+                remotePostId = 100,
+                remoteParentCommentId = remoteParentCommentId,
+                localSiteId = 10_000,
+                remoteSiteId = 100_000,
+                authorUrl = if (allowNulls) null else "https://test-debug-site.wordpress.com",
+                authorName = if (allowNulls) null else "authorname",
+                authorEmail = if (allowNulls) null else "email@wordpress.com",
+                authorProfileImageUrl = if (allowNulls) null else "https://gravatar.com/avatar/111222333",
+                postTitle = if (allowNulls) null else "again",
+                status = APPROVED.toString(),
+                datePublished = if (allowNulls) null else "2021-05-12T15:10:40+02:00",
+                publishedTimestamp = 1_000_000,
+                content = if (allowNulls) null else "content example",
+                url = if (allowNulls) null else "https://test-debug-site.wordpress.com/2021/02/25/again/#comment-137",
+                hasParent = true,
+                parentId = remoteParentCommentId,
+                iLike = false
+        )
+    }
+
+    private fun getDefaultCommentList(allowNulls: Boolean): CommentEntityList {
+        val comment = getDefaultComment(allowNulls)
+        return listOf(
+                comment.copy(id=1, remoteCommentId = 10, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id=2, remoteCommentId = 20, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id=3, remoteCommentId = 30, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id=4, remoteCommentId = 40, datePublished = "2021-07-24T00:51:43+02:00")
+        )
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
@@ -116,7 +116,7 @@ class CommentsMapperTest {
     private fun CommentEntity.toDto(): CommentWPComRestResponse {
         val entity = this
         return CommentWPComRestResponse().apply {
-            ID = entity.remoteCommentId //137
+            ID = entity.remoteCommentId
             URL = entity.url
             author = Author().apply {
                 ID = entity.remoteParentCommentId
@@ -140,7 +140,7 @@ class CommentsMapperTest {
             status = entity.status
         }
     }
-    
+
     private fun CommentEntity.toModel(): CommentModel {
         val entity = this
         return CommentModel().apply {
@@ -211,10 +211,10 @@ class CommentsMapperTest {
     private fun getDefaultCommentList(allowNulls: Boolean): CommentEntityList {
         val comment = getDefaultComment(allowNulls)
         return listOf(
-                comment.copy(id=1, remoteCommentId = 10, datePublished = "2021-07-24T00:51:43+02:00"),
-                comment.copy(id=2, remoteCommentId = 20, datePublished = "2021-07-24T00:51:43+02:00"),
-                comment.copy(id=3, remoteCommentId = 30, datePublished = "2021-07-24T00:51:43+02:00"),
-                comment.copy(id=4, remoteCommentId = 40, datePublished = "2021-07-24T00:51:43+02:00")
+                comment.copy(id = 1, remoteCommentId = 10, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id = 2, remoteCommentId = 20, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id = 3, remoteCommentId = 30, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id = 4, remoteCommentId = 40, datePublished = "2021-07-24T00:51:43+02:00")
         )
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
@@ -1,0 +1,607 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.comments
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentLikeWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentParent
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.CommentsWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentsRestClient
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class CommentsRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var commentErrorUtilsWrapper: CommentErrorUtilsWrapper
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var commentsMapper: CommentsMapper
+
+    private lateinit var restClient: CommentsRestClient
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var bodyCaptor: KArgumentCaptor<Map<String, Any>>
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        bodyCaptor = argumentCaptor()
+
+        restClient = CommentsRestClient(
+                appContext = null,
+                dispatcher = dispatcher,
+                requestQueue = requestQueue,
+                accessToken = accessToken,
+                userAgent = userAgent,
+                wpComGsonRequestBuilder = wpComGsonRequestBuilder,
+                commentErrorUtilsWrapper = commentErrorUtilsWrapper,
+                commentsMapper = commentsMapper
+        )
+        whenever(site.siteId).thenReturn(SITE_ID)
+    }
+
+    @Test
+    fun `fetchCommentsPage returns fetched page`() = test {
+        val response = getDefaultDto()
+
+        val commentsReponse = response.CommentsWPComRestResponse()
+        commentsReponse.comments = listOf(response, response, response)
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(response.toEntity())
+
+        initFetchPageResponse(commentsReponse)
+
+        val payload = restClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isFalse
+
+        val comments = payload.response!!
+        assertThat(comments.size).isEqualTo(commentsReponse.comments.size)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/"
+        )
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+                mutableMapOf(
+                        "status" to APPROVED.toString(),
+                        "offset" to 0.toString(),
+                        "number" to PAGE_LEN.toString(),
+                        "force" to "wpcom"
+                )
+        )
+    }
+
+    @Test
+    fun `fetchCommentsPage returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initFetchPageResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `pushComment returns updated comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+        initPushResponse(response)
+
+        val payload = restClient.pushComment(
+                site = site,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/${comment.remoteCommentId}/"
+        )
+        assertThat(bodyCaptor.lastValue).isEqualTo(
+                mutableMapOf(
+                        "content" to comment.content.orEmpty(),
+                        "date" to comment.datePublished.orEmpty(),
+                        "status" to comment.status.orEmpty()
+                )
+        )
+    }
+
+    @Test
+    fun `pushComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initPushResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.pushComment(
+                site = site,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `fetchComment returns comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+
+        initFetchResponse(response)
+
+        val payload = restClient.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isFalse
+
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/${comment.remoteCommentId}/"
+        )
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+                mapOf<String, String>()
+        )
+    }
+
+    @Test
+    fun `fetchComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initFetchResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `deleteComment returns deleted comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+        initDeleteResponse(response)
+
+        val payload = restClient.deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/" +
+                        "${comment.remoteCommentId}/delete/"
+        )
+        assertThat(bodyCaptor.lastValue).isNull()
+    }
+
+    @Test
+    fun `deleteComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initDeleteResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `createNewReply returns reply comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+        initReplyCreateResponse(response)
+
+        val payload = restClient.createNewReply(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.content
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/" +
+                        "${site.siteId}/comments/${comment.remoteCommentId}/replies/new/"
+        )
+        assertThat(bodyCaptor.lastValue).isEqualTo(
+                mutableMapOf("content" to comment.content.orEmpty())
+        )
+    }
+
+    @Test
+    fun `createNewReply returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initReplyCreateResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.createNewReply(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.content
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `createNewComment returns new comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+        initReplyCreateResponse(response)
+
+        val payload = restClient.createNewComment(
+                site = site,
+                remotePostId = comment.remotePostId,
+                comment.content
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/" +
+                        "${site.siteId}/posts/${comment.remotePostId}/replies/new/"
+        )
+        assertThat(bodyCaptor.lastValue).isEqualTo(
+                mutableMapOf("content" to comment.content.orEmpty())
+        )
+    }
+
+    @Test
+    fun `createNewComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initReplyCreateResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.createNewComment(
+                site = site,
+                remotePostId = comment.remotePostId,
+                comment.content
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `likeComment returns new liked comment`() = test {
+        val comment = getDefaultDto().toEntity()
+        val response = getDefaultLikeResponse(comment.iLike)
+
+        initLikeResponse(response)
+
+        val payload = restClient.likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.iLike
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/" +
+                        "${site.siteId}/comments/${comment.remoteCommentId}/likes/new/"
+        )
+        assertThat(bodyCaptor.lastValue).isNull()
+    }
+
+    @Test
+    fun `likeComment returns new unliked comment`() = test {
+        val comment = getDefaultDto().toEntity().copy(iLike = false)
+        val response = getDefaultLikeResponse(comment.iLike)
+
+        initLikeResponse(response)
+
+        val payload = restClient.likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.iLike
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/" +
+                        "${site.siteId}/comments/${comment.remoteCommentId}/likes/mine/delete/"
+        )
+        assertThat(bodyCaptor.lastValue).isNull()
+    }
+
+    @Test
+    fun `likeComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initLikeResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.iLike
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    private suspend fun initFetchPageResponse(
+        data: CommentsWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentsWPComRestResponse> {
+        return initGetResponse(CommentsWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initPushResponse(
+        data: CommentWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentWPComRestResponse> {
+        return initPostResponse(CommentWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initFetchResponse(
+        data: CommentWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentWPComRestResponse> {
+        return initGetResponse(CommentWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initDeleteResponse(
+        data: CommentWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentWPComRestResponse> {
+        return initPostResponse(CommentWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initReplyCreateResponse(
+        data: CommentWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentWPComRestResponse> {
+        return initPostResponse(CommentWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initLikeResponse(
+        data: CommentLikeWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentLikeWPComRestResponse> {
+        return initPostResponse(CommentLikeWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun <T> initGetResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null
+    ): Response<T> {
+        val response = if (error != null) Response.Error(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncGetRequest(
+                        eq(restClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        eq(kclass),
+                        any(),
+                        any(),
+                        any()
+
+                )
+        ).thenReturn(response)
+        return response
+    }
+
+    private suspend fun <T> initPostResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null
+    ): Response<T> {
+        val response = if (error != null) Response.Error(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncPostRequest(
+                        eq(restClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        bodyCaptor.capture(),
+                        eq(kclass),
+                        anyOrNull()
+                )
+        ).thenReturn(response)
+        return response
+    }
+
+    private fun getDefaultDto(): CommentWPComRestResponse {
+        return CommentWPComRestResponse().apply {
+            ID = 137
+            URL = "https://test-site.wordpress.com/2021/02/25/again/#comment-137"
+            author = Author().apply {
+                ID = 0
+                URL = "https://debugging-test.wordpress.com"
+                avatar_URL = "https://gravatar.com/avatar/avatarurl"
+                email = "email@mydomain.com"
+                name = "This is my name"
+            }
+            content = "example content"
+            date = "2021-05-12T15:10:40+02:00"
+            i_like = true
+            parent = CommentParent().apply { ID = 41 }
+            post = Post().apply {
+                ID = 85
+                link = "https://public-api.wordpress.com/rest/v1.1/sites/11111111/posts/85"
+                title = "again"
+                type = "post"
+            }
+            status = "approved"
+        }
+    }
+
+    private fun getDefaultLikeResponse(iLike: Boolean): CommentLikeWPComRestResponse {
+        return CommentLikeWPComRestResponse().apply {
+            success = true
+            i_like = iLike
+            like_count = 100
+        }
+    }
+
+    private fun CommentWPComRestResponse.toEntity(): CommentEntity {
+        val dto = this
+        return CommentEntity(
+                id = 0,
+                remoteCommentId = dto.ID,
+                remotePostId = dto.post.ID,
+                remoteParentCommentId = dto.author.ID,
+                localSiteId = 10,
+                remoteSiteId = 200,
+                authorUrl = dto.author.URL,
+                authorName = dto.author.name,
+                authorEmail = dto.author.email,
+                authorProfileImageUrl = dto.author.avatar_URL,
+                postTitle = dto.post.title,
+                status = dto.status,
+                datePublished = dto.date,
+                publishedTimestamp = 132456,
+                content = dto.content,
+                url = dto.URL,
+                hasParent = dto.parent != null,
+                parentId = dto.parent.ID,
+                iLike = dto.i_like
+        )
+    }
+
+    companion object {
+        private const val SITE_ID = 200L
+        private const val PAGE_LEN = 30
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
@@ -110,7 +110,7 @@ class CommentsMapper @Inject constructor(
         val datePublished = dateTimeUtilsWrapper.iso8601UTCFromDate(
                 XMLRPCUtils.safeGetMapValue(commentMap, "date_created_gmt", Date())
         )
-        // TODOD: use a wrapper for XMLRPCUtils?
+
         val remoteParentCommentId = XMLRPCUtils.safeGetMapValue(commentMap, "parent", 0L)
 
         return CommentEntity(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
@@ -1,0 +1,172 @@
+package org.wordpress.android.fluxc.model.comments
+
+import dagger.Reusable
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.SPAM
+import org.wordpress.android.fluxc.model.CommentStatus.TRASH
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCUtils
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.utils.DateTimeUtilsWrapper
+import java.util.ArrayList
+import java.util.Date
+import java.util.HashMap
+import javax.inject.Inject
+
+@Reusable
+class CommentsMapper @Inject constructor(
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
+) {
+    fun commentDtoToEntity(commentDto: CommentWPComRestResponse, site: SiteModel): CommentEntity {
+        return CommentEntity(
+            remoteCommentId = commentDto.ID,
+            localSiteId = site.id,
+            remoteSiteId = site.siteId,
+            authorUrl = commentDto.author?.URL,
+            authorName = commentDto.author?.name?.let {
+                StringEscapeUtils.unescapeHtml4(it)
+            },
+            authorEmail = commentDto.author?.email?.let {
+                if ("false".equals(it)) {
+                    ""
+                } else {
+                    it
+                }
+            },
+            authorProfileImageUrl = commentDto.author?.avatar_URL,
+            remotePostId = commentDto.post?.ID ?: 0,
+            postTitle = StringEscapeUtils.unescapeHtml4(commentDto.post?.title),
+            status = commentDto.status,
+            datePublished = commentDto.date,
+            publishedTimestamp = dateTimeUtilsWrapper.timestampFromIso8601(commentDto.date),
+            content = commentDto.content,
+            url = commentDto.URL,
+            remoteParentCommentId = commentDto.author?.ID ?: 0L,
+            hasParent = commentDto.parent != null,
+            parentId = commentDto.parent?.ID ?: 0,
+            iLike = commentDto.i_like
+        )
+    }
+
+    fun commentEntityToLegacyModel(entity: CommentEntity): CommentModel {
+        return CommentModel().apply {
+            this.id = entity.id.toInt()
+            this.remoteCommentId = entity.remoteCommentId
+            this.remotePostId = entity.remotePostId
+            this.remoteParentCommentId = entity.remoteParentCommentId
+            this.localSiteId = entity.localSiteId
+            this.remoteSiteId = entity.remoteSiteId
+            this.authorUrl = entity.authorUrl
+            this.authorName = entity.authorName
+            this.authorEmail = entity.authorEmail
+            this.authorProfileImageUrl = entity.authorProfileImageUrl
+            this.postTitle = entity.postTitle
+            this.status = entity.status
+            this.datePublished = entity.datePublished
+            this.publishedTimestamp = entity.publishedTimestamp
+            this.content = entity.content
+            this.url = entity.url
+            this.hasParent = entity.hasParent
+            this.parentId = entity.parentId
+            this.iLike = entity.iLike
+        }
+    }
+
+    fun commentLegacyModelToEntity(commentModel: CommentModel): CommentEntity {
+        return CommentEntity(
+                id = commentModel.id.toLong(),
+                remoteCommentId = commentModel.remoteCommentId,
+                remotePostId = commentModel.remotePostId,
+                remoteParentCommentId = commentModel.remoteParentCommentId,
+                localSiteId = commentModel.localSiteId,
+                remoteSiteId = commentModel.remoteSiteId,
+                authorUrl = commentModel.authorUrl,
+                authorName = commentModel.authorName,
+                authorEmail = commentModel.authorEmail,
+                authorProfileImageUrl = commentModel.authorProfileImageUrl,
+                postTitle = commentModel.postTitle,
+                status = commentModel.status,
+                datePublished = commentModel.datePublished,
+                publishedTimestamp = commentModel.publishedTimestamp,
+                content = commentModel.content,
+                url = commentModel.url,
+                hasParent = commentModel.hasParent,
+                parentId = commentModel.parentId,
+                iLike = commentModel.iLike
+        )
+    }
+
+    fun commentXmlRpcDTOToEntity(commentObject: Any?, site: SiteModel): CommentEntity? {
+        if (commentObject !is HashMap<*, *>) {
+            return null
+        }
+        val commentMap: HashMap<*, *> = commentObject
+
+        val datePublished = dateTimeUtilsWrapper.iso8601UTCFromDate(
+                XMLRPCUtils.safeGetMapValue(commentMap, "date_created_gmt", Date())
+        )
+        // TODOD: use a wrapper for XMLRPCUtils?
+        val remoteParentCommentId = XMLRPCUtils.safeGetMapValue(commentMap, "parent", 0L)
+
+        return CommentEntity(
+                remoteCommentId = XMLRPCUtils.safeGetMapValue(commentMap, "comment_id", 0L),
+                remotePostId = XMLRPCUtils.safeGetMapValue(commentMap, "post_id", 0L),
+                remoteParentCommentId = remoteParentCommentId,
+                localSiteId = site.id,
+                remoteSiteId = site.selfHostedSiteId,
+                authorUrl = XMLRPCUtils.safeGetMapValue(commentMap, "author_url", ""),
+                authorName = StringEscapeUtils.unescapeHtml4(
+                        XMLRPCUtils.safeGetMapValue(commentMap, "author", "")
+                ),
+                authorEmail = XMLRPCUtils.safeGetMapValue(commentMap, "author_email", ""),
+                // TODO: set authorProfileImageUrl - get the hash from the email address?
+                authorProfileImageUrl = null,
+                postTitle = StringEscapeUtils.unescapeHtml4(
+                        XMLRPCUtils.safeGetMapValue(
+                                commentMap,
+                                "post_title", ""
+                        )
+                ),
+                status = getCommentStatusFromXMLRPCStatusString(
+                        XMLRPCUtils.safeGetMapValue(commentMap, "status", "approve")
+                ).toString(),
+                datePublished = datePublished,
+                publishedTimestamp = dateTimeUtilsWrapper.timestampFromIso8601(datePublished),
+                content = XMLRPCUtils.safeGetMapValue(commentMap, "content", ""),
+                url = XMLRPCUtils.safeGetMapValue(commentMap, "link", ""),
+                hasParent = remoteParentCommentId > 0,
+                parentId = if (remoteParentCommentId > 0) remoteParentCommentId else 0,
+                iLike = false
+        )
+    }
+
+    fun commentXmlRpcDTOToEntityList(response: Any?, site: SiteModel): List<CommentEntity> {
+        val comments: MutableList<CommentEntity> = ArrayList()
+        if (response !is Array<*>) {
+            return comments
+        }
+
+        response.forEach { commentObject ->
+            commentXmlRpcDTOToEntity(commentObject, site)?.let {
+                comments.add(it)
+            }
+        }
+
+        return comments
+    }
+
+    private fun getCommentStatusFromXMLRPCStatusString(stringStatus: String): CommentStatus {
+        return when (stringStatus) {
+            "approve" -> APPROVED
+            "hold" -> UNAPPROVED
+            "spam" -> SPAM
+            "trash" -> TRASH
+            else -> APPROVED
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/common/comments/CommentsApiPayload.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/common/comments/CommentsApiPayload.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.network.common.comments
+
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+
+data class CommentsApiPayload<T>(
+    val response: T? = null
+) : Payload<CommentError>() {
+    constructor(error: CommentError, response: T? = null) : this(response) {
+        this.error = error
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -1,0 +1,225 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.comment
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.common.comments.CommentsApiPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.CommentsWPComRestResponse
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class CommentsRestClient @Inject constructor(
+    appContext: Context?,
+    dispatcher: Dispatcher,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    private val commentErrorUtilsWrapper: CommentErrorUtilsWrapper,
+    private val commentsMapper: CommentsMapper
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchCommentsPage(
+        site: SiteModel,
+        number: Int,
+        offset: Int,
+        status: CommentStatus
+    ): CommentsApiPayload<CommentEntityList> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.urlV1_1
+
+        val params = mutableMapOf(
+                "status" to status.toString(),
+                "offset" to offset.toString(),
+                "number" to number.toString(),
+                "force" to "wpcom"
+        )
+
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                params,
+                CommentsWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(response.data.comments.map { commentDto ->
+                    commentsMapper.commentDtoToEntity(commentDto, site)
+                })
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+
+    suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
+
+        val request = mutableMapOf(
+                "content" to comment.content.orEmpty(),
+                "date" to comment.datePublished.orEmpty(),
+                "status" to comment.status.orEmpty()
+        )
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                request,
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun fetchComment(site: SiteModel, remoteCommentId: Long): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).urlV1_1
+
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                mapOf(),
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun deleteComment(site: SiteModel, remoteCommentId: Long): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).delete.urlV1_1
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                null,
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun createNewReply(
+        site: SiteModel,
+        remoteCommentId: Long,
+        replayContent: String?
+    ): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).replies.new_.urlV1_1
+
+        val request = mutableMapOf(
+                "content" to replayContent.orEmpty(),
+        )
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                request,
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun createNewComment(
+        site: SiteModel,
+        remotePostId: Long,
+        content: String?
+    ): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).posts.post(remotePostId).replies.new_.urlV1_1
+
+        val request = mutableMapOf(
+                "content" to content.orEmpty(),
+        )
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                request,
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun likeComment(
+        site: SiteModel,
+        remoteCommentId: Long,
+        isLike: Boolean
+    ): CommentsApiPayload<CommentLikeWPComRestResponse> {
+        val url = if (isLike) {
+            WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).likes.new_.urlV1_1
+        } else {
+            WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).likes.mine.delete.urlV1_1
+        }
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                null,
+                CommentLikeWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(response.data)
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -67,7 +67,6 @@ class CommentsRestClient @Inject constructor(
         }
     }
 
-
     suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
         val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
 
@@ -144,7 +143,7 @@ class CommentsRestClient @Inject constructor(
         val url = WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).replies.new_.urlV1_1
 
         val request = mutableMapOf(
-                "content" to replayContent.orEmpty(),
+                "content" to replayContent.orEmpty()
         )
 
         val response = wpComGsonRequestBuilder.syncPostRequest(
@@ -173,7 +172,7 @@ class CommentsRestClient @Inject constructor(
         val url = WPCOMREST.sites.site(site.siteId).posts.post(remotePostId).replies.new_.urlV1_1
 
         val request = mutableMapOf(
-                "content" to content.orEmpty(),
+                "content" to content.orEmpty()
         )
 
         val response = wpComGsonRequestBuilder.syncPostRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -1,0 +1,269 @@
+package org.wordpress.android.fluxc.network.xmlrpc.comment
+
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.XMLRPC
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.SPAM
+import org.wordpress.android.fluxc.model.CommentStatus.TRASH
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.HTTPAuthManager
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.common.comments.CommentsApiPayload
+import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequestBuilder
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
+import java.util.ArrayList
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class CommentsXMLRPCClient @Inject constructor(
+    dispatcher: Dispatcher?,
+    @Named("custom-ssl") requestQueue: RequestQueue?,
+    userAgent: UserAgent?,
+    httpAuthManager: HTTPAuthManager?,
+    private val commentErrorUtilsWrapper: CommentErrorUtilsWrapper,
+    private val xmlrpcRequestBuilder: XMLRPCRequestBuilder,
+    private val commentsMapper: CommentsMapper
+) : BaseXMLRPCClient(dispatcher, requestQueue, userAgent, httpAuthManager) {
+    suspend fun fetchCommentsPage(
+        site: SiteModel,
+        number: Int,
+        offset: Int,
+        status: CommentStatus
+    ): CommentsApiPayload<CommentEntityList> {
+        val params: MutableList<Any> = ArrayList(4)
+
+        val commentParams = mutableMapOf<String, Any>(
+                "number" to number,
+                "offset" to offset
+        )
+
+        if (status != CommentStatus.ALL) {
+            commentParams["status"] = getXMLRPCCommentStatus(status)
+        }
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(commentParams)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.GET_COMMENTS,
+                params = params,
+                clazz = Array<Any>::class.java
+        )
+
+        return when(response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentXmlRpcDTOToEntityList(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
+        val params: MutableList<Any> = ArrayList(5)
+
+        val commentParams = mutableMapOf<String, Any?>(
+                "content" to comment.content,
+                "date" to comment.datePublished,
+                "status" to getXMLRPCCommentStatus(CommentStatus.fromString(comment.status))
+        )
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(comment.remoteCommentId)
+        params.add(commentParams)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.EDIT_COMMENT,
+                params = params,
+                clazz = Any::class.java
+        )
+
+        return when(response) {
+            is Success -> {
+                CommentsApiPayload(comment)
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun fetchComment(site: SiteModel, remoteCommentId: Long): CommentsApiPayload<CommentEntity> {
+        val params: MutableList<Any> = ArrayList(4)
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(remoteCommentId)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.GET_COMMENT,
+                params = params,
+                clazz = Map::class.java
+        )
+
+        return when(response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentXmlRpcDTOToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun deleteComment(site: SiteModel, remoteCommentId: Long): CommentsApiPayload<CommentEntity?> {
+        val params: MutableList<Any> = ArrayList(4)
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(remoteCommentId)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.DELETE_COMMENT,
+                params = params,
+                clazz = Any::class.java, // TODOD: better check this!
+        )
+
+        return when(response) {
+            is Success -> {
+                // This is ugly but the XMLRPC response doesn't contain any info about the updated comment.
+                // TODOD: check in debug that response doesn't contain any info
+                CommentsApiPayload(null)
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun createNewReply(
+        site: SiteModel,
+        comment: CommentEntity,
+        reply: CommentEntity
+    ): CommentsApiPayload<CommentEntity> {
+        val commentParams = mutableMapOf<String, Any?>(
+                "content" to reply.content,
+                "comment_parent" to comment.remoteCommentId,
+        )
+
+        if (reply.authorName != null) {
+            commentParams["author"] = reply.authorName
+        }
+
+        if (reply.authorUrl != null) {
+            commentParams["author_url"] = reply.authorUrl
+        }
+
+        if (reply.authorEmail != null) {
+            commentParams["author_email"] = reply.authorEmail
+        }
+
+        return newComment(site, comment.remotePostId, reply, comment.remoteCommentId, commentParams)
+    }
+
+    suspend fun createNewComment(
+        site: SiteModel,
+        remotePostId: Long,
+        comment: CommentEntity
+    ): CommentsApiPayload<CommentEntity> {
+        val commentParams = mutableMapOf<String, Any?>(
+                "content" to comment.content,
+        )
+
+        // TODOD: check how it is possible (if it is) to create a post comment from the app for a self-hsoted!
+        if (comment.remoteParentCommentId != 0L) {
+            commentParams["comment_parent"] = comment.remoteParentCommentId
+        }
+        if (comment.authorName != null) {
+            commentParams["author"] = comment.authorName
+        }
+        if (comment.authorUrl != null) {
+            commentParams["author_url"] = comment.authorUrl
+        }
+        if (comment.authorEmail != null) {
+            commentParams["author_email"] = comment.authorEmail
+        }
+
+        return newComment(site, remotePostId, comment, comment.remoteParentCommentId, commentParams)
+    }
+
+    private suspend fun newComment(
+        site: SiteModel,
+        remotePostId: Long,
+        comment: CommentEntity,
+        parentId: Long,
+        commentParams: Map<String, Any?>
+    ): CommentsApiPayload<CommentEntity> {
+        val params: MutableList<Any> = ArrayList(5)
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(remotePostId)
+        params.add(commentParams)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.NEW_COMMENT,
+                params = params,
+                clazz = Any::class.java
+        )
+
+        return when(response) {
+            is Success -> {
+                if (response.data is Int) {
+                    val newComment = comment.copy(
+                            remoteParentCommentId = parentId,
+                            remoteCommentId = response.data.toLong()
+                    )
+                    CommentsApiPayload(newComment)
+                } else {
+                    val newComment = comment.copy(remoteParentCommentId = parentId)
+                    CommentsApiPayload(CommentError(GENERIC_ERROR, ""), newComment)
+                }
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error), comment)
+            }
+        }
+    }
+
+    private fun getXMLRPCCommentStatus(status: CommentStatus): String {
+        return when (status) {
+            APPROVED -> "approve"
+            UNAPPROVED -> "hold"
+            SPAM -> "spam"
+            TRASH -> "trash"
+            else -> "approve"
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -67,7 +67,7 @@ class CommentsXMLRPCClient @Inject constructor(
                 clazz = Array<Any>::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 CommentsApiPayload(commentsMapper.commentXmlRpcDTOToEntityList(response.data, site))
             }
@@ -100,7 +100,7 @@ class CommentsXMLRPCClient @Inject constructor(
                 clazz = Any::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 CommentsApiPayload(comment)
             }
@@ -126,7 +126,7 @@ class CommentsXMLRPCClient @Inject constructor(
                 clazz = Map::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 CommentsApiPayload(commentsMapper.commentXmlRpcDTOToEntity(response.data, site))
             }
@@ -149,10 +149,10 @@ class CommentsXMLRPCClient @Inject constructor(
                 url = site.xmlRpcUrl,
                 method = XMLRPC.DELETE_COMMENT,
                 params = params,
-                clazz = Any::class.java, // TODOD: better check this!
+                clazz = Any::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 // This is ugly but the XMLRPC response doesn't contain any info about the updated comment.
                 // TODOD: check in debug that response doesn't contain any info
@@ -171,7 +171,7 @@ class CommentsXMLRPCClient @Inject constructor(
     ): CommentsApiPayload<CommentEntity> {
         val commentParams = mutableMapOf<String, Any?>(
                 "content" to reply.content,
-                "comment_parent" to comment.remoteCommentId,
+                "comment_parent" to comment.remoteCommentId
         )
 
         if (reply.authorName != null) {
@@ -195,7 +195,7 @@ class CommentsXMLRPCClient @Inject constructor(
         comment: CommentEntity
     ): CommentsApiPayload<CommentEntity> {
         val commentParams = mutableMapOf<String, Any?>(
-                "content" to comment.content,
+                "content" to comment.content
         )
 
         // TODOD: check how it is possible (if it is) to create a post comment from the app for a self-hsoted!
@@ -238,7 +238,7 @@ class CommentsXMLRPCClient @Inject constructor(
                 clazz = Any::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 if (response.data is Int) {
                     val newComment = comment.copy(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -155,7 +155,6 @@ class CommentsXMLRPCClient @Inject constructor(
         return when (response) {
             is Success -> {
                 // This is ugly but the XMLRPC response doesn't contain any info about the updated comment.
-                // TODOD: check in debug that response doesn't contain any info
                 CommentsApiPayload(null)
             }
             is Error -> {
@@ -198,7 +197,6 @@ class CommentsXMLRPCClient @Inject constructor(
                 "content" to comment.content
         )
 
-        // TODOD: check how it is possible (if it is) to create a post comment from the app for a self-hsoted!
         if (comment.remoteParentCommentId != 0L) {
             commentParams["comment_parent"] = comment.remoteParentCommentId
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -58,6 +58,10 @@ public class CommentErrorUtils {
         return payload;
     }
 
+    public static CommentError networkToCommentError(BaseNetworkError error) {
+        return new CommentError(genericToCommentError(error), getErrorMessage(error));
+    }
+
     private static CommentErrorType genericToCommentError(BaseNetworkError error) {
         CommentErrorType errorType = CommentErrorType.GENERIC_ERROR;
         if (error.isGeneric()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtilsWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtilsWrapper.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.utils
+
+import dagger.Reusable
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import javax.inject.Inject
+
+@Reusable
+class CommentErrorUtilsWrapper @Inject constructor() {
+    fun networkToCommentError(error: BaseNetworkError): CommentError = CommentErrorUtils.networkToCommentError(error)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/DateTimeUtilsWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/DateTimeUtilsWrapper.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.utils
+
+import dagger.Reusable
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+import javax.inject.Inject
+
+@Reusable
+class DateTimeUtilsWrapper @Inject constructor() {
+    fun timestampFromIso8601(strDate: String?) = DateTimeUtils.timestampFromIso8601(strDate)
+    fun iso8601UTCFromDate(date: Date?): String? = DateTimeUtils.iso8601UTCFromDate(date)
+}


### PR DESCRIPTION
This PR is part of the unified comments project and aims to bring the rest and xmlrpc network clients to kotlin.

I tried to extract some small parts of logic from the clients (like restoring the local comment id into the network reponse or similar) and moved them to the comments store that is using the client since that seemed a better place (at least for me). The Comments Store is coming in a separated PR.

This PR is going to be merged in a feature branch and basically should be code reviewed + checking that the tests are green.