### PR TITLE
Woo: identify Jetpack CP sites, and check WooCommerce's availability

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -63,9 +63,17 @@ class WooCommerceFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         log_sites.setOnClickListener {
-            for (site in wooCommerceStore.getWooCommerceSites()) {
-                prependToLog(site.name + ": " + if (site.isWpComStore) "WP.com store" else "Self-hosted store")
-                AppLog.i(T.API, LogUtils.toString(site))
+            coroutineScope.launch {
+                prependToLog("Fetching WooCommerce sites")
+                val result = wooCommerceStore.fetchWooCommerceSites()
+                if (result.isError) {
+                    prependToLog("Fetching WooCommerce sites failed, error message: ${result.error.message}")
+                } else {
+                    for (site in result.model!!) {
+                        prependToLog(site.name + ": " + if (site.isWpComStore) "WP.com store" else "Self-hosted store")
+                        AppLog.i(T.API, LogUtils.toString(site))
+                    }
+                }
             }
         }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -83,7 +83,7 @@ class SiteRestClientTest {
                 .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12")
         assertThat(paramsCaptor.lastValue).isEqualTo(
                 mapOf(
-                        "fields" to "ID,URL,name,description,jetpack," +
+                        "fields" to "ID,URL,name,description,jetpack,jetpack_connection," +
                                 "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
                                 "organization_id"
                 )
@@ -132,7 +132,7 @@ class SiteRestClientTest {
         assertThat(paramsCaptor.lastValue).isEqualTo(
                 mapOf(
                         "filters" to "wpcom",
-                        "fields" to "ID,URL,name,description,jetpack," +
+                        "fields" to "ID,URL,name,description,jetpack,jetpack_connection," +
                                 "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
                                 "organization_id"
                 )

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteUtils.java
@@ -73,6 +73,20 @@ public class SiteUtils {
         return example;
     }
 
+    public static SiteModel generateJetpackCPSite() {
+        SiteModel example = new SiteModel();
+        example.setSiteId(5623);
+        example.setIsWPCom(false);
+        example.setIsJetpackInstalled(false);
+        example.setIsJetpackConnected(false);
+        example.setIsJetpackCPConnected(true);
+        example.setIsVisible(true);
+        example.setUrl("http://jetpackcp.url");
+        example.setXmlRpcUrl("http://jetpackcp.url/xmlrpc.php");
+        example.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
+        return example;
+    }
+
     public static SiteModel generateSelfHostedSiteFutureJetpack() {
         SiteModel example = new SiteModel();
         example.setSelfHostedSiteId(8);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.model;
 
-import static java.lang.annotation.RetentionPolicy.SOURCE;
-
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 
@@ -21,6 +19,8 @@ import java.lang.annotation.Retention;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})
@@ -83,7 +83,8 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private boolean mIsJetpackInstalled;
     // mIsJetpackConnected is true if Jetpack is installed, activated and connected to a WordPress.com account.
     @Column private boolean mIsJetpackConnected;
-    // mIsJetpackCPConnected is true for self hosted sites that use Jetpack Connection Package, but don't have full jetpack plugin
+    // mIsJetpackCPConnected is true for self hosted sites that use Jetpack Connection Package,
+    // but don't have full jetpack plugin
     @Column(name = "IS_JETPACK_CP_CONNECTED") private boolean mIsJetpackCPConnected;
     @Column private String mJetpackVersion;
     @Column private String mJetpackUserEmail;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.model;
 
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 
@@ -19,8 +21,6 @@ import java.lang.annotation.Retention;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-
-import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})
@@ -83,6 +83,8 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private boolean mIsJetpackInstalled;
     // mIsJetpackConnected is true if Jetpack is installed, activated and connected to a WordPress.com account.
     @Column private boolean mIsJetpackConnected;
+    // mIsJetpackCPConnected is true for self hosted sites that use Jetpack Connection Package, but don't have full jetpack plugin
+    @Column(name = "IS_JETPACK_CP_CONNECTED") private boolean mIsJetpackCPConnected;
     @Column private String mJetpackVersion;
     @Column private String mJetpackUserEmail;
     @Column private boolean mIsAutomatedTransfer;
@@ -576,6 +578,14 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setIsJetpackConnected(boolean jetpackConnected) {
         mIsJetpackConnected = jetpackConnected;
+    }
+
+    public boolean isJetpackCPConnected() {
+        return mIsJetpackCPConnected;
+    }
+
+    public void setIsJetpackCPConnected(boolean isJetpackCPConnected) {
+        this.mIsJetpackCPConnected = isJetpackCPConnected;
     }
 
     public String getJetpackVersion() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -906,8 +906,9 @@ class SiteRestClient @Inject constructor(
         site.url = from.URL
         site.name = StringEscapeUtils.unescapeHtml4(from.name)
         site.description = StringEscapeUtils.unescapeHtml4(from.description)
-        site.setIsJetpackConnected(from.jetpack)
+        site.setIsJetpackConnected(from.jetpack && from.jetpack_connection)
         site.setIsJetpackInstalled(from.jetpack)
+        site.setIsJetpackCPConnected(from.jetpack_connection && !from.jetpack)
         site.setIsVisible(from.visible)
         site.setIsPrivate(from.is_private)
         site.setIsComingSoon(from.is_coming_soon)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1070,8 +1070,8 @@ class SiteRestClient @Inject constructor(
 
     companion object {
         private const val NEW_SITE_TIMEOUT_MS = 90000
-        private const val SITE_FIELDS = ("ID,URL,name,description,jetpack,visible,is_private,options,plan," +
-                "capabilities,quota,icon,meta,zendesk_site_meta,organization_id")
+        private const val SITE_FIELDS = "ID,URL,name,description,jetpack,jetpack_connection,visible,is_private," +
+                "options,plan,capabilities,quota,icon,meta,zendesk_site_meta,organization_id"
         private const val FIELDS = "fields"
         private const val FILTERS = "filters"
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -91,6 +91,7 @@ public class SiteWPComRestResponse implements Response {
     public String name;
     public String description;
     public boolean jetpack;
+    public boolean jetpack_connection;
     public boolean visible;
     public boolean is_private;
     public boolean is_coming_soon;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 164
+        return 165
     }
 
     override fun getDbName(): String {
@@ -1819,6 +1819,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 163 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD ORGANIZATION_ID INTEGER")
+                }
+                164 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD IS_JETPACK_CP_CONNECTED BOOLEAN")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -397,7 +397,7 @@ open class WooCommerceStore @Inject constructor(
      */
     @Subscribe(priority = 100)
     fun onSiteChanged(siteChanged: OnSiteChanged) {
-        if (siteChanged.isError || siteChanged.rowsAffected == 0) return
+        if (siteChanged.isError || siteChanged.rowsAffected == 0 || siteChanged.updatedSites.isEmpty()) return
         coroutineEngine.launch(T.API, this, "Check woocommerce availability") {
             siteChanged.updatedSites.filter { it.isJetpackCPConnected }
                 .forEach { site -> fetchAndUpdateWooCommerceAvailability(site) }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -388,9 +388,9 @@ open class WooCommerceStore @Inject constructor(
 
     /**
      * The goal of this is to make sure we update the sites if the fetching was done outside of [WooCommerceStore]
-     * TODO: confirm if this is needed
+     * We specify a higher priority to make sure this is delivered before reaching the final subscribers
      */
-    @Subscribe
+    @Subscribe(priority = 100)
     fun onSiteChanged(siteChanged: OnSiteChanged) {
         if (siteChanged.isError || siteChanged.rowsAffected == 0) return
         coroutineEngine.launch(T.API, this, "Check woocommerce availability") {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -144,6 +144,8 @@ open class WooCommerceStore @Inject constructor(
     suspend fun fetchWooCommerceSites(): WooResult<List<SiteModel>> {
         val fetchResult = siteStore.fetchSites(FetchSitesPayload())
         if (fetchResult.isError) {
+            emitChange(fetchResult)
+
             return WooResult(
                 WooError(
                     type = GENERIC_ERROR,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -13,7 +13,10 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductSettingsModel
 import org.wordpress.android.fluxc.model.WCSSRModel
 import org.wordpress.android.fluxc.model.WCSettingsModel
-import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.*
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.LEFT
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.LEFT_SPACE
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.RIGHT
+import org.wordpress.android.fluxc.model.WCSettingsModel.CurrencyPosition.RIGHT_SPACE
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -33,7 +36,7 @@ import org.wordpress.android.fluxc.utils.WCCurrencyUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.LanguageUtils
-import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.absoluteValue


### PR DESCRIPTION
As part of https://github.com/woocommerce/woocommerce-android/issues/4856, we need to be able to identify sites that use Jetpack Connection Package instead of the full Jetpack plugin.

WCAndroid's PR: https://github.com/woocommerce/woocommerce-android/pull/4933

This PR adds the following changes:
- It adds a new column to `SiteModel` to identify sites using Jetpack CP.
- Since we can't rely on the option `woocommerce_is_active` for sites using Jetpack CP, we need to check if WooCommerce is available manually.
In order to avoid performing this check from the apps other than WCAndroid, I added a helper function  `fetchWooCommerceSites` to WooCommerceStore, to fetch sites and perform the check. And for cases where we fetch sites using the old way (for example during login), WooCommerceStore will listen to those changes, and perform the Woo availability check.

#### Testing
1. You need a new site that doesn't have Jetpack, or if using an old one, please uninstall Jetpack, then disconnect the store from the [dashboard](https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs) to make sure the flag `jetpack` has been reset.
2. Install WCPay and WooCommerce in the store.
3. Go to Payments, then click on `Setup`, and perform the WordPress.com authorization (you don't need the rest of steps).
4. Open the example app.
5. Click on Woo.
6. Click on `Log Sites`
7. Confirm that you can see the new added site printed in the log.