### PR TITLE
Move `getAttributesAsString` logic to Woo app

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
@@ -90,8 +90,6 @@ class WCOrderModelTest {
 
             assertEquals("size", attributes[1].key)
             assertEquals("Medium", attributes[1].value)
-
-
         }
 
         with(renderedLineItems[1]) {

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
@@ -91,8 +91,7 @@ class WCOrderModelTest {
             assertEquals("size", attributes[1].key)
             assertEquals("Medium", attributes[1].value)
 
-            val asList = getAttributesAsString()
-            assertEquals("Red, Medium", asList)
+
         }
 
         with(renderedLineItems[1]) {
@@ -101,11 +100,6 @@ class WCOrderModelTest {
 
             assertEquals("size", attributes[0].key)
             assertEquals("medium", attributes[0].value)
-        }
-
-        with(renderedLineItems[2]) {
-            val attributes = getAttributesAsString()
-            assertEquals("Blue, Medium", attributes)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.OrderAddress.AddressType
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
-import java.util.Locale
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
@@ -123,19 +122,6 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
             }?.map {
                 Attribute(it.displayKey, it.displayValue as String)
             } ?: emptyList()
-        }
-
-        /**
-         * @return a comma-separated list of attribute values for display
-         */
-        fun getAttributesAsString(): String {
-            return getAttributeList()
-                    .filter {
-                        // Don't include null, empty, or the "_reduced_stock" key
-                        // skipping "_reduced_stock" is a temporary workaround until "type" is added to the response.
-                        it.value != null && it.value.isNotEmpty() && it.key != null &&
-                                it.key.isNotEmpty() && it.key.first().toString() != "_"
-                    }.joinToString { it.value?.capitalize(Locale.getDefault()) ?: "" }
         }
     }
 


### PR DESCRIPTION
Summary
==========
This PR simply removes the `getAttributesAsString` from FluxC following the changes made at https://github.com/woocommerce/woocommerce-android/pull/4561 as it makes more sense to be at the Woo side since it's a UI presentation operation.

⚠️ This PR must *NOT* be merged before the mentioned Woo PR above!
