### PR TITLE
Upgrade FluxC to Android 11

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CustomStatsDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CustomStatsDialog.kt
@@ -83,13 +83,16 @@ class CustomStatsDialog : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         stats_granularity.adapter =
-                ArrayAdapter<StatsGranularity>(requireActivity(), layout.simple_dropdown_item_1line, StatsGranularity.values())
+                ArrayAdapter<StatsGranularity>(
+                        requireActivity(), layout.simple_dropdown_item_1line, StatsGranularity.values())
 
         if (savedInstanceState != null) {
             stats_from_date.text = savedInstanceState.getString("start_date")
             stats_to_date.text = savedInstanceState.getString("end_date")
             stats_granularity.setSelection(savedInstanceState.getInt("granularity"))
-            wcOrderStatsAction = savedInstanceState.getString("action")?.let { WCOrderStatsAction.valueOf(it.toUpperCase()) }
+            wcOrderStatsAction = savedInstanceState.getString("action")?.let {
+                WCOrderStatsAction.valueOf(it.toUpperCase())
+            }
         } else {
             val startDate = startDate?.let { it } ?: DateUtils.getCurrentDateString()
             stats_from_date.text = startDate

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CustomStatsDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CustomStatsDialog.kt
@@ -83,13 +83,13 @@ class CustomStatsDialog : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         stats_granularity.adapter =
-                ArrayAdapter<StatsGranularity>(activity, layout.simple_dropdown_item_1line, StatsGranularity.values())
+                ArrayAdapter<StatsGranularity>(requireActivity(), layout.simple_dropdown_item_1line, StatsGranularity.values())
 
         if (savedInstanceState != null) {
             stats_from_date.text = savedInstanceState.getString("start_date")
             stats_to_date.text = savedInstanceState.getString("end_date")
             stats_granularity.setSelection(savedInstanceState.getInt("granularity"))
-            wcOrderStatsAction = WCOrderStatsAction.valueOf(savedInstanceState.getString("action").toUpperCase())
+            wcOrderStatsAction = savedInstanceState.getString("action")?.let { WCOrderStatsAction.valueOf(it.toUpperCase()) }
         } else {
             val startDate = startDate?.let { it } ?: DateUtils.getCurrentDateString()
             stats_from_date.text = startDate

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationTypeSubtypeDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationTypeSubtypeDialog.kt
@@ -36,9 +36,9 @@ class NotificationTypeSubtypeDialog : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         notif_type.adapter =
-                ArrayAdapter<Kind>(activity, android.R.layout.simple_dropdown_item_1line, Kind.values())
+                ArrayAdapter<Kind>(requireActivity(), android.R.layout.simple_dropdown_item_1line, Kind.values())
         notif_subtype.adapter =
-                ArrayAdapter<Subkind>(activity, android.R.layout.simple_dropdown_item_1line, Subkind.values())
+                ArrayAdapter<Subkind>(requireActivity(), android.R.layout.simple_dropdown_item_1line, Subkind.values())
 
         notif_dialog_ok.setOnClickListener {
             listener?.let {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SiteSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SiteSelectorDialog.kt
@@ -76,7 +76,11 @@ class SiteSelectorDialog : DialogFragment() {
                     .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
                         val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
                         val site = adapter.getItem(which)
-                        site?.let { siteModel -> listener?.onSiteSelected(siteModel, which) }
+                        if (site != null) {
+                            listener?.onSiteSelected(site, which)
+                        } else {
+                            prependToLog("SiteChanged error: site at position $which was null.")
+                        }
                         dialog.dismiss()
                     }
             // Create the AlertDialog object and return it

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SiteSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SiteSelectorDialog.kt
@@ -76,7 +76,7 @@ class SiteSelectorDialog : DialogFragment() {
                     .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
                         val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
                         val site = adapter.getItem(which)
-                        listener?.onSiteSelected(site, which)
+                        site?.let { siteModel -> listener?.onSiteSelected(siteModel, which) }
                         dialog.dismiss()
                     }
             // Create the AlertDialog object and return it
@@ -107,7 +107,7 @@ class SiteSelectorDialog : DialogFragment() {
             addAll(newItems)
         }
 
-        override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
             val cv = convertView
                     ?: LayoutInflater.from(context)
                             .inflate(android.R.layout.simple_list_item_single_choice, parent, false)
@@ -116,7 +116,7 @@ class SiteSelectorDialog : DialogFragment() {
             return cv
         }
 
-        override fun getItemId(position: Int) = getItem(position).id.toLong()
+        override fun getItemId(position: Int) = getItem(position)!!.id.toLong()
 
         override fun hasStableIds() = true
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WCAddOrderShipmentTrackingDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WCAddOrderShipmentTrackingDialog.kt
@@ -70,7 +70,8 @@ class WCAddOrderShipmentTrackingDialog : DialogFragment() {
         val allProviders = mutableListOf("Custom")
         allProviders.addAll(1, providers)
 
-        tracking_cboProvider.adapter = ArrayAdapter<String>(requireActivity(), layout.simple_dropdown_item_1line, allProviders)
+        tracking_cboProvider.adapter = ArrayAdapter<String>(
+                requireActivity(), layout.simple_dropdown_item_1line, allProviders)
         tracking_cboProvider.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {
                 tracking_cboProvider.setSelection(0)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WCAddOrderShipmentTrackingDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WCAddOrderShipmentTrackingDialog.kt
@@ -70,7 +70,7 @@ class WCAddOrderShipmentTrackingDialog : DialogFragment() {
         val allProviders = mutableListOf("Custom")
         allProviders.addAll(1, providers)
 
-        tracking_cboProvider.adapter = ArrayAdapter<String>(activity, layout.simple_dropdown_item_1line, allProviders)
+        tracking_cboProvider.adapter = ArrayAdapter<String>(requireActivity(), layout.simple_dropdown_item_1line, allProviders)
         tracking_cboProvider.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {
                 tracking_cboProvider.setSelection(0)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectorDialog.kt
@@ -12,6 +12,7 @@ import android.widget.TextView
 import androidx.fragment.app.DialogFragment
 import dagger.android.support.AndroidSupportInjection
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -50,7 +51,11 @@ class StoreSelectorDialog : DialogFragment() {
                     .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
                         val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
                         val site = adapter.getItem(which)
-                        site?.let { siteModel -> listener?.onSiteSelected(siteModel, which) }
+                        if (site != null) {
+                            listener?.onSiteSelected(site, which)
+                        } else {
+                            prependToLog("SiteChanged error: site at position $which was null.")
+                        }
                         dialog.dismiss()
                     }
             // Create the AlertDialog object and return it

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectorDialog.kt
@@ -50,7 +50,7 @@ class StoreSelectorDialog : DialogFragment() {
                     .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
                         val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
                         val site = adapter.getItem(which)
-                        listener?.onSiteSelected(site, which)
+                        site?.let { siteModel -> listener?.onSiteSelected(siteModel, which) }
                         dialog.dismiss()
                     }
             // Create the AlertDialog object and return it
@@ -67,16 +67,16 @@ class StoreSelectorDialog : DialogFragment() {
             addAll(newItems)
         }
 
-        override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
             val cv = convertView
                     ?: LayoutInflater.from(context)
                             .inflate(android.R.layout.simple_list_item_single_choice, parent, false)
             val site = getItem(position)
-            (cv as TextView).text = site.displayName ?: site.name
+            (cv as TextView).text = site?.displayName ?: site?.name
             return cv
         }
 
-        override fun getItemId(position: Int) = getItem(position).id.toLong()
+        override fun getItemId(position: Int) = getItem(position)!!.id.toLong()
 
         override fun hasStableIds() = true
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchFragment.kt
@@ -13,6 +13,7 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.parcel.Parcelize
 import kotlinx.android.synthetic.main.fragment_woo_customers_search.*
 import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -26,13 +27,15 @@ class WooCustomersSearchFragment : Fragment() {
     private val siteId by lazy { requireArguments().getInt(KEY_SELECTED_SITE_ID) }
     private val searchParams by lazy { requireArguments().getParcelable(KEY_SEARCH_PARAMS) as SearchParams? }
     private val pagedListWrapper by lazy {
+        if (searchParams == null) prependToLog("SearchParams: $searchParams were null.")
+
         val descriptor = SearchCustomerListDescriptor(
                 customerSite = getSelectedSite(),
-                customerSearchQuery = searchParams?.searchQuery,
-                customerEmail = searchParams?.email,
-                customerRole = searchParams?.role,
-                customerRemoteCustomerIds = searchParams?.includeIds,
-                customerExcludedCustomerIds = searchParams?.excludeIds
+                customerSearchQuery = searchParams!!.searchQuery,
+                customerEmail = searchParams!!.email,
+                customerRole = searchParams!!.role,
+                customerRemoteCustomerIds = searchParams!!.includeIds,
+                customerExcludedCustomerIds = searchParams!!.excludeIds
         )
         listStore.getList(
                 listDescriptor = descriptor,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchFragment.kt
@@ -24,15 +24,15 @@ class WooCustomersSearchFragment : Fragment() {
     @Inject internal lateinit var customersAdapter: WooCustomersSearchAdapter
 
     private val siteId by lazy { requireArguments().getInt(KEY_SELECTED_SITE_ID) }
-    private val searchParams by lazy { requireArguments().getParcelable(KEY_SEARCH_PARAMS) as SearchParams }
+    private val searchParams by lazy { requireArguments().getParcelable(KEY_SEARCH_PARAMS) as SearchParams? }
     private val pagedListWrapper by lazy {
         val descriptor = SearchCustomerListDescriptor(
                 customerSite = getSelectedSite(),
-                customerSearchQuery = searchParams.searchQuery,
-                customerEmail = searchParams.email,
-                customerRole = searchParams.role,
-                customerRemoteCustomerIds = searchParams.includeIds,
-                customerExcludedCustomerIds = searchParams.excludeIds
+                customerSearchQuery = searchParams?.searchQuery,
+                customerEmail = searchParams?.email,
+                customerRole = searchParams?.role,
+                customerRemoteCustomerIds = searchParams?.includeIds,
+                customerExcludedCustomerIds = searchParams?.excludeIds
         )
         listStore.getList(
                 listDescriptor = descriptor,

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 18
         targetSdkVersion 30
         javaCompileOptions {
             annotationProcessorOptions {

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -9,11 +9,11 @@ plugins {
 android {
     useLibrary 'org.apache.http.legacy'
 
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 18
-        targetSdkVersion 29
+        minSdkVersion 24
+        targetSdkVersion 30
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments += [

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.instaflux"
         minSdkVersion 18
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
     buildTypes {
         release {


### PR DESCRIPTION
Fixes [WordPress-Android#15338](https://github.com/wordpress-mobile/WordPress-Android/issues/15338)

Upgrade to Android 11 (API level 30)

Please see paqN3M-mr-p2 for details on mandatory requirement to upgrade to Android 11 by November 2021.

- upgrade minSdkVersion to 24 and targetSdkVersion, compileSdkVersion to 30