### PR TITLE
Fetch Global Add-on Groups

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.addons.WCProductAddonModel
 import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.WCAddonsStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload
@@ -71,6 +72,7 @@ import javax.inject.Inject
 class WooProductsFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wcProductStore: WCProductStore
+    @Inject lateinit var addonsStore: WCAddonsStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
     @Inject internal lateinit var mediaStore: MediaStore
 
@@ -393,6 +395,17 @@ class WooProductsFragment : Fragment() {
                                     .logAddons()
                         }
                     } ?: prependToLog("No valid remoteOrderId defined...doing nothing")
+                }
+            }
+        }
+
+        fetch_global_addons_groups.setOnClickListener {
+            selectedSite?.let { site ->
+                coroutineScope.launch {
+                    addonsStore.fetchAllGlobalAddonsGroups(site).run {
+                        error?.let { prependToLog("${it.type}: ${it.message}") }
+                            prependToLog("Global addons: ${this.model}")
+                    }
                 }
             }
         }

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -196,6 +196,13 @@
             android:text="Fetch Product Addons" />
 
         <Button
+            android:id="@+id/fetch_global_addons_groups"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Global Addons groups" />
+
+        <Button
             android:id="@+id/update_product"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -11,6 +11,8 @@ public class WCWPAPIEndpoint {
 
     private static final String WC_PREFIX_V4_ANALYTICS = "wc-analytics";
 
+    private static final String WC_PREFIX_V1_ADDONS = "wc-product-add-ons/v1";
+
     private final String mEndpoint;
 
     public WCWPAPIEndpoint(String endpoint) {
@@ -47,5 +49,9 @@ public class WCWPAPIEndpoint {
 
     public String getPathV4Analytics() {
         return "/" + WC_PREFIX_V4_ANALYTICS + mEndpoint;
+    }
+
+    public String getPathV1Addons() {
+        return "/" + WC_PREFIX_V1_ADDONS + mEndpoint;
     }
 }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -26,6 +26,8 @@
 /products/tags/<id>/
 /products/tags/batch/
 
+/product-add-ons/
+
 /customers/<id>
 /customers/
 /customers/<id>/downloads

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/addons/WCProductAddonModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/addons/WCProductAddonModel.kt
@@ -2,30 +2,30 @@ package org.wordpress.android.fluxc.model.addons
 
 import com.google.gson.annotations.SerializedName
 
-class WCProductAddonModel {
+data class WCProductAddonModel(
     @SerializedName("title_format")
-    val titleFormat: AddOnTitleFormat? = null
+    val titleFormat: AddOnTitleFormat? = null,
     @SerializedName("description_enable")
-    val descriptionEnabled: String? = null
+    val descriptionEnabled: String? = null,
     @SerializedName("restrictions_type")
-    val restrictionsType: AddOnRestrictionsType? = null
+    val restrictionsType: AddOnRestrictionsType? = null,
     @SerializedName("adjust_price")
-    val adjustPrice: String? = null
+    val adjustPrice: String? = null,
     @SerializedName("price_type")
-    val priceType: AddOnPriceType? = null
+    val priceType: AddOnPriceType? = null,
 
-    val type: AddOnType? = null
-    val display: AddOnDisplay? = null
-    val name: String? = null
-    val description: String? = null
-    val required: String? = null
-    val position: String? = null
-    val restrictions: String? = null
-    val price: String? = null
-    val min: String? = null
-    val max: String? = null
-    val options: Array<ProductAddonOption>? = null
-
+    val type: AddOnType? = null,
+    val display: AddOnDisplay? = null,
+    val name: String? = null,
+    val description: String? = null,
+    val required: String? = null,
+    val position: String? = null,
+    val restrictions: String? = null,
+    val price: String? = null,
+    val min: String? = null,
+    val max: String? = null,
+    val options: List<ProductAddonOption>? = null
+) {
     enum class AddOnType {
         @SerializedName("description_enable") MultipleChoice,
         @SerializedName("checkbox") Checkbox,
@@ -63,12 +63,12 @@ class WCProductAddonModel {
         @SerializedName("percentage_based") PercentageBased
     }
 
-    class ProductAddonOption {
+    data class ProductAddonOption(
         @SerializedName("price_type")
-        val priceType: AddOnPriceType? = null
+        val priceType: AddOnPriceType? = null,
 
-        val label: String? = null
-        val price: String? = null
+        val label: String? = null,
+        val price: String? = null,
         val image: String? = null
-    }
+    )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/AddOnsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/AddOnsRestClient.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.addons
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.dto.AddOnGroupDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class AddOnsRestClient @Inject constructor(
+    appContext: Context,
+    dispatcher: Dispatcher,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    private val requestBuilder: JetpackTunnelGsonRequestBuilder
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchGlobalAddOnGroups(site: SiteModel): WooPayload<List<AddOnGroupDto>> {
+        val url = WOOCOMMERCE.product_add_ons.pathV1Addons
+
+        val response = requestBuilder.syncGetRequest(
+                restClient = this,
+                site = site,
+                url = url,
+                params = emptyMap(),
+                clazz = Array<AddOnGroupDto>::class.java
+        )
+
+        return when (response) {
+            is JetpackSuccess -> WooPayload(response.data?.toList())
+            is JetpackError -> WooPayload(response.error.toWooError())
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/dto/AddOnGroupDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/dto/AddOnGroupDto.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.dto
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.model.addons.WCProductAddonModel
+
+data class AddOnGroupDto(
+    @SerializedName("id") val id: Int,
+    @SerializedName("name") val name: String,
+    @SerializedName("restrict_to_category_ids") val categoryIds: List<Int>,
+    @SerializedName("fields") val addons: List<WCProductAddonModel>
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCAddonsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCAddonsStore.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.fluxc.store
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.AddOnsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.dto.AddOnGroupDto
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WCAddonsStore @Inject constructor(
+    private val restClient: AddOnsRestClient,
+    private val coroutineEngine: CoroutineEngine
+) {
+    suspend fun fetchAllGlobalAddonsGroups(site: SiteModel): WooResult<List<AddOnGroupDto>> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchGlobalAddonsGroups") {
+            restClient.fetchGlobalAddOnGroups(site).asWooResult()
+        }
+    }
+}


### PR DESCRIPTION
Summary
============
This PR is part of issue https://github.com/woocommerce/woocommerce-android/issues/4410 - networking layer only.

I'll add tests and persistence in next PRs.

How to Test
===========
**Prerequisites:** Have your site with the [add ons plugin](https://woocommerce.com/products/product-add-ons/) installed, configured, and with at least one global add-on group defined. 

1. Launch the example app.
1. Navigate to the Product section inside the Woo area and select the `Fetch Product addons` button.
1. See that global add-ons groups info is being printed in the console.

Screenshot
===========
<img width="300" alt="Screenshot 2021-08-05 at 20 29 00" src="https://user-images.githubusercontent.com/5845095/128402506-ab181bbf-b563-43b8-9a3e-57bf8e0379d5.png">
