### PR TITLE
Add organization ID field to `SiteModel`

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -84,7 +84,8 @@ class SiteRestClientTest {
         assertThat(paramsCaptor.lastValue).isEqualTo(
                 mapOf(
                         "fields" to "ID,URL,name,description,jetpack," +
-                                "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta"
+                                "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
+                                "organization_id"
                 )
         )
     }
@@ -132,7 +133,8 @@ class SiteRestClientTest {
                 mapOf(
                         "filters" to "wpcom",
                         "fields" to "ID,URL,name,description,jetpack," +
-                                "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta"
+                                "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
+                                "organization_id"
                 )
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -58,6 +58,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private long mMaxUploadSize; // only set for Jetpack sites
     @Column private long mMemoryLimit; // only set for Jetpack sites
     @Column private int mOrigin = ORIGIN_UNKNOWN; // Does this site come from a WPCOM REST or XMLRPC fetch_sites call?
+    @Column private int mOrganizationId = -1;
 
     @Column private String mShowOnFront;
     @Column private long mPageOnFront = -1;
@@ -793,5 +794,13 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setZendeskAddOns(String zendeskAddOns) {
         mZendeskAddOns = zendeskAddOns;
+    }
+
+    public int getOrganizationId() {
+        return mOrganizationId;
+    }
+
+    public void setOrganizationId(int organizationId) {
+        mOrganizationId = organizationId;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1064,7 +1064,7 @@ class SiteRestClient @Inject constructor(
     companion object {
         private const val NEW_SITE_TIMEOUT_MS = 90000
         private const val SITE_FIELDS = ("ID,URL,name,description,jetpack,visible,is_private,options,plan," +
-                "capabilities,quota,icon,meta,zendesk_site_meta")
+                "capabilities,quota,icon,meta,zendesk_site_meta,organization_id")
         private const val FIELDS = "fields"
         private const val FILTERS = "filters"
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -905,6 +905,7 @@ class SiteRestClient @Inject constructor(
         site.setIsVisible(from.visible)
         site.setIsPrivate(from.is_private)
         site.setIsComingSoon(from.is_coming_soon)
+        site.organizationId = from.organization_id
         // Depending of user's role, options could be "hidden", for instance an "Author" can't read site options.
         if (from.options != null) {
             site.setIsFeaturedImageSupported(from.options.featured_images_enabled)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -94,6 +94,7 @@ public class SiteWPComRestResponse implements Response {
     public boolean visible;
     public boolean is_private;
     public boolean is_coming_soon;
+    public int organization_id;
     public Options options;
     public Capabilities capabilities;
     public Plan plan;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 163
+        return 164
     }
 
     override fun getDbName(): String {
@@ -1816,6 +1816,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 162 -> migrate(version) {
                     db.execSQL("ALTER TABLE PostModel ADD STICKY BOOLEAN")
+                }
+                163 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD ORGANIZATION_ID INTEGER")
                 }
             }
         }


### PR DESCRIPTION
This PR adds the `organization_id` field from the `/me/sites` endpoint to the `SiteModel`.

### To test

WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/15384

