### PR TITLE
Adding updateEditComment method.

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
@@ -180,6 +180,32 @@ class CommentsXMLRPCClientTest {
     }
 
     @Test
+    fun `updateEditComment returns pushed comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <boolean>1</boolean>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.updateEditComment(
+                site = site,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isEqualTo(comment)
+    }
+
+    @Test
     fun `fetchComment returns fetched comment`() = test {
         mockedResponse = """
             <?xml version="1.0" encoding="UTF-8"?>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -88,7 +88,11 @@ class CommentsRestClient @Inject constructor(
         return updateCommentFields(site, comment, request)
     }
 
-    private suspend fun updateCommentFields(site: SiteModel, comment: CommentEntity, request: Map<String, String>): CommentsApiPayload<CommentEntity> {
+    private suspend fun updateCommentFields(
+        site: SiteModel,
+        comment: CommentEntity,
+        request: Map<String, String>
+    ): CommentsApiPayload<CommentEntity> {
         val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
 
         val response = wpComGsonRequestBuilder.syncPostRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -68,13 +68,28 @@ class CommentsRestClient @Inject constructor(
     }
 
     suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
-        val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
-
         val request = mutableMapOf(
                 "content" to comment.content.orEmpty(),
                 "date" to comment.datePublished.orEmpty(),
                 "status" to comment.status.orEmpty()
         )
+
+        return updateCommentFields(site, comment, request)
+    }
+
+    suspend fun updateEditComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
+        val request = mutableMapOf(
+                "content" to comment.content.orEmpty(),
+                "author" to comment.authorName.orEmpty(),
+                "author_email" to comment.authorEmail.orEmpty(),
+                "author_url" to comment.authorUrl.orEmpty()
+        )
+
+        return updateCommentFields(site, comment, request)
+    }
+
+    private suspend fun updateCommentFields(site: SiteModel, comment: CommentEntity, request: Map<String, String>): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
 
         val response = wpComGsonRequestBuilder.syncPostRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -98,7 +98,11 @@ class CommentsXMLRPCClient @Inject constructor(
         return updateCommentFields(site, comment, commentParams)
     }
 
-    private suspend fun updateCommentFields(site: SiteModel, comment: CommentEntity, commentParams: Map<String, Any?>): CommentsApiPayload<CommentEntity> {
+    private suspend fun updateCommentFields(
+        site: SiteModel,
+        comment: CommentEntity,
+        commentParams: Map<String, Any?>
+    ): CommentsApiPayload<CommentEntity> {
         val params: MutableList<Any> = ArrayList(5)
 
         params.add(site.selfHostedSiteId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -78,13 +78,28 @@ class CommentsXMLRPCClient @Inject constructor(
     }
 
     suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
-        val params: MutableList<Any> = ArrayList(5)
-
         val commentParams = mutableMapOf<String, Any?>(
                 "content" to comment.content,
                 "date" to comment.datePublished,
                 "status" to getXMLRPCCommentStatus(CommentStatus.fromString(comment.status))
         )
+
+        return updateCommentFields(site, comment, commentParams)
+    }
+
+    suspend fun updateEditComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
+        val commentParams = mutableMapOf<String, Any?>(
+                "content" to comment.content,
+                "author" to comment.authorName,
+                "author_email" to comment.authorEmail,
+                "author_url" to comment.authorUrl
+        )
+
+        return updateCommentFields(site, comment, commentParams)
+    }
+
+    private suspend fun updateCommentFields(site: SiteModel, comment: CommentEntity, commentParams: Map<String, Any?>): CommentsApiPayload<CommentEntity> {
+        val params: MutableList<Any> = ArrayList(5)
 
         params.add(site.selfHostedSiteId)
         params.add(site.username)


### PR DESCRIPTION
This PR adds the updateEditComment method used for the new Edit Component in [this companion PR](https://github.com/wordpress-mobile/WordPress-Android/pull/15393). You can use that PR description to test this one. 