### PR TITLE
Expose and set `CookieManager` instance as the system default `CookieHandler`

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.network.rest.JsonObjectOrFalse;
 import org.wordpress.android.fluxc.network.rest.JsonObjectOrFalseDeserializer;
 
 import java.io.File;
+import java.net.CookieHandler;
 import java.net.CookieManager;
 
 import javax.inject.Named;
@@ -86,7 +87,9 @@ public class ReleaseNetworkModule {
     @Provides
     @Singleton
     public CookieManager provideCookieManager() {
-        return new CookieManager();
+        CookieManager cookieManager = new CookieManager();
+        CookieHandler.setDefault(cookieManager);
+        return cookieManager;
     }
 
     @Provides

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -84,6 +84,10 @@ public class ReleaseNetworkModule {
         return new MemorizingTrustManager();
     }
 
+    /**
+     * This sets a {@link CookieManager} as the system-wide {@link CookieHandler} and exposes it to the Dagger graph,
+     * allowing it to be shared with {@link OkHttpClient} via its {@link CookieJar}.
+     */
     @Provides
     @Singleton
     public CookieManager provideCookieManager() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -85,8 +85,14 @@ public class ReleaseNetworkModule {
 
     @Provides
     @Singleton
-    public CookieJar provideCookieJar() {
-        return new JavaNetCookieJar(new CookieManager());
+    public CookieManager provideCookieManager() {
+        return new CookieManager();
+    }
+
+    @Provides
+    @Singleton
+    public CookieJar provideCookieJar(CookieManager cookieManager) {
+        return new JavaNetCookieJar(cookieManager);
     }
 
     @Singleton


### PR DESCRIPTION
This PR exposes a `CookieManager` instance to the Dagger graph and sets it as the system-wide default `CookieHandler,` allowing us to share that same instance with `OkHttpClient` via its `CookieJar`.

This will be used on `WPAndroid` as a way to manually add and remove cookies to requests for debugging and testing. Check this internal ref for an example of what we're trying to achieve: pbArwn-2yE-p2

@wzieba I'm requesting your review here because you recently edited this module, but mostly because I think it would be great to have this double-checked by someone from Woo. Hope you don't mind! 😄