### PR TITLE
Database and model setup for SSR in WC Android

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.Provides
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.AddonsDao
+import org.wordpress.android.fluxc.persistence.dao.SSRDao
 import javax.inject.Singleton
 
 @Module
@@ -15,5 +16,9 @@ class WCDatabaseModule {
 
     @Provides internal fun provideAddonsDao(database: WCAndroidDatabase): AddonsDao {
         return database.addonsDao()
+    }
+
+    @Provides internal fun provideSSRDao(database: WCAndroidDatabase): SSRDao {
+        return database.ssrDao()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
@@ -1,8 +1,7 @@
 package org.wordpress.android.fluxc.model
 
 data class WCSSRModel(
-    val id: Int,
-    val localSiteId: Int,
+    val remoteSiteId: Int,
     val environment: String? = null,
     val database: String? = null,
     val activePlugins: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.model
 
 data class WCSSRModel(
+    val id: Int,
     val localSiteId: Int,
     val environment: String? = null,
     val database: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.model
 
 data class WCSSRModel(
-    val remoteSiteId: Int,
+    val remoteSiteId: Long,
     val environment: String? = null,
     val database: String? = null,
     val activePlugins: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.model
+
+data class WCSSRModel(
+    val localSiteId: Int,
+    val environment: String? = null,
+    val database: String? = null,
+    val activePlugins: String? = null,
+    val theme: String? = null,
+    val settings: String? = null,
+    val security: String? = null,
+    val pages: String? = null
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -7,21 +7,25 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import org.wordpress.android.fluxc.persistence.converters.LongListConverter
 import org.wordpress.android.fluxc.persistence.dao.AddonsDao
+import org.wordpress.android.fluxc.persistence.dao.SSRDao
 import org.wordpress.android.fluxc.persistence.entity.AddonEntity
 import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
 import org.wordpress.android.fluxc.persistence.entity.GlobalAddonGroupEntity
+import org.wordpress.android.fluxc.persistence.entity.SSREntity
 
 @Database(
-        version = 2,
+        version = 3,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,
-            GlobalAddonGroupEntity::class
+            GlobalAddonGroupEntity::class,
+            SSREntity::class
         ]
 )
 @TypeConverters(value = [LongListConverter::class])
 abstract class WCAndroidDatabase : RoomDatabase() {
     internal abstract fun addonsDao(): AddonsDao
+    internal abstract fun ssrDao(): SSRDao
 
     companion object {
         fun buildDb(applicationContext: Context) = Room.databaseBuilder(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import org.wordpress.android.fluxc.model.WCSSRModel
 import org.wordpress.android.fluxc.persistence.entity.SSREntity
 
 @Dao
@@ -11,6 +12,6 @@ abstract class SSRDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insertSSR(ssrEntity: SSREntity): Long
 
-    @Query("SELECT * FROM SSREntity WHERE localSiteId = :localSiteId")
-    abstract suspend fun getSSRbySite(localSiteId: Long)
+    @Query("SELECT * FROM SSREntity WHERE localSiteId = :localSiteId LIMIT 1")
+    abstract suspend fun getSSRbySite(localSiteId: Long): WCSSRModel
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
@@ -13,6 +13,6 @@ abstract class SSRDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insertSSR(ssrEntity: SSREntity)
 
-    @Query("SELECT * FROM SSREntity WHERE localSiteId = :localSiteId LIMIT 1")
-    abstract fun observeSSRForSite(localSiteId: Int): Flow<WCSSRModel>
+    @Query("SELECT * FROM SSREntity WHERE remoteSiteId = :remoteSiteId LIMIT 1")
+    abstract fun observeSSRForSite(remoteSiteId: Int): Flow<WCSSRModel>
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
@@ -13,5 +13,5 @@ abstract class SSRDao {
     abstract suspend fun insertSSR(ssrEntity: SSREntity): Long
 
     @Query("SELECT * FROM SSREntity WHERE localSiteId = :localSiteId LIMIT 1")
-    abstract suspend fun getSSRbySite(localSiteId: Long): WCSSRModel
+    abstract suspend fun getSSRbySite(localSiteId: Int): WCSSRModel
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.fluxc.persistence.entity.SSREntity
 @Dao
 abstract class SSRDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insertSSR(ssrEntity: SSREntity): Long
+    abstract suspend fun insertSSR(ssrEntity: SSREntity)
 
     @Query("SELECT * FROM SSREntity WHERE localSiteId = :localSiteId LIMIT 1")
     abstract suspend fun getSSRbySite(localSiteId: Int): WCSSRModel

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.WCSSRModel
 import org.wordpress.android.fluxc.persistence.entity.SSREntity
 
@@ -13,5 +14,5 @@ abstract class SSRDao {
     abstract suspend fun insertSSR(ssrEntity: SSREntity)
 
     @Query("SELECT * FROM SSREntity WHERE localSiteId = :localSiteId LIMIT 1")
-    abstract suspend fun getSSRbySite(localSiteId: Int): WCSSRModel
+    abstract fun observeSSRForSite(localSiteId: Int): Flow<WCSSRModel>
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
@@ -14,5 +14,5 @@ abstract class SSRDao {
     abstract suspend fun insertSSR(ssrEntity: SSREntity)
 
     @Query("SELECT * FROM SSREntity WHERE remoteSiteId = :remoteSiteId LIMIT 1")
-    abstract fun observeSSRForSite(remoteSiteId: Int): Flow<WCSSRModel>
+    abstract fun observeSSRForSite(remoteSiteId: Long): Flow<WCSSRModel>
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/SSRDao.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import org.wordpress.android.fluxc.persistence.entity.SSREntity
+
+@Dao
+abstract class SSRDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertSSR(ssrEntity: SSREntity): Long
+
+    @Query("SELECT * FROM SSREntity WHERE localSiteId = :localSiteId")
+    abstract suspend fun getSSRbySite(localSiteId: Long)
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.persistence.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class SSREntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val localSiteId: Long? = null,
+    val environment: String? = null,
+    val database: String? = null,
+    val active_plugins: String? = null,
+    val theme: String? = null,
+    val settings: String? = null,
+    val security: String? = null,
+    val pages: String? = null
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.persistence.entity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import org.wordpress.android.fluxc.model.WCSSRModel
 
 @Entity
 data class SSREntity(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
@@ -5,8 +5,7 @@ import androidx.room.PrimaryKey
 
 @Entity
 data class SSREntity(
-    @PrimaryKey(autoGenerate = true) val id: Int = 0,
-    val localSiteId: Int,
+    @PrimaryKey val remoteSiteId: Int,
     val environment: String? = null,
     val database: String? = null,
     val activePlugins: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
@@ -2,14 +2,15 @@ package org.wordpress.android.fluxc.persistence.entity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import org.wordpress.android.fluxc.model.WCSSRModel
 
 @Entity
 data class SSREntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val localSiteId: Long? = null,
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val localSiteId: Int,
     val environment: String? = null,
     val database: String? = null,
-    val active_plugins: String? = null,
+    val activePlugins: String? = null,
     val theme: String? = null,
     val settings: String? = null,
     val security: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/SSREntity.kt
@@ -5,7 +5,7 @@ import androidx.room.PrimaryKey
 
 @Entity
 data class SSREntity(
-    @PrimaryKey val remoteSiteId: Int,
+    @PrimaryKey val remoteSiteId: Long,
     val environment: String? = null,
     val database: String? = null,
     val activePlugins: String? = null,

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/SSRDaoTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/SSRDaoTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence.dao
 import android.app.Application
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -59,7 +60,7 @@ internal class SSRDaoTest {
     fun `save and retrieve SSR`(): Unit = runBlocking {
         sut.insertSSR(sampleEntity)
 
-        val resultFromDatabase = sut.getSSRbySite(TEST_SITE_LOCAL_ID)
+        val resultFromDatabase = sut.observeSSRForSite(TEST_SITE_LOCAL_ID).first()
         assertEquals(resultFromDatabase, sampleModel)
     }
 

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/SSRDaoTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/SSRDaoTest.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.fluxc.persistence.dao
+
+import android.app.Application
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.model.WCSSRModel
+import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
+import org.wordpress.android.fluxc.persistence.entity.SSREntity
+
+@RunWith(RobolectricTestRunner::class)
+internal class SSRDaoTest {
+    private lateinit var database: WCAndroidDatabase
+    private lateinit var sut: SSRDao
+
+    private companion object {
+        const val TEST_SITE_LOCAL_ID = 1337
+        const val DB_GENERATED_ID = 1
+        val sampleEntity = SSREntity(
+                id = DB_GENERATED_ID,
+                localSiteId = TEST_SITE_LOCAL_ID,
+                environment = "",
+                database = "",
+                activePlugins = "",
+                theme = "",
+                settings = "",
+                security = "",
+                pages = ""
+        )
+        val sampleModel = WCSSRModel(
+                id = DB_GENERATED_ID,
+                localSiteId = TEST_SITE_LOCAL_ID,
+                environment = "",
+                database = "",
+                activePlugins = "",
+                theme = "",
+                settings = "",
+                security = "",
+                pages = ""
+        )
+    }
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        database = Room.inMemoryDatabaseBuilder(context, WCAndroidDatabase::class.java)
+                .allowMainThreadQueries()
+                .build()
+        sut = database.ssrDao()
+    }
+
+    @Test
+    fun `save and retrieve SSR`(): Unit = runBlocking {
+        sut.insertSSR(sampleEntity)
+
+        val resultFromDatabase = sut.getSSRbySite(TEST_SITE_LOCAL_ID)
+        assertEquals(resultFromDatabase, sampleModel)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/SSRDaoTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/SSRDaoTest.kt
@@ -21,11 +21,9 @@ internal class SSRDaoTest {
     private lateinit var sut: SSRDao
 
     private companion object {
-        const val TEST_SITE_LOCAL_ID = 1337
-        const val DB_GENERATED_ID = 1
+        const val TEST_SITE_REMOTE_ID = 1337L
         val sampleEntity = SSREntity(
-                id = DB_GENERATED_ID,
-                localSiteId = TEST_SITE_LOCAL_ID,
+                remoteSiteId = TEST_SITE_REMOTE_ID,
                 environment = "",
                 database = "",
                 activePlugins = "",
@@ -35,8 +33,7 @@ internal class SSRDaoTest {
                 pages = ""
         )
         val sampleModel = WCSSRModel(
-                id = DB_GENERATED_ID,
-                localSiteId = TEST_SITE_LOCAL_ID,
+                remoteSiteId = TEST_SITE_REMOTE_ID,
                 environment = "",
                 database = "",
                 activePlugins = "",
@@ -60,7 +57,7 @@ internal class SSRDaoTest {
     fun `save and retrieve SSR`(): Unit = runBlocking {
         sut.insertSSR(sampleEntity)
 
-        val resultFromDatabase = sut.observeSSRForSite(TEST_SITE_LOCAL_ID).first()
+        val resultFromDatabase = sut.observeSSRForSite(TEST_SITE_REMOTE_ID).first()
         assertEquals(resultFromDatabase, sampleModel)
     }
 


### PR DESCRIPTION
## PR Description

I'm working on allowing merchants to share System Status Report (SSR) directly via app. The main issue thread is on https://github.com/woocommerce/woocommerce-android/issues/4781 .

This PR is the first part of that. It adds:

1. A new entity for it in the WooCommerce Room database
2. A DAO and its unit test
2. A model

## To test

Run `SSRDaoTest` and ensure it is successful.