### PR TITLE
Shipping labels: handle trivial address suggestions

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooVerifyAddressFragment.kt
@@ -79,7 +79,9 @@ class WooVerifyAddressFragment : Fragment() {
                             prependToLog("${result.error.message}")
                         }
                         result.model is Valid -> {
-                            prependToLog("${(result.model as Valid).suggestedAddress}")
+                            val model = result.model as Valid
+                            prependToLog("Suggested address: ${model.suggestedAddress}\n" +
+                                    "Trivial Change: ${model.isTrivialNormalization}")
                         }
                         result.model is InvalidAddress -> {
                             prependToLog("Address error: ${(result.model as InvalidAddress).message}")

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -305,7 +305,7 @@ class WCShippingLabelStoreTest {
     @Test
     fun `verify shipping address`() = test {
         val result = verifyAddress(ORIGIN)
-        assertThat(result.model).isEqualTo(Valid(address))
+        assertThat(result.model).isEqualTo(Valid(address, successfulVerifyAddressApiResponse.isTrivialNormalization))
 
         val invalidRequestResult = verifyAddress(DESTINATION)
         assertThat(invalidRequestResult.model).isNull()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAddressVerificationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCAddressVerificationResult.kt
@@ -3,7 +3,10 @@ package org.wordpress.android.fluxc.model.shippinglabels
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelAddress
 
 sealed class WCAddressVerificationResult {
-    data class Valid(val suggestedAddress: ShippingLabelAddress) : WCAddressVerificationResult()
+    data class Valid(
+        val suggestedAddress: ShippingLabelAddress,
+        val isTrivialNormalization: Boolean
+    ) : WCAddressVerificationResult()
     data class InvalidAddress(val message: String) : WCAddressVerificationResult()
     data class InvalidRequest(val message: String) : WCAddressVerificationResult()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -205,7 +205,12 @@ class WCShippingLabelStore @Inject constructor(
                     WooResult(InvalidRequest(response.result.error.message ?: ""))
                 }
             } else if (response.result?.suggestedAddress != null && response.result.isSuccess) {
-                WooResult(Valid(response.result.suggestedAddress))
+                WooResult(
+                        Valid(
+                                suggestedAddress = response.result.suggestedAddress,
+                                isTrivialNormalization = response.result.isTrivialNormalization
+                        )
+                )
             } else {
                 WooResult(WooError(GENERIC_ERROR, UNKNOWN, "Unknown error"))
             }


### PR DESCRIPTION
This PR simply exposes the `isTrivialNormalization` from the address validation response, to allow client apps to use it in their logic.