### PR TITLE
Update the PostModel table with the field "sticky"

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostImmutableModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostImmutableModel.kt
@@ -21,6 +21,7 @@ interface PostImmutableModel {
     val tagNames: String
     val tagNameList: List<String>
     val status: String
+    val sticky: Boolean
     val password: String
     val featuredImageId: Long
     val postFormat: String

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -48,6 +48,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Column private String mExcerpt;
     @Column private String mTagNames;
     @Column private String mStatus;
+    @Column private boolean mSticky;
     @Column private String mPassword;
     @Column private long mFeaturedImageId;
     @Column private String mPostFormat;
@@ -249,6 +250,14 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
 
     public void setStatus(String status) {
         mStatus = status;
+    }
+
+    @Override public boolean getSticky() {
+        return mSticky;
+    }
+
+    public void setSticky(boolean sticky) {
+        mSticky = sticky;
     }
 
     @Override
@@ -525,6 +534,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
                 && Double.compare(otherPost.getLatitude(), getLatitude()) == 0
                 && Double.compare(otherPost.getLongitude(), getLongitude()) == 0
                 && isPage() == otherPost.isPage()
+                && getSticky() == otherPost.getSticky()
                 && isLocalDraft() == otherPost.isLocalDraft() && isLocallyChanged() == otherPost.isLocallyChanged()
                 && getHasCapabilityPublishPost() == otherPost.getHasCapabilityPublishPost()
                 && getHasCapabilityEditPost() == otherPost.getHasCapabilityEditPost()
@@ -576,6 +586,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         result = 31 * result + (mExcerpt != null ? mExcerpt.hashCode() : 0);
         result = 31 * result + (mTagNames != null ? mTagNames.hashCode() : 0);
         result = 31 * result + (mStatus != null ? mStatus.hashCode() : 0);
+        result = 31 * result + (mSticky ? 1 : 0);
         result = 31 * result + (mPassword != null ? mPassword.hashCode() : 0);
         result = 31 * result + (int) (mAuthorId ^ (mAuthorId >>> 32));
         result = 31 * result + (mAuthorDisplayName != null ? mAuthorDisplayName.hashCode() : 0);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -494,6 +494,7 @@ public class PostRestClient extends BaseWPComRestClient {
         post.setStatus(from.getStatus());
         post.setPassword(from.getPassword());
         post.setIsPage(from.getType().equals("page"));
+        post.setSticky(from.getSticky());
 
         if (from.getAuthor() != null) {
             post.setAuthorId(from.getAuthor().getId());
@@ -602,6 +603,7 @@ public class PostRestClient extends BaseWPComRestClient {
         }
 
         params.put("password", StringUtils.notNullStr(post.getPassword()));
+        params.put("sticky", post.getSticky());
 
         // construct a json object with a `category` field holding a json array with the tags
         JsonObject termsById = new JsonObject();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1814,6 +1814,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 161 -> migrate(version) {
                     db.execSQL("ALTER TABLE EditorTheme ADD GALLERY_WITH_IMAGE_BLOCKS BOOLEAN")
                 }
+                162 -> migrate(version) {
+                    db.execSQL("ALTER TABLE PostModel ADD STICKY BOOLEAN")
+                }
             }
         }
         db.setTransactionSuccessful()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 162
+        return 163
     }
 
     override fun getDbName(): String {


### PR DESCRIPTION
Fixes #2125 

### Description

We wanna provide users the possibility to [mark their posts as sticky](https://wordpress.org/support/article/sticky-posts/) (the same is already present in iOS and Web).
This PR is the first part needed to fix https://github.com/wordpress-mobile/WordPress-Android/issues/7953. 

It adds the field `mSticky` to the PostModel. This field is already present in the `PostWPComRestResponse`, so it was already being fetched from the API, we're just populating the model with its value

### Test

Make sure the classes are correctly generated by running `./gradlew fluxc:build`