### PR TITLE
Update like status on success.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
@@ -611,6 +611,14 @@ class CommentsStore
                 payload.like
         )
 
+        if (!response.isError) {
+            response.data?.comments?.firstOrNull()?.let { entity ->
+                payload.comment?.apply {
+                    this.iLike = entity.iLike
+                }
+            }
+        }
+
         return createOnCommentChangedEvent(
                 response.data?.rowsAffected.orNone(),
                 CommentAction.LIKE_COMMENT,


### PR DESCRIPTION
This PR fixes [this](https://github.com/wordpress-mobile/WordPress-Android/issues/15171) WPAndroid issue 

It has a companion WPAndroid PR [here](https://github.com/wordpress-mobile/WordPress-Android/pull/15224) that includes testing steps.

The issue was due to the fact that CommentDetailFragment expects the original CommentModel like status to be updated by FluxC. This was done previously [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/3a258a7b0757607fe4fd3fc40b32b129d6a7a252/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java#L323). The CommentDetailFragment will be refactored in the upcoming phase 2 of the comments unification project, and we will use direct calls to suspend function provided by fluxc instead of using the event bus as it is now, so I confined the modification in the part of the like flow (the `onLikeComment` function) that is going to be superseded. 