### PR TITLE
Issue/4806 convert update order status to suspend

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -22,7 +22,6 @@ import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
 import org.wordpress.android.fluxc.action.WCOrderAction.POST_ORDER_NOTE
-import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.WCAddOrderShipmentTrackingDialog
 import org.wordpress.android.fluxc.example.WCOrderListActivity

--- a/example/src/test/java/org/wordpress/android/fluxc/tools/CoroutineEngineUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/tools/CoroutineEngineUtils.kt
@@ -5,6 +5,8 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import org.mockito.Mockito.lenient
 
@@ -38,6 +40,16 @@ fun initCoroutineEngine() = runBlocking {
             any(),
             any(),
             any<(suspend CoroutineScope.() -> Any)>()
+    )
+    lenient().doAnswer {
+        return@doAnswer runBlocking {
+            flow { it.getArgument<(suspend FlowCollector<Any>.() -> Unit)>(3).invoke(this) }
+        }
+    }.whenever(coroutineEngine).flowWithDefaultContext(
+            any(),
+            any(),
+            any(),
+            any<(suspend FlowCollector<Any>.() -> Unit)>()
     )
     coroutineEngine
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import com.yarolegovich.wellsql.WellSql
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -23,6 +24,12 @@ import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder.newFetchedOrderListAction
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.model.WCOrderSummaryModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.wc.order
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
@@ -2,6 +2,10 @@ package org.wordpress.android.fluxc.tools
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.utils.AppLogWrapper
@@ -31,6 +35,18 @@ open class CoroutineEngine
         appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage")
         return block()
     }
+
+    fun <RESULT_TYPE> flowWithDefaultContext(
+        tag: AppLog.T,
+        caller: Any,
+        loggedMessage: String,
+        block: suspend FlowCollector<RESULT_TYPE>.() -> Unit
+    ): Flow<RESULT_TYPE> =
+            flow { block() }
+                    .flowOn(context)
+//                    .onStart { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Started") }
+//                    .onEach { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage OnEvent: $it") }
+//                    .onCompletion { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Completed") }
 
     fun <RESULT_TYPE> launch(
         tag: AppLog.T,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.utils.AppLogWrapper
@@ -44,9 +47,9 @@ open class CoroutineEngine
     ): Flow<RESULT_TYPE> =
             flow { block() }
                     .flowOn(context)
