### PR TITLE
Issue/4806 convert fetch order notes into suspendable function

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked
 
 import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -23,7 +24,6 @@ import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
@@ -291,19 +291,14 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderNotesFetchSuccess() {
+    fun testOrderNotesFetchSuccess() = runBlocking {
         interceptor.respondWith("wc-order-notes-response-success.json")
-        orderRestClient.fetchOrderNotes(
+        val payload = orderRestClient.fetchOrderNotes(
                 localOrderId = 8,
                 remoteOrderId = 88,
                 site = siteModel
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_ORDER_NOTES, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchOrderNotesResponsePayload
         assertNull(payload.error)
         assertEquals(8, payload.notes.size)
 
@@ -337,19 +332,14 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderNotesFetchError() {
+    fun testOrderNotesFetchError() = runBlocking {
         interceptor.respondWithError("wc-order-notes-response-failure-invalid-id.json", 404)
-        orderRestClient.fetchOrderNotes(
+        val payload = orderRestClient.fetchOrderNotes(
                 localOrderId = 8,
                 remoteOrderId = 88,
                 site = siteModel
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_ORDER_NOTES, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchOrderNotesResponsePayload
         with(payload) {
             // Expecting a 'invalid id' error from the server
             assertNotNull(error)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import java.util.Calendar
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -49,7 +50,7 @@ import kotlin.test.assertTrue
 @RunWith(RobolectricTestRunner::class)
 class WCOrderStoreTest {
     private val orderFetcher: WCOrderFetcher = mock()
-    private val orderStore = WCOrderStore(Dispatcher(), mock(), orderFetcher)
+    private val orderStore = WCOrderStore(Dispatcher(), mock(), orderFetcher, initCoroutineEngine())
 
     @Before
     fun setUp() {

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -11,8 +11,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload;

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -48,8 +48,6 @@ public enum WCOrderAction implements IAction {
     FETCH_SINGLE_ORDER,
     @Action(payloadType = UpdateOrderStatusPayload.class)
     UPDATE_ORDER_STATUS,
-    @Action(payloadType = FetchOrderNotesPayload.class)
-    FETCH_ORDER_NOTES,
     @Action(payloadType = PostOrderNotePayload.class)
     POST_ORDER_NOTE,
     @Action(payloadType = FetchHasOrdersPayload.class)
@@ -80,8 +78,6 @@ public enum WCOrderAction implements IAction {
     FETCHED_SINGLE_ORDER,
     @Action(payloadType = RemoteOrderPayload.class)
     UPDATED_ORDER_STATUS,
-    @Action(payloadType = FetchOrderNotesResponsePayload.class)
-    FETCHED_ORDER_NOTES,
     @Action(payloadType = RemoteOrderNotePayload.class)
     POSTED_ORDER_NOTE,
     @Action(payloadType = FetchHasOrdersResponsePayload.class)


### PR DESCRIPTION
One review is enough ;) thanks!

"Not ready for merge" - Should be merged together with a PR in WCAndroid

This PR refactors fetchOrderNotes into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. Also it causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

To Test:
Test "fetchOrderNotes" action in the example app (you first need to click on fetchOrders, otherwise the "fetchOrderNotes" button doesn't do anything) or test in WCAndroid ([PR in WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/4808))