### PR TITLE
FetchSingleOrder - replace event bus with suspendable

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked
 
 import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -178,53 +179,38 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchSingleOrderSuccess() {
+    fun testFetchSingleOrderSuccess() = runBlocking {
         val remoteOrderId = 88L
         interceptor.respondWith("wc-fetch-order-response-success.json")
-        orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+        val response = orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteOrderPayload
-        with(payload) {
+        with(response) {
             assertNull(error)
             assertEquals(remoteOrderId, order.remoteOrderId)
         }
     }
 
     @Test
-    fun testFetchSingleOrderOrderKeySuccess() {
+    fun testFetchSingleOrderOrderKeySuccess() = runBlocking {
         val remoteOrderId = 88L
         val orderKey = "wc_order_5a77766b88986"
         interceptor.respondWith("wc-fetch-order-response-success.json")
-        orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+        val response = orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteOrderPayload
-        with(payload) {
+        with(response) {
             assertNull(error)
             assertEquals(orderKey, order.orderKey)
         }
     }
 
     @Test
-    fun testFetchSingleOrderError() {
+    fun testFetchSingleOrderError() = runBlocking{
         val remoteOrderId = 88L
 
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
-        orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+        val response = orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteOrderPayload
-        assertNotNull(payload.error)
+        assertNotNull(response.error)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -204,7 +204,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchSingleOrderError() = runBlocking{
+    fun testFetchSingleOrderError() = runBlocking {
         val remoteOrderId = 88L
 
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -175,9 +175,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
     @Throws(InterruptedException::class)
     @Test
     fun testFetchSingleOrder() = runBlocking {
-        val fetchedOrder = orderStore.fetchSingleOrder(sSite, orderModel.remoteOrderId)
-
-        assertTrue(fetchedOrder != null && fetchedOrder.remoteOrderId == orderModel.remoteOrderId)
+        orderStore.fetchSingleOrder(sSite, orderModel.remoteOrderId)
 
         val orderFromDb = orderStore.getOrderByIdentifier(
                 OrderIdentifier(

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -141,7 +141,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                     coroutineScope.launch {
                         enteredRemoteId?.let { id ->
                             prependToLog("Submitting request to fetch order by remoteOrderID: $enteredRemoteId")
-                            wcOrderStore.fetchSingleOrder(site, id).takeUnless {   it.isError }?.let {
+                            wcOrderStore.fetchSingleOrder(site, id).takeUnless { it.isError }?.let {
                                 prependToLog("Single order fetched successfully!")
                             } ?: prependToLog("WARNING: Fetched order not found in the local database!")
                         } ?: prependToLog("No valid remoteOrderId defined...doing nothing")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -141,14 +141,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                     coroutineScope.launch {
                         enteredRemoteId?.let { id ->
                             prependToLog("Submitting request to fetch order by remoteOrderID: $enteredRemoteId")
-                            wcOrderStore.fetchSingleOrder(site, id)
-                            wcOrderStore.getOrderByIdentifier(
-                                    OrderIdentifier(
-                                            WCOrderModel().apply {
-                                                remoteOrderId = enteredRemoteId
-                                                localSiteId = site.id
-                                            })
-                            )?.let {
+                            wcOrderStore.fetchSingleOrder(site, id).takeUnless {   it.isError }?.let {
                                 prependToLog("Single order fetched successfully!")
                             } ?: prependToLog("WARNING: Fetched order not found in the local database!")
                         } ?: prependToLog("No valid remoteOrderId defined...doing nothing")

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import java.util.Calendar
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -49,7 +50,7 @@ import kotlin.test.assertTrue
 @RunWith(RobolectricTestRunner::class)
 class WCOrderStoreTest {
     private val orderFetcher: WCOrderFetcher = mock()
-    private val orderStore = WCOrderStore(Dispatcher(), mock(), orderFetcher)
+    private val orderStore = WCOrderStore(Dispatcher(), mock(), orderFetcher, initCoroutineEngine())
 
     @Before
     fun setUp() {

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -44,8 +44,6 @@ public enum WCOrderAction implements IAction {
     FETCH_ORDERS_BY_IDS,
     @Action(payloadType = FetchOrdersCountPayload.class)
     FETCH_ORDERS_COUNT,
-    @Action(payloadType = FetchSingleOrderPayload.class)
-    FETCH_SINGLE_ORDER,
     @Action(payloadType = UpdateOrderStatusPayload.class)
     UPDATE_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesPayload.class)
@@ -76,8 +74,6 @@ public enum WCOrderAction implements IAction {
     FETCHED_ORDERS_BY_IDS,
     @Action(payloadType = FetchOrdersCountResponsePayload.class)
     FETCHED_ORDERS_COUNT,
-    @Action(payloadType = RemoteOrderPayload.class)
-    FETCHED_SINGLE_ORDER,
     @Action(payloadType = RemoteOrderPayload.class)
     UPDATED_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesResponsePayload.class)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchSingleOrderPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload;

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -504,24 +504,8 @@ class WCOrderStore @Inject constructor(
 
             val rowsAffected = if(!result.isError) OrderSqlUtils.insertOrUpdateOrder(result.order) else 0
 
-            emitLegacyOnOrderChangedEvent(result, rowsAffected)
-
             return@withDefaultContext if (!result.isError) result.order else null
         }
-    }
-
-    private fun emitLegacyOnOrderChangedEvent(
-        result: RemoteOrderPayload,
-        rowsAffected: Int,
-    ) {
-        val onOrderChanged: OnOrderChanged
-        if (result.isError) {
-            onOrderChanged = OnOrderChanged(rowsAffected).also { it.error = result.error }
-        } else {
-            onOrderChanged = OnOrderChanged(rowsAffected)
-        }
-        onOrderChanged.causeOfChange = FETCH_SINGLE_ORDER
-        emitChange(onOrderChanged)
     }
 
     private fun updateOrderStatus(payload: UpdateOrderStatusPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -38,7 +38,7 @@ class WCOrderStore @Inject constructor(
     dispatcher: Dispatcher,
     private val wcOrderRestClient: OrderRestClient,
     private val wcOrderFetcher: WCOrderFetcher,
-    private val coroutineEngine: CoroutineEngine,
+    private val coroutineEngine: CoroutineEngine
 ) : Store(dispatcher) {
     companion object {
         const val NUM_ORDERS_PER_FETCH = 15

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -502,9 +502,10 @@ class WCOrderStore @Inject constructor(
         return coroutineEngine.withDefaultContext(T.API, this, "fetchSingleOrder") {
             val result = wcOrderRestClient.fetchSingleOrder(site, remoteOrderId)
 
-            val rowsAffected = if(!result.isError) OrderSqlUtils.insertOrUpdateOrder(result.order) else 0
-
-            return@withDefaultContext if (!result.isError) result.order else null
+            return@withDefaultContext result.takeUnless { it.isError }?.let {
+                OrderSqlUtils.insertOrUpdateOrder(result.order)
+                result.order
+            }
         }
     }
 


### PR DESCRIPTION
This PR refactors `fetchSingleOrder` into a suspendable function - removes usage of the event bus. 

There are two reasons for this change
1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. Also it causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.


To Test:
Test "fetchSingleOrder" action in the example app or test in WCAndroid (PR https://github.com/woocommerce/woocommerce-android/pull/4791)