### PR TITLE
Combine Global and Product-specific Add-ons

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.example.ui.customer.search.WooCustomersSearch
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
+import org.wordpress.android.fluxc.example.ui.products.WooAddonsTestFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductAttributeFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductFiltersFragment
@@ -148,4 +149,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooCustomerCreationFragment(): WooCustomerCreationFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooAddonsTestFragment(): WooAddonsTestFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooAddonsTestFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooAddonsTestFragment.kt
@@ -1,0 +1,106 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_addons.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.generated.WCProductActionBuilder
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.WCAddonsStore
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
+import javax.inject.Inject
+
+class WooAddonsTestFragment : DialogFragment() {
+    @Inject lateinit var dispatcher: Dispatcher
+    @Inject lateinit var wcProductStore: WCProductStore
+    @Inject lateinit var wcAddonsStore: WCAddonsStore
+    @Inject lateinit var siteStore: SiteStore
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+
+    companion object {
+        private const val SELECTED_SITE_REMOTE_ID = "selected_site_remote_id"
+
+        @JvmStatic
+        fun show(fragmentManager: FragmentManager, selectedSiteRemoteId: Long) =
+                WooAddonsTestFragment().apply {
+                    arguments = Bundle().apply {
+                        this.putLong(SELECTED_SITE_REMOTE_ID, selectedSiteRemoteId)
+                    }
+                }.show(fragmentManager, null)
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        val view = inflater.inflate(layout.fragment_woo_addons, container, false)
+
+        addonsResult = view!!.findViewById(R.id.addons_result)
+        return view
+    }
+
+    lateinit var selectedProduct: WCProductModel
+    lateinit var addonsResult: TextView
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val selectedSiteRemoteId = arguments!!.getLong(SELECTED_SITE_REMOTE_ID)
+        val selectedSite = siteStore.getSiteBySiteId(selectedSiteRemoteId)!!
+
+        addons_product_remote_id_apply.setOnClickListener {
+            val selectedProductRemoteId = addons_product_remote_id.text.toString().toLong()
+            selectedProduct = wcProductStore.getProductByRemoteId(selectedSite, selectedProductRemoteId)!!
+
+            startObserving(selectedSiteRemoteId, selectedProduct)
+        }
+
+        addons_fetch_product.setOnClickListener {
+            dispatcher.dispatch(
+                    WCProductActionBuilder.newFetchSingleProductAction(
+                            FetchSingleProductPayload(
+                                    selectedSite,
+                                    selectedProduct.remoteProductId
+                            )
+                    )
+            )
+        }
+
+        addons_fetch_global.setOnClickListener {
+            coroutineScope.launch {
+                wcAddonsStore.fetchAllGlobalAddonsGroups(selectedSite)
+            }
+        }
+    }
+
+    private fun startObserving(selectedSiteRemoteId: Long, productModel: WCProductModel) {
+        coroutineScope.launch {
+            wcAddonsStore.observeAddonsForProduct(
+                    selectedSiteRemoteId,
+                    productModel
+            ).collect {
+                addonsResult.text = it.joinToString { addon ->
+                    "\n- \"${addon.addon.name}\" with ${addon.options.size} options"
+                }
+            }
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -10,7 +10,6 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_products.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -38,7 +37,6 @@ import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
-import org.wordpress.android.fluxc.model.addons.WCProductAddonModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.WCAddonsStore
 import org.wordpress.android.fluxc.store.WCProductStore
@@ -379,33 +377,9 @@ class WooProductsFragment : Fragment() {
             }
         }
 
-        fetch_product_addons.setOnClickListener {
+        test_add_ons.setOnClickListener {
             selectedSite?.let { site ->
-                showSingleLineDialog(
-                        activity,
-                        "Enter the remoteProductId of product to fetch the addons:"
-                ) { editText ->
-                    pendingFetchSingleProductRemoteId = editText.text.toString().toLongOrNull()
-                    pendingFetchSingleProductRemoteId?.let { id ->
-                        prependToLog("Submitting request to fetch product by remoteProductID $id")
-                        coroutineScope.launch {
-                            wcProductStore.fetchProductListSynced(site, listOf(id))
-                                    .takeUnless { it.isNullOrEmpty() }
-                                    ?.first()?.addons
-                                    .logAddons()
-                        }
-                    } ?: prependToLog("No valid remoteOrderId defined...doing nothing")
-                }
-            }
-        }
-
-        fetch_global_addons_groups.setOnClickListener {
-            selectedSite?.let { site ->
-                coroutineScope.launch {
-                    addonsStore.fetchAllGlobalAddonsGroups(site).error
-                            ?.let { prependToLog("${it.type}: ${it.message}") }
-                            ?: prependToLog("Global addons fetch successful")
-                }
+                WooAddonsTestFragment.show(childFragmentManager, site.siteId)
             }
         }
 
@@ -697,13 +671,5 @@ class WooProductsFragment : Fragment() {
                 else -> { }
             }
         }
-    }
-
-    private fun Array<WCProductAddonModel>?.logAddons() {
-        this?.forEachIndexed { index, addon ->
-            prependToLog(addon.description?.let { "description: $it" }.orEmpty())
-            prependToLog(addon.name?.let { "name: $it" }.orEmpty())
-            prependToLog("========== Product Add-on #$index =========")
-        } ?: prependToLog("No addons found for this product ID")
     }
 }

