### PR TITLE
Woo Shipping Labels: pass is_letter value when purchasing shipping labels

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -606,7 +606,7 @@ class WooShippingLabelFragment : Fragment() {
                             site,
                             order.remoteOrderId,
                             if (isInternational) origin.copy(phone = "0000000000") else origin,
-                            destination,
+                            if (isInternational) destination.copy(phone = "0000000000") else destination,
                             listOf(box),
                             customsData?.let { listOf(it) }
                     )
@@ -643,7 +643,7 @@ class WooShippingLabelFragment : Fragment() {
                             site,
                             order.remoteOrderId,
                             if (isInternational) origin.copy(phone = "0000000000") else origin,
-                            destination,
+                            if (isInternational) destination.copy(phone = "0000000000") else destination,
                             listOf(packageData),
                             customsData?.let { listOf(it) },
                             emailReceipts = true
@@ -769,6 +769,7 @@ class WooShippingLabelFragment : Fragment() {
 
         val origin = wooCommerceStore.getSiteSettings(site)?.let {
             ShippingLabelAddress(
+                    name = "Test Name",
                     address = it.address,
                     city = it.city,
                     postcode = it.postalCode,
@@ -780,6 +781,7 @@ class WooShippingLabelFragment : Fragment() {
         val order = wcOrderStore.getOrderByIdentifier(OrderIdentifier(site.id, orderId))
         val destination = order?.getShippingAddress()?.let {
             ShippingLabelAddress(
+                    name = "${it.firstName} ${it.lastName}",
                     address = it.address1,
                     city = it.city,
                     postcode = it.postcode,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -627,6 +627,7 @@ class WooShippingLabelFragment : Fragment() {
                     val packageData = WCShippingLabelPackageData(
                             id = "default",
                             boxId = boxId,
+                            isLetter = box.isLetter,
                             length = length,
                             height = height,
                             width = width,

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -142,6 +142,7 @@ class WCShippingLabelStoreTest {
             WCShippingLabelPackageData(
                     id = "id1",
                     boxId = "medium_flat_box_top",
+                    isLetter = false,
                     height = 10f,
                     width = 10f,
                     length = 10f,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPackageData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPackageData.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName
 data class WCShippingLabelPackageData(
     val id: String,
     @SerializedName("box_id") val boxId: String,
+    @SerializedName("is_letter") val isLetter: Boolean,
     val length: Float,
     val width: Float,
     val height: Float,


### PR DESCRIPTION
This change is only to align with the requirements of the API, even though the call succeeds without it.