### PR TITLE
Issue/4818 add locations store endpoint

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release
 
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.example.test.BuildConfig
@@ -44,7 +45,7 @@ class ReleaseStack_WCPayTest : ReleaseStack_WCBase() {
         assertEquals(false, result.model?.hasOverdueRequirements)
         assertEquals("DO.WPMT.CO", result.model?.statementDescriptor)
         assertEquals("US", result.model?.country)
-        assertEquals(false, result.model?.isCardPresentEligible)
+        assertEquals(true, result.model?.isCardPresentEligible)
         assertEquals("usd", result.model?.storeCurrencies?.default)
         assertEquals(listOf("usd"), result.model?.storeCurrencies?.supportedCurrencies)
         assertEquals(WCPayAccountStatusEnum.COMPLETE, result.model?.status)
@@ -68,5 +69,20 @@ class ReleaseStack_WCPayTest : ReleaseStack_WCBase() {
         )
 
         assertTrue(result.isError)
+    }
+
+    @Test
+    fun givenSiteHasWCPayAndStripeAddressThenLocationDataReturned() = runBlocking {
+        val result = payStore.getStoreLocationForSite(sSite)
+
+        assertFalse(result.isError)
+        assertEquals("tml_EUZ4bQQTxLWMq2", result.locationId)
+        assertEquals("Woo WCPay", result.displayName)
+        assertEquals("San Francisco", result.address?.city)
+        assertEquals("US", result.address?.country)
+        assertEquals("1230 Lawton St", result.address?.line1)
+        assertEquals("71", result.address?.line2)
+        assertEquals("94122", result.address?.postalCode)
+        assertEquals("CA", result.address?.state)
     }
 }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -49,7 +49,7 @@
 /payments/accounts
 /payments/orders/<order_id>/create_customer
 
-/terminal/locations/store
+/payments/terminal/locations/store
 
 /taxes
 /taxes/classes/

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -49,6 +49,8 @@
 /payments/accounts
 /payments/orders/<order_id>/create_customer
 
+/terminal/locations/store
+
 /taxes
 /taxes/classes/
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
@@ -1,10 +1,38 @@
 package org.wordpress.android.fluxc.model.pay
 
+import org.wordpress.android.fluxc.FluxCError
 import org.wordpress.android.fluxc.Payload
-import org.wordpress.android.fluxc.store.Store.OnChangedError
 
 data class WCTerminalStoreLocationResult(
-    val locationId: String
-) : Payload<WCTerminalStoreLocationError>()
+    val locationId: String?,
+    val displayName: String?,
+    val liveMode: Boolean?,
+    val address: StoreAddress?,
+) : Payload<WCTerminalStoreLocationError?>() {
+    constructor(
+        error: WCTerminalStoreLocationError,
+    ) : this(null, null, null, null) {
+        this.error = error
+    }
 
-class WCTerminalStoreLocationError : OnChangedError
+    data class StoreAddress(
+        val city: String?,
+        val country: String?,
+        val line1: String?,
+        val line2: String?,
+        val postalCode: String?,
+        val state: String?,
+    )
+}
+
+data class WCTerminalStoreLocationError(
+    val type: WCTerminalStoreLocationErrorType = WCTerminalStoreLocationErrorType.GENERIC_ERROR,
+    val message: String = ""
+) : FluxCError
+
+enum class WCTerminalStoreLocationErrorType {
+    GENERIC_ERROR,
+    MISSING_ADDRESS,
+    SERVER_ERROR,
+    NETWORK_ERROR
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.model.pay
+
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.store.Store.OnChangedError
+
+data class WCTerminalStoreLocationResult(
+    val locationId: String
+) : Payload<WCTerminalStoreLocationError>()
+
+class WCTerminalStoreLocationError : OnChangedError

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
@@ -7,10 +7,10 @@ data class WCTerminalStoreLocationResult(
     val locationId: String?,
     val displayName: String?,
     val liveMode: Boolean?,
-    val address: StoreAddress?,
+    val address: StoreAddress?
 ) : Payload<WCTerminalStoreLocationError?>() {
     constructor(
-        error: WCTerminalStoreLocationError,
+        error: WCTerminalStoreLocationError
     ) : this(null, null, null, null) {
         this.error = error
     }
@@ -21,7 +21,7 @@ data class WCTerminalStoreLocationResult(
         val line1: String?,
         val line2: String?,
         val postalCode: String?,
-        val state: String?,
+        val state: String?
     )
 }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -135,6 +135,24 @@ class PayRestClient @Inject constructor(
         }
     }
 
