### PR TITLE
uc v1 feature branch

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -61,6 +61,11 @@ android {
             }
         }
     }
+
+    sourceSets {
+        // Adds exported schema location as test app assets.
+        getByName("androidTest").assets.srcDirs += "$projectDir/../fluxc/schemas"
+    }
 }
 
 if (["tests.properties", "tests.properties-extra"].any { file(it).exists() }) {
@@ -115,6 +120,7 @@ dependencies {
     implementation "androidx.room:room-runtime:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
     implementation "androidx.room:room-ktx:$roomVersion"
+    androidTestImplementation "androidx.room:room-testing:$roomVersion"
 
     // Dagger
     implementation "com.google.dagger:dagger:$daggerVersion"

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/CommentsDaoTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/CommentsDaoTest.kt
@@ -131,9 +131,14 @@ class CommentsDaoTest {
                     comments = commentList
             )
 
-            val result = commentsDao.getFilteredComments(commentList.first().localSiteId, listOf(APPROVED).map { it.toString() })
+            val result = commentsDao.getFilteredComments(
+                    commentList.first().localSiteId,
+                    listOf(APPROVED).map { it.toString() }
+            )
 
-            assertThat(result.sortedBy { it.remoteCommentId } ).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
+            assertThat(
+                    result.sortedBy { it.remoteCommentId }
+            ).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
         }
     }
 
@@ -198,7 +203,9 @@ class CommentsDaoTest {
                     orderAscending = false
             )
 
