### PR TITLE
Add support for test_mode parameter on payments/accounts endpoint

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
@@ -41,7 +41,14 @@ data class WCPaymentAccountResult(
      * A boolean flag indicating if this Account is test/live.
      */
     @SerializedName("is_live")
-    val isLive: Boolean
+    val isLive: Boolean,
+
+    /**
+     * A boolean flag indicating if the test mode on the site is enabled. When "null" the state is unknown (the most
+     * probable reason is that the site is using outdated version of wcpay plugin).
+     */
+    @SerializedName("test_mode")
+    val testMode: Boolean?
 ) {
     /**
      * Represents all of the possible Site Plugin Statuses in enum form

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -153,6 +153,6 @@ class PayRestClient @Inject constructor(
     companion object {
         private const val ACCOUNT_REQUESTED_FIELDS: String =
                 "status,has_pending_requirements,has_overdue_requirements,current_deadline,statement_descriptor," +
-                        "store_currencies,country,card_present_eligible,is_live"
+                        "store_currencies,country,card_present_eligible,is_live,test_mode"
     }
 }


### PR DESCRIPTION
Parent issue https://github.com/woocommerce/woocommerce-android/issues/4579

This PR adds support for "test_mode" flag on "payments/accounts" endpoint. The flag is "true" when the test mode on the site is enabled, "false" when it's disabled and "null" when it's unknown.

To test:
Test in WCAndroid PR (tbd)