--- a/example/src/main/res/layout/fragment_woo_addons.xml
+++ b/example/src/main/res/layout/fragment_woo_addons.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/addons_product_remote_id"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="Enter product remote id"
+            android:inputType="number" />
+
+        <Button
+            android:id="@+id/addons_product_remote_id_apply"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Start observing DB" />
+
+    </LinearLayout>
+
+
+    <Button
+        android:id="@+id/addons_fetch_product"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Fetch product" />
+
+    <Button
+        android:id="@+id/addons_fetch_global"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Fetch global addons" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:text="Only brief informations of addons are presented here. For detailed list, please use Database Inspector." />
+
+    <TextView
+        android:id="@+id/addons_result"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="vertical" />
+
+</LinearLayout>

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -189,18 +189,11 @@
             android:text="Add Product Tags" />
 
         <Button
-            android:id="@+id/fetch_product_addons"
+            android:id="@+id/test_add_ons"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Product Addons" />
-
-        <Button
-            android:id="@+id/fetch_global_addons_groups"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:enabled="false"
-            android:text="Fetch and Cache Global Addons groups" />
+            android:text="Test Add-ons" />
 
         <Button
             android:id="@+id/update_product"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
 import org.wordpress.android.fluxc.persistence.entity.GlobalAddonGroupEntity
 
 @Database(
-        version = 3,
+        version = 1,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
 import org.wordpress.android.fluxc.persistence.entity.GlobalAddonGroupEntity
 
 @Database(
-        version = 1,
+        version = 3,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCAddonsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCAddonsStore.kt
@@ -1,12 +1,18 @@
 package org.wordpress.android.fluxc.store
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.AddOnsRestClient
 import org.wordpress.android.fluxc.persistence.dao.AddonsDao
+import org.wordpress.android.fluxc.persistence.entity.AddonWithOptions
+import org.wordpress.android.fluxc.persistence.entity.GlobalAddonGroupEntity
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
@@ -31,5 +37,33 @@ class WCAddonsStore @Inject internal constructor(
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }
+    }
+
+    // TODO: 18/08/2021 @wzieba add tests for this method 
+    fun observeAddonsForProduct(siteRemoteId: Long, product: WCProductModel): Flow<List<AddonWithOptions>> {
+        return dao.observeGlobalAddonsForSite(siteRemoteId = siteRemoteId)
+                .map { globalGroups ->
+                    globalGroups.filter { globalGroup ->
+                        globalGroup.group.appliesToEveryProduct() || globalGroup.group.appliesToProduct(product)
+                    }.flatMap { it.addons }
+                }
+                .combine(
+                        dao.observeSingleProductAddons(
+                                siteRemoteId = siteRemoteId,
+                                productRemoteId = product.remoteProductId
+                        )
+                ) { fromGlobalAddons, fromSingleProductAddons ->
+                    fromGlobalAddons + fromSingleProductAddons
+                }
+    }
+
+    private fun GlobalAddonGroupEntity.appliesToEveryProduct(): Boolean {
+        return this.restrictedCategoriesIds.isEmpty()
+    }
+
+    private fun GlobalAddonGroupEntity.appliesToProduct(product: WCProductModel): Boolean {
+        val productCategoriesIds = product.getCategoryList().map { it.id }
+
+        return restrictedCategoriesIds.intersect(productCategoriesIds).isNotEmpty()
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce-android/issues/4647

### Description

This PR offers a logic for receiving combined Global and Product-specific Add-ons.

### Disclaimer

Like in #2102 I unfortunately didn't make it to write tests for added behaviour. I think it can be very valuable to do this but I think it's better this way to unblock further progress. 

### Demo

On the demo you can see that after pressing "start observing db", the view is updated in case of any change after fetching a product or global add-ons.

❗️I didn't test scenarios with global-addons specific to a product category. 

https://user-images.githubusercontent.com/5845095/129912967-d959c97f-1803-4a2a-8b12-f02b807f8f53.mov

### To test

1. Please go to example app (you might need to reinstall it due to changes in database schema in previous PR)
2. Go to `Woo` -> `Products`
3. Select site
4. Click on `Test Add-ons`
5. Enter remote product it you want to observe add ons on
6. Click on `Start observing DB`
7. **Assert there's list of currently stored add-ons there**
8. Add/remove/update specific-product add-ons on site. Click on `Fetch product` and assert that list has been updated.
9. Add/remove/update global add-ons on site. Click on `Fetch global addons` and assert that list has been updated.
10. Please also test categories restrictions for global add-ons (declared on site).


## Note about add-on option

I've noticed that to every Add-on, API adds  an empty option (even if its add-on without possibility to specify options). This problem will be resolved by domain mapping (#2101) but for now every Add-on will have at least one option.