-            assertThat(result.sortedBy { it.remoteCommentId }).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
+            assertThat(
+                    result.sortedBy { it.remoteCommentId }
+            ).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/CommentsDaoTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/CommentsDaoTest.kt
@@ -1,0 +1,463 @@
+package org.wordpress.android.fluxc.persistence.room
+
+import androidx.room.Room
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.SPAM
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus.TRASH
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class CommentsDaoTest {
+    private lateinit var commentsDao: CommentsDao
+    private lateinit var db: WPAndroidDatabase
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        db = Room.inMemoryDatabaseBuilder(
+                context, WPAndroidDatabase::class.java).allowMainThreadQueries().build()
+        commentsDao = db.commentsDao()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun commentIsInsertedWhenNotPresent() {
+        runBlocking {
+            val comment = getDefaultComment()
+
+            val entityId = commentsDao.insertOrUpdateComment(comment)
+
+            assertThat(entityId).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun commentIsUpdatedWhenPresent() {
+        runBlocking {
+            val comment = getDefaultComment()
+
+            var entityId = commentsDao.insertOrUpdateComment(comment)
+
+            assertThat(entityId).isEqualTo(1)
+
+            val updatedComment = comment.copy(
+                    id = entityId,
+                    authorUrl = "authorUrl",
+                    iLike = true
+            )
+
+            entityId = commentsDao.insertOrUpdateComment(updatedComment)
+
+            assertThat(entityId).isEqualTo(1)
+
+            assertThat(commentsDao.getCommentById(entityId).firstOrNull()).isEqualTo(updatedComment)
+        }
+    }
+
+    @Test
+    fun commentIsUpdatedWhenMatchedByRemoteCommentId() {
+        runBlocking {
+            val comment = getDefaultComment()
+
+            var entityId = commentsDao.insertOrUpdateComment(comment)
+
+            assertThat(entityId).isEqualTo(1)
+
+            val updatedComment = comment.copy(
+                    id = 20,
+                    authorUrl = "authorUrl",
+                    iLike = true
+            )
+
+            entityId = commentsDao.insertOrUpdateComment(updatedComment)
+
+            assertThat(entityId).isEqualTo(1)
+
+            assertThat(commentsDao.getCommentById(entityId).firstOrNull()).isEqualTo(updatedComment.copy(id = entityId))
+        }
+    }
+
+    @Test
+    fun insertOrUpdateCanReturnUpdatedComment() {
+        runBlocking {
+            val comment = getDefaultComment()
+
+            val updatedComment = commentsDao.insertOrUpdateCommentForResult(comment).firstOrNull()
+
+            assertThat(updatedComment).isNotNull
+            assertThat(updatedComment?.id).isEqualTo(1)
+
+            assertThat(updatedComment).isEqualTo(comment)
+        }
+    }
+
+    @Test
+    fun getFilteredCommentsIsEmptyWhenFiltersDoNotMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(
+                    comments = commentList
+            )
+
+            val result = commentsDao.getFilteredComments(100, listOf(TRASH).map { it.toString() })
+
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun getFilteredCommentsIsNotEmptyWhenFiltersMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(
+                    comments = commentList
+            )
+
+            val result = commentsDao.getFilteredComments(commentList.first().localSiteId, listOf(APPROVED).map { it.toString() })
+
+            assertThat(result.sortedBy { it.remoteCommentId } ).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
+        }
+    }
+
+    @Test
+    fun getFilteredCommentsReturnAllCommentsWhenFiltersAreEmpty() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(
+                    comments = commentList
+            )
+
+            val result = commentsDao.getFilteredComments(commentList.first().localSiteId, listOf())
+
+            assertThat(result.sortedBy { it.remoteCommentId }).isEqualTo(commentList)
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteLimitsResults() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(),
+                    limit = commentList.size - 1,
+                    orderAscending = false
+            )
+
+            assertThat(result.size).isEqualTo(commentList.size - 1)
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteDoesNotLimitsResults() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(),
+                    limit = -1,
+                    orderAscending = false
+            )
+
+            assertThat(result.size).isEqualTo(commentList.size)
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteFilters() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(APPROVED).map { it.toString() },
+                    limit = -1,
+                    orderAscending = false
+            )
+
+            assertThat(result.sortedBy { it.remoteCommentId }).isEqualTo(commentList.filter { it.status == APPROVED.toString() })
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteOrdersAscending() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(),
+                    limit = -1,
+                    orderAscending = true
+            )
+
+            assertThat(result).isEqualTo(commentList)
+        }
+    }
+
+    @Test
+    fun getCommentsForSiteOrdersDescending() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = commentList.first().localSiteId,
+                    statuses = listOf(),
+                    limit = -1,
+                    orderAscending = false
+            )
+
+            assertThat(result).isEqualTo(commentList.reversed())
+        }
+    }
+
+    @Test
+    fun commentIsDeletedByDeleteComment() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToDelete = commentList.last()
+
+            val result = commentsDao.deleteComment(commentToDelete)
+
+            assertThat(result).isEqualTo(1)
+            val comments = commentsDao.getFilteredComments(
+                    localSiteId = commentToDelete.localSiteId,
+                    statuses = listOf()
+            )
+
+            assertThat(comments.size).isEqualTo(commentList.size - 1)
+            assertThat(comments.filter { it.remoteCommentId == commentToDelete.remoteCommentId }).isEmpty()
+        }
+    }
+
+    @Test
+    fun commentIsDeletedByRemoteCommentId() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            val notPresentId = commentList.map { it.id }.maxOrNull()!! * 10
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToDelete = commentList.last().copy(id = notPresentId)
+
+            val result = commentsDao.deleteComment(commentToDelete)
+
+            assertThat(result).isEqualTo(1)
+            val comments = commentsDao.getFilteredComments(
+                    localSiteId = commentToDelete.localSiteId,
+                    statuses = listOf()
+            )
+
+            assertThat(comments.size).isEqualTo(commentList.size - 1)
+            assertThat(comments.filter { it.remoteCommentId == commentToDelete.remoteCommentId }).isEmpty()
+        }
+    }
+
+    @Test
+    fun getCommentByIdReturnsComment() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToFind = commentList[commentList.size / 2]
+
+            val result = commentsDao.getCommentById(commentToFind.id).first()
+
+            assertThat(result).isEqualTo(commentToFind)
+        }
+    }
+
+    @Test
+    fun getCommentByIdReturnsNothingWhenNoMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            val notPresentId = commentList.map { it.id }.maxOrNull()!! * 10
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentById(notPresentId)
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun getCommentsByLocalSiteAndRemoteCommentIdReturnsComment() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToFind = commentList[commentList.size / 2]
+
+            val result = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                    commentToFind.localSiteId,
+                    commentToFind.remoteCommentId
+            ).first()
+
+            assertThat(result).isEqualTo(commentToFind)
+        }
+    }
+
+    @Test
+    fun getCommentsByLocalSiteAndRemoteCommentIdReturnsNothingWhenNoMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            val notPresentId = commentList.map { it.remoteCommentId }.maxOrNull()!! * 10
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                    commentList.first().localSiteId,
+                    notPresentId
+            )
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun getCommentsByLocalSiteIdAndRemoteCommentIdReturnsComment() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+            val commentToFind = commentList[commentList.size / 2]
+
+            val result = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                    commentToFind.localSiteId,
+                    commentToFind.remoteCommentId
+            ).first()
+
+            assertThat(result).isEqualTo(commentToFind)
+        }
+    }
+
+    @Test
+    fun getCommentsByLocalSiteIdAndRemoteCommentIdReturnsNothingWhenNoMatch() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            val notPresentId = commentList.map { it.remoteCommentId }.maxOrNull()!! * 10
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                    commentList.first().localSiteId,
+                    notPresentId
+            )
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Test
+    fun clearAllBySiteIdAndFiltersRemovesBySite() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.clearAllBySiteIdAndFilters(
+                    commentList.first().localSiteId,
+                    listOf()
+            )
+
+            assertThat(result).isEqualTo(commentList.size)
+        }
+    }
+
+    @Test
+    fun clearAllBySiteIdAndFiltersRemovesByFilters() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.clearAllBySiteIdAndFilters(
+                    commentList.first().localSiteId,
+                    listOf(SPAM.toString())
+            )
+
+            assertThat(result).isEqualTo(commentList.filter { it.status == SPAM.toString() }.size)
+        }
+    }
+
+    @Test
+    fun clearAllBySiteIdAndFiltersCanRemoveNothing() {
+        runBlocking {
+            val commentList = getDefaultCommentList()
+            commentsDao.appendOrUpdateComments(comments = commentList)
+
+            val result = commentsDao.clearAllBySiteIdAndFilters(
+                    commentList.first().localSiteId,
+                    listOf(TRASH.toString())
+            )
+
+            assertThat(result).isEqualTo(0)
+        }
+    }
+
+    private fun getDefaultComment() = CommentEntity(
+            id = 1,
+            remoteCommentId = 10,
+            remotePostId = 100,
+            remoteParentCommentId = 1_000,
+            localSiteId = 10_000,
+            remoteSiteId = 100_000,
+            authorUrl = null,
+            authorName = null,
+            authorEmail = null,
+            authorProfileImageUrl = null,
+            postTitle = null,
+            status = APPROVED.toString(),
+            datePublished = null,
+            publishedTimestamp = 1_000_000,
+            content = null,
+            url = null,
+            hasParent = false,
+            parentId = 10_000_000,
+            iLike = false
+    )
+
+    private fun getDefaultCommentList(): CommentEntityList {
+        val comment = getDefaultComment()
+        return listOf(
+                comment.copy(
+                        id = 1,
+                        remoteCommentId = 10,
+                        datePublished = "2021-07-24T00:51:43+02:00",
+                        status = APPROVED.toString()
+                ),
+                comment.copy(
+                        id = 2,
+                        remoteCommentId = 20,
+                        datePublished = "2021-07-24T00:52:43+02:00",
+                        status = UNAPPROVED.toString()
+                ),
+                comment.copy(
+                        id = 3,
+                        remoteCommentId = 30,
+                        datePublished = "2021-07-24T00:53:43+02:00",
+                        status = APPROVED.toString()
+                ),
+                comment.copy(
+                        id = 4,
+                        remoteCommentId = 40,
+                        datePublished = "2021-07-24T00:54:43+02:00",
+                        status = SPAM.toString()
+                )
+        )
+    }
+}

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/WPAndroidDatabaseMigrationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/WPAndroidDatabaseMigrationTest.kt
@@ -1,0 +1,85 @@
+package org.wordpress.android.fluxc.persistence.room
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.MIGRATION_1_2
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.MIGRATION_2_3
+import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.WP_DB_NAME
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class WPAndroidDatabaseMigrationTest {
+    @Rule
+    @JvmField
+    val helper: MigrationTestHelper = MigrationTestHelper(
+            InstrumentationRegistry.getInstrumentation(),
+            WPAndroidDatabase::class.java.canonicalName,
+            FrameworkSQLiteOpenHelperFactory()
+    )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate1To2() {
+        helper.createDatabase(WP_DB_NAME, 1).apply {
+            // populate BloggingReminders with some data
+            execSQL("""
+                INSERT INTO BloggingReminders 
+                (localSiteId, monday, tuesday, wednesday, thursday, friday, saturday, sunday) 
+                VALUES (1000,1, 1, 0, 0, 1, 0, 1) 
+                 """
+            )
+            close()
+        }
+
+        // Re-open the database with version 3 and provide migration to check against.
+        // Ask MigrationTestHelper to verify the schema changes
+        val db = helper.runMigrationsAndValidate(WP_DB_NAME, 2, true, MIGRATION_1_2)
+
+        // Validate that the data was migrated properly.
+        val cursor = db.query("SELECT * FROM BloggingReminders")
+
+        assertThat(cursor.count).isEqualTo(1)
+        cursor.moveToFirst()
+        assertThat(cursor.getInt(0)).isEqualTo(1000)
+        assertThat(cursor.getInt(2)).isEqualTo(1)
+        assertThat(cursor.getInt(4)).isEqualTo(0)
+        cursor.close()
+        db.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate2To3() {
+        helper.createDatabase(WP_DB_NAME, 2).apply {
+            // populate BloggingReminders with some data
+            execSQL(""" 
+                INSERT INTO BloggingReminders 
+                (localSiteId, monday, tuesday, wednesday, thursday, friday, saturday, sunday) 
+                VALUES (1000,1, 1, 0, 0, 1, 0, 1) 
+            """)
+            close()
+        }
+
+        // Re-open the database with version 3 and provide migration to check against.
+        // Ask MigrationTestHelper to verify the schema changes
+        val db = helper.runMigrationsAndValidate(WP_DB_NAME, 3, true, MIGRATION_2_3)
+
+        // Validate that the data was migrated properly.
+        val cursor = db.query("SELECT * FROM BloggingReminders")
+
+        assertThat(cursor.count).isEqualTo(1)
+        cursor.moveToFirst()
+        assertThat(cursor.getInt(0)).isEqualTo(1000)
+        assertThat(cursor.getInt(2)).isEqualTo(1)
+        assertThat(cursor.getInt(4)).isEqualTo(0)
+        cursor.close()
+        db.close()
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsStoreTest.kt
@@ -1,0 +1,697 @@
+package org.wordpress.android.fluxc.comments
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.DELETED
+import org.wordpress.android.fluxc.model.CommentStatus.SPAM
+import org.wordpress.android.fluxc.model.CommentStatus.TRASH
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.common.comments.CommentsApiPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentLikeWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentsRestClient
+import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentsXMLRPCClient
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.CommentsStore
+import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.CommentsActionData
+import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.CommentsActionEntityIds
+import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.PagingData
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class CommentsStoreTest {
+    @Mock lateinit var restClient: CommentsRestClient
+    @Mock lateinit var xmlRpcClient: CommentsXMLRPCClient
+    @Mock lateinit var commentsDao: CommentsDao
+    @Mock lateinit var mapper: CommentsMapper
+    @Mock lateinit var dispatcher: Dispatcher
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var appLogWrapper: AppLogWrapper
+
+    private lateinit var commentsStore: CommentsStore
+    private val commentError = CommentError(GENERIC_ERROR, "")
+
+    @Before
+    fun setUp() {
+        commentsStore = CommentsStore(
+                commentsRestClient = restClient,
+                commentsXMLRPCClient = xmlRpcClient,
+                commentsDao = commentsDao,
+                commentsMapper = mapper,
+                coroutineEngine = initCoroutineEngine(),
+                dispatcher = dispatcher,
+                appLogWrapper = appLogWrapper
+        )
+        whenever(site.id).thenReturn(SITE_LOCAL_ID)
+        whenever(site.isUsingWpComRestApi).thenReturn(true)
+
+        test {
+            whenever(commentsDao.removeGapsFromTheTop(any(), any(), any(), any())).thenReturn(0)
+            whenever(commentsDao.removeGapsFromTheBottom(any(), any(), any(), any())).thenReturn(0)
+            whenever(commentsDao.removeGapsFromTheMiddle(any(), any(), any(), any(), any())).thenReturn(0)
+        }
+    }
+
+    @Test
+    fun `getCommentsForSite returns comments from cache`() = test {
+        commentsStore.getCommentsForSite(
+                site = site,
+                orderByDateAscending = false,
+                limit = -1,
+                statuses = listOf(APPROVED).toTypedArray()
+        )
+
+        verify(commentsDao, times(1)).getCommentsByLocalSiteId(
+                site.id,
+                listOf(APPROVED.toString()),
+                -1,
+                false
+        )
+    }
+
+    @Test
+    fun `fetchComments returns fetched ids for WPCom`() = test {
+        val comments = getDefaultCommentList()
+        whenever(restClient.fetchCommentsPage(any(), any(), any(), any())).thenReturn(CommentsApiPayload(comments))
+        whenever(commentsDao.insertOrUpdateComment(any())).thenReturn(10)
+
+        val result = commentsStore.fetchComments(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                networkStatusFilter = APPROVED
+        )
+
+        verify(restClient, times(1)).fetchCommentsPage(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat((result.data as CommentsActionEntityIds).entityIds.size).isEqualTo(comments.size)
+    }
+
+    @Test
+    fun `fetchComments returns fetched ids for Self-Hosted`() = test {
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        val comments = getDefaultCommentList()
+        whenever(xmlRpcClient.fetchCommentsPage(any(), any(), any(), any())).thenReturn(CommentsApiPayload(comments))
+        whenever(commentsDao.insertOrUpdateComment(any())).thenReturn(10)
+
+        val result = commentsStore.fetchComments(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                networkStatusFilter = APPROVED
+        )
+
+        verify(xmlRpcClient, times(1)).fetchCommentsPage(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat((result.data as CommentsActionEntityIds).entityIds.size).isEqualTo(comments.size)
+    }
+
+    @Test
+    fun `fetchComments returns error on failure`() = test {
+        whenever(restClient.fetchCommentsPage(any(), any(), any(), any())).thenReturn(CommentsApiPayload(commentError))
+
+        val result = commentsStore.fetchComments(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                networkStatusFilter = APPROVED
+        )
+
+        verify(restClient, times(1)).fetchCommentsPage(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(result.isError).isTrue
+    }
+
+    @Test
+    fun `fetchComment returns fetched comment for WPCom`() = test {
+        val comment = getDefaultCommentList().first()
+        whenever(restClient.fetchComment(any(), any())).thenReturn(CommentsApiPayload(comment))
+        whenever(commentsDao.insertOrUpdateCommentForResult(any())).thenReturn(listOf(comment))
+
+        val result = commentsStore.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment = comment
+        )
+
+        verify(restClient, times(1)).fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first()).isEqualTo(comment)
+    }
+
+    @Test
+    fun `fetchComment returns fetched comment for Self-Hosted`() = test {
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        val comment = getDefaultCommentList().first()
+        whenever(xmlRpcClient.fetchComment(any(), any())).thenReturn(CommentsApiPayload(comment))
+        whenever(commentsDao.insertOrUpdateCommentForResult(any())).thenReturn(listOf(comment))
+
+        val result = commentsStore.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment = comment
+        )
+
+        verify(xmlRpcClient, times(1)).fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first()).isEqualTo(comment)
+    }
+
+    @Test
+    fun `fetchComment returns error on failure`() = test {
+        val comment = getDefaultCommentList().first()
+        whenever(restClient.fetchComment(any(), any())).thenReturn(CommentsApiPayload(commentError))
+
+        val result = commentsStore.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment = comment
+        )
+
+        verify(restClient, times(1)).fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(result.isError).isTrue
+    }
+
+    @Test
+    fun `createNewComment returns new comment for WPCom`() = test {
+        val comment = getDefaultCommentList().first()
+        whenever(restClient.createNewComment(any(), anyLong(), anyOrNull())).thenReturn(CommentsApiPayload(comment))
+        whenever(commentsDao.insertOrUpdateCommentForResult(any())).thenReturn(listOf(comment))
+
+        val result = commentsStore.createNewComment(
+                site = site,
+                comment
+        )
+
+        verify(restClient, times(1)).createNewComment(
+                site = site,
+                remotePostId = comment.remotePostId,
+                content = comment.content
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first()).isEqualTo(comment)
+    }
+
+    @Test
+    fun `createNewComment returns new comment for Self-Hosted`() = test {
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        val comment = getDefaultCommentList().first()
+        whenever(xmlRpcClient.createNewComment(any(), anyLong(), any())).thenReturn(CommentsApiPayload(comment))
+        whenever(commentsDao.insertOrUpdateCommentForResult(any())).thenReturn(listOf(comment))
+
+        val result = commentsStore.createNewComment(
+                site = site,
+                comment
+        )
+
+        verify(xmlRpcClient, times(1)).createNewComment(
+                site = site,
+                remotePostId = comment.remotePostId,
+                comment = comment
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first()).isEqualTo(comment)
+    }
+
+    @Test
+    fun `createNewComment returns error on failure`() = test {
+        val comment = getDefaultCommentList().first()
+        whenever(restClient.createNewComment(any(), anyLong(), anyOrNull()))
+                .thenReturn(CommentsApiPayload(commentError))
+
+        val result = commentsStore.createNewComment(
+                site = site,
+                comment
+        )
+
+        verify(restClient, times(1)).createNewComment(
+                site = site,
+                remotePostId = comment.remotePostId,
+                content = comment.content
+        )
+
+        assertThat(result.isError).isTrue
+    }
+
+    @Test
+    fun `createNewReply returns new reply for WPCom`() = test {
+        val comment = getDefaultCommentList().first()
+        val reply = comment.copy(id = comment.id + 1, content = "this is a reply")
+        whenever(restClient.createNewReply(any(), anyLong(), anyOrNull())).thenReturn(CommentsApiPayload(reply))
+        whenever(commentsDao.insertOrUpdateCommentForResult(any())).thenReturn(listOf(reply))
+
+        val result = commentsStore.createNewReply(
+                site = site,
+                comment,
+                reply
+        )
+
+        verify(restClient, times(1)).createNewReply(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                replayContent = reply.content
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first().content).isEqualTo(reply.content)
+    }
+
+    @Test
+    fun `createNewReply returns new reply for Self-Hosted`() = test {
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        val comment = getDefaultCommentList().first()
+        val reply = comment.copy(id = comment.id + 1, content = "this is a reply")
+        whenever(xmlRpcClient.createNewReply(any(), any(), any())).thenReturn(CommentsApiPayload(reply))
+        whenever(commentsDao.insertOrUpdateCommentForResult(any())).thenReturn(listOf(reply))
+
+        val result = commentsStore.createNewReply(
+                site = site,
+                comment,
+                reply
+        )
+
+        verify(xmlRpcClient, times(1)).createNewReply(
+                site = site,
+                comment = comment,
+                reply = reply
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first().content).isEqualTo(reply.content)
+    }
+
+    @Test
+    fun `createNewReply returns error on failure`() = test {
+        val comment = getDefaultCommentList().first()
+        val reply = comment.copy(id = comment.id + 1, content = "this is a reply")
+        whenever(restClient.createNewReply(any(), anyLong(), anyOrNull())).thenReturn(CommentsApiPayload(commentError))
+
+        val result = commentsStore.createNewReply(
+                site = site,
+                comment = comment,
+                reply = reply
+        )
+
+        verify(restClient, times(1)).createNewReply(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                replayContent = reply.content
+        )
+
+        assertThat(result.isError).isTrue
+    }
+
+    @Test
+    fun `pushComment returns updated comment for WPCom`() = test {
+        val comment = getDefaultCommentList().first().copy(id = 220)
+        val commentFromEndpoint = comment.copy(id = 0)
+        whenever(restClient.pushComment(any(), any())).thenReturn(CommentsApiPayload(commentFromEndpoint))
+        whenever(commentsDao.insertOrUpdateCommentForResult(any())).thenReturn(listOf(comment))
+
+        val result = commentsStore.pushComment(
+                site = site,
+                comment
+        )
+
+        verify(restClient, times(1)).pushComment(
+                site = site,
+                comment = comment
+        )
+        verify(commentsDao, times(1)).insertOrUpdateCommentForResult(
+                comment
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first()).isEqualTo(comment)
+    }
+
+    @Test
+    fun `pushComment returns updated comment for Self-Hosted`() = test {
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        val comment = getDefaultCommentList().first().copy(id = 220)
+        val commentFromEndpoint = comment.copy(id = 0)
+        whenever(xmlRpcClient.pushComment(any(), any())).thenReturn(CommentsApiPayload(commentFromEndpoint))
+        whenever(commentsDao.insertOrUpdateCommentForResult(any())).thenReturn(listOf(comment))
+
+        val result = commentsStore.pushComment(
+                site = site,
+                comment
+        )
+
+        verify(xmlRpcClient, times(1)).pushComment(
+                site = site,
+                comment = comment
+        )
+        verify(commentsDao, times(1)).insertOrUpdateCommentForResult(
+                comment
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first()).isEqualTo(comment)
+    }
+
+    @Test
+    fun `pushComment returns error on failure`() = test {
+        val comment = getDefaultCommentList().first()
+        whenever(restClient.pushComment(any(), any())).thenReturn(CommentsApiPayload(commentError))
+
+        val result = commentsStore.pushComment(
+                site = site,
+                comment = comment
+        )
+
+        verify(restClient, times(1)).pushComment(
+                site = site,
+                comment = comment
+        )
+
+        assertThat(result.isError).isTrue
+    }
+
+    @Test
+    fun `deleteComment returns updated comment for WPCom`() = test {
+        val comment = getDefaultCommentList().first()
+        val commentApiResponse = comment.copy(status = DELETED.toString(), id = 0)
+        whenever(restClient.deleteComment(any(), anyLong())).thenReturn(CommentsApiPayload(commentApiResponse))
+        whenever(commentsDao.deleteComment(any())).thenReturn(1)
+
+        val result = commentsStore.deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment = comment
+        )
+
+        verify(restClient, times(1)).deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        val deletedComment = commentApiResponse.copy(id = comment.id)
+
+        verify(commentsDao, times(1)).deleteComment(
+                deletedComment
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first()).isEqualTo(deletedComment)
+    }
+
+    @Test
+    fun `deleteComment returns updated comment for Self-Hosted`() = test {
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        val comment = getDefaultCommentList().first().copy(status = TRASH.toString())
+        val commentApiResponse = comment.copy(status = DELETED.toString(), id = 0)
+        whenever(xmlRpcClient.deleteComment(any(), anyLong())).thenReturn(CommentsApiPayload(commentApiResponse))
+        whenever(commentsDao.deleteComment(any())).thenReturn(1)
+
+        val result = commentsStore.deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment = comment
+        )
+
+        verify(xmlRpcClient, times(1)).deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        val deletedComment = commentApiResponse.copy(id = comment.id)
+
+        verify(commentsDao, times(1)).deleteComment(
+                deletedComment
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first()).isEqualTo(deletedComment)
+    }
+
+    @Test
+    fun `deleteComment returns error on failure`() = test {
+        val comment = getDefaultCommentList().first()
+        whenever(restClient.deleteComment(any(), anyLong())).thenReturn(CommentsApiPayload(commentError))
+
+        val result = commentsStore.deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment = comment
+        )
+
+        verify(restClient, times(1)).deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(result.isError).isTrue
+    }
+
+    @Test
+    fun `likeComment returns updated comment for WPCom`() = test {
+        val comment = getDefaultCommentList().first().copy(id = 220, iLike = false)
+        val commentApiResponse = comment.copy(iLike = true)
+        whenever(restClient.likeComment(any(), anyLong(), anyBoolean())).thenReturn(CommentsApiPayload(
+                CommentLikeWPComRestResponse().apply { i_like = true }
+        ))
+        whenever(commentsDao.insertOrUpdateCommentForResult(any())).thenReturn(listOf(commentApiResponse))
+
+        val result = commentsStore.likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment = comment,
+                isLike = commentApiResponse.iLike
+        )
+
+        verify(restClient, times(1)).likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                isLike = commentApiResponse.iLike
+
+        )
+        verify(commentsDao, times(1)).insertOrUpdateCommentForResult(
+                commentApiResponse
+        )
+
+        assertThat((result.data as CommentsActionData).comments.first()).isEqualTo(commentApiResponse)
+    }
+
+    @Test
+    fun `likeComment give error for Self-Hosted`() = test {
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        val comment = getDefaultCommentList().first().copy(id = 220, iLike = false)
+        val commentApiResponse = comment.copy(iLike = true)
+
+        val result = commentsStore.likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment = comment,
+                isLike = commentApiResponse.iLike
+        )
+
+        assertThat(result.isError).isTrue
+    }
+
+    @Test
+    fun `likeComment returns error on failure`() = test {
+        val comment = getDefaultCommentList().first().copy(id = 220, iLike = false)
+        val commentApiResponse = comment.copy(iLike = true)
+        whenever(restClient.likeComment(any(), anyLong(), anyBoolean())).thenReturn(CommentsApiPayload(commentError))
+
+        val result = commentsStore.likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment = comment,
+                isLike = commentApiResponse.iLike
+        )
+
+        verify(restClient, times(1)).likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                isLike = commentApiResponse.iLike
+        )
+
+        assertThat(result.isError).isTrue
+    }
+
+    @Test
+    fun `fetchCommentsPage returns fetched paging data for WPCom`() = test {
+        val comments = getDefaultCommentList()
+        whenever(restClient.fetchCommentsPage(any(), any(), any(), any())).thenReturn(CommentsApiPayload(comments))
+        whenever(commentsDao.appendOrUpdateComments(any())).thenReturn(comments.size)
+        whenever(commentsDao.getCommentsByLocalSiteId(anyInt(), any(), anyInt(), anyBoolean())).thenReturn(comments)
+
+        val result = commentsStore.fetchCommentsPage(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                networkStatusFilter = APPROVED,
+                cacheStatuses = listOf(APPROVED)
+        )
+
+        verify(restClient, times(1)).fetchCommentsPage(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                status = APPROVED
+        )
+
+        verify(commentsDao, times(1)).getCommentsByLocalSiteId(
+                localSiteId = site.id,
+                statuses = listOf(APPROVED.toString()),
+                limit = 0 + comments.size,
+                orderAscending = false
+        )
+
+        assertThat((result.data as PagingData).comments).isEqualTo(comments)
+    }
+
+    @Test
+    fun `fetchCommentsPage returns fetched paging data for Self-Hosted`() = test {
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        val comments = getDefaultCommentList()
+        whenever(xmlRpcClient.fetchCommentsPage(any(), any(), any(), any())).thenReturn(CommentsApiPayload(comments))
+        whenever(commentsDao.appendOrUpdateComments(any())).thenReturn(comments.size)
+        whenever(commentsDao.getCommentsByLocalSiteId(anyInt(), any(), anyInt(), anyBoolean())).thenReturn(comments)
+
+        val result = commentsStore.fetchCommentsPage(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                networkStatusFilter = APPROVED,
+                cacheStatuses = listOf(APPROVED)
+        )
+
+        verify(xmlRpcClient, times(1)).fetchCommentsPage(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                status = APPROVED
+        )
+
+        verify(commentsDao, times(1)).getCommentsByLocalSiteId(
+                localSiteId = site.id,
+                statuses = listOf(APPROVED.toString()),
+                limit = 0 + comments.size,
+                orderAscending = false
+        )
+
+        assertThat((result.data as PagingData).comments).isEqualTo(comments)
+    }
+
+    @Test
+    fun `fetchCommentsPage returns error on failure`() = test {
+        whenever(restClient.fetchCommentsPage(any(), any(), any(), any())).thenReturn(CommentsApiPayload(commentError))
+
+        val result = commentsStore.fetchCommentsPage(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                networkStatusFilter = APPROVED,
+                cacheStatuses = listOf(APPROVED)
+        )
+
+        verify(restClient, times(1)).fetchCommentsPage(
+                site = site,
+                number = NUMBER_PER_PAGE,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(result.isError).isTrue
+    }
+
+    private fun getDefaultComment() = CommentEntity(
+            id = 1,
+            remoteCommentId = 10,
+            remotePostId = 100,
+            remoteParentCommentId = 1_000,
+            localSiteId = 10_000,
+            remoteSiteId = 100_000,
+            authorUrl = null,
+            authorName = null,
+            authorEmail = null,
+            authorProfileImageUrl = null,
+            postTitle = null,
+            status = APPROVED.toString(),
+            datePublished = null,
+            publishedTimestamp = 1_000_000,
+            content = null,
+            url = null,
+            hasParent = false,
+            parentId = 10_000_000,
+            iLike = false
+    )
+
+    private fun getDefaultCommentList(): CommentEntityList {
+        val comment = getDefaultComment()
+        return listOf(
+                comment.copy(
+                        id = 1,
+                        remoteCommentId = 10,
+                        datePublished = "2021-07-24T00:51:43+02:00",
+                        status = APPROVED.toString()
+                ),
+                comment.copy(
+                        id = 2,
+                        remoteCommentId = 20,
+                        datePublished = "2021-07-24T00:52:43+02:00",
+                        status = UNAPPROVED.toString()
+                ),
+                comment.copy(
+                        id = 3,
+                        remoteCommentId = 30,
+                        datePublished = "2021-07-24T00:53:43+02:00",
+                        status = APPROVED.toString()
+                ),
+                comment.copy(
+                        id = 4,
+                        remoteCommentId = 40,
+                        datePublished = "2021-07-24T00:54:43+02:00",
+                        status = SPAM.toString()
+                )
+        )
+    }
+
+    companion object {
+        private const val SITE_LOCAL_ID = 200
+        private const val NUMBER_PER_PAGE = 30
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
@@ -1,0 +1,351 @@
+package org.wordpress.android.fluxc.comments
+
+import com.android.volley.NetworkResponse
+import com.android.volley.RequestQueue
+import com.android.volley.Response
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.HTTPAuthManager
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequestBuilder
+import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentsXMLRPCClient
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
+import org.wordpress.android.fluxc.utils.DateTimeUtilsWrapper
+import java.util.concurrent.CountDownLatch
+
+@RunWith(RobolectricTestRunner::class)
+class CommentsXMLRPCClientTest {
+    private lateinit var dispatcher: Dispatcher
+    private lateinit var requestQueue: RequestQueue
+    private lateinit var accessToken: AccessToken
+    private lateinit var userAgent: UserAgent
+    private lateinit var httpAuthManager: HTTPAuthManager
+    private lateinit var commentsMapper: CommentsMapper
+    private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    private lateinit var commentErrorUtilsWrapper: CommentErrorUtilsWrapper
+    private lateinit var site: SiteModel
+
+    private lateinit var xmlRpcClient: CommentsXMLRPCClient
+    private var mockedResponse = ""
+    private var countDownLatch: CountDownLatch? = null
+
+    @Before
+    fun setUp() {
+        dispatcher = Mockito.mock(Dispatcher::class.java)
+        requestQueue = Mockito.mock(RequestQueue::class.java)
+        userAgent = Mockito.mock(UserAgent::class.java)
+        httpAuthManager = Mockito.mock(HTTPAuthManager::class.java)
+        commentErrorUtilsWrapper = Mockito.mock(CommentErrorUtilsWrapper::class.java)
+        commentsMapper = CommentsMapper(DateTimeUtilsWrapper())
+        site = Mockito.mock(SiteModel::class.java)
+
+        doAnswer { invocation ->
+            val request = invocation.arguments[0] as XMLRPCRequest
+            try {
+                val requestClass = Class.forName(
+                        "org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest"
+                ) as Class<XMLRPCRequest>
+                // Reflection code equivalent to:
+                // Object o = request.parseNetworkResponse(data)
+                val parseNetworkResponse = requestClass.getDeclaredMethod(
+                        "parseNetworkResponse",
+                        NetworkResponse::class.java
+                )
+                parseNetworkResponse.isAccessible = true
+                val nr = NetworkResponse(mockedResponse.toByteArray())
+                val o = parseNetworkResponse.invoke(request, nr) as Response<Any>
+                // Reflection code equivalent to:
+                // request.deliverResponse(o)
+                val deliverResponse = requestClass.getDeclaredMethod("deliverResponse", Any::class.java)
+                deliverResponse.isAccessible = true
+                deliverResponse.invoke(request, o.result)
+            } catch (e: Exception) {
+                Assert.assertTrue("Unexpected exception: $e", false)
+            }
+            countDownLatch?.countDown()
+            null
+        }.whenever(requestQueue).add<Any>(any())
+
+        xmlRpcClient = CommentsXMLRPCClient(
+                dispatcher = dispatcher,
+                requestQueue = requestQueue,
+                userAgent = userAgent,
+                httpAuthManager = httpAuthManager,
+                commentErrorUtilsWrapper = commentErrorUtilsWrapper,
+                xmlrpcRequestBuilder = XMLRPCRequestBuilder(),
+                commentsMapper = commentsMapper
+        )
+
+        whenever(site.selfHostedSiteId).thenReturn(SITE_ID)
+        whenever(site.username).thenReturn("username")
+        whenever(site.password).thenReturn("password")
+        whenever(site.xmlRpcUrl).thenReturn("https://self-hosted/xmlrpc.php")
+    }
+
+    @Test
+    fun `fetchCommentsPage returns fetched page`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?><methodResponse><params><param><value><array><data>
+            <value><struct><member><name>date_created_gmt</name><value><dateTime.iso8601>20210727T23:56:21
+            </dateTime.iso8601></value></member><member><name>user_id</name><value><string>1</string>
+            </value></member><member><name>comment_id</name><value><string>44</string></value></member>
+            <member><name>parent</name><value><string>41</string></value></member><member><name>status</name>
+            <value><string>hold</string></value></member><member><name>content</name><value><string>
+            this is a content example</string></value></member><member><name>link</name><value><string>
+            http://test-debug/index.php/2021/04/01/happy-monday/#comment-44</string></value>
+            </member><member><name>post_id</name><value><string>367</string></value></member>
+            <member><name>post_title</name><value><string>happy-monday</string></value></member>
+            <member><name>author</name><value><string>authorname</string></value></member><member>
+            <name>author_url</name><value><string></string></value></member><member><name>author_email</name>
+            <value><string>authorname@mydomain.com</string></value></member><member><name>author_ip
+            </name><value><string>111.222.333.444</string></value></member><member><name>type
+            </name><value><string></string></value></member></struct></value></data>
+            </array></value></param></params></methodResponse>
+        """
+
+        val payload = xmlRpcClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isNotEmpty
+    }
+
+    @Test
+    fun `fetchCommentsPage returns error on API fail`() = test {
+        mockedResponse = """<?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse><params><param><value>
+            <string>error</string>
+            </value></param></params></methodResponse>
+        """
+
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any())).thenReturn(CommentError(GENERIC_ERROR, ""))
+
+        val payload = xmlRpcClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isTrue
+    }
+
+    @Test
+    fun `pushComment returns pushed comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <boolean>1</boolean>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.pushComment(
+                site = site,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isEqualTo(comment)
+    }
+
+    @Test
+    fun `fetchComment returns fetched comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <struct>
+              <member><name>date_created_gmt</name><value><dateTime.iso8601>20210727T20:33:41</dateTime.iso8601></value></member>
+              <member><name>user_id</name><value><string>1</string></value></member>
+              <member><name>comment_id</name><value><string>34</string></value></member>
+              <member><name>parent</name><value><string>33</string></value></member>
+              <member><name>status</name><value><string>approve</string></value></member>
+              <member><name>content</name><value><string>test1000</string></value></member>
+              <member><name>link</name><value><string>http://test-debug.org/index.php/2021/04/01/no-jp/#comment-34</string></value></member>
+              <member><name>post_id</name><value><string>367</string></value></member>
+              <member><name>post_title</name><value><string>no jp</string></value></member>
+              <member><name>author</name><value><string>authorname</string></value></member>
+              <member><name>author_url</name><value><string></string></value></member>
+              <member><name>author_email</name><value><string>authorname@mydomain.com</string></value></member>
+              <member><name>author_ip</name><value><string>111.111.111.111</string></value></member>
+              <member><name>type</name><value><string></string></value></member>
+            </struct>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isEqualTo(comment)
+    }
+
+    @Test
+    fun `fetchComment returns error on API fail`() = test {
+        mockedResponse = """<?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse><params><param><value>
+            <string>error</string>
+            </value></param></params></methodResponse>
+        """
+
+        val comment = getDefaultComment()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any())).thenReturn(CommentError(GENERIC_ERROR, ""))
+
+        val payload = xmlRpcClient.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isTrue
+    }
+
+    @Test
+    fun `deleteComment returns no comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <boolean>1</boolean>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isNull()
+    }
+
+    @Test
+    fun `createNewReply returns udpated reply`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <int>56</int>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+        val reply = comment.copy(content = "new reply content")
+
+        val payload = xmlRpcClient.createNewReply(
+                site = site,
+                comment = comment,
+                reply = reply
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response is CommentEntity).isTrue
+        assertThat((payload.response as CommentEntity).remoteCommentId).isEqualTo(56)
+    }
+
+    @Test
+    fun `createNewComment returns udpated comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <int>56</int>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.createNewComment(
+                site = site,
+                remotePostId = 100,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response is CommentEntity).isTrue
+        assertThat((payload.response as CommentEntity).remoteCommentId).isEqualTo(56)
+    }
+
+    private fun getDefaultComment() = CommentEntity(
+            id = 0,
+            remoteCommentId = 34,
+            remotePostId = 367,
+            remoteParentCommentId = 33,
+            localSiteId = 0,
+            remoteSiteId = 200,
+            authorUrl = "",
+            authorName = "authorname",
+            authorEmail = "authorname@mydomain.com",
+            authorProfileImageUrl = null,
+            postTitle = "no jp",
+            status = "approved",
+            datePublished = "2021-07-27T20:33:41+00:00",
+            publishedTimestamp = 0,
+            content = "test1000",
+            url = "http://test-debug.org/index.php/2021/04/01/no-jp/#comment-34",
+            hasParent = true,
+            parentId = 33,
+            iLike = false
+    )
+
+    companion object {
+        private const val SITE_ID = 200L
+        private const val PAGE_LEN = 30
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
@@ -1,0 +1,220 @@
+package org.wordpress.android.fluxc.common
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentParent
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.utils.DateTimeUtilsWrapper
+import java.util.Date
+
+class CommentsMapperTest {
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper = mock()
+    private val mapper = CommentsMapper(dateTimeUtilsWrapper)
+
+    @Test
+    fun `xmlrpc dto is converted to entity`() {
+        val comment = getDefaultComment(false).copy(
+                authorProfileImageUrl = null,
+                datePublished = "2021-07-29T21:29:27+00:00"
+        )
+        val site = SiteModel().apply {
+            id = comment.localSiteId
+            selfHostedSiteId = comment.remoteSiteId
+        }
+        val xmlRpcDto = comment.toXmlRpcDto()
+
+        whenever(dateTimeUtilsWrapper.timestampFromIso8601(any())).thenReturn(comment.publishedTimestamp)
+        whenever(dateTimeUtilsWrapper.iso8601UTCFromDate(any())).thenReturn(comment.datePublished)
+        val mappedEntity = mapper.commentXmlRpcDTOToEntity(xmlRpcDto, site)
+
+        assertThat(mappedEntity).isEqualTo(comment)
+    }
+
+    @Test
+    fun `xmlrpc dto list is converted to entity list`() {
+        val commentList = getDefaultCommentList(false).map { it.copy(id = 0, authorProfileImageUrl = null) }
+        val site = SiteModel().apply {
+            id = commentList.first().localSiteId
+            selfHostedSiteId = commentList.first().remoteSiteId
+        }
+        val xmlRpcDtoList = commentList.map { it.toXmlRpcDto() }
+
+        whenever(dateTimeUtilsWrapper.timestampFromIso8601(any())).thenReturn(commentList.first().publishedTimestamp)
+        whenever(dateTimeUtilsWrapper.iso8601UTCFromDate(any())).thenReturn(commentList.first().datePublished)
+
+        val mappedEntityList = mapper.commentXmlRpcDTOToEntityList(xmlRpcDtoList.toTypedArray(), site)
+
+        assertThat(mappedEntityList).isEqualTo(commentList)
+    }
+
+    @Test
+    fun `dto is converted to entity`() {
+        val comment = getDefaultComment(true).copy(datePublished = "2021-07-29T21:29:27+00:00")
+        val site = SiteModel().apply {
+            id = comment.localSiteId
+            siteId = comment.remoteSiteId
+        }
+        val commentDto = comment.toDto()
+
+        whenever(dateTimeUtilsWrapper.timestampFromIso8601(any())).thenReturn(comment.publishedTimestamp)
+        val mappedEntity = mapper.commentDtoToEntity(commentDto, site)
+
+        assertThat(mappedEntity).isEqualTo(comment)
+    }
+
+    @Test
+    fun `entity is converted to model`() {
+        val comment = getDefaultComment(true).copy(datePublished = "2021-07-29T21:29:27+00:00")
+        val commentModel = comment.toModel()
+
+        val mappedModel = mapper.commentEntityToLegacyModel(comment)
+
+        assertModelsEqual(mappedModel, commentModel)
+    }
+
+    @Test
+    fun `model is converted to entity`() {
+        val comment = getDefaultComment(true).copy(datePublished = "2021-07-29T21:29:27+00:00")
+        val commentModel = comment.toModel()
+
+        val mappedEntity = mapper.commentLegacyModelToEntity(commentModel)
+
+        assertThat(mappedEntity).isEqualTo(comment)
+    }
+
+    private fun assertModelsEqual(mappedModel: CommentModel, commentModel: CommentModel): Boolean {
+        return mappedModel.id == commentModel.id &&
+        mappedModel.remoteCommentId == commentModel.remoteCommentId &&
+        mappedModel.remotePostId == commentModel.remotePostId &&
+        mappedModel.remoteParentCommentId == commentModel.remoteParentCommentId &&
+        mappedModel.localSiteId == commentModel.localSiteId &&
+        mappedModel.remoteSiteId == commentModel.remoteSiteId &&
+        mappedModel.authorUrl == commentModel.authorUrl &&
+        mappedModel.authorName == commentModel.authorName &&
+        mappedModel.authorEmail == commentModel.authorEmail &&
+        mappedModel.authorProfileImageUrl == commentModel.authorProfileImageUrl &&
+        mappedModel.postTitle == commentModel.postTitle &&
+        mappedModel.status == commentModel.status &&
+        mappedModel.datePublished == commentModel.datePublished &&
+        mappedModel.publishedTimestamp == commentModel.publishedTimestamp &&
+        mappedModel.content == commentModel.content &&
+        mappedModel.url == commentModel.url &&
+        mappedModel.hasParent == commentModel.hasParent &&
+        mappedModel.parentId == commentModel.parentId &&
+        mappedModel.iLike == commentModel.iLike
+    }
+
+    private fun CommentEntity.toDto(): CommentWPComRestResponse {
+        val entity = this
+        return CommentWPComRestResponse().apply {
+            ID = entity.remoteCommentId //137
+            URL = entity.url
+            author = Author().apply {
+                ID = entity.remoteParentCommentId
+                URL = entity.authorUrl
+                avatar_URL = entity.authorProfileImageUrl
+                email = entity.authorEmail
+                name = entity.authorName
+            }
+            content = entity.content
+            date = entity.datePublished
+            i_like = entity.iLike
+            parent = CommentParent().apply {
+                ID = entity.parentId
+            }
+            post = Post().apply {
+                type = "post"
+                title = entity.postTitle
+                link = "https://public-api.wordpress.com/rest/v1.1/sites/185464053/posts/85"
+                ID = entity.remotePostId
+            }
+            status = entity.status
+        }
+    }
+    
+    private fun CommentEntity.toModel(): CommentModel {
+        val entity = this
+        return CommentModel().apply {
+            id = entity.id.toInt()
+            remoteCommentId = entity.remoteCommentId
+            remotePostId = entity.remotePostId
+            remoteParentCommentId = entity.remoteParentCommentId
+            localSiteId = entity.localSiteId
+            remoteSiteId = entity.remoteSiteId
+            authorUrl = entity.authorUrl
+            authorName = entity.authorName
+            authorEmail = entity.authorEmail
+            authorProfileImageUrl = entity.authorProfileImageUrl
+            postTitle = entity.postTitle
+            status = entity.status
+            datePublished = entity.datePublished
+            publishedTimestamp = entity.publishedTimestamp
+            content = entity.content
+            url = entity.authorProfileImageUrl
+            hasParent = entity.hasParent
+            parentId = entity.parentId
+            iLike = entity.iLike
+        }
+    }
+
+    private fun CommentEntity.toXmlRpcDto(): HashMap<*, *> {
+        return hashMapOf<String, Any?>(
+                "parent" to this.remoteParentCommentId.toString(),
+                "post_title" to this.postTitle,
+                "author" to this.authorName,
+                "link" to this.url,
+                "date_created_gmt" to Date(),
+                "comment_id" to this.remoteCommentId.toString(),
+                "content" to this.content,
+                "author_url" to this.authorUrl,
+                "post_id" to this.remotePostId,
+                "user_id" to "1",
+                "author_email" to this.authorEmail,
+                "status" to this.status
+        )
+    }
+
+    private fun getDefaultComment(allowNulls: Boolean): CommentEntity {
+        val remoteParentCommentId = 1_000L
+        return CommentEntity(
+                id = 0,
+                remoteCommentId = 10,
+                remotePostId = 100,
+                remoteParentCommentId = remoteParentCommentId,
+                localSiteId = 10_000,
+                remoteSiteId = 100_000,
+                authorUrl = if (allowNulls) null else "https://test-debug-site.wordpress.com",
+                authorName = if (allowNulls) null else "authorname",
+                authorEmail = if (allowNulls) null else "email@wordpress.com",
+                authorProfileImageUrl = if (allowNulls) null else "https://gravatar.com/avatar/111222333",
+                postTitle = if (allowNulls) null else "again",
+                status = APPROVED.toString(),
+                datePublished = if (allowNulls) null else "2021-05-12T15:10:40+02:00",
+                publishedTimestamp = 1_000_000,
+                content = if (allowNulls) null else "content example",
+                url = if (allowNulls) null else "https://test-debug-site.wordpress.com/2021/02/25/again/#comment-137",
+                hasParent = true,
+                parentId = remoteParentCommentId,
+                iLike = false
+        )
+    }
+
+    private fun getDefaultCommentList(allowNulls: Boolean): CommentEntityList {
+        val comment = getDefaultComment(allowNulls)
+        return listOf(
+                comment.copy(id=1, remoteCommentId = 10, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id=2, remoteCommentId = 20, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id=3, remoteCommentId = 30, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id=4, remoteCommentId = 40, datePublished = "2021-07-24T00:51:43+02:00")
+        )
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
@@ -116,7 +116,7 @@ class CommentsMapperTest {
     private fun CommentEntity.toDto(): CommentWPComRestResponse {
         val entity = this
         return CommentWPComRestResponse().apply {
-            ID = entity.remoteCommentId //137
+            ID = entity.remoteCommentId
             URL = entity.url
             author = Author().apply {
                 ID = entity.remoteParentCommentId
@@ -140,7 +140,7 @@ class CommentsMapperTest {
             status = entity.status
         }
     }
-    
+
     private fun CommentEntity.toModel(): CommentModel {
         val entity = this
         return CommentModel().apply {
@@ -211,10 +211,10 @@ class CommentsMapperTest {
     private fun getDefaultCommentList(allowNulls: Boolean): CommentEntityList {
         val comment = getDefaultComment(allowNulls)
         return listOf(
-                comment.copy(id=1, remoteCommentId = 10, datePublished = "2021-07-24T00:51:43+02:00"),
-                comment.copy(id=2, remoteCommentId = 20, datePublished = "2021-07-24T00:51:43+02:00"),
-                comment.copy(id=3, remoteCommentId = 30, datePublished = "2021-07-24T00:51:43+02:00"),
-                comment.copy(id=4, remoteCommentId = 40, datePublished = "2021-07-24T00:51:43+02:00")
+                comment.copy(id = 1, remoteCommentId = 10, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id = 2, remoteCommentId = 20, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id = 3, remoteCommentId = 30, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id = 4, remoteCommentId = 40, datePublished = "2021-07-24T00:51:43+02:00")
         )
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
@@ -1,0 +1,607 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.comments
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentLikeWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentParent
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.CommentsWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentsRestClient
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class CommentsRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var commentErrorUtilsWrapper: CommentErrorUtilsWrapper
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var commentsMapper: CommentsMapper
+
+    private lateinit var restClient: CommentsRestClient
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var bodyCaptor: KArgumentCaptor<Map<String, Any>>
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        bodyCaptor = argumentCaptor()
+
+        restClient = CommentsRestClient(
+                appContext = null,
+                dispatcher = dispatcher,
+                requestQueue = requestQueue,
+                accessToken = accessToken,
+                userAgent = userAgent,
+                wpComGsonRequestBuilder = wpComGsonRequestBuilder,
+                commentErrorUtilsWrapper = commentErrorUtilsWrapper,
+                commentsMapper = commentsMapper
+        )
+        whenever(site.siteId).thenReturn(SITE_ID)
+    }
+
+    @Test
+    fun `fetchCommentsPage returns fetched page`() = test {
+        val response = getDefaultDto()
+
+        val commentsReponse = response.CommentsWPComRestResponse()
+        commentsReponse.comments = listOf(response, response, response)
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(response.toEntity())
+
+        initFetchPageResponse(commentsReponse)
+
+        val payload = restClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isFalse
+
+        val comments = payload.response!!
+        assertThat(comments.size).isEqualTo(commentsReponse.comments.size)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/"
+        )
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+                mutableMapOf(
+                        "status" to APPROVED.toString(),
+                        "offset" to 0.toString(),
+                        "number" to PAGE_LEN.toString(),
+                        "force" to "wpcom"
+                )
+        )
+    }
+
+    @Test
+    fun `fetchCommentsPage returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initFetchPageResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `pushComment returns updated comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+        initPushResponse(response)
+
+        val payload = restClient.pushComment(
+                site = site,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/${comment.remoteCommentId}/"
+        )
+        assertThat(bodyCaptor.lastValue).isEqualTo(
+                mutableMapOf(
+                        "content" to comment.content.orEmpty(),
+                        "date" to comment.datePublished.orEmpty(),
+                        "status" to comment.status.orEmpty()
+                )
+        )
+    }
+
+    @Test
+    fun `pushComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initPushResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.pushComment(
+                site = site,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `fetchComment returns comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+
+        initFetchResponse(response)
+
+        val payload = restClient.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isFalse
+
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/${comment.remoteCommentId}/"
+        )
+        assertThat(paramsCaptor.lastValue).isEqualTo(
+                mapOf<String, String>()
+        )
+    }
+
+    @Test
+    fun `fetchComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initFetchResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.fetchComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `deleteComment returns deleted comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+        initDeleteResponse(response)
+
+        val payload = restClient.deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/" +
+                        "${comment.remoteCommentId}/delete/"
+        )
+        assertThat(bodyCaptor.lastValue).isNull()
+    }
+
+    @Test
+    fun `deleteComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initDeleteResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.deleteComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `createNewReply returns reply comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+        initReplyCreateResponse(response)
+
+        val payload = restClient.createNewReply(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.content
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/" +
+                        "${site.siteId}/comments/${comment.remoteCommentId}/replies/new/"
+        )
+        assertThat(bodyCaptor.lastValue).isEqualTo(
+                mutableMapOf("content" to comment.content.orEmpty())
+        )
+    }
+
+    @Test
+    fun `createNewReply returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initReplyCreateResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.createNewReply(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.content
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `createNewComment returns new comment`() = test {
+        val response = getDefaultDto()
+        val comment = response.toEntity()
+
+        whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(comment)
+        initReplyCreateResponse(response)
+
+        val payload = restClient.createNewComment(
+                site = site,
+                remotePostId = comment.remotePostId,
+                comment.content
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(commentResponse).isEqualTo(comment)
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/" +
+                        "${site.siteId}/posts/${comment.remotePostId}/replies/new/"
+        )
+        assertThat(bodyCaptor.lastValue).isEqualTo(
+                mutableMapOf("content" to comment.content.orEmpty())
+        )
+    }
+
+    @Test
+    fun `createNewComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initReplyCreateResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.createNewComment(
+                site = site,
+                remotePostId = comment.remotePostId,
+                comment.content
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `likeComment returns new liked comment`() = test {
+        val comment = getDefaultDto().toEntity()
+        val response = getDefaultLikeResponse(comment.iLike)
+
+        initLikeResponse(response)
+
+        val payload = restClient.likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.iLike
+        )
+
+        assertThat(payload.isError).isFalse
+        val commentResponse = payload.response!!
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/" +
+                        "${site.siteId}/comments/${comment.remoteCommentId}/likes/new/"
+        )
+        assertThat(bodyCaptor.lastValue).isNull()
+    }
+
+    @Test
+    fun `likeComment returns new unliked comment`() = test {
+        val comment = getDefaultDto().toEntity().copy(iLike = false)
+        val response = getDefaultLikeResponse(comment.iLike)
+
+        initLikeResponse(response)
+
+        val payload = restClient.likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.iLike
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(urlCaptor.lastValue).isEqualTo(
+                "https://public-api.wordpress.com/rest/v1.1/sites/" +
+                        "${site.siteId}/comments/${comment.remoteCommentId}/likes/mine/delete/"
+        )
+        assertThat(bodyCaptor.lastValue).isNull()
+    }
+
+    @Test
+    fun `likeComment returns an error on API fail`() = test {
+        val errorMessage = "this is an error"
+        val comment = getDefaultDto().toEntity()
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any()))
+                .thenReturn(CommentError(INVALID_RESPONSE, errorMessage))
+
+        initLikeResponse(error = WPComGsonNetworkError(
+                BaseNetworkError(
+                        NETWORK_ERROR,
+                        errorMessage,
+                        VolleyError(errorMessage)
+                )
+        ))
+
+        val payload = restClient.likeComment(
+                site = site,
+                remoteCommentId = comment.remoteCommentId,
+                comment.iLike
+        )
+
+        assertThat(payload.isError).isTrue
+        assertThat(payload.error.type).isEqualTo(INVALID_RESPONSE)
+        assertThat(payload.error.message).isEqualTo(errorMessage)
+    }
+
+    private suspend fun initFetchPageResponse(
+        data: CommentsWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentsWPComRestResponse> {
+        return initGetResponse(CommentsWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initPushResponse(
+        data: CommentWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentWPComRestResponse> {
+        return initPostResponse(CommentWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initFetchResponse(
+        data: CommentWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentWPComRestResponse> {
+        return initGetResponse(CommentWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initDeleteResponse(
+        data: CommentWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentWPComRestResponse> {
+        return initPostResponse(CommentWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initReplyCreateResponse(
+        data: CommentWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentWPComRestResponse> {
+        return initPostResponse(CommentWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun initLikeResponse(
+        data: CommentLikeWPComRestResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<CommentLikeWPComRestResponse> {
+        return initPostResponse(CommentLikeWPComRestResponse::class.java, data ?: mock(), error)
+    }
+
+    private suspend fun <T> initGetResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null
+    ): Response<T> {
+        val response = if (error != null) Response.Error(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncGetRequest(
+                        eq(restClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        eq(kclass),
+                        any(),
+                        any(),
+                        any()
+
+                )
+        ).thenReturn(response)
+        return response
+    }
+
+    private suspend fun <T> initPostResponse(
+        kclass: Class<T>,
+        data: T,
+        error: WPComGsonNetworkError? = null
+    ): Response<T> {
+        val response = if (error != null) Response.Error(error) else Success(data)
+        whenever(
+                wpComGsonRequestBuilder.syncPostRequest(
+                        eq(restClient),
+                        urlCaptor.capture(),
+                        paramsCaptor.capture(),
+                        bodyCaptor.capture(),
+                        eq(kclass),
+                        anyOrNull()
+                )
+        ).thenReturn(response)
+        return response
+    }
+
+    private fun getDefaultDto(): CommentWPComRestResponse {
+        return CommentWPComRestResponse().apply {
+            ID = 137
+            URL = "https://test-site.wordpress.com/2021/02/25/again/#comment-137"
+            author = Author().apply {
+                ID = 0
+                URL = "https://debugging-test.wordpress.com"
+                avatar_URL = "https://gravatar.com/avatar/avatarurl"
+                email = "email@mydomain.com"
+                name = "This is my name"
+            }
+            content = "example content"
+            date = "2021-05-12T15:10:40+02:00"
+            i_like = true
+            parent = CommentParent().apply { ID = 41 }
+            post = Post().apply {
+                ID = 85
+                link = "https://public-api.wordpress.com/rest/v1.1/sites/11111111/posts/85"
+                title = "again"
+                type = "post"
+            }
+            status = "approved"
+        }
+    }
+
+    private fun getDefaultLikeResponse(iLike: Boolean): CommentLikeWPComRestResponse {
+        return CommentLikeWPComRestResponse().apply {
+            success = true
+            i_like = iLike
+            like_count = 100
+        }
+    }
+
+    private fun CommentWPComRestResponse.toEntity(): CommentEntity {
+        val dto = this
+        return CommentEntity(
+                id = 0,
+                remoteCommentId = dto.ID,
+                remotePostId = dto.post.ID,
+                remoteParentCommentId = dto.author.ID,
+                localSiteId = 10,
+                remoteSiteId = 200,
+                authorUrl = dto.author.URL,
+                authorName = dto.author.name,
+                authorEmail = dto.author.email,
+                authorProfileImageUrl = dto.author.avatar_URL,
+                postTitle = dto.post.title,
+                status = dto.status,
+                datePublished = dto.date,
+                publishedTimestamp = 132456,
+                content = dto.content,
+                url = dto.URL,
+                hasParent = dto.parent != null,
+                parentId = dto.parent.ID,
+                iLike = dto.i_like
+        )
+    }
+
+    companion object {
+        private const val SITE_ID = 200L
+        private const val PAGE_LEN = 30
+    }
+}

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/3.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/3.json
@@ -1,0 +1,369 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "264f8aa9a1fcd9a55dee7fb6aae8ef94",
+    "entities": [
+      {
+        "tableName": "BloggingReminders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `monday` INTEGER NOT NULL, `tuesday` INTEGER NOT NULL, `wednesday` INTEGER NOT NULL, `thursday` INTEGER NOT NULL, `friday` INTEGER NOT NULL, `saturday` INTEGER NOT NULL, `sunday` INTEGER NOT NULL, PRIMARY KEY(`localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monday",
+            "columnName": "monday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tuesday",
+            "columnName": "tuesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wednesday",
+            "columnName": "wednesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thursday",
+            "columnName": "thursday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friday",
+            "columnName": "friday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saturday",
+            "columnName": "saturday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sunday",
+            "columnName": "sunday",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOffers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `name` TEXT, `shortName` TEXT, `tagline` TEXT, `description` TEXT, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "shortName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_PlanOffers_internalPlanId",
+            "unique": true,
+            "columnNames": [
+              "internalPlanId"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_PlanOffers_internalPlanId` ON `${TABLE_NAME}` (`internalPlanId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOfferIds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `productId` INTEGER NOT NULL, `internalPlanId` INTEGER NOT NULL, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PlanOfferFeatures",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `stringId` TEXT, `name` TEXT, `description` TEXT, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringId",
+            "columnName": "stringId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Comments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remoteCommentId` INTEGER NOT NULL, `remotePostId` INTEGER NOT NULL, `remoteParentCommentId` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `remoteSiteId` INTEGER NOT NULL, `authorUrl` TEXT, `authorName` TEXT, `authorEmail` TEXT, `authorProfileImageUrl` TEXT, `postTitle` TEXT, `status` TEXT, `datePublished` TEXT, `publishedTimestamp` INTEGER NOT NULL, `content` TEXT, `url` TEXT, `hasParent` INTEGER NOT NULL, `parentId` INTEGER NOT NULL, `iLike` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteCommentId",
+            "columnName": "remoteCommentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePostId",
+            "columnName": "remotePostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteParentCommentId",
+            "columnName": "remoteParentCommentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteSiteId",
+            "columnName": "remoteSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorUrl",
+            "columnName": "authorUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorEmail",
+            "columnName": "authorEmail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorProfileImageUrl",
+            "columnName": "authorProfileImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "postTitle",
+            "columnName": "postTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "datePublished",
+            "columnName": "datePublished",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publishedTimestamp",
+            "columnName": "publishedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasParent",
+            "columnName": "hasParent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iLike",
+            "columnName": "iLike",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '264f8aa9a1fcd9a55dee7fb6aae8ef94')"
+    ]
+  }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/CommentsAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/CommentsAction.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.fluxc.action
+
+import org.wordpress.android.fluxc.annotations.Action
+import org.wordpress.android.fluxc.annotations.ActionEnum
+import org.wordpress.android.fluxc.annotations.action.IAction
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsPayload
+import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsResponsePayload
+import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentPayload
+import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentResponsePayload
+import org.wordpress.android.fluxc.store.CommentStore.RemoteCreateCommentPayload
+
+@Deprecated(
+        "This is a temporary code for backward compatibility and will be replaced with " +
+                "Comments Unification project."
+)
+@ActionEnum
+enum class CommentsAction : IAction {
+    // Remote actions
+    @Action(payloadType = FetchCommentsPayload::class)
+    FETCH_COMMENTS,
+
+    @Action(payloadType = RemoteCommentPayload::class)
+    FETCH_COMMENT,
+
+    @Action(payloadType = RemoteCreateCommentPayload::class)
+    CREATE_NEW_COMMENT,
+
+    @Action(payloadType = RemoteCommentPayload::class)
+    PUSH_COMMENT,
+
+    @Action(payloadType = RemoteCommentPayload::class)
+    DELETE_COMMENT,
+
+    @Action(payloadType = RemoteCommentPayload::class)
+    LIKE_COMMENT,
+
+    // Remote responses
+    @Action(payloadType = FetchCommentsResponsePayload::class)
+    FETCHED_COMMENTS,
+
+    @Action(payloadType = RemoteCommentResponsePayload::class)
+    FETCHED_COMMENT,
+
+    @Action(payloadType = RemoteCommentResponsePayload::class)
+    CREATED_NEW_COMMENT,
+
+    @Action(payloadType = RemoteCommentResponsePayload::class)
+    PUSHED_COMMENT,
+
+    @Action(payloadType = RemoteCommentResponsePayload::class)
+    DELETED_COMMENT,
+
+    @Action(payloadType = RemoteCommentResponsePayload::class)
+    LIKED_COMMENT,
+
+    // Local actions
+    @Action(payloadType = CommentModel::class)
+    UPDATE_COMMENT
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
@@ -110,7 +110,7 @@ class CommentsMapper @Inject constructor(
         val datePublished = dateTimeUtilsWrapper.iso8601UTCFromDate(
                 XMLRPCUtils.safeGetMapValue(commentMap, "date_created_gmt", Date())
         )
-        // TODOD: use a wrapper for XMLRPCUtils?
+
         val remoteParentCommentId = XMLRPCUtils.safeGetMapValue(commentMap, "parent", 0L)
 
         return CommentEntity(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
@@ -1,0 +1,172 @@
+package org.wordpress.android.fluxc.model.comments
+
+import dagger.Reusable
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.SPAM
+import org.wordpress.android.fluxc.model.CommentStatus.TRASH
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCUtils
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.utils.DateTimeUtilsWrapper
+import java.util.ArrayList
+import java.util.Date
+import java.util.HashMap
+import javax.inject.Inject
+
+@Reusable
+class CommentsMapper @Inject constructor(
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
+) {
+    fun commentDtoToEntity(commentDto: CommentWPComRestResponse, site: SiteModel): CommentEntity {
+        return CommentEntity(
+            remoteCommentId = commentDto.ID,
+            localSiteId = site.id,
+            remoteSiteId = site.siteId,
+            authorUrl = commentDto.author?.URL,
+            authorName = commentDto.author?.name?.let {
+                StringEscapeUtils.unescapeHtml4(it)
+            },
+            authorEmail = commentDto.author?.email?.let {
+                if ("false".equals(it)) {
+                    ""
+                } else {
+                    it
+                }
+            },
+            authorProfileImageUrl = commentDto.author?.avatar_URL,
+            remotePostId = commentDto.post?.ID ?: 0,
+            postTitle = StringEscapeUtils.unescapeHtml4(commentDto.post?.title),
+            status = commentDto.status,
+            datePublished = commentDto.date,
+            publishedTimestamp = dateTimeUtilsWrapper.timestampFromIso8601(commentDto.date),
+            content = commentDto.content,
+            url = commentDto.URL,
+            remoteParentCommentId = commentDto.author?.ID ?: 0L,
+            hasParent = commentDto.parent != null,
+            parentId = commentDto.parent?.ID ?: 0,
+            iLike = commentDto.i_like
+        )
+    }
+
+    fun commentEntityToLegacyModel(entity: CommentEntity): CommentModel {
+        return CommentModel().apply {
+            this.id = entity.id.toInt()
+            this.remoteCommentId = entity.remoteCommentId
+            this.remotePostId = entity.remotePostId
+            this.remoteParentCommentId = entity.remoteParentCommentId
+            this.localSiteId = entity.localSiteId
+            this.remoteSiteId = entity.remoteSiteId
+            this.authorUrl = entity.authorUrl
+            this.authorName = entity.authorName
+            this.authorEmail = entity.authorEmail
+            this.authorProfileImageUrl = entity.authorProfileImageUrl
+            this.postTitle = entity.postTitle
+            this.status = entity.status
+            this.datePublished = entity.datePublished
+            this.publishedTimestamp = entity.publishedTimestamp
+            this.content = entity.content
+            this.url = entity.url
+            this.hasParent = entity.hasParent
+            this.parentId = entity.parentId
+            this.iLike = entity.iLike
+        }
+    }
+
+    fun commentLegacyModelToEntity(commentModel: CommentModel): CommentEntity {
+        return CommentEntity(
+                id = commentModel.id.toLong(),
+                remoteCommentId = commentModel.remoteCommentId,
+                remotePostId = commentModel.remotePostId,
+                remoteParentCommentId = commentModel.remoteParentCommentId,
+                localSiteId = commentModel.localSiteId,
+                remoteSiteId = commentModel.remoteSiteId,
+                authorUrl = commentModel.authorUrl,
+                authorName = commentModel.authorName,
+                authorEmail = commentModel.authorEmail,
+                authorProfileImageUrl = commentModel.authorProfileImageUrl,
+                postTitle = commentModel.postTitle,
+                status = commentModel.status,
+                datePublished = commentModel.datePublished,
+                publishedTimestamp = commentModel.publishedTimestamp,
+                content = commentModel.content,
+                url = commentModel.url,
+                hasParent = commentModel.hasParent,
+                parentId = commentModel.parentId,
+                iLike = commentModel.iLike
+        )
+    }
+
+    fun commentXmlRpcDTOToEntity(commentObject: Any?, site: SiteModel): CommentEntity? {
+        if (commentObject !is HashMap<*, *>) {
+            return null
+        }
+        val commentMap: HashMap<*, *> = commentObject
+
+        val datePublished = dateTimeUtilsWrapper.iso8601UTCFromDate(
+                XMLRPCUtils.safeGetMapValue(commentMap, "date_created_gmt", Date())
+        )
+        // TODOD: use a wrapper for XMLRPCUtils?
+        val remoteParentCommentId = XMLRPCUtils.safeGetMapValue(commentMap, "parent", 0L)
+
+        return CommentEntity(
+                remoteCommentId = XMLRPCUtils.safeGetMapValue(commentMap, "comment_id", 0L),
+                remotePostId = XMLRPCUtils.safeGetMapValue(commentMap, "post_id", 0L),
+                remoteParentCommentId = remoteParentCommentId,
+                localSiteId = site.id,
+                remoteSiteId = site.selfHostedSiteId,
+                authorUrl = XMLRPCUtils.safeGetMapValue(commentMap, "author_url", ""),
+                authorName = StringEscapeUtils.unescapeHtml4(
+                        XMLRPCUtils.safeGetMapValue(commentMap, "author", "")
+                ),
+                authorEmail = XMLRPCUtils.safeGetMapValue(commentMap, "author_email", ""),
+                // TODO: set authorProfileImageUrl - get the hash from the email address?
+                authorProfileImageUrl = null,
+                postTitle = StringEscapeUtils.unescapeHtml4(
+                        XMLRPCUtils.safeGetMapValue(
+                                commentMap,
+                                "post_title", ""
+                        )
+                ),
+                status = getCommentStatusFromXMLRPCStatusString(
+                        XMLRPCUtils.safeGetMapValue(commentMap, "status", "approve")
+                ).toString(),
+                datePublished = datePublished,
+                publishedTimestamp = dateTimeUtilsWrapper.timestampFromIso8601(datePublished),
+                content = XMLRPCUtils.safeGetMapValue(commentMap, "content", ""),
+                url = XMLRPCUtils.safeGetMapValue(commentMap, "link", ""),
+                hasParent = remoteParentCommentId > 0,
+                parentId = if (remoteParentCommentId > 0) remoteParentCommentId else 0,
+                iLike = false
+        )
+    }
+
+    fun commentXmlRpcDTOToEntityList(response: Any?, site: SiteModel): List<CommentEntity> {
+        val comments: MutableList<CommentEntity> = ArrayList()
+        if (response !is Array<*>) {
+            return comments
+        }
+
+        response.forEach { commentObject ->
+            commentXmlRpcDTOToEntity(commentObject, site)?.let {
+                comments.add(it)
+            }
+        }
+
+        return comments
+    }
+
+    private fun getCommentStatusFromXMLRPCStatusString(stringStatus: String): CommentStatus {
+        return when (stringStatus) {
+            "approve" -> APPROVED
+            "hold" -> UNAPPROVED
+            "spam" -> SPAM
+            "trash" -> TRASH
+            else -> APPROVED
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.persistence.BloggingRemindersDao
 import org.wordpress.android.fluxc.persistence.PlanOffersDao
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.buildDb
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao
 import javax.inject.Singleton
 
 @Module
@@ -21,5 +22,9 @@ class DatabaseModule {
 
     @Singleton @Provides fun providePlanOffersDao(wpAndroidDatabase: WPAndroidDatabase): PlanOffersDao {
         return wpAndroidDatabase.planOffersDao()
+    }
+
+    @Singleton @Provides fun provideCommentsDao(wpAndroidDatabase: WPAndroidDatabase): CommentsDao {
+        return wpAndroidDatabase.commentsDao()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/common/comments/CommentsApiPayload.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/common/comments/CommentsApiPayload.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.network.common.comments
+
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+
+data class CommentsApiPayload<T>(
+    val response: T? = null
+) : Payload<CommentError>() {
+    constructor(error: CommentError, response: T? = null) : this(response) {
+        this.error = error
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -1,0 +1,225 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.comment
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.common.comments.CommentsApiPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.CommentsWPComRestResponse
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class CommentsRestClient @Inject constructor(
+    appContext: Context?,
+    dispatcher: Dispatcher,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    private val commentErrorUtilsWrapper: CommentErrorUtilsWrapper,
+    private val commentsMapper: CommentsMapper
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchCommentsPage(
+        site: SiteModel,
+        number: Int,
+        offset: Int,
+        status: CommentStatus
+    ): CommentsApiPayload<CommentEntityList> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.urlV1_1
+
+        val params = mutableMapOf(
+                "status" to status.toString(),
+                "offset" to offset.toString(),
+                "number" to number.toString(),
+                "force" to "wpcom"
+        )
+
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                params,
+                CommentsWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(response.data.comments.map { commentDto ->
+                    commentsMapper.commentDtoToEntity(commentDto, site)
+                })
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+
+    suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
+
+        val request = mutableMapOf(
+                "content" to comment.content.orEmpty(),
+                "date" to comment.datePublished.orEmpty(),
+                "status" to comment.status.orEmpty()
+        )
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                request,
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun fetchComment(site: SiteModel, remoteCommentId: Long): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).urlV1_1
+
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+                this,
+                url,
+                mapOf(),
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun deleteComment(site: SiteModel, remoteCommentId: Long): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).delete.urlV1_1
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                null,
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun createNewReply(
+        site: SiteModel,
+        remoteCommentId: Long,
+        replayContent: String?
+    ): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).replies.new_.urlV1_1
+
+        val request = mutableMapOf(
+                "content" to replayContent.orEmpty(),
+        )
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                request,
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun createNewComment(
+        site: SiteModel,
+        remotePostId: Long,
+        content: String?
+    ): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).posts.post(remotePostId).replies.new_.urlV1_1
+
+        val request = mutableMapOf(
+                "content" to content.orEmpty(),
+        )
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                request,
+                CommentWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentDtoToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun likeComment(
+        site: SiteModel,
+        remoteCommentId: Long,
+        isLike: Boolean
+    ): CommentsApiPayload<CommentLikeWPComRestResponse> {
+        val url = if (isLike) {
+            WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).likes.new_.urlV1_1
+        } else {
+            WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).likes.mine.delete.urlV1_1
+        }
+
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                null,
+                null,
+                CommentLikeWPComRestResponse::class.java
+        )
+
+        return when (response) {
+            is Success -> {
+                CommentsApiPayload(response.data)
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -57,9 +57,9 @@ class CommentsRestClient @Inject constructor(
 
         return when (response) {
             is Success -> {
-                CommentsApiPayload(response.data.comments.map { commentDto ->
+                CommentsApiPayload(response.data.comments?.map { commentDto ->
                     commentsMapper.commentDtoToEntity(commentDto, site)
-                })
+                } ?: listOf())
             }
             is Error -> {
                 CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -67,7 +67,6 @@ class CommentsRestClient @Inject constructor(
         }
     }
 
-
     suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
         val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
 
@@ -144,7 +143,7 @@ class CommentsRestClient @Inject constructor(
         val url = WPCOMREST.sites.site(site.siteId).comments.comment(remoteCommentId).replies.new_.urlV1_1
 
         val request = mutableMapOf(
-                "content" to replayContent.orEmpty(),
+                "content" to replayContent.orEmpty()
         )
 
         val response = wpComGsonRequestBuilder.syncPostRequest(
@@ -173,7 +172,7 @@ class CommentsRestClient @Inject constructor(
         val url = WPCOMREST.sites.site(site.siteId).posts.post(remotePostId).replies.new_.urlV1_1
 
         val request = mutableMapOf(
-                "content" to content.orEmpty(),
+                "content" to content.orEmpty()
         )
 
         val response = wpComGsonRequestBuilder.syncPostRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -1,0 +1,269 @@
+package org.wordpress.android.fluxc.network.xmlrpc.comment
+
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.XMLRPC
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.SPAM
+import org.wordpress.android.fluxc.model.CommentStatus.TRASH
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.HTTPAuthManager
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.common.comments.CommentsApiPayload
+import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequestBuilder
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.utils.CommentErrorUtilsWrapper
+import java.util.ArrayList
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class CommentsXMLRPCClient @Inject constructor(
+    dispatcher: Dispatcher?,
+    @Named("custom-ssl") requestQueue: RequestQueue?,
+    userAgent: UserAgent?,
+    httpAuthManager: HTTPAuthManager?,
+    private val commentErrorUtilsWrapper: CommentErrorUtilsWrapper,
+    private val xmlrpcRequestBuilder: XMLRPCRequestBuilder,
+    private val commentsMapper: CommentsMapper
+) : BaseXMLRPCClient(dispatcher, requestQueue, userAgent, httpAuthManager) {
+    suspend fun fetchCommentsPage(
+        site: SiteModel,
+        number: Int,
+        offset: Int,
+        status: CommentStatus
+    ): CommentsApiPayload<CommentEntityList> {
+        val params: MutableList<Any> = ArrayList(4)
+
+        val commentParams = mutableMapOf<String, Any>(
+                "number" to number,
+                "offset" to offset
+        )
+
+        if (status != CommentStatus.ALL) {
+            commentParams["status"] = getXMLRPCCommentStatus(status)
+        }
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(commentParams)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.GET_COMMENTS,
+                params = params,
+                clazz = Array<Any>::class.java
+        )
+
+        return when(response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentXmlRpcDTOToEntityList(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
+        val params: MutableList<Any> = ArrayList(5)
+
+        val commentParams = mutableMapOf<String, Any?>(
+                "content" to comment.content,
+                "date" to comment.datePublished,
+                "status" to getXMLRPCCommentStatus(CommentStatus.fromString(comment.status))
+        )
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(comment.remoteCommentId)
+        params.add(commentParams)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.EDIT_COMMENT,
+                params = params,
+                clazz = Any::class.java
+        )
+
+        return when(response) {
+            is Success -> {
+                CommentsApiPayload(comment)
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun fetchComment(site: SiteModel, remoteCommentId: Long): CommentsApiPayload<CommentEntity> {
+        val params: MutableList<Any> = ArrayList(4)
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(remoteCommentId)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.GET_COMMENT,
+                params = params,
+                clazz = Map::class.java
+        )
+
+        return when(response) {
+            is Success -> {
+                CommentsApiPayload(commentsMapper.commentXmlRpcDTOToEntity(response.data, site))
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun deleteComment(site: SiteModel, remoteCommentId: Long): CommentsApiPayload<CommentEntity?> {
+        val params: MutableList<Any> = ArrayList(4)
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(remoteCommentId)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.DELETE_COMMENT,
+                params = params,
+                clazz = Any::class.java, // TODOD: better check this!
+        )
+
+        return when(response) {
+            is Success -> {
+                // This is ugly but the XMLRPC response doesn't contain any info about the updated comment.
+                // TODOD: check in debug that response doesn't contain any info
+                CommentsApiPayload(null)
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error))
+            }
+        }
+    }
+
+    suspend fun createNewReply(
+        site: SiteModel,
+        comment: CommentEntity,
+        reply: CommentEntity
+    ): CommentsApiPayload<CommentEntity> {
+        val commentParams = mutableMapOf<String, Any?>(
+                "content" to reply.content,
+                "comment_parent" to comment.remoteCommentId,
+        )
+
+        if (reply.authorName != null) {
+            commentParams["author"] = reply.authorName
+        }
+
+        if (reply.authorUrl != null) {
+            commentParams["author_url"] = reply.authorUrl
+        }
+
+        if (reply.authorEmail != null) {
+            commentParams["author_email"] = reply.authorEmail
+        }
+
+        return newComment(site, comment.remotePostId, reply, comment.remoteCommentId, commentParams)
+    }
+
+    suspend fun createNewComment(
+        site: SiteModel,
+        remotePostId: Long,
+        comment: CommentEntity
+    ): CommentsApiPayload<CommentEntity> {
+        val commentParams = mutableMapOf<String, Any?>(
+                "content" to comment.content,
+        )
+
+        // TODOD: check how it is possible (if it is) to create a post comment from the app for a self-hsoted!
+        if (comment.remoteParentCommentId != 0L) {
+            commentParams["comment_parent"] = comment.remoteParentCommentId
+        }
+        if (comment.authorName != null) {
+            commentParams["author"] = comment.authorName
+        }
+        if (comment.authorUrl != null) {
+            commentParams["author_url"] = comment.authorUrl
+        }
+        if (comment.authorEmail != null) {
+            commentParams["author_email"] = comment.authorEmail
+        }
+
+        return newComment(site, remotePostId, comment, comment.remoteParentCommentId, commentParams)
+    }
+
+    private suspend fun newComment(
+        site: SiteModel,
+        remotePostId: Long,
+        comment: CommentEntity,
+        parentId: Long,
+        commentParams: Map<String, Any?>
+    ): CommentsApiPayload<CommentEntity> {
+        val params: MutableList<Any> = ArrayList(5)
+
+        params.add(site.selfHostedSiteId)
+        params.add(site.username)
+        params.add(site.password)
+        params.add(remotePostId)
+        params.add(commentParams)
+
+        val response = xmlrpcRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = site.xmlRpcUrl,
+                method = XMLRPC.NEW_COMMENT,
+                params = params,
+                clazz = Any::class.java
+        )
+
+        return when(response) {
+            is Success -> {
+                if (response.data is Int) {
+                    val newComment = comment.copy(
+                            remoteParentCommentId = parentId,
+                            remoteCommentId = response.data.toLong()
+                    )
+                    CommentsApiPayload(newComment)
+                } else {
+                    val newComment = comment.copy(remoteParentCommentId = parentId)
+                    CommentsApiPayload(CommentError(GENERIC_ERROR, ""), newComment)
+                }
+            }
+            is Error -> {
+                CommentsApiPayload(commentErrorUtilsWrapper.networkToCommentError(response.error), comment)
+            }
+        }
+    }
+
+    private fun getXMLRPCCommentStatus(status: CommentStatus): String {
+        return when (status) {
+            APPROVED -> "approve"
+            UNAPPROVED -> "hold"
+            SPAM -> "spam"
+            TRASH -> "trash"
+            else -> "approve"
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -67,7 +67,7 @@ class CommentsXMLRPCClient @Inject constructor(
                 clazz = Array<Any>::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 CommentsApiPayload(commentsMapper.commentXmlRpcDTOToEntityList(response.data, site))
             }
@@ -100,7 +100,7 @@ class CommentsXMLRPCClient @Inject constructor(
                 clazz = Any::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 CommentsApiPayload(comment)
             }
@@ -126,7 +126,7 @@ class CommentsXMLRPCClient @Inject constructor(
                 clazz = Map::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 CommentsApiPayload(commentsMapper.commentXmlRpcDTOToEntity(response.data, site))
             }
@@ -149,10 +149,10 @@ class CommentsXMLRPCClient @Inject constructor(
                 url = site.xmlRpcUrl,
                 method = XMLRPC.DELETE_COMMENT,
                 params = params,
-                clazz = Any::class.java, // TODOD: better check this!
+                clazz = Any::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 // This is ugly but the XMLRPC response doesn't contain any info about the updated comment.
                 // TODOD: check in debug that response doesn't contain any info
@@ -171,7 +171,7 @@ class CommentsXMLRPCClient @Inject constructor(
     ): CommentsApiPayload<CommentEntity> {
         val commentParams = mutableMapOf<String, Any?>(
                 "content" to reply.content,
-                "comment_parent" to comment.remoteCommentId,
+                "comment_parent" to comment.remoteCommentId
         )
 
         if (reply.authorName != null) {
@@ -195,7 +195,7 @@ class CommentsXMLRPCClient @Inject constructor(
         comment: CommentEntity
     ): CommentsApiPayload<CommentEntity> {
         val commentParams = mutableMapOf<String, Any?>(
-                "content" to comment.content,
+                "content" to comment.content
         )
 
         // TODOD: check how it is possible (if it is) to create a post comment from the app for a self-hsoted!
@@ -238,7 +238,7 @@ class CommentsXMLRPCClient @Inject constructor(
                 clazz = Any::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is Success -> {
                 if (response.data is Int) {
                     val newComment = comment.copy(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -155,7 +155,6 @@ class CommentsXMLRPCClient @Inject constructor(
         return when (response) {
             is Success -> {
                 // This is ugly but the XMLRPC response doesn't contain any info about the updated comment.
-                // TODOD: check in debug that response doesn't contain any info
                 CommentsApiPayload(null)
             }
             is Error -> {
@@ -198,7 +197,6 @@ class CommentsXMLRPCClient @Inject constructor(
                 "content" to comment.content
         )
 
-        // TODOD: check how it is possible (if it is) to create a post comment from the app for a self-hsoted!
         if (comment.remoteParentCommentId != 0L) {
             commentParams["comment_parent"] = comment.remoteParentCommentId
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/comments/CommentsDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/comments/CommentsDao.kt
@@ -112,7 +112,6 @@ abstract class CommentsDao {
         )
     }
 
-
     @Query("SELECT * FROM Comments WHERE id = :localId LIMIT 1")
     abstract suspend fun getCommentById(localId: Long): CommentEntityList
 
@@ -184,7 +183,6 @@ abstract class CommentsDao {
         statuses: List<String>
     ): Int
 
-
     @Query("""
         DELETE FROM Comments 
         WHERE localSiteId = :localSiteId 
@@ -216,7 +214,6 @@ abstract class CommentsDao {
         remoteIds: List<Long>,
         endOfRange: Long
     ): Int
-
 
     @Query("""
         DELETE FROM Comments 
@@ -294,7 +291,7 @@ abstract class CommentsDao {
         val hasParent: Boolean,
         val parentId: Long,
         val iLike: Boolean
-    ){
+    ) {
         @Ignore
         var level: Int = 0
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/comments/CommentsDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/comments/CommentsDao.kt
@@ -1,0 +1,305 @@
+package org.wordpress.android.fluxc.persistence.comments
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Ignore
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+
+typealias CommentEntityList = List<CommentEntity>
+
+@Dao
+abstract class CommentsDao {
+    // Public methods
+    @Transaction
+    open suspend fun insertOrUpdateComment(comment: CommentEntity): Long {
+        return insertOrUpdateCommentInternal(comment)
+    }
+
+    @Transaction
+    open suspend fun insertOrUpdateCommentForResult(comment: CommentEntity): CommentEntityList {
+        val entityId = insertOrUpdateCommentInternal(comment)
+        return getCommentById(entityId)
+    }
+
+    @Transaction
+    open suspend fun getFilteredComments(localSiteId: Int, statuses: List<String>): CommentEntityList {
+        return getFilteredCommentsInternal(localSiteId, statuses, statuses.isNotEmpty())
+    }
+
+    @Transaction
+    open suspend fun getCommentsByLocalSiteId(
+        localSiteId: Int,
+        statuses: List<String>,
+        limit: Int,
+        orderAscending: Boolean
+    ): CommentEntityList {
+        return getCommentsByLocalSiteIdInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses,
+                limit = limit,
+                orderAscending = orderAscending
+        )
+    }
+
+    @Transaction
+    open suspend fun deleteComment(comment: CommentEntity): Int {
+        val result = deleteById(comment.id)
+
+        return if (result > 0) {
+            result
+        } else {
+            deleteByLocalSiteAndRemoteIds(comment.localSiteId, comment.remoteCommentId)
+        }
+    }
+
+    @Transaction
+    open suspend fun removeGapsFromTheTop(
+        localSiteId: Int,
+        statuses: List<String>,
+        remoteIds: List<Long>,
+        startOfRange: Long
+    ): Int {
+        return removeGapsFromTheTopInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses,
+                filterByIds = remoteIds.isNotEmpty(),
+                remoteIds = remoteIds,
+                startOfRange = startOfRange
+        )
+    }
+
+    @Transaction
+    open suspend fun removeGapsFromTheBottom(
+        localSiteId: Int,
+        statuses: List<String>,
+        remoteIds: List<Long>,
+        endOfRange: Long
+    ): Int {
+        return removeGapsFromTheBottomInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses,
+                filterByIds = remoteIds.isNotEmpty(),
+                remoteIds = remoteIds,
+                endOfRange = endOfRange
+        )
+    }
+
+    @Transaction
+    open suspend fun removeGapsFromTheMiddle(
+        localSiteId: Int,
+        statuses: List<String>,
+        remoteIds: List<Long>,
+        startOfRange: Long,
+        endOfRange: Long
+    ): Int {
+        return removeGapsFromTheMiddleInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses,
+                filterByIds = remoteIds.isNotEmpty(),
+                remoteIds = remoteIds,
+                startOfRange = startOfRange,
+                endOfRange = endOfRange
+        )
+    }
+
+
+    @Query("SELECT * FROM Comments WHERE id = :localId LIMIT 1")
+    abstract suspend fun getCommentById(localId: Long): CommentEntityList
+
+    @Query("SELECT * FROM Comments WHERE localSiteId = :localSiteId AND remoteCommentId = :remoteCommentId")
+    abstract suspend fun getCommentsByLocalSiteAndRemoteCommentId(
+        localSiteId: Int,
+        remoteCommentId: Long
+    ): CommentEntityList
+
+    @Transaction
+    open suspend fun appendOrUpdateComments(comments: CommentEntityList): Int {
+        val affectedIdList = insertOrUpdateCommentsInternal(comments)
+        return affectedIdList.size
+    }
+
+    @Transaction
+    open suspend fun clearAllBySiteIdAndFilters(localSiteId: Int, statuses: List<String>): Int {
+        return clearAllBySiteIdAndFiltersInternal(
+                localSiteId = localSiteId,
+                filterByStatuses = statuses.isNotEmpty(),
+                statuses = statuses
+        )
+    }
+
+    // Protected methods
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    protected abstract fun insert(comment: CommentEntity): Long
+
+    @Update
+    protected abstract fun update(comment: CommentEntity): Int
+
+    @Query("""
+        SELECT * FROM Comments WHERE localSiteId = :localSiteId 
+        AND CASE WHEN :filterByStatuses = 1 THEN status IN (:statuses) ELSE 1 END 
+        ORDER BY datePublished DESC
+    """)
+    protected abstract fun getFilteredCommentsInternal(
+        localSiteId: Int,
+        statuses: List<String>,
+        filterByStatuses: Boolean
+    ): CommentEntityList
+
+    @Query("""
+        SELECT * FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+        ORDER BY 
+        CASE WHEN :orderAscending = 1 THEN datePublished END ASC,
+        CASE WHEN :orderAscending = 0 THEN datePublished END DESC
+        LIMIT CASE WHEN :limit > 0 THEN :limit ELSE -1 END
+    """)
+    protected abstract fun getCommentsByLocalSiteIdInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>,
+        limit: Int,
+        orderAscending: Boolean
+    ): CommentEntityList
+
+    @Query("""
+        DELETE FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+    """)
+    protected abstract fun clearAllBySiteIdAndFiltersInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>
+    ): Int
+
+
+    @Query("""
+        DELETE FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+        AND CASE WHEN (:filterByIds = 1) THEN (remoteCommentId NOT IN (:remoteIds)) ELSE 1 END
+        AND publishedTimestamp >= :startOfRange
+    """)
+    protected abstract fun removeGapsFromTheTopInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>,
+        filterByIds: Boolean,
+        remoteIds: List<Long>,
+        startOfRange: Long
+    ): Int
+
+    @Query("""
+        DELETE FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+        AND CASE WHEN (:filterByIds = 1) THEN (remoteCommentId NOT IN (:remoteIds)) ELSE 1 END
+        AND publishedTimestamp <= :endOfRange
+    """)
+    protected abstract fun removeGapsFromTheBottomInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>,
+        filterByIds: Boolean,
+        remoteIds: List<Long>,
+        endOfRange: Long
+    ): Int
+
+
+    @Query("""
+        DELETE FROM Comments 
+        WHERE localSiteId = :localSiteId 
+        AND CASE WHEN (:filterByStatuses = 1) THEN (status IN (:statuses)) ELSE 1 END
+        AND CASE WHEN (:filterByIds = 1) THEN (remoteCommentId NOT IN (:remoteIds)) ELSE 1 END
+        AND publishedTimestamp <= :startOfRange
+        AND publishedTimestamp >= :endOfRange
+    """)
+    protected abstract fun removeGapsFromTheMiddleInternal(
+        localSiteId: Int,
+        filterByStatuses: Boolean,
+        statuses: List<String>,
+        filterByIds: Boolean,
+        remoteIds: List<Long>,
+        startOfRange: Long,
+        endOfRange: Long
+    ): Int
+
+    @Query("DELETE FROM Comments WHERE id = :commentId")
+    protected abstract fun deleteById(commentId: Long): Int
+
+    @Query("DELETE FROM Comments WHERE localSiteId = :localSiteId AND remoteCommentId = :remoteCommentId")
+    protected abstract fun deleteByLocalSiteAndRemoteIds(localSiteId: Int, remoteCommentId: Long): Int
+
+    // Private methods
+    private suspend fun insertOrUpdateCommentsInternal(comments: CommentEntityList): List<Long> {
+        return comments.map { comment ->
+            insertOrUpdateCommentInternal(comment)
+        }
+    }
+
+    private suspend fun insertOrUpdateCommentInternal(comment: CommentEntity): Long {
+        val commentByLocalId = getCommentById(comment.id)
+
+        val matchingComments = if (commentByLocalId.isEmpty()) {
+            getCommentsByLocalSiteAndRemoteCommentId(comment.localSiteId, comment.remoteCommentId)
+        } else {
+            commentByLocalId
+        }
+
+        return if (matchingComments.isEmpty()) {
+            insert(comment)
+        } else {
+            // We are forcing the id of the matching comment so the update can
+            // act on the expected entity
+            val matchingComment = matchingComments.first()
+
+            update(comment.copy(id = matchingComment.id))
+            matchingComment.id
+        }
+    }
+
+    @Entity(
+            tableName = "Comments"
+    )
+    data class CommentEntity(
+        @PrimaryKey(autoGenerate = true)
+        val id: Long = 0,
+        val remoteCommentId: Long,
+        val remotePostId: Long,
+        val remoteParentCommentId: Long,
+        val localSiteId: Int,
+        val remoteSiteId: Long,
+        val authorUrl: String?,
+        val authorName: String?,
+        val authorEmail: String?,
+        val authorProfileImageUrl: String?,
+        val postTitle: String?,
+        val status: String?,
+        val datePublished: String?,
+        val publishedTimestamp: Long,
+        val content: String?,
+        val url: String?,
+        val hasParent: Boolean,
+        val parentId: Long,
+        val iLike: Boolean
+    ){
+        @Ignore
+        var level: Int = 0
+    }
+
+    companion object {
+        const val EMPTY_ID = -1L
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
@@ -1,0 +1,830 @@
+package org.wordpress.android.fluxc.store
+
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.action.CommentAction
+import org.wordpress.android.fluxc.action.CommentsAction
+import org.wordpress.android.fluxc.action.CommentsAction.CREATED_NEW_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.CREATE_NEW_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.DELETED_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.DELETE_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.FETCHED_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.FETCHED_COMMENTS
+import org.wordpress.android.fluxc.action.CommentsAction.FETCH_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.FETCH_COMMENTS
+import org.wordpress.android.fluxc.action.CommentsAction.LIKED_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.LIKE_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.PUSHED_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.PUSH_COMMENT
+import org.wordpress.android.fluxc.action.CommentsAction.UPDATE_COMMENT
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.CommentStatus.ALL
+import org.wordpress.android.fluxc.model.CommentStatus.APPROVED
+import org.wordpress.android.fluxc.model.CommentStatus.DELETED
+import org.wordpress.android.fluxc.model.CommentStatus.TRASH
+import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentsRestClient
+import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentsXMLRPCClient
+import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.INVALID_INPUT
+import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.store.CommentStore.FetchCommentsPayload
+import org.wordpress.android.fluxc.store.CommentStore.OnCommentChanged
+import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentPayload
+import org.wordpress.android.fluxc.store.CommentStore.RemoteCreateCommentPayload
+import org.wordpress.android.fluxc.store.CommentStore.RemoteLikeCommentPayload
+import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.CommentsActionData
+import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.CommentsActionEntityIds
+import org.wordpress.android.fluxc.store.CommentsStore.CommentsData.PagingData
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.API
+import org.wordpress.android.util.AppLog.T.COMMENTS
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CommentsStore
+@Inject constructor(
+    private val commentsRestClient: CommentsRestClient,
+    private val commentsXMLRPCClient: CommentsXMLRPCClient,
+    private val commentsDao: CommentsDao,
+    private val commentsMapper: CommentsMapper,
+    private val coroutineEngine: CoroutineEngine,
+    private val appLogWrapper: AppLogWrapper,
+    dispatcher: Dispatcher
+) : Store(dispatcher) {
+    data class CommentsActionPayload<T>(
+        val data: T? = null
+    ) : Payload<CommentError>() {
+        constructor(error: CommentError) : this() {
+            this.error = error
+        }
+
+        constructor(error: CommentError, data: T?) : this(data) {
+            this.error = error
+        }
+    }
+
+    sealed class CommentsData {
+        data class PagingData(val comments: CommentEntityList, val hasMore: Boolean) : CommentsData() {
+            companion object {
+                fun empty() = PagingData(comments = listOf(), hasMore = false)
+            }
+        }
+        data class CommentsActionData(val comments: CommentEntityList, val rowsAffected: Int) : CommentsData()
+        data class CommentsActionEntityIds(val entityIds: List<Long>, val rowsAffected: Int) : CommentsData()
+        object DoNotCare : CommentsData()
+    }
+
+    suspend fun getCommentsForSite(
+        site: SiteModel?,
+        orderByDateAscending: Boolean,
+        limit: Int,
+        vararg statuses: CommentStatus
+    ): CommentEntityList {
+        if (site == null) return listOf()
+
+        return commentsDao.getCommentsByLocalSiteId(
+                localSiteId = site.id,
+                statuses = if (statuses.asList().contains(ALL)) listOf() else statuses.map { it.toString() },
+                limit = limit,
+                orderAscending = orderByDateAscending
+        )
+    }
+
+    suspend fun fetchComments(
+        site: SiteModel,
+        number: Int,
+        offset: Int,
+        networkStatusFilter: CommentStatus
+    ): CommentsActionPayload<CommentsActionEntityIds> {
+        val payload = if (site.isUsingWpComRestApi) {
+            commentsRestClient.fetchCommentsPage(
+                    site = site,
+                    number = number,
+                    offset = offset,
+                    status = networkStatusFilter
+            )
+        } else {
+            commentsXMLRPCClient.fetchCommentsPage(
+                    site = site,
+                    number = number,
+                    offset = offset,
+                    status = networkStatusFilter
+            )
+        }
+
+        return if (payload.isError) {
+            CommentsActionPayload(payload.error)
+        } else {
+            payload.response?.let { comments ->
+                removeCommentGaps(site, comments, number, offset, networkStatusFilter)
+
+                val entityIds = comments.map { comment ->
+                    commentsDao.insertOrUpdateComment(comment)
+                }
+                CommentsActionPayload(CommentsActionEntityIds(entityIds, entityIds.size))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+        }
+    }
+
+    suspend fun fetchComment(
+        site: SiteModel,
+        remoteCommentId: Long,
+        comment: CommentEntity?
+    ): CommentsActionPayload<CommentsActionData> {
+        val remoteCommentIdToFetch = comment?.remoteCommentId ?: remoteCommentId
+
+        val payload = if (site.isUsingWpComRestApi) {
+            commentsRestClient.fetchComment(site, remoteCommentIdToFetch)
+        } else {
+            commentsXMLRPCClient.fetchComment(site, remoteCommentIdToFetch)
+        }
+
+        return if (payload.isError) {
+            CommentsActionPayload(payload.error, CommentsActionData(comment.toListOrEmpty(), 0))
+        } else {
+            payload.response?.let {
+                val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(it)
+                CommentsActionPayload(CommentsActionData(cachedCommentAsList, cachedCommentAsList.size))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+        }
+    }
+
+    suspend fun createNewComment(site: SiteModel, comment: CommentEntity): CommentsActionPayload<CommentsActionData> {
+        val payload = if (site.isUsingWpComRestApi) {
+            commentsRestClient.createNewComment(site, comment.remotePostId, comment.content)
+        } else {
+            commentsXMLRPCClient.createNewComment(site, comment.remotePostId, comment)
+        }
+
+        return if (payload.isError) {
+            CommentsActionPayload(payload.error, CommentsActionData(comment.toListOrEmpty(), 0))
+        } else {
+            payload.response?.let {
+                val commentUpdated = it.copy(id = comment.id)
+                val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(commentUpdated)
+                CommentsActionPayload(CommentsActionData(cachedCommentAsList, cachedCommentAsList.size))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+        }
+    }
+
+    suspend fun createNewReply(
+        site: SiteModel,
+        comment: CommentEntity,
+        reply: CommentEntity
+    ): CommentsActionPayload<CommentsActionData> {
+        val payload = if (site.isUsingWpComRestApi) {
+            commentsRestClient.createNewReply(site, comment.remoteCommentId, reply.content)
+        } else {
+            commentsXMLRPCClient.createNewReply(site, comment, reply)
+        }
+
+        return if (payload.isError) {
+            CommentsActionPayload(payload.error, CommentsActionData(reply.toListOrEmpty(), 0))
+        } else {
+            payload.response?.let {
+                val commentUpdated = it.copy(id = reply.id)
+                val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(commentUpdated)
+                CommentsActionPayload(CommentsActionData(cachedCommentAsList, cachedCommentAsList.size))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+        }
+    }
+
+    suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsActionPayload<CommentsActionData> {
+        val payload = if (site.isUsingWpComRestApi) {
+            commentsRestClient.pushComment(site, comment)
+        } else {
+            commentsXMLRPCClient.pushComment(site, comment)
+        }
+
+        return if (payload.isError) {
+            CommentsActionPayload(payload.error, CommentsActionData(comment.toListOrEmpty(), 0))
+        } else {
+            payload.response?.let {
+                val commentUpdated = it.copy(id = comment.id)
+                val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(commentUpdated)
+                CommentsActionPayload(CommentsActionData(cachedCommentAsList, cachedCommentAsList.size))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+        }
+    }
+
+    suspend fun deleteComment(
+        site: SiteModel,
+        remoteCommentId: Long,
+        comment: CommentEntity?
+    ): CommentsActionPayload<CommentsActionData> {
+        // If the comment is stored locally, we want to update it locally (needed because in some
+        // cases we use this to update comments by remote id).
+        val commentToDelete = comment ?: commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                site.id,
+                remoteCommentId
+        ).firstOrNull()
+
+        val remoteCommentIdToDelete = commentToDelete?.remoteCommentId ?: remoteCommentId
+
+        val payload = if (site.isUsingWpComRestApi) {
+            commentsRestClient.deleteComment(site, remoteCommentIdToDelete)
+        } else {
+            commentsXMLRPCClient.deleteComment(site, remoteCommentIdToDelete)
+        }
+
+        if (payload.isError) {
+            return CommentsActionPayload(payload.error, CommentsActionData(commentToDelete.toListOrEmpty(), 0))
+        } else {
+            val targetComment = when {
+                site.isUsingWpComRestApi && payload.response == null -> {
+                    return CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+                }
+                site.isUsingWpComRestApi && payload.response != null -> {
+                    val commentFromEndpoint: CommentEntity = payload.response
+                    commentToDelete?.let { entity ->
+                        commentFromEndpoint.copy(id = entity.id)
+                    } ?: commentFromEndpoint
+                }
+                else -> { // this means !site.isUsingWpComRestApi is true
+                    // This is ugly but the XMLRPC response doesn't contain any info about the update comment.
+                    // So we're copying the logic here: if the comment status was "trash" before and the delete
+                    // call is successful, then we want to delete this comment. Setting the "deleted" status
+                    // will ensure the comment is deleted in the rest of the logic.
+                    commentToDelete?.let {
+                        it.copy(
+                                status = if (DELETED.toString() == it.status || TRASH.toString() == it.status) {
+                                    DELETED.toString()
+                                } else {
+                                    TRASH.toString()
+                                }
+                        )
+                    }
+                }
+            }
+
+            return targetComment?.let {
+                // Delete once means "send to trash", so we don't want to remove it from the DB, just update it's
+                // status. Delete twice means "farewell comment, we won't see you ever again". Only delete from the
+                // DB if the status is "deleted".
+                val deletedCommentAsList = if (it.status?.equals(DELETED.toString()) == true) {
+                    commentsDao.deleteComment(it)
+                    it.toListOrEmpty()
+                } else {
+                    // Update the local copy, only the status should have changed ("trash")
+                    commentsDao.insertOrUpdateCommentForResult(it)
+                }
+
+                CommentsActionPayload(CommentsActionData(deletedCommentAsList, deletedCommentAsList.size))
+            } ?: CommentsActionPayload(CommentsActionData(listOf(), 0))
+        }
+    }
+
+    suspend fun likeComment(
+        site: SiteModel,
+        remoteCommentId: Long,
+        comment: CommentEntity?,
+        isLike: Boolean
+    ): CommentsActionPayload<CommentsActionData> {
+        // If the comment is stored locally, we want to update it locally (needed because in some
+        // cases we use this to update comments by remote id).
+        val commentToLike = comment ?: commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                site.id,
+                remoteCommentId
+        ).firstOrNull()
+        val remoteCommentIdToLike = commentToLike?.remoteCommentId ?: remoteCommentId
+
+        val payload = if (site.isUsingWpComRestApi) {
+            commentsRestClient.likeComment(site, remoteCommentIdToLike, isLike)
+        } else {
+            return CommentsActionPayload(
+                    CommentError(
+                            INVALID_INPUT,
+                            "Can't like a comment on XMLRPC API"
+                    ),
+                    CommentsActionData(
+                            commentToLike.toListOrEmpty(),
+                            0
+                    )
+            )
+        }
+
+        return if (payload.isError) {
+            CommentsActionPayload(payload.error, CommentsActionData(commentToLike.toListOrEmpty(), 0))
+        } else {
+            payload.response?.let { endpointResponse ->
+                val updatedComment = commentToLike?.copy(iLike = endpointResponse.i_like)
+
+                val (rowsAffected, likedCommentAsList) = updatedComment?.let {
+                    Pair(1, commentsDao.insertOrUpdateCommentForResult(it))
+                } ?: Pair(0, updatedComment.toListOrEmpty())
+
+                CommentsActionPayload(CommentsActionData(likedCommentAsList, rowsAffected))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+        }
+    }
+
+    suspend fun updateComment(
+        isError: Boolean,
+        commentId: Long,
+        comment: CommentEntity
+    ): CommentsActionPayload<CommentsActionEntityIds> {
+        val (entityId, rowsAffected) = if (isError) {
+            Pair(commentId, 0)
+        } else {
+            Pair(commentsDao.insertOrUpdateComment(comment), 1)
+        }
+
+        return CommentsActionPayload(CommentsActionEntityIds(listOf(entityId), rowsAffected))
+    }
+
+    suspend fun fetchCommentsPage(
+        site: SiteModel,
+        number: Int,
+        offset: Int,
+        networkStatusFilter: CommentStatus,
+        cacheStatuses: List<CommentStatus>
+    ): CommentsActionPayload<PagingData> {
+        val payload = if (site.isUsingWpComRestApi) {
+            commentsRestClient.fetchCommentsPage(
+                    site = site,
+                    number = number,
+                    offset = offset,
+                    status = networkStatusFilter
+            )
+        } else {
+            commentsXMLRPCClient.fetchCommentsPage(
+                    site = site,
+                    number = number,
+                    offset = offset,
+                    status = networkStatusFilter
+            )
+        }
+
+        return if (payload.isError) {
+            val cachedComments = if (offset > 0) {
+                commentsDao.getCommentsByLocalSiteId(
+                        localSiteId = site.id,
+                        statuses = cacheStatuses.map { it.toString() },
+                        limit = offset,
+                        orderAscending = false
+                )
+            } else {
+                listOf()
+            }
+            CommentsActionPayload(payload.error, PagingData(
+                    comments = cachedComments,
+                    hasMore = cachedComments.isNotEmpty()
+            ))
+        } else {
+            val comments = payload.response?.map { it } ?: listOf()
+
+            removeCommentGaps(site, comments, number, offset, networkStatusFilter)
+
+            commentsDao.appendOrUpdateComments(comments = comments)
+
+            val cachedComments = commentsDao.getCommentsByLocalSiteId(
+                    localSiteId = site.id,
+                    statuses = cacheStatuses.map { it.toString() },
+                    limit = offset + comments.size,
+                    orderAscending = false
+            )
+
+            CommentsActionPayload(PagingData(comments = cachedComments, hasMore = comments.size == number))
+        }
+    }
+
+    suspend fun moderateCommentLocally(
+        site: SiteModel,
+        remoteCommentId: Long,
+        newStatus: CommentStatus
+    ): CommentsActionPayload<CommentsActionData> {
+        // TODOD: add message to all CommentError to be used in logs (since not localized) in the WPAndroid
+        val comment = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                site.id,
+                remoteCommentId
+        ).firstOrNull() ?: return CommentsActionPayload(CommentError(INVALID_INPUT, ""))
+
+        val commentToModerate = comment.copy(status = newStatus.toString())
+        val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(commentToModerate)
+
+        return CommentsActionPayload(CommentsActionData(
+                comments = cachedCommentAsList,
+                rowsAffected = cachedCommentAsList.size
+        ))
+    }
+
+    suspend fun getCommentByLocalId(localId: Long) = commentsDao.getCommentById(localId)
+
+    suspend fun getCommentByLocalSiteAndRemoteId(localSiteId: Int, remoteCommentId: Long) =
+            commentsDao.getCommentsByLocalSiteAndRemoteCommentId(localSiteId, remoteCommentId)
+
+    suspend fun pushLocalCommentByRemoteId(
+        site: SiteModel,
+        remoteCommentId: Long
+    ): CommentsActionPayload<CommentsActionData> {
+        val comment = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
+                site.id,
+                remoteCommentId
+        ).firstOrNull() ?: return CommentsActionPayload(CommentError(INVALID_INPUT, ""))
+
+        return pushComment(site, comment)
+    }
+
+    suspend fun getCachedComments(
+        site: SiteModel,
+        cacheStatuses: List<CommentStatus>,
+        imposeHasMore: Boolean
+    ): CommentsActionPayload<PagingData> {
+        val cachedComments = commentsDao.getFilteredComments(
+                localSiteId = site.id,
+                statuses = cacheStatuses.map { it.toString() }
+        )
+
+        return CommentsActionPayload(PagingData(comments = cachedComments, imposeHasMore))
+    }
+
+    @Deprecated(
+            "Action and event bus support should be gradually replaced while the Comments Unification project proceeds"
+    )
+    override fun onRegister() {
+        // We cannot use the AppLogWrapper here since it's still null at this point
+        AppLog.d(API, this.javaClass.name + ": onRegister")
+    }
+
+    @Deprecated(
+            "Action and event bus support should be gradually replaced while the Comments Unification project proceeds"
+    )
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    override fun onAction(action: Action<*>) {
+        val actionType = action.type as? CommentsAction ?: return
+
+        when (actionType) {
+            FETCH_COMMENTS -> {
+                coroutineEngine.launch(API, this, "CommentsStore: On FETCH_COMMENTS") {
+                    emitChange(onFetchComments(action.payload as FetchCommentsPayload))
+                }
+            }
+            FETCH_COMMENT -> {
+                coroutineEngine.launch(API, this, "CommentsStore: On FETCH_COMMENT") {
+                    emitChange(onFetchComment(action.payload as RemoteCommentPayload))
+                }
+            }
+            CREATE_NEW_COMMENT -> {
+                coroutineEngine.launch(API, this, "CommentsStore: On CREATE_NEW_COMMENT") {
+                    emitChange(onCreateNewComment(action.payload as RemoteCreateCommentPayload))
+                }
+            }
+            PUSH_COMMENT -> {
+                coroutineEngine.launch(API, this, "CommentsStore: On PUSH_COMMENT") {
+                    emitChange(onPushComment(action.payload as RemoteCommentPayload))
+                }
+            }
+            DELETE_COMMENT -> {
+                coroutineEngine.launch(API, this, "CommentsStore: On DELETE_COMMENT") {
+                    emitChange(onDeleteComment(action.payload as RemoteCommentPayload))
+                }
+            }
+            LIKE_COMMENT -> {
+                coroutineEngine.launch(API, this, "CommentsStore: On LIKE_COMMENT") {
+                    emitChange(onLikeComment(action.payload as RemoteLikeCommentPayload))
+                }
+            }
+            UPDATE_COMMENT -> {
+                coroutineEngine.launch(API, this, "CommentsStore: On UPDATE_COMMENT") {
+                    emitChange(onUpdateComment(action.payload as CommentModel))
+                }
+            }
+            FETCHED_COMMENTS,
+            FETCHED_COMMENT,
+            CREATED_NEW_COMMENT,
+            PUSHED_COMMENT,
+            DELETED_COMMENT,
+            LIKED_COMMENT -> throw IllegalArgumentException(
+                    "CommentsStore > onAction: received illegal action type [$actionType]"
+            )
+        }
+    }
+
+    @Deprecated(
+            "Action and event bus support should be gradually replaced while the Comments Unification project proceeds",
+            ReplaceWith("use fetchComments suspend fun directly")
+    )
+    private suspend fun onFetchComments(payload: FetchCommentsPayload): OnCommentChanged {
+        val response = fetchComments(
+                site = payload.site,
+                number = payload.number,
+                offset = payload.offset,
+                networkStatusFilter = payload.status
+        )
+
+        return createOnCommentChangedEvent(
+                response.data?.rowsAffected.orNone(),
+                CommentAction.FETCH_COMMENTS,
+                response.error,
+                response.data.toCommentIdsListOrEmpty(),
+                payload.status,
+                payload.offset
+        )
+    }
+
+    @Deprecated(
+        message = "Action and event bus support should be gradually replaced while the " +
+                "Comments Unification project proceeds",
+        replaceWith = ReplaceWith("use fetchComment suspend fun directly")
+    )
+    private suspend fun onFetchComment(payload: RemoteCommentPayload): OnCommentChanged {
+        val response = fetchComment(
+                payload.site,
+                payload.remoteCommentId,
+                payload.comment?.let { commentsMapper.commentLegacyModelToEntity(it) }
+        )
+
+        return createOnCommentChangedEvent(
+                response.data?.rowsAffected.orNone(),
+                CommentAction.FETCH_COMMENT,
+                response.error,
+                response.data.toCommentIdsListOrEmpty()
+        )
+    }
+
+    @Deprecated(
+            message = "Action and event bus support should be gradually replaced while the " +
+                    "Comments Unification project proceeds",
+            replaceWith = ReplaceWith("use updateComment suspend fun directly")
+    )
+    private suspend fun onUpdateComment(payload: CommentModel): OnCommentChanged {
+        val response = updateComment(
+                isError = payload.isError,
+                commentId = payload.id.toLong(),
+                comment = commentsMapper.commentLegacyModelToEntity(payload)
+        )
+
+        return createOnCommentChangedEvent(
+                response.data?.rowsAffected.orNone(),
+                CommentAction.UPDATE_COMMENT,
+                null,
+                response.data.toCommentIdsListOrEmpty()
+        )
+    }
+
+    @Deprecated(
+            message = "Action and event bus support should be gradually replaced while the " +
+                    "Comments Unification project proceeds",
+            replaceWith = ReplaceWith("use deleteComment suspend fun directly")
+    )
+    private suspend fun onDeleteComment(payload: RemoteCommentPayload): OnCommentChanged {
+        val response = deleteComment(
+                payload.site,
+                payload.remoteCommentId,
+                payload.comment?.let { commentsMapper.commentLegacyModelToEntity(it) }
+        )
+
+        return createOnCommentChangedEvent(
+                // Keeping here the rowsAffected set to 0 as it is in original handleDeletedCommentResponse
+                0,
+                CommentAction.DELETE_COMMENT,
+                response.error,
+                response.data.toCommentIdsListOrEmpty()
+        )
+    }
+
+    @Deprecated(
+            message = "Action and event bus support should be gradually replaced while the " +
+                    "Comments Unification project proceeds",
+            replaceWith = ReplaceWith("use likeComment suspend fun directly")
+    )
+    private suspend fun onLikeComment(payload: RemoteLikeCommentPayload): OnCommentChanged {
+        val response = likeComment(
+                payload.site,
+                payload.remoteCommentId,
+                payload.comment?.let { commentsMapper.commentLegacyModelToEntity(it) },
+                payload.like
+        )
+
+        return createOnCommentChangedEvent(
+                response.data?.rowsAffected.orNone(),
+                CommentAction.LIKE_COMMENT,
+                response.error,
+                response.data.toCommentIdsListOrEmpty()
+        )
+    }
+
+    @Deprecated(
+            message = "Action and event bus support should be gradually replaced while the " +
+                    "Comments Unification project proceeds",
+            replaceWith = ReplaceWith("use pushComment suspend fun directly")
+    )
+    private suspend fun onPushComment(payload: RemoteCommentPayload): OnCommentChanged {
+        if (payload.comment == null) {
+            return OnCommentChanged(0).apply {
+                this.causeOfChange = CommentAction.PUSH_COMMENT
+                this.error = CommentError(INVALID_INPUT, "Comment can't be null")
+            }
+        }
+
+        val response = pushComment(
+                payload.site,
+                commentsMapper.commentLegacyModelToEntity(payload.comment)
+        )
+
+        return createOnCommentChangedEvent(
+                response.data?.rowsAffected.orNone(),
+                CommentAction.PUSH_COMMENT,
+                response.error,
+                response.data.toCommentIdsListOrEmpty()
+        )
+    }
+
+    @Deprecated(
+            message = "Action and event bus support should be gradually replaced while the " +
+                    "Comments Unification project proceeds",
+            replaceWith = ReplaceWith("use createNewComment suspend fun directly")
+    )
+    private suspend fun onCreateNewComment(payload: RemoteCreateCommentPayload): OnCommentChanged {
+        val response = if (payload.reply == null) {
+            // Create a new comment on a specific Post
+            createNewComment(
+                    payload.site,
+                    commentsMapper.commentLegacyModelToEntity(payload.comment)
+            )
+        } else {
+            // Create a new reply to a specific Comment
+            createNewReply(
+                    payload.site,
+                    commentsMapper.commentLegacyModelToEntity(payload.comment),
+                    commentsMapper.commentLegacyModelToEntity(payload.reply)
+            )
+        }
+
+        return createOnCommentChangedEvent(
+                response.data?.rowsAffected.orNone(),
+                CommentAction.CREATE_NEW_COMMENT,
+                response.error,
+                response.data.toCommentIdsListOrEmpty()
+        )
+    }
+
+    private fun createOnCommentChangedEvent(
+        rowsAffected: Int,
+        actionType: CommentAction,
+        error: CommentError?,
+        commentLocalIds: List<Int>,
+        status: CommentStatus? = null,
+        offset: Int? = null
+    ): OnCommentChanged {
+        return OnCommentChanged(rowsAffected).apply {
+            this.changedCommentsLocalIds.addAll(commentLocalIds)
+            this.causeOfChange = actionType
+            this.error = error
+            status?.let {
+                this.requestedStatus = it
+            }
+            offset?.let {
+                this.offset = offset
+            }
+        }
+    }
+
+    private fun CommentsActionData?.toCommentIdsListOrEmpty(): List<Int> {
+        return this?.comments?.map { it.id.toInt() } ?: listOf()
+    }
+
+    private fun CommentsActionEntityIds?.toCommentIdsListOrEmpty(): List<Int> {
+        return this?.entityIds?.map { it.toInt() } ?: listOf()
+    }
+
+    private fun CommentEntity?.toListOrEmpty(): List<CommentEntity> {
+        return this?.let {
+            listOf(it)
+        } ?: listOf()
+    }
+
+    private fun Int?.orNone(): Int {
+        return this ?: 0
+    }
+
+    private suspend fun removeCommentGaps(
+        site: SiteModel?,
+        commentsList: CommentEntityList?,
+        maxEntriesInResponse: Int,
+        requestOffset: Int,
+        vararg statuses: CommentStatus
+    ): Int {
+        if (site == null || commentsList == null) {
+            return 0
+        }
+
+        val targetStatuses = if (listOf(*statuses).contains(ALL)) {
+            listOf(APPROVED, UNAPPROVED)
+        } else {
+            listOf(*statuses)
+        }.map { it.toString() }
+
+        appLogWrapper.d(
+                COMMENTS,
+                "removeCommentGaps -> siteId [${site.siteId}]  targetStatuses [$targetStatuses]"
+        )
+
+        if (commentsList.isEmpty()) {
+            return if (requestOffset == 0) {
+                val numOfDeletedComments = commentsDao.clearAllBySiteIdAndFilters(
+                        localSiteId = site.id,
+                        statuses = targetStatuses
+                )
+
+                appLogWrapper.d(
+                        COMMENTS,
+                        "removeCommentGaps -> commentsList empty deleted $numOfDeletedComments items"
+                )
+
+                numOfDeletedComments
+            } else {
+                appLogWrapper.d(
+                        COMMENTS,
+                        "removeCommentGaps -> commentsList empty and requestOffset != 0"
+                )
+                0
+            }
+        }
+
+        val comments = mutableListOf<CommentEntity>().apply { addAll(commentsList) }
+
+        comments.sortWith { o1, o2 ->
+            val x = o2.publishedTimestamp
+            val y = o1.publishedTimestamp
+            when {
+                x < y -> -1
+                x == y -> 0
+                else -> 1
+            }
+        }
+
+        val remoteIds = comments.map { it.remoteCommentId }
+
+        val startOfRange = comments.first().publishedTimestamp
+        val endOfRange = comments.last().publishedTimestamp
+
+        appLogWrapper.d(
+                COMMENTS,
+                "removeCommentGaps -> startOfRange [" + startOfRange + " - " +
+                        comments.first().datePublished + "] " + "endOfRange [" + endOfRange + " - " +
+                        comments.last().datePublished + "]"
+        )
+
+        var numOfDeletedComments = 0
+
+        // try to trim comments from the top
+        if (requestOffset == 0) {
+            numOfDeletedComments += commentsDao.removeGapsFromTheTop(
+                    localSiteId = site.id,
+                    statuses = targetStatuses,
+                    remoteIds = remoteIds,
+                    startOfRange = startOfRange
+            )
+            appLogWrapper.d(
+                    COMMENTS,
+                    "removeCommentGaps -> requestOffset == 0 -> numOfDeletedComments $numOfDeletedComments"
+            )
+        }
+
+        // try to trim comments from the bottom
+        if (comments.size < maxEntriesInResponse) {
+            numOfDeletedComments += commentsDao.removeGapsFromTheBottom(
+                    localSiteId = site.id,
+                    statuses = targetStatuses,
+                    remoteIds = remoteIds,
+                    endOfRange = endOfRange
+            )
+            appLogWrapper.d(
+                    COMMENTS,
+                    "removeCommentGaps -> comments.size() [" +
+                            comments.size + "] < maxEntriesInResponse [" +
+                            maxEntriesInResponse + "]" + "-> numOfDeletedComments " + numOfDeletedComments
+            )
+        }
+
+        // remove comments from the middle
+        numOfDeletedComments += commentsDao.removeGapsFromTheMiddle(
+                localSiteId = site.id,
+                statuses = targetStatuses,
+                remoteIds = remoteIds,
+                startOfRange = startOfRange,
+                endOfRange = endOfRange
+        )
+
+        appLogWrapper.d(
+                COMMENTS,
+                "removeCommentGaps -> removing from middle -> numOfDeletedComments $numOfDeletedComments"
+        )
+
+        return numOfDeletedComments
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
@@ -135,7 +135,7 @@ class CommentsStore
                     commentsDao.insertOrUpdateComment(comment)
                 }
                 CommentsActionPayload(CommentsActionEntityIds(entityIds, entityIds.size))
-            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, "Network response was valid but empty!"))
         }
     }
 
@@ -158,7 +158,7 @@ class CommentsStore
             payload.response?.let {
                 val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(it)
                 CommentsActionPayload(CommentsActionData(cachedCommentAsList, cachedCommentAsList.size))
-            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, "Network response was valid but empty!"))
         }
     }
 
@@ -176,7 +176,7 @@ class CommentsStore
                 val commentUpdated = it.copy(id = comment.id)
                 val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(commentUpdated)
                 CommentsActionPayload(CommentsActionData(cachedCommentAsList, cachedCommentAsList.size))
-            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, "Network response was valid but empty!"))
         }
     }
 
@@ -198,7 +198,7 @@ class CommentsStore
                 val commentUpdated = it.copy(id = reply.id)
                 val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(commentUpdated)
                 CommentsActionPayload(CommentsActionData(cachedCommentAsList, cachedCommentAsList.size))
-            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, "Network response was valid but empty!"))
         }
     }
 
@@ -216,7 +216,7 @@ class CommentsStore
                 val commentUpdated = it.copy(id = comment.id)
                 val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(commentUpdated)
                 CommentsActionPayload(CommentsActionData(cachedCommentAsList, cachedCommentAsList.size))
-            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, "Network response was valid but empty!"))
         }
     }
 
@@ -245,7 +245,7 @@ class CommentsStore
         } else {
             val targetComment = when {
                 site.isUsingWpComRestApi && payload.response == null -> {
-                    return CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+                    return CommentsActionPayload(CommentError(INVALID_RESPONSE, "Network response was valid but empty!"))
                 }
                 site.isUsingWpComRestApi && payload.response != null -> {
                     val commentFromEndpoint: CommentEntity = payload.response
@@ -327,7 +327,7 @@ class CommentsStore
                 } ?: Pair(0, updatedComment.toListOrEmpty())
 
                 CommentsActionPayload(CommentsActionData(likedCommentAsList, rowsAffected))
-            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, ""))
+            } ?: CommentsActionPayload(CommentError(INVALID_RESPONSE, "Network response was valid but empty!"))
         }
     }
 
@@ -406,11 +406,10 @@ class CommentsStore
         remoteCommentId: Long,
         newStatus: CommentStatus
     ): CommentsActionPayload<CommentsActionData> {
-        // TODOD: add message to all CommentError to be used in logs (since not localized) in the WPAndroid
         val comment = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
                 site.id,
                 remoteCommentId
-        ).firstOrNull() ?: return CommentsActionPayload(CommentError(INVALID_INPUT, ""))
+        ).firstOrNull() ?: return CommentsActionPayload(CommentError(INVALID_INPUT, "Comment cannot be null!"))
 
         val commentToModerate = comment.copy(status = newStatus.toString())
         val cachedCommentAsList = commentsDao.insertOrUpdateCommentForResult(commentToModerate)
@@ -433,7 +432,7 @@ class CommentsStore
         val comment = commentsDao.getCommentsByLocalSiteAndRemoteCommentId(
                 site.id,
                 remoteCommentId
-        ).firstOrNull() ?: return CommentsActionPayload(CommentError(INVALID_INPUT, ""))
+        ).firstOrNull() ?: return CommentsActionPayload(CommentError(INVALID_INPUT, "Comment cannot be null!"))
 
         return pushComment(site, comment)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
@@ -245,7 +245,10 @@ class CommentsStore
         } else {
             val targetComment = when {
                 site.isUsingWpComRestApi && payload.response == null -> {
-                    return CommentsActionPayload(CommentError(INVALID_RESPONSE, "Network response was valid but empty!"))
+                    return CommentsActionPayload(CommentError(
+                            INVALID_RESPONSE,
+                            "Network response was valid but empty!"
+                    ))
                 }
                 site.isUsingWpComRestApi && payload.response != null -> {
                     val commentFromEndpoint: CommentEntity = payload.response

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -58,6 +58,10 @@ public class CommentErrorUtils {
         return payload;
     }
 
+    public static CommentError networkToCommentError(BaseNetworkError error) {
+        return new CommentError(genericToCommentError(error), getErrorMessage(error));
+    }
+
     private static CommentErrorType genericToCommentError(BaseNetworkError error) {
         CommentErrorType errorType = CommentErrorType.GENERIC_ERROR;
         if (error.isGeneric()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtilsWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtilsWrapper.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.utils
+
+import dagger.Reusable
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.store.CommentStore.CommentError
+import javax.inject.Inject
+
+@Reusable
+class CommentErrorUtilsWrapper @Inject constructor() {
+    fun networkToCommentError(error: BaseNetworkError): CommentError = CommentErrorUtils.networkToCommentError(error)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/DateTimeUtilsWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/DateTimeUtilsWrapper.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.utils
+
+import dagger.Reusable
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+import javax.inject.Inject
+
+@Reusable
+class DateTimeUtilsWrapper @Inject constructor() {
+    fun timestampFromIso8601(strDate: String?) = DateTimeUtils.timestampFromIso8601(strDate)
+    fun iso8601UTCFromDate(date: Date?): String? = DateTimeUtils.iso8601UTCFromDate(date)
+}


### PR DESCRIPTION
This PR mostly lands changes already reviewed in previous PRs. The only change I added that should be reviewed is this  https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/023719cae6362b731beb74a299616d07a06d5b82

In principle comments value could be null there, even though kotlin compiler is not complaining since the java side is not marking with nullable annotation. So I placed a guard returning empty list eventually.

This said we can use this PR code to final check/test the feature.