### PR TITLE
Introduce domain models for Add-ons feature

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/domain/Addon.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/domain/Addon.kt
@@ -1,0 +1,127 @@
+package org.wordpress.android.fluxc.domain
+
+import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price
+
+sealed class Addon {
+    abstract val name: String
+    abstract val titleFormat: TitleFormat
+    abstract val description: String
+    abstract val required: Boolean
+    abstract val position: Int
+
+    interface HasOptions {
+        val options: List<AddonOption>
+    }
+
+    interface HasAdjustablePrice {
+        val price: Price
+
+        sealed class Price {
+            data class Adjusted(val priceType: PriceType, val value: String) : Price() {
+                enum class PriceType {
+                    FlatFee,
+                    QuantityBased,
+                    PercentageBased
+                }
+            }
+
+            object NotAdjusted : Price()
+        }
+    }
+
+    data class CustomText(
+        override val name: String,
+        override val titleFormat: TitleFormat,
+        override val description: String,
+        override val required: Boolean,
+        override val position: Int,
+        override val price: Price,
+        val restrictions: Restrictions,
+        val characterLength: LongRange?
+    ) : Addon(), HasAdjustablePrice {
+        enum class Restrictions {
+            AnyText,
+            OnlyLetters,
+            OnlyNumbers,
+            OnlyLettersNumbers,
+            Email
+        }
+    }
+
+    data class CustomTextArea(
+        override val name: String,
+        override val titleFormat: TitleFormat,
+        override val description: String,
+        override val required: Boolean,
+        override val position: Int,
+        override val price: Price,
+        val characterLength: LongRange?
+    ) : Addon(), HasAdjustablePrice
+
+    data class FileUpload(
+        override val name: String,
+        override val titleFormat: TitleFormat,
+        override val description: String,
+        override val required: Boolean,
+        override val position: Int,
+        override val price: Price
+    ) : Addon(), HasAdjustablePrice
+
+    data class InputMultiplier(
+        override val name: String,
+        override val titleFormat: TitleFormat,
+        override val description: String,
+        override val required: Boolean,
+        override val position: Int,
+        override val price: Price,
+        val quantityRange: LongRange?
+    ) : Addon(), HasAdjustablePrice
+
+    data class CustomPrice(
+        override val name: String,
+        override val titleFormat: TitleFormat,
+        override val description: String,
+        override val required: Boolean,
+        override val position: Int,
+        val priceRange: LongRange?
+    ) : Addon()
+
+    data class MultipleChoice(
+        override val name: String,
+        override val titleFormat: TitleFormat,
+        override val description: String,
+        override val required: Boolean,
+        override val position: Int,
+        override val options: List<AddonOption>,
+        val display: Display
+    ) : Addon(), HasOptions {
+        enum class Display {
+            Select,
+            RadioButton,
+            Images
+        }
+    }
+
+    data class Checkbox(
+        override val name: String,
+        override val titleFormat: TitleFormat,
+        override val description: String,
+        override val required: Boolean,
+        override val position: Int,
+        override val options: List<AddonOption>
+    ) : Addon(), HasOptions
+
+    data class Heading(
+        override val name: String,
+        override val titleFormat: TitleFormat,
+        override val description: String,
+        override val required: Boolean,
+        override val position: Int
+    ) : Addon()
+
+    enum class TitleFormat {
+        Label,
+        Heading,
+        Hide
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/domain/AddonOption.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/domain/AddonOption.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.domain
+
+import org.wordpress.android.fluxc.domain.Addon.HasAdjustablePrice.Price
+
+data class AddonOption(
+    val price: Price.Adjusted,
+    val label: String?,
+    val image: String?
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/domain/GlobalAddonGroup.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/domain/GlobalAddonGroup.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.domain
+
+data class GlobalAddonGroup(
+    val name: String,
+    val restrictedCategoriesIds: CategoriesRestriction,
+    val addons: List<Addon>
+) {
+    sealed class CategoriesRestriction {
+        object AllProductsCategories : CategoriesRestriction()
+        data class SpecifiedProductCategories(val productCategories: List<Long>) : CategoriesRestriction()
+    }
+}


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-android/issues/4645

### Description

This PR introduces domain models for the "Add-ons world". This models are based on what I could understand from how the features works on the live site and what features are available in each of the add-on type.

I'm pretty content with those `sealed class` models as they help to:
- offer only valid states to presentation layer
- add much more context without looking into API or live site, things like:
    - `display` has only sense in case of `MultipleChoice` add-on
    - `restrictions` has only sense in case of `CustomText`
    - not every add-on has `options`
    - not every add-on has `price`
    - `min` and `max` fields differ in meaning in different add-ons types. They can be `characterLength` as well as `quantityRange`

and other. I believe such modelling will make our lives much easier when working on presentation as well as in the future, during creating an order with add-ons in the app.

### Flow

This PR introduces only models but I think it can be valuable to present idea where those models will be in use:
<img width=350px src="https://user-images.githubusercontent.com/5845095/129880267-c5181f20-3ddc-41a2-add9-27be36eed995.png">

This way we'll have a single source of getting data from (cache/database) of valid data.

### How to test

This PR doesn't contain tests as mappers but it is valuable to test correctness of the model.

To do this, please:
- refer to API specification as well as live site
- create each type of the add-on and validate if all fields/features are covered by domain model

