### PR TITLE
Issue/4806 convert fetch order shipment tracking into suspendable function

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked
 
 import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -25,7 +26,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackin
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
@@ -450,16 +450,11 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderShipmentTrackingsFetchSuccess() {
+    fun testOrderShipmentTrackingsFetchSuccess() = runBlocking {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         interceptor.respondWith("wc-order-shipment-trackings-success.json")
-        orderRestClient.fetchOrderShipmentTrackings(siteModel, orderModel.id, orderModel.remoteOrderId)
+        val payload = orderRestClient.fetchOrderShipmentTrackings(siteModel, orderModel.id, orderModel.remoteOrderId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_ORDER_SHIPMENT_TRACKINGS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchOrderShipmentTrackingsResponsePayload
         assertNull(payload.error)
         assertEquals(2, payload.trackings.size)
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.release
 
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.junit.Assert.assertEquals
@@ -9,7 +10,6 @@ import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCOrderAction.ADD_ORDER_SHIPMENT_TRACKING
 import org.wordpress.android.fluxc.action.WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING
-import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_SHIPMENT_TRACKINGS
 import org.wordpress.android.fluxc.example.BuildConfig
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderModel
@@ -33,7 +33,6 @@ import javax.inject.Inject
 class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
     internal enum class TestEvent {
         NONE,
-        FETCHED_ORDER_SHIPMENT_TRACKINGS,
         ADD_ORDER_SHIPMENT_TRACKING,
         DELETE_ORDER_SHIPMENT_TRACKING,
         FETCHED_ORDER_SHIPMENT_PROVIDERS
@@ -65,18 +64,13 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
      */
     @Throws(InterruptedException::class)
     @Test
-    fun testFetchShipmentTrackingsForOrder_hasTrackings() {
-        nextEvent = TestEvent.FETCHED_ORDER_SHIPMENT_TRACKINGS
-        mCountDownLatch = CountDownLatch(1)
-
+    fun testFetchShipmentTrackingsForOrder_hasTrackings() = runBlocking {
         val orderModel = WCOrderModel().apply {
             id = 8
             remoteOrderId = BuildConfig.TEST_WC_ORDER_WITH_SHIPMENT_TRACKINGS_ID.toLong()
             localSiteId = sSite.id
         }
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(
-                FetchOrderShipmentTrackingsPayload(orderModel.id, orderModel.remoteOrderId, sSite)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        orderStore.fetchOrderShipmentTrackings(orderModel.id, orderModel.remoteOrderId, sSite)
 
         val trackings = orderStore.getShipmentTrackingsForOrder(
                 sSite, orderModel.id
@@ -91,18 +85,14 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
      */
     @Throws(InterruptedException::class)
     @Test
-    fun testFetchShipmentTrackingsForOrder_noTrackings() {
-        nextEvent = TestEvent.FETCHED_ORDER_SHIPMENT_TRACKINGS
-        mCountDownLatch = CountDownLatch(1)
-
+    fun testFetchShipmentTrackingsForOrder_noTrackings() = runBlocking {
         val orderModel = WCOrderModel().apply {
             id = 9
             remoteOrderId = BuildConfig.TEST_WC_ORDER_WITHOUT_SHIPMENT_TRACKINGS_ID.toLong()
             localSiteId = sSite.id
         }
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(
-                FetchOrderShipmentTrackingsPayload(orderModel.id, orderModel.remoteOrderId, sSite)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        orderStore.fetchOrderShipmentTrackings(orderModel.id, orderModel.remoteOrderId, sSite)
 
         val trackings = orderStore.getShipmentTrackingsForOrder(
                 sSite, orderModel.id
@@ -291,10 +281,6 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
         lastEvent = event
 
         when (event.causeOfChange) {
-            FETCH_ORDER_SHIPMENT_TRACKINGS -> {
-                assertEquals(TestEvent.FETCHED_ORDER_SHIPMENT_TRACKINGS, nextEvent)
-                mCountDownLatch.countDown()
-            }
             ADD_ORDER_SHIPMENT_TRACKING -> {
                 assertEquals(TestEvent.ADD_ORDER_SHIPMENT_TRACKING, nextEvent)
                 mCountDownLatch.countDown()

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderShipmentProvidersChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderError

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.release
 
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -18,7 +19,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersByIdsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
@@ -48,8 +48,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         POST_ORDER_NOTE,
         POSTED_ORDER_NOTE,
         ERROR_ORDER_STATUS_NOT_FOUND,
-        FETCHED_ORDER_STATUS_OPTIONS,
-        ERROR_ORDER_SHIPMENT_TRACKINGS_PLUGIN_NOT_ACTIVE
+        FETCHED_ORDER_STATUS_OPTIONS
     }
 
     @Inject internal lateinit var orderStore: WCOrderStore
@@ -270,14 +269,10 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
      */
     @Throws(InterruptedException::class)
     @Test
-    fun testFetchShipmentTrackingsForOrder_pluginNotInstalled() {
-        nextEvent = TestEvent.ERROR_ORDER_SHIPMENT_TRACKINGS_PLUGIN_NOT_ACTIVE
-        mCountDownLatch = CountDownLatch(1)
-
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(
-                FetchOrderShipmentTrackingsPayload(orderModel.id, orderModel.remoteOrderId, sSite)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
+    fun testFetchShipmentTrackingsForOrder_pluginNotInstalled() = runBlocking {
+        val result = orderStore.fetchOrderShipmentTrackings(orderModel.id, orderModel.remoteOrderId, sSite)
+        assertTrue(result.isError)
+        assertEquals(OrderErrorType.PLUGIN_NOT_ACTIVE, result.error.type)
         val trackings = orderStore.getShipmentTrackingsForOrder(sSite, orderModel.id)
         assertTrue(trackings.isEmpty())
     }
@@ -289,13 +284,6 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
             when (event.causeOfChange) {
                 WCOrderAction.FETCH_ORDERS_COUNT -> {
                     assertEquals(TestEvent.ERROR_ORDER_STATUS_NOT_FOUND, nextEvent)
-                    mCountDownLatch.countDown()
-                    return
-                }
-                WCOrderAction.FETCH_ORDER_SHIPMENT_TRACKINGS -> {
-                    assertEquals(TestEvent.ERROR_ORDER_SHIPMENT_TRACKINGS_PLUGIN_NOT_ACTIVE, nextEvent)
-                    assertTrue(event.isError)
-                    assertEquals(OrderErrorType.PLUGIN_NOT_ACTIVE, event.error.type)
                     mCountDownLatch.countDown()
                     return
                 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import java.util.Calendar
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -49,7 +50,7 @@ import kotlin.test.assertTrue
 @RunWith(RobolectricTestRunner::class)
 class WCOrderStoreTest {
     private val orderFetcher: WCOrderFetcher = mock()
-    private val orderStore = WCOrderStore(Dispatcher(), mock(), orderFetcher)
+    private val orderStore = WCOrderStore(Dispatcher(), mock(), orderFetcher, initCoroutineEngine())
 
     @Before
     fun setUp() {

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -15,8 +15,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersByIdsPayload;

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -58,8 +58,6 @@ public enum WCOrderAction implements IAction {
     SEARCH_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsPayload.class)
     FETCH_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = FetchOrderShipmentTrackingsPayload.class)
-    FETCH_ORDER_SHIPMENT_TRACKINGS,
     @Action(payloadType = AddOrderShipmentTrackingPayload.class)
     ADD_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = DeleteOrderShipmentTrackingPayload.class)
@@ -90,8 +88,6 @@ public enum WCOrderAction implements IAction {
     SEARCHED_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsResponsePayload.class)
     FETCHED_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = FetchOrderShipmentTrackingsResponsePayload.class)
-    FETCHED_ORDER_SHIPMENT_TRACKINGS,
     @Action(payloadType = AddOrderShipmentTrackingResponsePayload.class)
     ADDED_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = DeleteOrderShipmentTrackingResponsePayload.class)


### PR DESCRIPTION
"Not ready for merge" - Should be merged together with a PR in WCAndroid

This PR refactors fetchOrderShipmentTrackings into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

To Test:
Test "fetchShipmentTrackings" action in the example app (you first need to click on fetchOrders, otherwise the "fetchShipmentTrackings" button doesn't do anything) or test in WCAndroid ([PR in WAndroid](https://github.com/woocommerce/woocommerce-android/pull/4812))