### PR TITLE
Add isLive flag to payments/accounts endpoint

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
@@ -118,4 +118,13 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         assertTrue(result.result?.status == WCPayAccountStatusEnum.RESTRICTED_SOON)
     }
+
+    @Test
+    fun whenLoadAccountIsLiveThenIsLiveFlagIsTrue() = runBlocking {
+        interceptor.respondWithError("wc-pay-load-account-response-is-live-account.json", 200)
+
+        val result = payRestClient.loadAccount(SiteModel().apply { siteId = 123L })
+
+        assertTrue(result.result!!.isLive)
+    }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
@@ -37,15 +37,14 @@ class ReleaseStack_WCPayTest : ReleaseStack_WCBase() {
     fun givenSiteHasWCPayWhenLoadAccountThenTestAccountReturned() = runBlocking {
         val result = payStore.loadAccount(sSite)
 
-        assertEquals(result.model!!.country, "US")
-        assertEquals(result.model!!.hasPendingRequirements, false)
-        assertEquals(result.model!!.hasOverdueRequirements, false)
-        assertEquals(result.model!!.statementDescriptor, "DO.WPMT.CO")
-        assertEquals(result.model!!.country, "US")
-        assertEquals(result.model!!.isCardPresentEligible, false)
-        assertEquals(result.model!!.storeCurrencies.default, "usd")
-        assertEquals(result.model!!.storeCurrencies.supportedCurrencies, listOf("usd"))
-        assertEquals(result.model!!.status, WCPayAccountStatusEnum.COMPLETE)
-        assertEquals(result.model!!.isLive, true)
+        assertEquals(result.model?.country, "US")
+        assertEquals(result.model?.hasPendingRequirements, false)
+        assertEquals(result.model?.hasOverdueRequirements, false)
+        assertEquals(result.model?.statementDescriptor, "DO.WPMT.CO")
+        assertEquals(result.model?.country, "US")
+        assertEquals(result.model?.isCardPresentEligible, false)
+        assertEquals(result.model?.storeCurrencies?.default, "usd")
+        assertEquals(result.model?.storeCurrencies?.supportedCurrencies, listOf("usd"))
+        assertEquals(result.model?.status, WCPayAccountStatusEnum.COMPLETE)
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
@@ -37,14 +37,15 @@ class ReleaseStack_WCPayTest : ReleaseStack_WCBase() {
     fun givenSiteHasWCPayWhenLoadAccountThenTestAccountReturned() = runBlocking {
         val result = payStore.loadAccount(sSite)
 
-        assertEquals(result.model?.country, "US")
-        assertEquals(result.model?.hasPendingRequirements, false)
-        assertEquals(result.model?.hasOverdueRequirements, false)
-        assertEquals(result.model?.statementDescriptor, "DO.WPMT.CO")
-        assertEquals(result.model?.country, "US")
-        assertEquals(result.model?.isCardPresentEligible, false)
-        assertEquals(result.model?.storeCurrencies?.default, "usd")
-        assertEquals(result.model?.storeCurrencies?.supportedCurrencies, listOf("usd"))
-        assertEquals(result.model?.status, WCPayAccountStatusEnum.COMPLETE)
+        assertEquals(result.model!!.country, "US")
+        assertEquals(result.model!!.hasPendingRequirements, false)
+        assertEquals(result.model!!.hasOverdueRequirements, false)
+        assertEquals(result.model!!.statementDescriptor, "DO.WPMT.CO")
+        assertEquals(result.model!!.country, "US")
+        assertEquals(result.model!!.isCardPresentEligible, false)
+        assertEquals(result.model!!.storeCurrencies.default, "usd")
+        assertEquals(result.model!!.storeCurrencies.supportedCurrencies, listOf("usd"))
+        assertEquals(result.model!!.status, WCPayAccountStatusEnum.COMPLETE)
+        assertEquals(result.model!!.isLive, true)
     }
 }

--- a/example/src/androidTest/resources/wc-pay-load-account-response-is-live-account.json
+++ b/example/src/androidTest/resources/wc-pay-load-account-response-is-live-account.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "has_pending_requirements": false,
+    "has_overdue_requirements": false,
+    "current_deadline": null,
+    "is_live": true,
+    "status": "restricted_soon",
+    "statement_descriptor": "DO.WPMT.CO",
+    "store_currencies": {
+      "default": "usd",
+      "supported": ["usd"]
+    },
+    "country": "US",
+    "card_present_eligible": false
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
@@ -36,7 +36,12 @@ data class WCPaymentAccountResult(
      * A boolean flag indicating if this Account is eligible for card present payments
      */
     @SerializedName("card_present_eligible")
-    val isCardPresentEligible: Boolean
+    val isCardPresentEligible: Boolean,
+    /**
+     * A boolean flag indicating if this Account is test/live.
+     */
+    @SerializedName("is_live")
+    val isLive: Boolean
 ) {
     /**
      * Represents all of the possible Site Plugin Statuses in enum form

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -132,6 +132,6 @@ class PayRestClient @Inject constructor(
     companion object {
         private const val ACCOUNT_REQUESTED_FIELDS: String =
                 "status,has_pending_requirements,has_overdue_requirements,current_deadline,statement_descriptor," +
-                        "store_currencies,country,card_present_eligible, is_live"
+                        "store_currencies,country,card_present_eligible,is_live"
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -132,6 +132,6 @@ class PayRestClient @Inject constructor(
     companion object {
         private const val ACCOUNT_REQUESTED_FIELDS: String =
                 "status,has_pending_requirements,has_overdue_requirements,current_deadline,statement_descriptor," +
-                        "store_currencies,country,card_present_eligible"
+                        "store_currencies,country,card_present_eligible, is_live"
     }
 }


### PR DESCRIPTION
Parent issue https://github.com/woocommerce/woocommerce-android/issues/4413

This PR adds `is_live` parameter to `payments/accounts` requests which indicates whether the connected account is live or test.

To test:
Test in WCAndroid (tbd)