-//                    .onStart { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Started") }
-//                    .onEach { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage OnEvent: $it") }
-//                    .onCompletion { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Completed") }
+                    .onStart { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Started") }
+                    .onEach { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage OnEvent: $it") }
+                    .onCompletion { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Completed") }
 
     fun <RESULT_TYPE> launch(
         tag: AppLog.T,

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -40,6 +40,7 @@ public enum WCOrderAction implements IAction {
     @Action(payloadType = FetchOrdersCountPayload.class)
     FETCH_ORDERS_COUNT,
     @Action(payloadType = UpdateOrderStatusPayload.class)
+    @Deprecated // Use suspendable WCOrderStore.updateOrderStatus(..) directly.
     UPDATE_ORDER_STATUS,
     @Action(payloadType = PostOrderNotePayload.class)
     POST_ORDER_NOTE,
@@ -65,8 +66,6 @@ public enum WCOrderAction implements IAction {
     FETCHED_ORDERS_BY_IDS,
     @Action(payloadType = FetchOrdersCountResponsePayload.class)
     FETCHED_ORDERS_COUNT,
-    @Action(payloadType = RemoteOrderPayload.class)
-    UPDATED_ORDER_STATUS,
     @Action(payloadType = RemoteOrderNotePayload.class)
     POSTED_ORDER_NOTE,
     @Action(payloadType = FetchHasOrdersResponsePayload.class)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -23,7 +23,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload;

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -401,7 +401,7 @@ class OrderRestClient @Inject constructor(
         val url = WOOCOMMERCE.orders.id(orderToUpdate.remoteOrderId).pathV3
         val params = mapOf("status" to status)
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+        val response = jetpackTunnelGsonRequestBuilder.syncPutRequest(
             this,
             site,
             url,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -388,41 +388,50 @@ class OrderRestClient @Inject constructor(
      * Makes a PUT call to `/wc/v3/orders/<id>` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * updating the status for the given [order] to [status].
      *
-     * Dispatches a [WCOrderAction.UPDATED_ORDER_STATUS] with the updated [WCOrderModel].
      *
      * Possible non-generic errors:
      * [OrderErrorType.INVALID_PARAM] if the [status] is not a valid order status on the server
      * [OrderErrorType.INVALID_ID] if an order by this id was not found on the server
      */
-    fun updateOrderStatus(
+    suspend fun updateOrderStatus(
         orderToUpdate: WCOrderModel,
         site: SiteModel,
         status: String
-    ) {
+    ): RemoteOrderPayload {
         val url = WOOCOMMERCE.orders.id(orderToUpdate.remoteOrderId).pathV3
         val params = mapOf("status" to status)
 
-        val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, params, OrderApiResponse::class.java,
-                listener = { response: OrderApiResponse? ->
-                    response?.let {
-                        val newModel = orderResponseToOrderModel(it).apply {
-                            id = orderToUpdate.id
-                            localSiteId = orderToUpdate.localSiteId
-                        }
-                        val payload = RemoteOrderPayload(newModel, site)
-                        dispatcher.dispatch(WCOrderActionBuilder.newUpdatedOrderStatusAction(payload))
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+            this,
+            site,
+            url,
+            params,
+            OrderApiResponse::class.java
+        )
+
+        return when (response) {
+            is JetpackSuccess -> {
+                response.data?.let {
+                    val newModel = orderResponseToOrderModel(it).apply {
+                        id = orderToUpdate.id
+                        localSiteId = orderToUpdate.localSiteId
                     }
-                },
-                errorListener = { networkError ->
-                    val orderError = networkErrorToOrderError(networkError)
-                    val payload = RemoteOrderPayload(
-                            orderError,
-                            orderToUpdate,
-                            site
-                    )
-                    dispatcher.dispatch(WCOrderActionBuilder.newUpdatedOrderStatusAction(payload))
-                })
-        add(request)
+                    RemoteOrderPayload(newModel, site)
+                } ?: RemoteOrderPayload(
+                    OrderError(type = GENERIC_ERROR, message = "Success response with empty data"),
+                    orderToUpdate,
+                    site
+                )
+            }
+            is JetpackError -> {
+                val orderError = networkErrorToOrderError(response.error)
+                RemoteOrderPayload(
+                    orderError,
+                    orderToUpdate,
+                    site
+                )
+            }
+        }
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -26,8 +26,8 @@ import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 import org.wordpress.android.fluxc.store.ListStore.ListError
 import org.wordpress.android.fluxc.store.ListStore.ListErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
-import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusResult.OptimisticUpdateResult
-import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusResult.RemoteUpdateResult
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -169,11 +169,11 @@ class WCOrderStore @Inject constructor(
         constructor(error: OrderError, order: WCOrderModel, site: SiteModel) : this(order, site) { this.error = error }
     }
 
-    sealed class UpdateOrderStatusResult {
+    sealed class UpdateOrderResult {
         abstract val event: OnOrderChanged
 
-        data class OptimisticUpdateResult(override val event: OnOrderChanged) : UpdateOrderStatusResult()
-        data class RemoteUpdateResult(override val event: OnOrderChanged) : UpdateOrderStatusResult()
+        data class OptimisticUpdateResult(override val event: OnOrderChanged) : UpdateOrderResult()
+        data class RemoteUpdateResult(override val event: OnOrderChanged) : UpdateOrderResult()
     }
 
     class FetchOrderNotesPayload(
@@ -514,7 +514,7 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    suspend fun updateOrderStatus(payload: UpdateOrderStatusPayload): Flow<UpdateOrderStatusResult> {
+    suspend fun updateOrderStatus(payload: UpdateOrderStatusPayload): Flow<UpdateOrderResult> {
         return coroutineEngine.flowWithDefaultContext(T.API, this, "updateOrderStatus") {
             val rowsAffected = updateOrderStatusLocally(payload.order.id, payload.status)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import kotlinx.coroutines.flow.Flow
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -25,6 +26,8 @@ import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 import org.wordpress.android.fluxc.store.ListStore.ListError
 import org.wordpress.android.fluxc.store.ListStore.ListErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusResult.OptimisticUpdateResult
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -164,6 +167,13 @@ class WCOrderStore @Inject constructor(
         val site: SiteModel
     ) : Payload<OrderError>() {
         constructor(error: OrderError, order: WCOrderModel, site: SiteModel) : this(order, site) { this.error = error }
+    }
+
+    sealed class UpdateOrderStatusResult {
+        abstract val event: OnOrderChanged
+
+        data class OptimisticUpdateResult(override val event: OnOrderChanged) : UpdateOrderStatusResult()
+        data class RemoteUpdateResult(override val event: OnOrderChanged) : UpdateOrderStatusResult()
     }
 
     class FetchOrderNotesPayload(
@@ -418,7 +428,8 @@ class WCOrderStore @Inject constructor(
             WCOrderAction.FETCH_ORDER_LIST -> fetchOrderList(action.payload as FetchOrderListPayload)
             WCOrderAction.FETCH_ORDERS_BY_IDS -> fetchOrdersByIds(action.payload as FetchOrdersByIdsPayload)
             WCOrderAction.FETCH_ORDERS_COUNT -> fetchOrdersCount(action.payload as FetchOrdersCountPayload)
-            WCOrderAction.UPDATE_ORDER_STATUS -> updateOrderStatus(action.payload as UpdateOrderStatusPayload)
+            WCOrderAction.UPDATE_ORDER_STATUS ->
+                throw IllegalStateException("Invalid action. Use suspendable updateOrderStatus(..) directly")
             WCOrderAction.POST_ORDER_NOTE -> postOrderNote(action.payload as PostOrderNotePayload)
             WCOrderAction.FETCH_HAS_ORDERS -> fetchHasOrders(action.payload as FetchHasOrdersPayload)
             WCOrderAction.SEARCH_ORDERS -> searchOrders(action.payload as SearchOrdersPayload)
@@ -439,7 +450,6 @@ class WCOrderStore @Inject constructor(
                 handleFetchOrderByIdsCompleted(action.payload as FetchOrdersByIdsResponsePayload)
             WCOrderAction.FETCHED_ORDERS_COUNT ->
                 handleFetchOrdersCountCompleted(action.payload as FetchOrdersCountResponsePayload)
-            WCOrderAction.UPDATED_ORDER_STATUS -> handleUpdateOrderStatusCompleted(action.payload as RemoteOrderPayload)
             WCOrderAction.POSTED_ORDER_NOTE -> handlePostOrderNoteCompleted(action.payload as RemoteOrderNotePayload)
             WCOrderAction.FETCHED_HAS_ORDERS -> handleFetchHasOrdersCompleted(
                     action.payload as FetchHasOrdersResponsePayload)
@@ -504,13 +514,28 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    private fun updateOrderStatus(payload: UpdateOrderStatusPayload) {
-        with(payload) {
+    suspend fun updateOrderStatus(payload: UpdateOrderStatusPayload): Flow<UpdateOrderStatusResult> {
+        return coroutineEngine.flowWithDefaultContext(T.API, this, "updateOrderStatus") {
             val rowsAffected = updateOrderStatusLocally(payload.order.id, payload.status)
 
-            emitChange(OnOrderChanged(rowsAffected).apply { causeOfChange = WCOrderAction.UPDATED_ORDER_STATUS })
+            val optimisticUpdateResult = OnOrderChanged(rowsAffected)
+                    .apply { causeOfChange = WCOrderAction.UPDATE_ORDER_STATUS }
 
-            wcOrderRestClient.updateOrderStatus(payload.order, site, status)
+            emit(OptimisticUpdateResult(optimisticUpdateResult))
+
+            val remotePayload = wcOrderRestClient.updateOrderStatus(payload.order, payload.site, payload.status)
+            val remoteUpdateResult: OnOrderChanged = if (remotePayload.isError) {
+                revertOrderStatus(remotePayload)
+            } else {
+                val rowsAffected = OrderSqlUtils.insertOrUpdateOrder(remotePayload.order)
+                OnOrderChanged(rowsAffected)
+            }
+
+            remoteUpdateResult.causeOfChange = WCOrderAction.UPDATE_ORDER_STATUS
+
+            emit(RemoteUpdateResult(remoteUpdateResult))
+            // Needs to remain here until all event bus observables are removed from the client code
+            emitChange(remoteUpdateResult)
         }
     }
 
@@ -727,19 +752,6 @@ class WCOrderStore @Inject constructor(
                 OnOrderChanged(rowsAffected, statusFilter)
             }
         }.also { it.causeOfChange = WCOrderAction.FETCH_HAS_ORDERS }
-        emitChange(onOrderChanged)
-    }
-
-    private fun handleUpdateOrderStatusCompleted(payload: RemoteOrderPayload) {
-        val onOrderChanged: OnOrderChanged = if (payload.isError) {
-            revertOrderStatus(payload)
-        } else {
-            val rowsAffected = OrderSqlUtils.insertOrUpdateOrder(payload.order)
-            OnOrderChanged(rowsAffected)
-        }
-
-        onOrderChanged.causeOfChange = WCOrderAction.UPDATE_ORDER_STATUS
-
         emitChange(onOrderChanged)
     }
 


### PR DESCRIPTION
"Not ready for merge" - Should be merged together with a PR in WCAndroid

This PR refactors updateOrderStatus into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

To Test:
1. Test updateOrderStatus action in the example app or test in WCAndroid ([PR](https://github.com/woocommerce/woocommerce-android/pull/4955))
