### PR TITLE
Add support for restricted_soon status

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
@@ -100,4 +100,13 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         assertTrue(result.result?.status == WCPayAccountStatusEnum.NO_ACCOUNT)
     }
+
+    @Test
+    fun whenOverdueRequirementsThenCurrentDeadlineCorrectlyParsed() = runBlocking {
+        interceptor.respondWithError("wc-pay-load-account-response-current-deadline.json", 200)
+
+        val result = payRestClient.loadAccount(SiteModel().apply { siteId = 123L })
+
+        assertTrue(result.result?.currentDeadline == 1628258304L)
+    }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
@@ -100,4 +100,13 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         assertTrue(result.result?.status == WCPayAccountStatusEnum.NO_ACCOUNT)
     }
+
+    @Test
+    fun whenLoadAccountRestrictedSoonStatusThenRestrictedSoonStatusReturned() = runBlocking {
+        interceptor.respondWithError("wc-pay-load-account-response-restricted-soon-status.json", 200)
+
+        val result = payRestClient.loadAccount(SiteModel().apply { siteId = 123L })
+
+        assertTrue(result.result?.status == WCPayAccountStatusEnum.RESTRICTED_SOON)
+    }
 }

--- a/example/src/androidTest/resources/wc-pay-load-account-response-current-deadline.json
+++ b/example/src/androidTest/resources/wc-pay-load-account-response-current-deadline.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "has_pending_requirements": false,
+    "has_overdue_requirements": true,
+    "current_deadline": 1628258304,
+    "status": "",
+    "statement_descriptor": "DO.WPMT.CO",
+    "store_currencies": {
+      "default": "usd",
+      "supported": ["usd"]
+    },
+    "country": "US",
+    "card_present_eligible": false
+  }
+}

--- a/example/src/androidTest/resources/wc-pay-load-account-response-restricted-soon-status.json
+++ b/example/src/androidTest/resources/wc-pay-load-account-response-restricted-soon-status.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "has_pending_requirements": false,
+    "has_overdue_requirements": false,
+    "current_deadline": null,
+    "status": "restricted_soon",
+    "statement_descriptor": "DO.WPMT.CO",
+    "store_currencies": {
+      "default": "usd",
+      "supported": ["usd"]
+    },
+    "country": "US",
+    "card_present_eligible": false
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
@@ -17,7 +17,7 @@ data class WCPaymentAccountResult(
     @SerializedName("has_overdue_requirements")
     val hasOverdueRequirements: Boolean,
     @SerializedName("current_deadline")
-    val currentDeadline: Date?,
+    val currentDeadline: Long?,
     /**
      * An alphanumeric string set by the merchant, e.g. `MYSTORE.COM`
      * See https://stripe.com/docs/statement-descriptors

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
@@ -54,13 +54,21 @@ data class WCPaymentAccountResult(
          * This state occurs when there is required business information missing from the account.
          * If `hasOverdueRequirements` is also true, then the deadline for providing that information HAS PASSED and
          * the merchant will probably NOT be able to collect card present payments.
-         * Otherwise, if `hasPendingRequirements` is true, then the deadline for providing that information has not yet passed.
-         * The deadline is available in `currentDeadline` and the merchant will probably be able to collect card present payments
-         * until the deadline.
-         * Otherwise, if neither `hasOverdueRequirements` nor `hasPendingRequirements` is true, then the account is under
-         * review by Stripe and the merchant will probably not be able to collect card present payments.
+         * Otherwise, if `hasPendingRequirements` is true, then the deadline for providing that information has not yet
+         * passed.
+         * The deadline is available in `currentDeadline` and the merchant will probably be able to collect card present
+         * payments until the deadline.
+         * Otherwise, if neither `hasOverdueRequirements` nor `hasPendingRequirements` is true, then the account is
+         * under review by Stripe and the merchant will probably not be able to collect card present payments.
          */
         RESTRICTED,
+
+        /**
+         * This state occurs when there is required business information missing from the account but the
+         * currentDeadline hasn't passed yet (aka there are no overdueRequirements). The merchant will probably be able
+         * to collect card present payments.
+         */
+        RESTRICTED_SOON,
 
         /**
          * This state occurs when our payment processor rejects the merchant account due to suspected fraudulent
@@ -105,6 +113,7 @@ data class WCPaymentAccountResult(
                     when (json.asString) {
                         "complete" -> COMPLETE
                         "restricted" -> RESTRICTED
+                        "restricted_soon" -> RESTRICTED_SOON
                         "rejected.fraud" -> REJECTED_FRAUD
                         "rejected.terms_of_service" -> REJECTED_TERMS_OF_SERVICE
                         "rejected.listed" -> REJECTED_LISTED

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
@@ -7,7 +7,6 @@ import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.model.pay.WCPaymentAccountResult.WCPayAccountStatusEnum.StoreCurrencies
 import java.lang.reflect.Type
-import java.util.Date
 
 data class WCPaymentAccountResult(
     @SerializedName("status")


### PR DESCRIPTION
Issue https://github.com/woocommerce/woocommerce-android/issues/4413

**https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2077 needs to be merged first**

Adds support for "restricted_soon" status response from the backend which indicates that there are missing required business information but the merchant still has some time to complete the setup before the account gets moved to "restricted" state.

To test
Test in WCAndroid - PR tbd