### PR TITLE
This commit adds order_key column into WCOrderModel table and maps order_key into the order model.

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -196,6 +196,24 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
+    fun testFetchSingleOrderOrderKeySuccess() {
+        val remoteOrderId = 88L
+        val orderKey = "wc_order_5a77766b88986"
+        interceptor.respondWith("wc-fetch-order-response-success.json")
+        orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
+        val payload = lastAction!!.payload as RemoteOrderPayload
+        with(payload) {
+            assertNull(error)
+            assertEquals(orderKey, order.orderKey)
+        }
+    }
+
+    @Test
     fun testFetchSingleOrderError() {
         val remoteOrderId = 88L
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -34,7 +34,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
 import kotlin.properties.Delegates.notNull
@@ -71,7 +70,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         orderRestClient.fetchOrders(siteModel, 0)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.FETCHED_ORDERS, lastAction!!.type)
         val payload = lastAction!!.payload as FetchOrdersResponsePayload
@@ -127,7 +126,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         orderRestClient.searchOrders(siteModel, "", 0)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.SEARCHED_ORDERS, lastAction!!.type)
         val payload = lastAction!!.payload as SearchOrdersResponsePayload
@@ -141,7 +140,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         orderRestClient.searchOrders(SiteModel(), "", 0)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.SEARCHED_ORDERS, lastAction!!.type)
         val payload = lastAction!!.payload as SearchOrdersResponsePayload
@@ -156,7 +155,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         orderRestClient.fetchOrderCount(siteModel, statusFilter)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.FETCHED_ORDERS_COUNT, lastAction!!.type)
         val payload = lastAction!!.payload as FetchOrdersCountResponsePayload
@@ -171,7 +170,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         orderRestClient.fetchOrders(SiteModel(), 0)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.FETCHED_ORDERS, lastAction!!.type)
         val payload = lastAction!!.payload as FetchOrdersResponsePayload
@@ -185,7 +184,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteOrderPayload
@@ -203,7 +202,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteOrderPayload
@@ -221,7 +220,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteOrderPayload
@@ -245,7 +244,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         )
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.UPDATED_ORDER_STATUS, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteOrderPayload
@@ -280,7 +279,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         )
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.UPDATED_ORDER_STATUS, lastAction!!.type)
         val payload = lastAction!!.payload as RemoteOrderPayload
@@ -347,7 +346,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         )
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.FETCHED_ORDER_NOTES, lastAction!!.type)
         val payload = lastAction!!.payload as FetchOrderNotesResponsePayload
@@ -422,7 +421,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         orderRestClient.fetchHasOrders(siteModel, filterByStatus = null)
 
         countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         assertEquals(WCOrderAction.FETCHED_HAS_ORDERS, lastAction!!.type)
         val payload = lastAction!!.payload as FetchHasOrdersResponsePayload

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 160
+        return 161
     }
 
     override fun getDbName(): String {
@@ -1807,6 +1807,10 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 159 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD METADATA TEXT")
+                }
+
+                160 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCOrderModel ADD ORDER_KEY TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -19,6 +19,7 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var number = "" // The order number to display to the user
     @Column var status = ""
     @Column var currency = ""
+    @Column var orderKey = ""
     @Column var dateCreated = "" // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @Column var dateModified = "" // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @Column var total = "" // Complete total, including taxes

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderApiResponse.kt
@@ -42,6 +42,7 @@ class OrderApiResponse : Response {
     val billing: Billing? = null
     val coupon_lines: List<CouponLine>? = null
     val currency: String? = null
+    val order_key: String? = null
     val customer_note: String? = null
     val date_created_gmt: String? = null
     val date_modified_gmt: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -679,6 +679,7 @@ class OrderRestClient @Inject constructor(
             number = response.number ?: remoteOrderId.toString()
             status = response.status ?: ""
             currency = response.currency ?: ""
+            orderKey = response.order_key ?: ""
             dateCreated = convertDateToUTCString(response.date_created_gmt)
             dateModified = convertDateToUTCString(response.date_modified_gmt)
             total = response.total ?: ""
@@ -809,6 +810,7 @@ class OrderRestClient @Inject constructor(
                 "billing",
                 "coupon_lines",
                 "currency",
+                "order_key",
                 "customer_note",
                 "date_created_gmt",
                 "date_modified_gmt",


### PR DESCRIPTION

parent issue: https://github.com/woocommerce/woocommerce-android/issues/4030 (Add order_key to PaymentIntent's metadata)
### Description
This PR adds the order_key column into the WCOrderModel table and maps order_key into the order model.

### Testing instructions
Since this PR adds a new column into the WCOrder model table. Here are some of the things we need to test to see if adding a new column didn't break anything.

1. Install the app on top of an existing app
2. See that the app doesn't crash on startup
3. You can use Flipper for making sure there is a column called ORDER_KEY created in WCOrderModel
4. Run the unit test and ensure it passes