### PR TITLE
Prevents null styles/features from being converted to string

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -31,8 +31,8 @@ data class EditorTheme(
             themeSupport = EditorThemeSupport(
                     blockEditorSettings.colors,
                     blockEditorSettings.gradients,
-                    blockEditorSettings.styles.toString(),
-                    blockEditorSettings.features.toString(),
+                    blockEditorSettings.styles?.toString(),
+                    blockEditorSettings.features?.toString(),
                     blockEditorSettings.isFSETheme,
                     blockEditorSettings.galleryWithImageBlocks
             ),


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3936

`WordPress-Android` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/15312

### Description
Prevents null styles and features from being converted to string