### PR TITLE
Merge `release/1.25.1` into `develop`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ ext {
     assertJVersion = '3.19.0'
     kotlinCoroutinesVersion = '1.3.9'
     roomVersion = "2.3.0"
+    wordPressUtilsVersion = "develop-eebc5d8e91a1d90190919f900f924b39c861a528"
 
     fluxcAnnotationsProjectDependency = project.hasProperty("fluxcAnnotationsVersion") ? "org.wordpress.fluxc:fluxc-annotations:${project.getProperty("fluxcAnnotationsVersion")}" : project(":fluxc-annotations")
     fluxcProcessorProjectDependency = project.hasProperty("fluxcProcessorVersion") ? "org.wordpress.fluxc:fluxc-processor:${project.getProperty("fluxcProcessorVersion")}" : project(":fluxc-processor")

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.7'
 
     // WordPress libs
-    implementation('org.wordpress:utils:1.20.0') {
+    implementation('org.wordpress:utils:develop-eebc5d8e91a1d90190919f900f924b39c861a528') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.7'
 
     // WordPress libs
-    implementation('org.wordpress:utils:develop-eebc5d8e91a1d90190919f900f924b39c861a528') {
+    implementation("org.wordpress:utils:$wordPressUtilsVersion") {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:1.0.0"
 
     // WordPress libs
-    implementation('org.wordpress:utils:1.30.3-beta.1') {
+    implementation('org.wordpress:utils:90-39e7741284f91fb568bd1242cf1ee0661085dda8') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:1.0.0"
 
     // WordPress libs
-    implementation('org.wordpress:utils:develop-eebc5d8e91a1d90190919f900f924b39c861a528') {
+    implementation("org.wordpress:utils:$wordPressUtilsVersion") {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:1.0.0"
 
     // WordPress libs
-    implementation('org.wordpress:utils:90-39e7741284f91fb568bd1242cf1ee0661085dda8') {
+    implementation('org.wordpress:utils:develop-eebc5d8e91a1d90190919f900f924b39c861a528') {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Error
 import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.VersionUtils
 import org.wordpress.android.util.helpers.Version
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -181,29 +182,5 @@ class EditorThemeStore
     }
 
     private fun editorSettingsAvailable(site: SiteModel, gssEnabled: Boolean) =
-            gssEnabled && hasRequiredWordPressVersion(site.softwareVersion, EDITOR_SETTINGS_WP_VERSION)
-
-    /**
-     * Checks if the [SiteModel.getSoftwareVersion] is higher or equal to the [requiredVersion]
-     *
-     * Note: At this point semantic version information (alpha, beta etc) is stripped since it
-     * is not supported by our [Version] utility
-     *
-     * @param requiredVersion the required WordPress version
-     * @return true if the check is met
-     */
-    private fun hasRequiredWordPressVersion(softwareVersion: String?, requiredVersion: String): Boolean {
-        if (softwareVersion == null) {
-            return false
-        }
-        return try {
-            val version = if (softwareVersion.contains("-")) {
-                // strip semantic versioning information (alpha, beta etc)
-                softwareVersion.substringBefore("-")
-            } else softwareVersion
-            Version(version) >= Version(requiredVersion)
-        } catch (e: IllegalArgumentException) {
-            false // if version parsing fails return false
-        }
-    }
+            gssEnabled && VersionUtils.checkMinimalVersion(site.softwareVersion, EDITOR_SETTINGS_WP_VERSION)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.store.ReactNativeFetchResponse.Success
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.VersionUtils
-import org.wordpress.android.util.helpers.Version
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -181,7 +181,7 @@ class EditorThemeStore
     }
 
     private fun editorSettingsAvailable(site: SiteModel, gssEnabled: Boolean) =
-            gssEnabled && site.hasRequiredWordPressVersion(EDITOR_SETTINGS_WP_VERSION)
+            gssEnabled && hasRequiredWordPressVersion(site.softwareVersion, EDITOR_SETTINGS_WP_VERSION)
 
     /**
      * Checks if the [SiteModel.getSoftwareVersion] is higher or equal to the [requiredVersion]
@@ -192,13 +192,18 @@ class EditorThemeStore
      * @param requiredVersion the required WordPress version
      * @return true if the check is met
      */
-    private fun SiteModel.hasRequiredWordPressVersion(requiredVersion: String) = try {
-        val version = if (softwareVersion.contains("-")) {
-            // strip semantic versioning information (alpha, beta etc)
-            softwareVersion.substringBefore("-")
-        } else softwareVersion
-        Version(version) >= Version(requiredVersion)
-    } catch (e: IllegalArgumentException) {
-        false // if version parsing fails return false
+    private fun hasRequiredWordPressVersion(softwareVersion: String?, requiredVersion: String): Boolean {
+        if (softwareVersion == null) {
+            return false
+        }
+        return try {
+            val version = if (softwareVersion.contains("-")) {
+                // strip semantic versioning information (alpha, beta etc)
+                softwareVersion.substringBefore("-")
+            } else softwareVersion
+            Version(version) >= Version(requiredVersion)
+        } catch (e: IllegalArgumentException) {
+            false // if version parsing fails return false
+        }
     }
 }

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation project(':fluxc');
 
     // WordPress libs
-    implementation('org.wordpress:utils:1.20.0') {
+    implementation("org.wordpress:utils:$wordPressUtilsVersion") {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.7'
 
     // WordPress libs
-    implementation ('org.wordpress:utils:1.20.0') {
+    implementation ("org.wordpress:utils:$wordPressUtilsVersion") {
         // Using official volley package
         exclude group: "com.mcxiaoke.volley"
         exclude group: "com.android.support"


### PR DESCRIPTION
This PR merges the `release/1.25.1` branch into `develop`.

The `release/1.25.1` contains the changes from #2109 (https://github.com/wordpress-mobile/WordPress-Android/pull/15286)

Related PR to merge into trunk: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2115