### PR TITLE
Remove `multidex`. Fix `connectedAndroidTest` task.

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.example"
-        minSdkVersion 18
+        minSdkVersion 21
         // Keep the targetSdkVersion 22 so we don't need to grant runtime permissions to the tests and the example app
         // An alternative would be granting the permissions via adb before running the test, like here:
         // https://afterecho.uk/blog/granting-marshmallow-permissions-for-testing-flavoured-builds.html
@@ -24,7 +24,6 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments += [
@@ -159,9 +158,6 @@ dependencies {
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
-
-    // Multidex
-    implementation 'androidx.multidex:multidex:2.0.1'
 }
 
 def loadPropertiesOrUseExampleProperties(fileName, warningDetail) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.example
 
-import androidx.multidex.MultiDexApplication
+import android.app.Application
 import com.yarolegovich.wellsql.WellSql
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -10,7 +10,7 @@ import org.wordpress.android.fluxc.example.di.DaggerAppComponent
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import javax.inject.Inject
 
-open class ExampleApp : MultiDexApplication(), HasAndroidInjector {
+open class ExampleApp : Application(), HasAndroidInjector {
     @Inject lateinit var androidInjector: DispatchingAndroidInjector<Any>
 
     protected open val component: AppComponent by lazy {

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 29
         javaCompileOptions {
             annotationProcessorOptions {

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -9,12 +9,10 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.instaflux"
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"
-
-        multiDexEnabled true
     }
 
     compileOptions {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 29
     }
     buildTypes {


### PR DESCRIPTION
Closes: #2120 

### Description

This PR removes `multidex` dependency from the project as, starting from API 21, multidex is enabled by default ([source](https://developer.android.com/studio/build/multidex#mdex-on-l)).

I've bumped `minSdkVersion` to 21 to make external `multidex` not needed. It's okay as clients of the library (WordPress and Woo apps) use version 21 and higher already.

### To test

1. Make sure `./gradlew connectedAndroidTest` builds fine (doesn't mean tests will pass).
2. Check if building project works fine: `./gradlew assemble`
3. Build WordPress and Woo apps with FluxC build from this PR.