### PR TITLE
Support fetching and getting products filtered by category

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductFiltersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductFiltersFragment.kt
@@ -22,9 +22,11 @@ import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
+import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.CATEGORY
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STATUS
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.STOCK_STATUS
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption.TYPE
@@ -35,6 +37,7 @@ import javax.inject.Inject
 class WooProductFiltersFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+    @Inject internal lateinit var wcProductStore: WCProductStore
 
     private var selectedSiteId: Int = -1
     private var filterOptions: MutableMap<ProductFilterOption, String>? = null
@@ -98,6 +101,15 @@ class WooProductFiltersFragment : Fragment() {
             )
         }
 
+        filter_by_category.setOnClickListener {
+            getWCSite()?.let { site ->
+                val selectedCategory = wcProductStore.getProductCategoriesForSite(site).random().remoteCategoryId
+                filterOptions?.clear()
+                filterOptions?.put(CATEGORY, selectedCategory.toString())
+                prependToLog("Selected category: $selectedCategory")
+            }
+        }
+
         filter_products.setOnClickListener {
             getWCSite()?.let { site ->
                 val payload = FetchProductsPayload(site, filterOptions = filterOptions)
@@ -151,6 +163,11 @@ class WooProductFiltersFragment : Fragment() {
 
         if (event.causeOfChange == FETCH_PRODUCTS) {
             prependToLog("Fetched ${event.rowsAffected} products")
+            filterOptions?.let {
+                if(it.containsKey(CATEGORY)) {
+                    prependToLog("From category ID " + it[CATEGORY])
+                }
+            }
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductFiltersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductFiltersFragment.kt
@@ -41,6 +41,7 @@ class WooProductFiltersFragment : Fragment() {
 
     private var selectedSiteId: Int = -1
     private var filterOptions: MutableMap<ProductFilterOption, String>? = null
+
     companion object {
         const val ARG_SELECTED_SITE_ID = "ARG_SELECTED_SITE_ID"
         const val ARG_SELECTED_FILTER_OPTIONS = "ARG_SELECTED_FILTER_OPTIONS"
@@ -164,7 +165,7 @@ class WooProductFiltersFragment : Fragment() {
         if (event.causeOfChange == FETCH_PRODUCTS) {
             prependToLog("Fetched ${event.rowsAffected} products")
             filterOptions?.let {
-                if(it.containsKey(CATEGORY)) {
+                if (it.containsKey(CATEGORY)) {
                     prependToLog("From category ID " + it[CATEGORY])
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductFiltersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductFiltersFragment.kt
@@ -104,10 +104,10 @@ class WooProductFiltersFragment : Fragment() {
 
         filter_by_category.setOnClickListener {
             getWCSite()?.let { site ->
-                val selectedCategory = wcProductStore.getProductCategoriesForSite(site).random().remoteCategoryId
+                val randomCategory = wcProductStore.getProductCategoriesForSite(site).random()
                 filterOptions?.clear()
-                filterOptions?.put(CATEGORY, selectedCategory.toString())
-                prependToLog("Selected category: $selectedCategory")
+                filterOptions?.put(CATEGORY, randomCategory.remoteCategoryId.toString())
+                prependToLog("Selected category: ${randomCategory.name} id: ${randomCategory.remoteCategoryId}")
             }
         }
 

--- a/example/src/main/res/layout/fragment_woo_product_filters.xml
+++ b/example/src/main/res/layout/fragment_woo_product_filters.xml
@@ -44,6 +44,6 @@
             android:id="@+id/filter_products"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Apply Filte" />
+            android:text="Apply Filter" />
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/fragment_woo_product_filters.xml
+++ b/example/src/main/res/layout/fragment_woo_product_filters.xml
@@ -31,6 +31,12 @@
             android:layout_height="wrap_content"
             android:text="Filter by Product Type" />
 
+        <Button
+            android:id="@+id/filter_by_category"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Filter by A Random Category" />
+
         <View
             style="@style/Divider" />
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -22,7 +22,8 @@ object ProductTestUtils {
         siteId: Int = 6,
         stockStatus: String = CoreProductStockStatus.IN_STOCK.value,
         status: String = "publish",
-        stockQuantity: Double = 0.0
+        stockQuantity: Double = 0.0,
+        categories: String = ""
     ): WCProductModel {
         return WCProductModel().apply {
             remoteProductId = remoteId
@@ -33,6 +34,7 @@ object ProductTestUtils {
             this.stockStatus = stockStatus
             this.status = status
             this.stockQuantity = stockQuantity
+            this.categories = categories
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -165,7 +165,8 @@ class WCProductStoreTest {
         val filterOptions = mapOf<ProductFilterOption, String>(
                 ProductFilterOption.TYPE to "simple",
                 ProductFilterOption.STOCK_STATUS to "instock",
-                ProductFilterOption.STATUS to "publish"
+                ProductFilterOption.STATUS to "publish",
+                ProductFilterOption.CATEGORY to "1337"
         )
         val product1 = ProductTestUtils.generateSampleProduct(3)
         val product2 = ProductTestUtils.generateSampleProduct(
@@ -175,9 +176,13 @@ class WCProductStoreTest {
                 42, stockStatus = "onbackorder", status = "pending"
                 )
 
+        val product4 = ProductTestUtils.generateSampleProduct(
+                43, categories = "[{\"id\":1337,\"name\":\"Clothing\",\"slug\":\"clothing\"}]")
+
         ProductSqlUtils.insertOrUpdateProduct(product1)
         ProductSqlUtils.insertOrUpdateProduct(product2)
         ProductSqlUtils.insertOrUpdateProduct(product3)
+        ProductSqlUtils.insertOrUpdateProduct(product4)
 
         val site = SiteModel().apply { id = product1.localSiteId }
         val products = productStore.getProductsByFilterOptions(site, filterOptions)
@@ -191,10 +196,13 @@ class WCProductStoreTest {
         val differentSiteProduct3 = ProductTestUtils.generateSampleProduct(
                 12, siteId = 10, stockStatus = "onbackorder", status = "pending"
         )
+        val differentSiteProduct4 = ProductTestUtils.generateSampleProduct(
+                13, siteId = 10, categories = "[{\"id\":1337,\"name\":\"Clothing\",\"slug\":\"clothing\"}]")
 
         ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct1)
         ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct2)
         ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct3)
+        ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct4)
 
         // verify that the products for the first site is still 1
         assertEquals(1, productStore.getProductsByFilterOptions(site, filterOptions).size)
@@ -210,6 +218,11 @@ class WCProductStoreTest {
         val differentProductFilters = productStore.getProductsByFilterOptions(site2, filterOptions3)
         assertEquals(1, differentProductFilters.size)
         assertEquals(differentSiteProduct3.stockStatus, differentProductFilters[0].stockStatus)
+
+        val filterByCategory = mapOf(ProductFilterOption.CATEGORY to "1337")
+        val productsFilteredByCategory = productStore.getProductsByFilterOptions(site2, filterByCategory)
+        assertEquals(1, productsFilteredByCategory.size)
+        assertTrue(productsFilteredByCategory[0].categories.contains("1337"))
     }
 
     @Test

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -137,6 +137,12 @@ object ProductSqlUtils {
         if (filterOptions.containsKey(ProductFilterOption.TYPE)) {
             queryBuilder.equals(WCProductModelTable.TYPE, filterOptions[ProductFilterOption.TYPE])
         }
+        if (filterOptions.containsKey(ProductFilterOption.CATEGORY)) {
+            // Building a custom filter, because in the table a product's categories are saved as JSON string, e.g:
+            // [{"id":1377,"name":"Decor","slug":"decor"},{"id":1374,"name":"Hoodies","slug":"hoodies"}]
+            val categoryFilter = "id:" + filterOptions[ProductFilterOption.CATEGORY] + ","
+            queryBuilder.contains(WCProductModelTable.CATEGORIES, categoryFilter)
+        }
 
         excludedProductIds?.let {
             if (it.isNotEmpty()) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -140,7 +140,7 @@ object ProductSqlUtils {
         if (filterOptions.containsKey(ProductFilterOption.CATEGORY)) {
             // Building a custom filter, because in the table a product's categories are saved as JSON string, e.g:
             // [{"id":1377,"name":"Decor","slug":"decor"},{"id":1374,"name":"Hoodies","slug":"hoodies"}]
-            val categoryFilter = "id:" + filterOptions[ProductFilterOption.CATEGORY] + ","
+            val categoryFilter = "\"id\":${filterOptions[ProductFilterOption.CATEGORY]},"
             queryBuilder.contains(WCProductModelTable.CATEGORIES, categoryFilter)
         }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -676,8 +676,9 @@ class WCProductStore @Inject constructor(
             ProductSqlUtils.getProductsByRemoteIds(site, remoteProductIds)
 
     /**
-     * returns a list of [WCProductModel] for the give [SiteModel] and [filterOptions]
-     * if it exists in the database
+     * returns a list of [WCProductModel] for the given [SiteModel] and [filterOptions]
+     * if it exists in the database. To filter by category, make sure the [filterOptions] value
+     * is the category ID in String.
      */
     fun getProductsByFilterOptions(
         site: SiteModel,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -58,7 +58,7 @@ class WCProductStore @Inject constructor(
      * Defines the filter options currently supported in the app
      */
     enum class ProductFilterOption {
-        STOCK_STATUS, STATUS, TYPE;
+        STOCK_STATUS, STATUS, TYPE, CATEGORY;
 
         override fun toString() = name.toLowerCase(Locale.US)
     }


### PR DESCRIPTION
### What this PR is about:

The PR adds support on the FluxC side to 
- fetch a list of products, filtered by category
- get a list of products from the database filtered by category

This PR is related to https://github.com/woocommerce/woocommerce-android/issues/4578 

### What the PR does:
- Add `CATEGORY` as one of the `ProductFilterOption` (later usable in Woo Mobile).
- Update the SQL utility to get product with filter, to include filtering with category.
- Update unit test related to getting product with filter, to include filtering with category.
- Add an example case for testing in the Example app (more below in the testing area).

Finally, this does not modify the REST client part as it's already flexible enough to accept the additional category parameter.

### Testing instruction:
 **Unit test:** 
- Run `testGetProductsByFilterOptions` in `WCProductStoreTest.kt` and make sure it passes.

**Example app:**
- In the Example app, go to Woo -> Products. 
- Tap "Select Site" and pick a site containing products with categories set on them.
- On the next screen, select "Fetch Products With Filters".
- Tap "Filter By A Random Category". This will show "Selected category:  [name] id:[id number]" on the log area if a category is selected properly.
- Tap "Apply Filter". If it finds some product, it will show "From category ID [id number]" and "Fetched X products".
- Go to the wp-admin of the test site selected on the second step, and open Product > Categories. Find the category name with the same name as on the Example app, and make sure the "Count" value shown there is the same as what's reported by the Example app.