### PR TITLE
Store functionalities for SSR

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.mocked;
 
+import org.wordpress.android.fluxc.di.WCDatabaseModule;
 import org.wordpress.android.fluxc.example.di.AppConfigModule;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.MockedNetworkModule;
@@ -12,7 +13,8 @@ import dagger.Component;
 @Component(modules = {
         AppContextModule.class,
         AppConfigModule.class,
-        MockedNetworkModule.class // Mocked module
+        MockedNetworkModule.class,
+        WCDatabaseModule.class
 })
 public interface MockedNetworkAppComponent {
     void inject(MockedStack_AccountTest object);

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.example.ui.customer.WooCustomersFragment
 import org.wordpress.android.fluxc.example.ui.customer.creation.WooCustomerCreationFragment
 import org.wordpress.android.fluxc.example.ui.customer.search.WooCustomersSearchFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
+import org.wordpress.android.fluxc.example.ui.helpsupport.WooHelpSupportFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooAddonsTestFragment
@@ -152,4 +153,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooAddonsTestFragment(): WooAddonsTestFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooHelpSupportFragment(): WooHelpSupportFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.customer.WooCustomersFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
+import org.wordpress.android.fluxc.example.ui.helpsupport.WooHelpSupportFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductAttributeFragment
@@ -169,6 +170,12 @@ class WooCommerceFragment : Fragment() {
         customers.setOnClickListener {
             getFirstWCSite()?.let {
                 replaceFragment(WooCustomersFragment())
+            } ?: showNoWCSitesToast()
+        }
+
+        help_support.setOnClickListener {
+            getFirstWCSite()?.let {
+                replaceFragment(WooHelpSupportFragment())
             } ?: showNoWCSitesToast()
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/helpsupport/WooHelpSupportFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/helpsupport/WooHelpSupportFragment.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.fluxc.example.ui.helpsupport
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_help_support.*
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
+import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class WooHelpSupportFragment : Fragment() {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    private var selectedPos: Int = -1
+    private var selectedSite: SiteModel? = null
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_woo_help_support, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        help_support_select_site.setOnClickListener {
+            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                override fun onSiteSelected(site: SiteModel, pos: Int) {
+                    selectedSite = site
+                    selectedPos = pos
+                    buttonContainer.toggleSiteDependentButtons(true)
+                    help_support_selected_site.text = site.name ?: site.displayName
+                }
+            })
+        }
+
+        fetch_ssr.setOnClickListener {
+            selectedSite?.let { site ->
+                TODO()
+            }
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/helpsupport/WooHelpSupportFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/helpsupport/WooHelpSupportFragment.kt
@@ -8,8 +8,13 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_help_support.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
@@ -23,6 +28,8 @@ class WooHelpSupportFragment : Fragment() {
 
     private var selectedPos: Int = -1
     private var selectedSite: SiteModel? = null
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -48,7 +55,19 @@ class WooHelpSupportFragment : Fragment() {
 
         fetch_ssr.setOnClickListener {
             selectedSite?.let { site ->
-                TODO()
+                coroutineScope.launch {
+                    val result = withContext(Dispatchers.Default) {
+                        wooCommerceStore.fetchSSR(site)
+                    }
+
+                    result.error?.let {
+                        prependToLog("${it.type}: ${it.message}")
+                        return@launch
+                    }
+                    result.model?.let {
+                        prependToLog("Fetched data: $it")
+                    }
+                }
             }
         }
     }

--- a/example/src/main/res/layout/fragment_woo_help_support.xml
+++ b/example/src/main/res/layout/fragment_woo_help_support.xml
@@ -1,0 +1,52 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    tools:context="org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment"
+    tools:ignore="HardcodedText">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:text="Perform actions on a selected site:"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/help_support_select_site"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Select Site" />
+
+            <TextView
+                android:id="@+id/help_support_selected_site"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="10dp"
+                android:paddingLeft="10dp"
+                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+                android:textColor="@android:color/holo_blue_bright" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/fetch_ssr"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch System Status Report" />
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -118,5 +118,11 @@
             android:layout_height="wrap_content"
             android:text="Customers" />
 
+        <Button
+            android:id="@+id/help_support"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Help &amp; Support" />
+
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -16,7 +16,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
@@ -48,11 +47,11 @@ class WooCommerceStoreTest {
         const val TEST_SITE_REMOTE_ID = 1337L
     }
 
-    private val appContext = RuntimeEnvironment.application.applicationContext
+    private val appContext = ApplicationProvider.getApplicationContext<Application>()
     private val restClient = mock<WooSystemRestClient>()
 
     private val roomDB = Room.inMemoryDatabaseBuilder(
-            ApplicationProvider.getApplicationContext<Application>(),
+            appContext,
             WCAndroidDatabase::class.java
     )
             .allowMainThreadQueries()
@@ -184,11 +183,13 @@ class WooCommerceStoreTest {
     }
 
     @Test
-    fun `when fetching ssr succeeds, then success returned`() = test {
-        val result = fetchSSR(isError = false)
+    fun `when fetching ssr succeeds, then success returned`() {
+        runBlocking {
+            val result = fetchSSR(isError = false)
 
-        Assertions.assertThat(result.isError).isFalse
-        Assertions.assertThat(result.model).isNotNull
+            Assertions.assertThat(result.isError).isFalse
+            Assertions.assertThat(result.model).isNotNull
+        }
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -68,7 +68,10 @@ class WooCommerceStoreTest {
             roomDB.ssrDao()
     )
     private val error = WooError(INVALID_RESPONSE, NETWORK_ERROR, "Invalid site ID")
-    private val site = SiteModel().apply { id = 1 }
+    private val site = SiteModel().apply {
+        id = 1
+        siteId = TEST_SITE_REMOTE_ID
+    }
 
     private val response = ActivePluginsResponse(
             listOf(

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -51,9 +51,12 @@ class WooCommerceStoreTest {
     private val appContext = RuntimeEnvironment.application.applicationContext
     private val restClient = mock<WooSystemRestClient>()
 
-    private val roomDB = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext<Application>(), WCAndroidDatabase::class.java)
-    .allowMainThreadQueries()
-    .build()
+    private val roomDB = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext<Application>(),
+            WCAndroidDatabase::class.java
+    )
+            .allowMainThreadQueries()
+            .build()
 
     private val wooCommerceStore = WooCommerceStore(
             appContext,
@@ -185,11 +188,11 @@ class WooCommerceStoreTest {
         Assertions.assertThat(result.model).isNotNull
     }
 
-
     @Test
     fun `when fetching ssr succeeds, then data is saved to database`() {
         runBlocking {
-            fetchSSR()
+            whenever(restClient.fetchSSR(any())).thenReturn(WooPayload(ssrResponse))
+            wooCommerceStore.fetchSSR(site)
 
             val result = wooCommerceStore.observeSSRForSite(TEST_SITE_REMOTE_ID).first()
             Assertions.assertThat(result).isEqualTo(ssrModel)
@@ -208,7 +211,7 @@ class WooCommerceStoreTest {
 
     private suspend fun fetchSSR(isError: Boolean = false): WooResult<WCSSRModel> {
         val payload = WooPayload(ssrResponse)
-        if(isError) {
+        if (isError) {
             whenever(restClient.fetchSSR(any())).thenReturn(WooPayload(error))
         } else {
             whenever(restClient.fetchSSR(any())).thenReturn(payload)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -1,9 +1,16 @@
 package org.wordpress.android.fluxc.wc
 
+import android.app.Application
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.yarolegovich.wellsql.WellSql
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
@@ -14,7 +21,9 @@ import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.SingleStoreWellSqlConfigForTests
 import org.wordpress.android.fluxc.TestSiteSqlUtils
+import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCSSRModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
@@ -23,6 +32,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse.SystemPluginModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.SSRResponse
+import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils.WCPluginModel
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -33,15 +44,25 @@ import kotlin.test.assertEquals
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
 class WooCommerceStoreTest {
+    private companion object {
+        const val TEST_SITE_REMOTE_ID = 1337L
+    }
+
     private val appContext = RuntimeEnvironment.application.applicationContext
     private val restClient = mock<WooSystemRestClient>()
+
+    private val roomDB = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext<Application>(), WCAndroidDatabase::class.java)
+    .allowMainThreadQueries()
+    .build()
+
     private val wooCommerceStore = WooCommerceStore(
             appContext,
             Dispatcher(),
             initCoroutineEngine(),
             restClient,
             mock(),
-            TestSiteSqlUtils.siteSqlUtils
+            TestSiteSqlUtils.siteSqlUtils,
+            roomDB.ssrDao()
     )
     private val error = WooError(INVALID_RESPONSE, NETWORK_ERROR, "Invalid site ID")
     private val site = SiteModel().apply { id = 1 }
@@ -55,6 +76,35 @@ class WooCommerceStoreTest {
                     SystemPluginModel("Inactive", "1.0")
             )
     )
+
+    private val sampleJsonObj = stringToJsonObject(
+            UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/system-status.json")
+    )
+
+    private val ssrResponse = SSRResponse(
+            environment = sampleJsonObj.get("environment"),
+            database = sampleJsonObj.get("database"),
+            activePlugins = sampleJsonObj.get("active_plugins"),
+            theme = sampleJsonObj.get("theme"),
+            settings = sampleJsonObj.get("settings"),
+            security = sampleJsonObj.get("security"),
+            pages = sampleJsonObj.get("pages")
+    )
+
+    private val ssrModel = WCSSRModel(
+            TEST_SITE_REMOTE_ID,
+            ssrResponse.environment?.toString(),
+            ssrResponse.database?.toString(),
+            ssrResponse.activePlugins?.toString(),
+            ssrResponse.theme?.toString(),
+            ssrResponse.settings?.toString(),
+            ssrResponse.security?.toString(),
+            ssrResponse.pages?.toString()
+    )
+
+    private fun stringToJsonObject(jsonText: String): JsonObject {
+        return JsonParser().parse(jsonText).asJsonObject
+    }
 
     @Before
     fun setUp() {
@@ -120,6 +170,32 @@ class WooCommerceStoreTest {
         Assertions.assertThat(result).isEqualTo(expectedModel)
     }
 
+    @Test
+    fun `when fetching ssr fails, then error returned`() = test {
+        val result = fetchSSR(isError = true)
+
+        Assertions.assertThat(result.error).isEqualTo(error)
+    }
+
+    @Test
+    fun `when fetching ssr succeeds, then success returned`() = test {
+        val result = fetchSSR(isError = false)
+
+        Assertions.assertThat(result.isError).isFalse
+        Assertions.assertThat(result.model).isNotNull
+    }
+
+
+    @Test
+    fun `when fetching ssr succeeds, then data is saved to database`() {
+        runBlocking {
+            fetchSSR()
+
+            val result = wooCommerceStore.observeSSRForSite(TEST_SITE_REMOTE_ID).first()
+            Assertions.assertThat(result).isEqualTo(ssrModel)
+        }
+    }
+
     private suspend fun getPlugin(isError: Boolean = false): WooResult<List<WCPluginModel>> {
         val payload = WooPayload(response)
         if (isError) {
@@ -128,5 +204,15 @@ class WooCommerceStoreTest {
             whenever(restClient.fetchInstalledPlugins(any())).thenReturn(payload)
         }
         return wooCommerceStore.fetchSitePlugins(site)
+    }
+
+    private suspend fun fetchSSR(isError: Boolean = false): WooResult<WCSSRModel> {
+        val payload = WooPayload(ssrResponse)
+        if(isError) {
+            whenever(restClient.fetchSSR(any())).thenReturn(WooPayload(error))
+        } else {
+            whenever(restClient.fetchSSR(any())).thenReturn(payload)
+        }
+        return wooCommerceStore.fetchSSR(site)
     }
 }

--- a/example/src/test/resources/wc/system-status.json
+++ b/example/src/test/resources/wc/system-status.json
@@ -1,0 +1,144 @@
+{
+  "environment": {
+    "home_url": "http://example.com",
+    "site_url": "http://example.com",
+    "version": "3.0.0",
+    "log_directory": "/var/www/woocommerce/wp-content/uploads/wc-logs/",
+    "log_directory_writable": true,
+    "wp_version": "4.7.3",
+    "wp_multisite": false,
+    "wp_memory_limit": 134217728,
+    "wp_debug_mode": true,
+    "wp_cron": true,
+    "language": "en_US",
+    "server_info": "Apache/2.4.18 (Ubuntu)",
+    "php_version": "7.1.3-2+deb.sury.org~yakkety+1",
+    "php_post_max_size": 8388608,
+    "php_max_execution_time": 30,
+    "php_max_input_vars": 1000,
+    "curl_version": "7.50.1, OpenSSL/1.0.2g",
+    "suhosin_installed": false,
+    "max_upload_size": 2097152,
+    "mysql_version": "5.7.17",
+    "default_timezone": "UTC",
+    "fsockopen_or_curl_enabled": true,
+    "soapclient_enabled": true,
+    "domdocument_enabled": true,
+    "gzip_enabled": true,
+    "mbstring_enabled": true,
+    "remote_post_successful": true,
+    "remote_post_response": "200",
+    "remote_get_successful": true,
+    "remote_get_response": "200"
+  },
+  "database": {
+    "wc_database_version": "3.0.0",
+    "database_prefix": "wp_",
+    "maxmind_geoip_database": "/var/www/woocommerce/wp-content/uploads/GeoIP.dat",
+    "database_tables": {
+      "woocommerce_sessions": true,
+      "woocommerce_api_keys": true,
+      "woocommerce_attribute_taxonomies": true,
+      "woocommerce_downloadable_product_permissions": true,
+      "woocommerce_order_items": true,
+      "woocommerce_order_itemmeta": true,
+      "woocommerce_tax_rates": true,
+      "woocommerce_tax_rate_locations": true,
+      "woocommerce_shipping_zones": true,
+      "woocommerce_shipping_zone_locations": true,
+      "woocommerce_shipping_zone_methods": true,
+      "woocommerce_payment_tokens": true,
+      "woocommerce_payment_tokenmeta": true
+    }
+  },
+  "active_plugins": [
+    {
+      "plugin": "woocommerce/woocommerce.php",
+      "name": "WooCommerce",
+      "version": "3.0.0-rc.1",
+      "version_latest": "2.6.14",
+      "url": "https://woocommerce.com/",
+      "author_name": "Automattic",
+      "author_url": "https://woocommerce.com",
+      "network_activated": false
+    }
+  ],
+  "theme": {
+    "name": "Twenty Sixteen",
+    "version": "1.3",
+    "version_latest": "1.3",
+    "author_url": "https://wordpress.org/",
+    "is_child_theme": false,
+    "has_woocommerce_support": true,
+    "has_woocommerce_file": false,
+    "has_outdated_templates": false,
+    "overrides": [],
+    "parent_name": "",
+    "parent_version": "",
+    "parent_version_latest": "",
+    "parent_author_url": ""
+  },
+  "settings": {
+    "api_enabled": true,
+    "force_ssl": false,
+    "currency": "USD",
+    "currency_symbol": "&#36;",
+    "currency_position": "left",
+    "thousand_separator": ",",
+    "decimal_separator": ".",
+    "number_of_decimals": 2,
+    "geolocation_enabled": false,
+    "taxonomies": {
+      "external": "external",
+      "grouped": "grouped",
+      "simple": "simple",
+      "variable": "variable"
+    }
+  },
+  "security": {
+    "secure_connection": true,
+    "hide_errors": true
+  },
+  "pages": [
+    {
+      "page_name": "Shop base",
+      "page_id": "4",
+      "page_set": true,
+      "page_exists": true,
+      "page_visible": true,
+      "shortcode": "",
+      "shortcode_required": false,
+      "shortcode_present": false
+    },
+    {
+      "page_name": "Cart",
+      "page_id": "5",
+      "page_set": true,
+      "page_exists": true,
+      "page_visible": true,
+      "shortcode": "[woocommerce_cart]",
+      "shortcode_required": true,
+      "shortcode_present": true
+    },
+    {
+      "page_name": "Checkout",
+      "page_id": "6",
+      "page_set": true,
+      "page_exists": true,
+      "page_visible": true,
+      "shortcode": "[woocommerce_checkout]",
+      "shortcode_required": true,
+      "shortcode_present": true
+    },
+    {
+      "page_name": "My account",
+      "page_id": "7",
+      "page_set": true,
+      "page_exists": true,
+      "page_visible": true,
+      "shortcode": "[woocommerce_my_account]",
+      "shortcode_required": true,
+      "shortcode_present": true
+    }
+  ]
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
@@ -18,7 +18,7 @@ class WCDatabaseModule {
         return database.addonsDao()
     }
 
-    @Provides internal fun provideSSRDao(database: WCAndroidDatabase): SSRDao {
+    @Provides fun provideSSRDao(database: WCAndroidDatabase): SSRDao {
         return database.ssrDao()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.model
 
+import org.wordpress.android.fluxc.persistence.entity.SSREntity
+
 data class WCSSRModel(
     val id: Int,
     val localSiteId: Int,
@@ -10,4 +12,18 @@ data class WCSSRModel(
     val settings: String? = null,
     val security: String? = null,
     val pages: String? = null
-)
+) {
+    fun mapToEntity(): SSREntity {
+        return SSREntity(
+                id = id,
+                localSiteId = localSiteId,
+                environment = environment,
+                database = database,
+                activePlugins = activePlugins,
+                theme = theme,
+                settings = settings,
+                security = security,
+                pages = pages
+        )
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSSRModel.kt
@@ -14,8 +14,7 @@ data class WCSSRModel(
 ) {
     fun mapToEntity(): SSREntity {
         return SSREntity(
-                id = id,
-                localSiteId = localSiteId,
+                remoteSiteId = remoteSiteId,
                 environment = environment,
                 database = database,
                 activePlugins = activePlugins,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -25,7 +25,7 @@ import org.wordpress.android.fluxc.persistence.entity.SSREntity
 @TypeConverters(value = [LongListConverter::class])
 abstract class WCAndroidDatabase : RoomDatabase() {
     internal abstract fun addonsDao(): AddonsDao
-    internal abstract fun ssrDao(): SSRDao
+    abstract fun ssrDao(): SSRDao
 
     companion object {
         fun buildDb(applicationContext: Context) = Room.databaseBuilder(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.store
 
 import android.content.Context
 import com.wellsql.generated.SiteModelTable
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.Flow
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -215,8 +215,8 @@ open class WooCommerceStore @Inject constructor(
         }
     }
 
-    suspend fun getSSR(remoteSiteId: Long): WCSSRModel {
-        return ssrDao.observeSSRForSite(remoteSiteId).first()
+    fun observeSSRForSite(remoteSiteId: Long): Flow<WCSSRModel> {
+        return ssrDao.observeSSRForSite(remoteSiteId)
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.store
 
 import android.content.Context
 import com.wellsql.generated.SiteModelTable
+import kotlinx.coroutines.flow.first
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -212,6 +213,10 @@ open class WooCommerceStore @Inject constructor(
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }
+    }
+
+    suspend fun getSSR(remoteSiteId: Long): WCSSRModel {
+        return ssrDao.observeSSRForSite(remoteSiteId).first()
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -197,8 +197,7 @@ open class WooCommerceStore @Inject constructor(
                 }
                 response.result != null -> {
                     val ssr = WCSSRModel(
-                            id = 0,
-                            localSiteId = site.id,
+                            remoteSiteId = site.siteId,
                             environment = response.result.environment?.toString(),
                             database = response.result.database?.toString(),
                             activePlugins = response.result.activePlugins?.toString(),


### PR DESCRIPTION
## PR Description

I'm working on allowing merchants to share System Status Report (SSR) directly via app. The main issue thread is on https://github.com/woocommerce/woocommerce-android/issues/4781 .

This PR is the second part of that. It adds:

1. A fetch SSR function in `WooCommerceStore`
2. REST API call in `WooSystemRestClient`
3. Unit tests for above
4. A new section in Example app to test it. 

## To test
**Example app:**
1. Assuming you're logged in, go to Woo -> Help & Support. 
2. Select a WooCommerce site, then tap "Fetch System Status Report". 
3. Observe the log and ensure it outputs fetched data.

**Unit tests**
Run `WooCommerceStoreTest` and ensure everything is successful.