+    suspend fun getStoreLocationForSite(site: SiteModel): WooPayload<StoreLocationApiResponse> {
+        val url = WOOCOMMERCE.terminal.locations.store.pathV3
+        val params = mapOf("_fields" to STORE_LOCATION_FIELDS)
+
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                params,
+                StoreLocationApiResponse::class.java
+        )
+
+        return when (response) {
+            is JetpackSuccess -> WooPayload(response.data)
+            is JetpackError -> WooPayload(response.error.toWooError())
+        }
+    }
+
     private fun mapToCapturePaymentError(error: WPComGsonNetworkError?, message: String): WCCapturePaymentError {
         val type = when {
             error == null -> GENERIC_ERROR
@@ -154,5 +172,6 @@ class PayRestClient @Inject constructor(
         private const val ACCOUNT_REQUESTED_FIELDS: String =
                 "status,has_pending_requirements,has_overdue_requirements,current_deadline,statement_descriptor," +
                         "store_currencies,country,card_present_eligible,is_live,test_mode"
+        private const val STORE_LOCATION_FIELDS: String = "id,address,display_mode,livemode"
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -163,19 +163,19 @@ class PayRestClient @Inject constructor(
                                     line1 = data.address?.line1,
                                     line2 = data.address?.line2,
                                     postalCode = data.address?.postalCode,
-                                    state = data.address?.state,
+                                    state = data.address?.state
                             )
                     )
                 } ?: WCTerminalStoreLocationResult(
                         mapToStoreLocationForSiteError(
                                 error = null,
                                 message = "status field is null, but isError == false"
-                        ),
+                        )
                 )
             }
             is JetpackError -> {
                 WCTerminalStoreLocationResult(
-                        mapToStoreLocationForSiteError(response.error, response.error.message ?: "Unexpected error"),
+                        mapToStoreLocationForSiteError(response.error, response.error.message ?: "Unexpected error")
                 )
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/StoreLocationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/StoreLocationApiResponse.kt
@@ -6,7 +6,7 @@ data class StoreLocationApiResponse(
     @SerializedName("id") val id: String,
     @SerializedName("display_name") val displayName: String?,
     @SerializedName("livemode") val liveMode: Boolean?,
-    @SerializedName("address") val address: StoreAddress?,
+    @SerializedName("address") val address: StoreAddress?
 ) {
     data class StoreAddress(
         @SerializedName("city") val city: String?,
@@ -14,6 +14,6 @@ data class StoreLocationApiResponse(
         @SerializedName("line1") val line1: String?,
         @SerializedName("line2") val line2: String?,
         @SerializedName("postal_code") val postalCode: String?,
-        @SerializedName("state") val state: String?,
+        @SerializedName("state") val state: String?
     )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/StoreLocationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/StoreLocationApiResponse.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.pay
+
+import com.google.gson.annotations.SerializedName
+
+data class StoreLocationApiResponse(
+    @SerializedName("id") val id: String,
+    @SerializedName("display_name") val displayName: String?,
+    @SerializedName("livemode") val liveMode: Boolean?,
+    @SerializedName("address") val address: StoreAddress?,
+) {
+    data class StoreAddress(
+        @SerializedName("city") val city: String?,
+        @SerializedName("country") val country: String?,
+        @SerializedName("line1") val line1: String?,
+        @SerializedName("line2") val line2: String?,
+        @SerializedName("postal_code") val postalCode: String?,
+        @SerializedName("state") val state: String?,
+    )
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.model.pay.WCCapturePaymentResponsePayload
 import org.wordpress.android.fluxc.model.pay.WCConnectionTokenResult
 import org.wordpress.android.fluxc.model.pay.WCPaymentAccountResult
 import org.wordpress.android.fluxc.model.pay.WCPaymentCreateCustomerByOrderIdResult
+import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationResult
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -53,6 +54,12 @@ class WCPayStore @Inject constructor(
     ): WooResult<WCPaymentCreateCustomerByOrderIdResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "createCustomerByOrderId") {
             restClient.createCustomerByOrderId(site, orderId).asWooResult()
+        }
+    }
+
+    suspend fun getStoreLocationForSite(site: SiteModel): WCTerminalStoreLocationResult {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "getStoreLocationForSite") {
+            restClient.getStoreLocationForSite(site)
         }
     }
 }


### PR DESCRIPTION
Closes #4818

The PR implements endpoint that uses the default merchant address to fetch a location id and return it back to us. We don't cover a case when merchant doesn't an address yet, because this is not implemented yet on the backend


### How to test
To verify please run e2e test