### PR TITLE
Merge release 1.27.0 into trunk

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.example"
-        minSdkVersion 18
+        minSdkVersion 21
         // Keep the targetSdkVersion 22 so we don't need to grant runtime permissions to the tests and the example app
         // An alternative would be granting the permissions via adb before running the test, like here:
         // https://afterecho.uk/blog/granting-marshmallow-permissions-for-testing-flavoured-builds.html
@@ -24,7 +24,6 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments += [
@@ -159,9 +158,6 @@ dependencies {
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
-
-    // Multidex
-    implementation 'androidx.multidex:multidex:2.0.1'
 }
 
 def loadPropertiesOrUseExampleProperties(fileName, warningDetail) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked
 
 import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -25,7 +26,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackin
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
@@ -450,16 +450,11 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderShipmentTrackingsFetchSuccess() {
+    fun testOrderShipmentTrackingsFetchSuccess() = runBlocking {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         interceptor.respondWith("wc-order-shipment-trackings-success.json")
-        orderRestClient.fetchOrderShipmentTrackings(siteModel, orderModel.id, orderModel.remoteOrderId)
+        val payload = orderRestClient.fetchOrderShipmentTrackings(siteModel, orderModel.id, orderModel.remoteOrderId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_ORDER_SHIPMENT_TRACKINGS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchOrderShipmentTrackingsResponsePayload
         assertNull(payload.error)
         assertEquals(2, payload.trackings.size)
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked
 
 import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -178,53 +179,38 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchSingleOrderSuccess() {
+    fun testFetchSingleOrderSuccess() = runBlocking {
         val remoteOrderId = 88L
         interceptor.respondWith("wc-fetch-order-response-success.json")
-        orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+        val response = orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteOrderPayload
-        with(payload) {
+        with(response) {
             assertNull(error)
             assertEquals(remoteOrderId, order.remoteOrderId)
         }
     }
 
     @Test
-    fun testFetchSingleOrderOrderKeySuccess() {
+    fun testFetchSingleOrderOrderKeySuccess() = runBlocking {
         val remoteOrderId = 88L
         val orderKey = "wc_order_5a77766b88986"
         interceptor.respondWith("wc-fetch-order-response-success.json")
-        orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+        val response = orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteOrderPayload
-        with(payload) {
+        with(response) {
             assertNull(error)
             assertEquals(orderKey, order.orderKey)
         }
     }
 
     @Test
-    fun testFetchSingleOrderError() {
+    fun testFetchSingleOrderError() = runBlocking{
         val remoteOrderId = 88L
 
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
-        orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+        val response = orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_SINGLE_ORDER, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteOrderPayload
-        assertNotNull(payload.error)
+        assertNotNull(response.error)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -204,7 +204,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchSingleOrderError() = runBlocking{
+    fun testFetchSingleOrderError() = runBlocking {
         val remoteOrderId = 88L
 
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked
 
 import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -23,7 +24,6 @@ import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
@@ -291,19 +291,14 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderNotesFetchSuccess() {
+    fun testOrderNotesFetchSuccess() = runBlocking {
         interceptor.respondWith("wc-order-notes-response-success.json")
-        orderRestClient.fetchOrderNotes(
+        val payload = orderRestClient.fetchOrderNotes(
                 localOrderId = 8,
                 remoteOrderId = 88,
                 site = siteModel
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_ORDER_NOTES, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchOrderNotesResponsePayload
         assertNull(payload.error)
         assertEquals(8, payload.notes.size)
 
@@ -337,19 +332,14 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderNotesFetchError() {
+    fun testOrderNotesFetchError() = runBlocking {
         interceptor.respondWithError("wc-order-notes-response-failure-invalid-id.json", 404)
-        orderRestClient.fetchOrderNotes(
+        val payload = orderRestClient.fetchOrderNotes(
                 localOrderId = 8,
                 remoteOrderId = 88,
                 site = siteModel
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_ORDER_NOTES, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchOrderNotesResponsePayload
         with(payload) {
             // Expecting a 'invalid id' error from the server
             assertNotNull(error)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.release
 
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.junit.Assert.assertEquals
@@ -9,7 +10,6 @@ import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCOrderAction.ADD_ORDER_SHIPMENT_TRACKING
 import org.wordpress.android.fluxc.action.WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING
-import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDER_SHIPMENT_TRACKINGS
 import org.wordpress.android.fluxc.example.BuildConfig
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderModel
@@ -33,7 +33,6 @@ import javax.inject.Inject
 class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
     internal enum class TestEvent {
         NONE,
-        FETCHED_ORDER_SHIPMENT_TRACKINGS,
         ADD_ORDER_SHIPMENT_TRACKING,
         DELETE_ORDER_SHIPMENT_TRACKING,
         FETCHED_ORDER_SHIPMENT_PROVIDERS
@@ -65,18 +64,13 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
      */
     @Throws(InterruptedException::class)
     @Test
-    fun testFetchShipmentTrackingsForOrder_hasTrackings() {
-        nextEvent = TestEvent.FETCHED_ORDER_SHIPMENT_TRACKINGS
-        mCountDownLatch = CountDownLatch(1)
-
+    fun testFetchShipmentTrackingsForOrder_hasTrackings() = runBlocking {
         val orderModel = WCOrderModel().apply {
             id = 8
             remoteOrderId = BuildConfig.TEST_WC_ORDER_WITH_SHIPMENT_TRACKINGS_ID.toLong()
             localSiteId = sSite.id
         }
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(
-                FetchOrderShipmentTrackingsPayload(orderModel.id, orderModel.remoteOrderId, sSite)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        orderStore.fetchOrderShipmentTrackings(orderModel.id, orderModel.remoteOrderId, sSite)
 
         val trackings = orderStore.getShipmentTrackingsForOrder(
                 sSite, orderModel.id
@@ -91,18 +85,14 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
      */
     @Throws(InterruptedException::class)
     @Test
-    fun testFetchShipmentTrackingsForOrder_noTrackings() {
-        nextEvent = TestEvent.FETCHED_ORDER_SHIPMENT_TRACKINGS
-        mCountDownLatch = CountDownLatch(1)
-
+    fun testFetchShipmentTrackingsForOrder_noTrackings() = runBlocking {
         val orderModel = WCOrderModel().apply {
             id = 9
             remoteOrderId = BuildConfig.TEST_WC_ORDER_WITHOUT_SHIPMENT_TRACKINGS_ID.toLong()
             localSiteId = sSite.id
         }
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(
-                FetchOrderShipmentTrackingsPayload(orderModel.id, orderModel.remoteOrderId, sSite)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        orderStore.fetchOrderShipmentTrackings(orderModel.id, orderModel.remoteOrderId, sSite)
 
         val trackings = orderStore.getShipmentTrackingsForOrder(
                 sSite, orderModel.id
@@ -291,10 +281,6 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
         lastEvent = event
 
         when (event.causeOfChange) {
-            FETCH_ORDER_SHIPMENT_TRACKINGS -> {
-                assertEquals(TestEvent.FETCHED_ORDER_SHIPMENT_TRACKINGS, nextEvent)
-                mCountDownLatch.countDown()
-            }
             ADD_ORDER_SHIPMENT_TRACKING -> {
                 assertEquals(TestEvent.ADD_ORDER_SHIPMENT_TRACKING, nextEvent)
                 mCountDownLatch.countDown()

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderShipmentProvidersChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderError

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -175,9 +175,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
     @Throws(InterruptedException::class)
     @Test
     fun testFetchSingleOrder() = runBlocking {
-        val fetchedOrder = orderStore.fetchSingleOrder(sSite, orderModel.remoteOrderId)
-
-        assertTrue(fetchedOrder != null && fetchedOrder.remoteOrderId == orderModel.remoteOrderId)
+        orderStore.fetchSingleOrder(sSite, orderModel.remoteOrderId)
 
         val orderFromDb = orderStore.getOrderByIdentifier(
                 OrderIdentifier(

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.release
 
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -18,7 +19,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersByIdsPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
@@ -48,8 +48,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         POST_ORDER_NOTE,
         POSTED_ORDER_NOTE,
         ERROR_ORDER_STATUS_NOT_FOUND,
-        FETCHED_ORDER_STATUS_OPTIONS,
-        ERROR_ORDER_SHIPMENT_TRACKINGS_PLUGIN_NOT_ACTIVE
+        FETCHED_ORDER_STATUS_OPTIONS
     }
 
     @Inject internal lateinit var orderStore: WCOrderStore
@@ -270,14 +269,10 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
      */
     @Throws(InterruptedException::class)
     @Test
-    fun testFetchShipmentTrackingsForOrder_pluginNotInstalled() {
-        nextEvent = TestEvent.ERROR_ORDER_SHIPMENT_TRACKINGS_PLUGIN_NOT_ACTIVE
-        mCountDownLatch = CountDownLatch(1)
-
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentTrackingsAction(
-                FetchOrderShipmentTrackingsPayload(orderModel.id, orderModel.remoteOrderId, sSite)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
+    fun testFetchShipmentTrackingsForOrder_pluginNotInstalled() = runBlocking {
+        val result = orderStore.fetchOrderShipmentTrackings(orderModel.id, orderModel.remoteOrderId, sSite)
+        assertTrue(result.isError)
+        assertEquals(OrderErrorType.PLUGIN_NOT_ACTIVE, result.error.type)
         val trackings = orderStore.getShipmentTrackingsForOrder(sSite, orderModel.id)
         assertTrue(trackings.isEmpty())
     }
@@ -289,13 +284,6 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
             when (event.causeOfChange) {
                 WCOrderAction.FETCH_ORDERS_COUNT -> {
                     assertEquals(TestEvent.ERROR_ORDER_STATUS_NOT_FOUND, nextEvent)
-                    mCountDownLatch.countDown()
-                    return
-                }
-                WCOrderAction.FETCH_ORDER_SHIPMENT_TRACKINGS -> {
-                    assertEquals(TestEvent.ERROR_ORDER_SHIPMENT_TRACKINGS_PLUGIN_NOT_ACTIVE, nextEvent)
-                    assertTrue(event.isError)
-                    assertEquals(OrderErrorType.PLUGIN_NOT_ACTIVE, event.error.type)
                     mCountDownLatch.countDown()
                     return
                 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release
 
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.example.test.BuildConfig
@@ -44,7 +45,7 @@ class ReleaseStack_WCPayTest : ReleaseStack_WCBase() {
         assertEquals(false, result.model?.hasOverdueRequirements)
         assertEquals("DO.WPMT.CO", result.model?.statementDescriptor)
         assertEquals("US", result.model?.country)
-        assertEquals(false, result.model?.isCardPresentEligible)
+        assertEquals(true, result.model?.isCardPresentEligible)
         assertEquals("usd", result.model?.storeCurrencies?.default)
         assertEquals(listOf("usd"), result.model?.storeCurrencies?.supportedCurrencies)
         assertEquals(WCPayAccountStatusEnum.COMPLETE, result.model?.status)
@@ -68,5 +69,20 @@ class ReleaseStack_WCPayTest : ReleaseStack_WCBase() {
         )
 
         assertTrue(result.isError)
+    }
+
+    @Test
+    fun givenSiteHasWCPayAndStripeAddressThenLocationDataReturned() = runBlocking {
+        val result = payStore.getStoreLocationForSite(sSite)
+
+        assertFalse(result.isError)
+        assertEquals("tml_EUZ4bQQTxLWMq2", result.locationId)
+        assertEquals("Woo WCPay", result.displayName)
+        assertEquals("San Francisco", result.address?.city)
+        assertEquals("US", result.address?.country)
+        assertEquals("1230 Lawton St", result.address?.line1)
+        assertEquals("71", result.address?.line2)
+        assertEquals("94122", result.address?.postalCode)
+        assertEquals("CA", result.address?.state)
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ExampleApp.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.example
 
-import androidx.multidex.MultiDexApplication
+import android.app.Application
 import com.yarolegovich.wellsql.WellSql
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -10,7 +10,7 @@ import org.wordpress.android.fluxc.example.di.DaggerAppComponent
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import javax.inject.Inject
 
-open class ExampleApp : MultiDexApplication(), HasAndroidInjector {
+open class ExampleApp : Application(), HasAndroidInjector {
     @Inject lateinit var androidInjector: DispatchingAndroidInjector<Any>
 
     protected open val component: AppComponent by lazy {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -141,7 +141,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                     coroutineScope.launch {
                         enteredRemoteId?.let { id ->
                             prependToLog("Submitting request to fetch order by remoteOrderID: $enteredRemoteId")
-                            wcOrderStore.fetchSingleOrder(site, id).takeUnless {   it.isError }?.let {
+                            wcOrderStore.fetchSingleOrder(site, id).takeUnless { it.isError }?.let {
                                 prependToLog("Single order fetched successfully!")
                             } ?: prependToLog("WARNING: Fetched order not found in the local database!")
                         } ?: prependToLog("No valid remoteOrderId defined...doing nothing")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -141,14 +141,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                     coroutineScope.launch {
                         enteredRemoteId?.let { id ->
                             prependToLog("Submitting request to fetch order by remoteOrderID: $enteredRemoteId")
-                            wcOrderStore.fetchSingleOrder(site, id)
-                            wcOrderStore.getOrderByIdentifier(
-                                    OrderIdentifier(
-                                            WCOrderModel().apply {
-                                                remoteOrderId = enteredRemoteId
-                                                localSiteId = site.id
-                                            })
-                            )?.let {
+                            wcOrderStore.fetchSingleOrder(site, id).takeUnless {   it.isError }?.let {
                                 prependToLog("Single order fetched successfully!")
                             } ?: prependToLog("WARNING: Fetched order not found in the local database!")
                         } ?: prependToLog("No valid remoteOrderId defined...doing nothing")

--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
@@ -180,6 +180,32 @@ class CommentsXMLRPCClientTest {
     }
 
     @Test
+    fun `updateEditComment returns pushed comment`() = test {
+        mockedResponse = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                  <boolean>1</boolean>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>
+        """
+
+        val comment = getDefaultComment()
+
+        val payload = xmlRpcClient.updateEditComment(
+                site = site,
+                comment = comment
+        )
+
+        assertThat(payload.isError).isFalse
+        assertThat(payload.response).isEqualTo(comment)
+    }
+
+    @Test
     fun `fetchComment returns fetched comment`() = test {
         mockedResponse = """
             <?xml version="1.0" encoding="UTF-8"?>

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -84,7 +84,8 @@ class SiteRestClientTest {
         assertThat(paramsCaptor.lastValue).isEqualTo(
                 mapOf(
                         "fields" to "ID,URL,name,description,jetpack," +
-                                "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta"
+                                "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
+                                "organization_id"
                 )
         )
     }
@@ -132,7 +133,8 @@ class SiteRestClientTest {
                 mapOf(
                         "filters" to "wpcom",
                         "fields" to "ID,URL,name,description,jetpack," +
-                                "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta"
+                                "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
+                                "organization_id"
                 )
         )
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import java.util.Calendar
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -49,7 +50,7 @@ import kotlin.test.assertTrue
 @RunWith(RobolectricTestRunner::class)
 class WCOrderStoreTest {
     private val orderFetcher: WCOrderFetcher = mock()
-    private val orderStore = WCOrderStore(Dispatcher(), mock(), orderFetcher)
+    private val orderStore = WCOrderStore(Dispatcher(), mock(), orderFetcher, initCoroutineEngine())
 
     @Before
     fun setUp() {

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -49,7 +49,7 @@
 /payments/accounts
 /payments/orders/<order_id>/create_customer
 
-/terminal/locations/store
+/payments/terminal/locations/store
 
 /taxes
 /taxes/classes/

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -49,6 +49,8 @@
 /payments/accounts
 /payments/orders/<order_id>/create_customer
 
+/terminal/locations/store
+
 /taxes
 /taxes/classes/
 

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 29
         javaCompileOptions {
             annotationProcessorOptions {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -90,8 +90,6 @@ public enum SiteAction implements IAction {
     FETCH_DOMAIN_SUPPORTED_COUNTRIES,
     @Action(payloadType = CompleteQuickStartPayload.class)
     COMPLETE_QUICK_START,
-    @Action(payloadType = SiteModel.class)
-    FETCH_DOMAINS,
     @Action(payloadType = DesignatePrimaryDomainPayload.class)
     DESIGNATE_PRIMARY_DOMAIN,
     @Action(payloadType = FetchPrivateAtomicCookiePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -26,7 +26,6 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchJetpackCapabilitiesPaylo
 import org.wordpress.android.fluxc.store.SiteStore.FetchPrivateAtomicCookiePayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedBlockLayoutsResponsePayload;
-import org.wordpress.android.fluxc.store.SiteStore.FetchedDomainsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedEditorsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedJetpackCapabilitiesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
@@ -133,8 +132,6 @@ public enum SiteAction implements IAction {
     FETCHED_DOMAIN_SUPPORTED_COUNTRIES,
     @Action(payloadType = QuickStartCompletedResponsePayload.class)
     COMPLETED_QUICK_START,
-    @Action(payloadType = FetchedDomainsPayload.class)
-    FETCHED_DOMAINS,
     @Action(payloadType = DesignatedPrimaryDomainPayload.class)
     DESIGNATED_PRIMARY_DOMAIN,
     @Action(payloadType = FetchedPrivateAtomicCookiePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchJetpackCapabilitiesPaylo
 import org.wordpress.android.fluxc.store.SiteStore.FetchPrivateAtomicCookiePayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedBlockLayoutsResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.FetchedDomainsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedEditorsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedJetpackCapabilitiesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload;
@@ -90,6 +91,8 @@ public enum SiteAction implements IAction {
     FETCH_DOMAIN_SUPPORTED_COUNTRIES,
     @Action(payloadType = CompleteQuickStartPayload.class)
     COMPLETE_QUICK_START,
+    @Action(payloadType = SiteModel.class)
+    FETCH_DOMAINS,
     @Action(payloadType = DesignatePrimaryDomainPayload.class)
     DESIGNATE_PRIMARY_DOMAIN,
     @Action(payloadType = FetchPrivateAtomicCookiePayload.class)
@@ -130,6 +133,8 @@ public enum SiteAction implements IAction {
     FETCHED_DOMAIN_SUPPORTED_COUNTRIES,
     @Action(payloadType = QuickStartCompletedResponsePayload.class)
     COMPLETED_QUICK_START,
+    @Action(payloadType = FetchedDomainsPayload.class)
+    FETCHED_DOMAINS,
     @Action(payloadType = DesignatedPrimaryDomainPayload.class)
     DESIGNATED_PRIMARY_DOMAIN,
     @Action(payloadType = FetchedPrivateAtomicCookiePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostImmutableModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostImmutableModel.kt
@@ -21,6 +21,7 @@ interface PostImmutableModel {
     val tagNames: String
     val tagNameList: List<String>
     val status: String
+    val sticky: Boolean
     val password: String
     val featuredImageId: Long
     val postFormat: String

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -48,6 +48,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Column private String mExcerpt;
     @Column private String mTagNames;
     @Column private String mStatus;
+    @Column private boolean mSticky;
     @Column private String mPassword;
     @Column private long mFeaturedImageId;
     @Column private String mPostFormat;
@@ -249,6 +250,14 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
 
     public void setStatus(String status) {
         mStatus = status;
+    }
+
+    @Override public boolean getSticky() {
+        return mSticky;
+    }
+
+    public void setSticky(boolean sticky) {
+        mSticky = sticky;
     }
 
     @Override
@@ -525,6 +534,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
                 && Double.compare(otherPost.getLatitude(), getLatitude()) == 0
                 && Double.compare(otherPost.getLongitude(), getLongitude()) == 0
                 && isPage() == otherPost.isPage()
+                && getSticky() == otherPost.getSticky()
                 && isLocalDraft() == otherPost.isLocalDraft() && isLocallyChanged() == otherPost.isLocallyChanged()
                 && getHasCapabilityPublishPost() == otherPost.getHasCapabilityPublishPost()
                 && getHasCapabilityEditPost() == otherPost.getHasCapabilityEditPost()
@@ -576,6 +586,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         result = 31 * result + (mExcerpt != null ? mExcerpt.hashCode() : 0);
         result = 31 * result + (mTagNames != null ? mTagNames.hashCode() : 0);
         result = 31 * result + (mStatus != null ? mStatus.hashCode() : 0);
+        result = 31 * result + (mSticky ? 1 : 0);
         result = 31 * result + (mPassword != null ? mPassword.hashCode() : 0);
         result = 31 * result + (int) (mAuthorId ^ (mAuthorId >>> 32));
         result = 31 * result + (mAuthorDisplayName != null ? mAuthorDisplayName.hashCode() : 0);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -58,6 +58,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private long mMaxUploadSize; // only set for Jetpack sites
     @Column private long mMemoryLimit; // only set for Jetpack sites
     @Column private int mOrigin = ORIGIN_UNKNOWN; // Does this site come from a WPCOM REST or XMLRPC fetch_sites call?
+    @Column private int mOrganizationId = -1;
 
     @Column private String mShowOnFront;
     @Column private long mPageOnFront = -1;
@@ -793,5 +794,13 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setZendeskAddOns(String zendeskAddOns) {
         mZendeskAddOns = zendeskAddOns;
+    }
+
+    public int getOrganizationId() {
+        return mOrganizationId;
+    }
+
+    public void setOrganizationId(int organizationId) {
+        mOrganizationId = organizationId;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -88,7 +88,11 @@ class CommentsRestClient @Inject constructor(
         return updateCommentFields(site, comment, request)
     }
 
-    private suspend fun updateCommentFields(site: SiteModel, comment: CommentEntity, request: Map<String, String>): CommentsApiPayload<CommentEntity> {
+    private suspend fun updateCommentFields(
+        site: SiteModel,
+        comment: CommentEntity,
+        request: Map<String, String>
+    ): CommentsApiPayload<CommentEntity> {
         val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
 
         val response = wpComGsonRequestBuilder.syncPostRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -68,13 +68,28 @@ class CommentsRestClient @Inject constructor(
     }
 
     suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
-        val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
-
         val request = mutableMapOf(
                 "content" to comment.content.orEmpty(),
                 "date" to comment.datePublished.orEmpty(),
                 "status" to comment.status.orEmpty()
         )
+
+        return updateCommentFields(site, comment, request)
+    }
+
+    suspend fun updateEditComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
+        val request = mutableMapOf(
+                "content" to comment.content.orEmpty(),
+                "author" to comment.authorName.orEmpty(),
+                "author_email" to comment.authorEmail.orEmpty(),
+                "author_url" to comment.authorUrl.orEmpty()
+        )
+
+        return updateCommentFields(site, comment, request)
+    }
+
+    private suspend fun updateCommentFields(site: SiteModel, comment: CommentEntity, request: Map<String, String>): CommentsApiPayload<CommentEntity> {
+        val url = WPCOMREST.sites.site(site.siteId).comments.comment(comment.remoteCommentId).urlV1_1
 
         val response = wpComGsonRequestBuilder.syncPostRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -494,6 +494,7 @@ public class PostRestClient extends BaseWPComRestClient {
         post.setStatus(from.getStatus());
         post.setPassword(from.getPassword());
         post.setIsPage(from.getType().equals("page"));
+        post.setSticky(from.getSticky());
 
         if (from.getAuthor() != null) {
             post.setAuthorId(from.getAuthor().getId());
@@ -602,6 +603,7 @@ public class PostRestClient extends BaseWPComRestClient {
         }
 
         params.put("password", StringUtils.notNullStr(post.getPassword()));
+        params.put("sticky", post.getSticky());
 
         // construct a json object with a `category` field holding a json array with the tags
         JsonObject termsById = new JsonObject();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainsResponse.kt
@@ -169,5 +169,3 @@ internal class BooleanTypeAdapter : JsonDeserializer<Boolean?> {
         }
     }
 }
-
-

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainsResponse.kt
@@ -1,0 +1,173 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import com.google.gson.annotations.JsonAdapter
+import com.google.gson.annotations.SerializedName
+import java.lang.reflect.Type
+import java.util.Locale
+
+data class DomainsResponse(val domains: List<Domain>)
+
+data class Domain(
+    @SerializedName("a_records_required_for_mapping")
+    val aRecordsRequiredForMapping: List<String>? = null,
+    @SerializedName("auto_renewal_date")
+    val autoRenewalDate: String? = null,
+    @SerializedName("auto_renewing")
+    @JsonAdapter(BooleanTypeAdapter::class)
+    val autoRenewing: Boolean = false,
+    @SerializedName("blog_id")
+    val blogId: Long = 0,
+    @SerializedName("bundled_plan_subscription_id")
+    val bundledPlanSubscriptionId: String? = null,
+    @SerializedName("can_set_as_primary")
+    val canSetAsPrimary: Boolean = false,
+    @SerializedName("connection_mode")
+    val connectionMode: String? = null,
+    @SerializedName("contact_info_disclosed")
+    val contactInfoDisclosed: Boolean = false,
+    @SerializedName("contact_info_disclosure_available")
+    val contactInfoDisclosureAvailable: Boolean = false,
+    @SerializedName("current_user_can_add_email")
+    val currentUserCanAddEmail: Boolean = false,
+    @SerializedName("current_user_can_create_site_from_domain_only")
+    val currentUserCanCreateSiteFromDomainOnly: Boolean = false,
+    @SerializedName("current_user_can_manage")
+    val currentUserCanManage: Boolean = false,
+    @SerializedName("current_user_cannot_add_email_reason")
+    val currentUserCannotAddEmailReason: String? = null,
+    @SerializedName("domain")
+    val domain: String? = null,
+    @SerializedName("domain_locking_available")
+    val domainLockingAvailable: Boolean = false,
+    @SerializedName("domain_registration_agreement_url")
+    val domainRegistrationAgreementUrl: String? = null,
+    @SerializedName("email_forwards_count")
+    val emailForwardsCount: Int = 0,
+    @SerializedName("expired")
+    val expired: Boolean = false,
+    @SerializedName("expiry")
+    val expiry: String? = null,
+    @SerializedName("expiry_soon")
+    val expirySoon: Boolean = false,
+    @SerializedName("google_apps_subscription")
+    val googleAppsSubscription: GoogleAppsSubscription? = null,
+    @SerializedName("has_private_registration")
+    val hasPrivateRegistration: Boolean = false,
+    @SerializedName("has_registration")
+    val hasRegistration: Boolean = false,
+    @SerializedName("has_wpcom_nameservers")
+    val hasWpcomNameservers: Boolean = false,
+    @SerializedName("has_zone")
+    val hasZone: Boolean = false,
+    @SerializedName("is_eligible_for_inbound_transfer")
+    val isEligibleForInboundTransfer: Boolean = false,
+    @SerializedName("is_locked")
+    val isLocked: Boolean = false,
+    @SerializedName("is_pending_icann_verification")
+    val isPendingIcannVerification: Boolean = false,
+    @SerializedName("is_premium")
+    val isPremium: Boolean = false,
+    @SerializedName("is_redeemable")
+    val isRedeemable: Boolean = false,
+    @SerializedName("is_renewable")
+    val isRenewable: Boolean = false,
+    @SerializedName("is_subdomain")
+    val isSubdomain: Boolean = false,
+    @SerializedName("is_whois_editable")
+    val isWhoisEditable: Boolean = false,
+    @SerializedName("is_wpcom_staging_domain")
+    val isWpcomStagingDomain: Boolean = false,
+    @SerializedName("manual_transfer_required")
+    val manualTransferRequired: Boolean = false,
+    @SerializedName("new_registration")
+    val newRegistration: Boolean = false,
+    @SerializedName("owner")
+    val owner: String? = null,
+    @SerializedName("partner_domain")
+    val partnerDomain: Boolean = false,
+    @SerializedName("pending_registration")
+    val pendingRegistration: Boolean = false,
+    @SerializedName("pending_registration_time")
+    val pendingRegistrationTime: String? = null,
+    @SerializedName("pending_transfer")
+    val pendingTransfer: Boolean = false,
+    @SerializedName("pending_whois_update")
+    val pendingWhoisUpdate: Boolean = false,
+    @SerializedName("points_to_wpcom")
+    val pointsToWpcom: Boolean = false,
+    @SerializedName("primary_domain")
+    val primaryDomain: Boolean = false,
+    @SerializedName("privacy_available")
+    val privacyAvailable: Boolean = false,
+    @SerializedName("private_domain")
+    val privateDomain: Boolean = false,
+    @SerializedName("product_slug")
+    val productSlug: String? = null,
+    @SerializedName("redeemable_until")
+    val redeemableUntil: String? = null,
+    @SerializedName("registrar")
+    val registrar: String? = null,
+    @SerializedName("registration_date")
+    val registrationDate: String? = null,
+    @SerializedName("renewable_until")
+    val renewableUntil: String? = null,
+    @SerializedName("ssl_status")
+    val sslStatus: String? = null,
+    @SerializedName("subdomain_part")
+    val subdomainPart: String? = null,
+    @SerializedName("subscription_id")
+    val subscriptionId: String? = null,
+    @SerializedName("supports_domain_connect")
+    val supportsDomainConnect: Boolean = false,
+    @SerializedName("supports_gdpr_consent_management")
+    val supportsGdprConsentManagement: Boolean = false,
+    @SerializedName("supports_transfer_approval")
+    val supportsTransferApproval: Boolean = false,
+    @SerializedName("titan_mail_subscription")
+    val titanMailSubscription: TitanMailSubscription? = null,
+    @SerializedName("tld_maintenance_end_time")
+    val tldMaintenanceEndTime: Int = 0,
+    @SerializedName("transfer_away_eligible_at")
+    val transferAwayEligibleAt: String? = null,
+    @SerializedName("transfer_lock_on_whois_update_optional")
+    val transferLockOnWhoisUpdateOptional: Boolean = false,
+    @SerializedName("type")
+    val type: String? = null,
+    @SerializedName("whois_update_unmodifiable_fields")
+    val whoisUpdateUnmodifiableFields: List<String>? = null,
+    @SerializedName("wpcom_domain")
+    val wpcomDomain: Boolean = false
+)
+
+data class GoogleAppsSubscription(
+    @SerializedName("status")
+    val status: String? = null
+)
+
+data class TitanMailSubscription(
+    @SerializedName("is_eligible_for_introductory_offer")
+    val isEligibleForIntroductoryOffer: Boolean = false,
+    @SerializedName("status")
+    val status: String? = null
+)
+
+internal class BooleanTypeAdapter : JsonDeserializer<Boolean?> {
+    private val TRUE_STRINGS: Set<String> = HashSet(listOf("true", "1", "yes"))
+
+    @Throws(JsonParseException::class)
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Boolean {
+        val jsonPrimitive = json.asJsonPrimitive
+        return when {
+            jsonPrimitive.isBoolean -> jsonPrimitive.asBoolean
+            jsonPrimitive.isNumber -> jsonPrimitive.asNumber.toInt() == 1
+            jsonPrimitive.isString -> TRUE_STRINGS.contains(jsonPrimitive.asString.toLowerCase(Locale.getDefault()))
+            else -> false
+        }
+    }
+}
+
+

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -704,7 +704,7 @@ class SiteRestClient @Inject constructor(
 
     suspend fun fetchSiteDomains(site: SiteModel): Response<DomainsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).domains.urlV1_1
-         return  wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), DomainsResponse::class.java)
+        return wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), DomainsResponse::class.java)
     }
 
     fun designatePrimaryDomain(site: SiteModel, domain: String) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1064,7 +1064,7 @@ class SiteRestClient @Inject constructor(
     companion object {
         private const val NEW_SITE_TIMEOUT_MS = 90000
         private const val SITE_FIELDS = ("ID,URL,name,description,jetpack,visible,is_private,options,plan," +
-                "capabilities,quota,icon,meta,zendesk_site_meta")
+                "capabilities,quota,icon,meta,zendesk_site_meta,organization_id")
         private const val FIELDS = "fields"
         private const val FILTERS = "filters"
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -905,6 +905,7 @@ class SiteRestClient @Inject constructor(
         site.setIsVisible(from.visible)
         site.setIsPrivate(from.is_private)
         site.setIsComingSoon(from.is_coming_soon)
+        site.organizationId = from.organization_id
         // Depending of user's role, options could be "hidden", for instance an "Author" can't read site options.
         if (from.options != null) {
             site.setIsFeaturedImageSupported(from.options.featured_images_enabled)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
@@ -51,7 +52,6 @@ import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesError
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesErrorType
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesResponsePayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchedBlockLayoutsResponsePayload
-import org.wordpress.android.fluxc.store.SiteStore.FetchedDomainsPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchedEditorsPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchedJetpackCapabilitiesPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload
@@ -702,24 +702,9 @@ class SiteRestClient @Inject constructor(
         add(request)
     }
 
-    suspend fun fetchSiteDomains(site: SiteModel): FetchedDomainsPayload {
+    suspend fun fetchSiteDomains(site: SiteModel): Response<DomainsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).domains.urlV1_1
-        val response =
-                wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), DomainsResponse::class.java)
-        return when (response) {
-            is Success -> {
-                FetchedDomainsPayload(site, response.data.domains)
-            }
-            is Error -> {
-                val siteErrorType = when (response.error.apiError) {
-                    "unauthorized" -> UNAUTHORIZED
-                    "unknown_blog" -> UNKNOWN_SITE
-                    else -> SiteErrorType.GENERIC_ERROR
-                }
-                val domainsError = SiteError(siteErrorType, response.error.message)
-                FetchedDomainsPayload(site, domainsError)
-            }
-        }
+         return  wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), DomainsResponse::class.java)
     }
 
     fun designatePrimaryDomain(site: SiteModel, domain: String) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -94,6 +94,7 @@ public class SiteWPComRestResponse implements Response {
     public boolean visible;
     public boolean is_private;
     public boolean is_coming_soon;
+    public int organization_id;
     public Options options;
     public Capabilities capabilities;
     public Plan plan;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -98,7 +98,11 @@ class CommentsXMLRPCClient @Inject constructor(
         return updateCommentFields(site, comment, commentParams)
     }
 
-    private suspend fun updateCommentFields(site: SiteModel, comment: CommentEntity, commentParams: Map<String, Any?>): CommentsApiPayload<CommentEntity> {
+    private suspend fun updateCommentFields(
+        site: SiteModel,
+        comment: CommentEntity,
+        commentParams: Map<String, Any?>
+    ): CommentsApiPayload<CommentEntity> {
         val params: MutableList<Any> = ArrayList(5)
 
         params.add(site.selfHostedSiteId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -78,13 +78,28 @@ class CommentsXMLRPCClient @Inject constructor(
     }
 
     suspend fun pushComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
-        val params: MutableList<Any> = ArrayList(5)
-
         val commentParams = mutableMapOf<String, Any?>(
                 "content" to comment.content,
                 "date" to comment.datePublished,
                 "status" to getXMLRPCCommentStatus(CommentStatus.fromString(comment.status))
         )
+
+        return updateCommentFields(site, comment, commentParams)
+    }
+
+    suspend fun updateEditComment(site: SiteModel, comment: CommentEntity): CommentsApiPayload<CommentEntity> {
+        val commentParams = mutableMapOf<String, Any?>(
+                "content" to comment.content,
+                "author" to comment.authorName,
+                "author_email" to comment.authorEmail,
+                "author_url" to comment.authorUrl
+        )
+
+        return updateCommentFields(site, comment, commentParams)
+    }
+
+    private suspend fun updateCommentFields(site: SiteModel, comment: CommentEntity, commentParams: Map<String, Any?>): CommentsApiPayload<CommentEntity> {
+        val params: MutableList<Any> = ArrayList(5)
 
         params.add(site.selfHostedSiteId)
         params.add(site.username)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1814,6 +1814,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 161 -> migrate(version) {
                     db.execSQL("ALTER TABLE EditorTheme ADD GALLERY_WITH_IMAGE_BLOCKS BOOLEAN")
                 }
+                162 -> migrate(version) {
+                    db.execSQL("ALTER TABLE PostModel ADD STICKY BOOLEAN")
+                }
             }
         }
         db.setTransactionSuccessful()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 163
+        return 164
     }
 
     override fun getDbName(): String {
@@ -1816,6 +1816,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 162 -> migrate(version) {
                     db.execSQL("ALTER TABLE PostModel ADD STICKY BOOLEAN")
+                }
+                163 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD ORGANIZATION_ID INTEGER")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 162
+        return 163
     }
 
     override fun getDbName(): String {

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -9,12 +9,10 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android.fluxc.instaflux"
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"
-
-        multiDexEnabled true
     }
 
     compileOptions {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 29
     }
     buildTypes {

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -15,8 +15,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersByIdsPayload;

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -58,8 +58,6 @@ public enum WCOrderAction implements IAction {
     SEARCH_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsPayload.class)
     FETCH_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = FetchOrderShipmentTrackingsPayload.class)
-    FETCH_ORDER_SHIPMENT_TRACKINGS,
     @Action(payloadType = AddOrderShipmentTrackingPayload.class)
     ADD_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = DeleteOrderShipmentTrackingPayload.class)
@@ -90,8 +88,6 @@ public enum WCOrderAction implements IAction {
     SEARCHED_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsResponsePayload.class)
     FETCHED_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = FetchOrderShipmentTrackingsResponsePayload.class)
-    FETCHED_ORDER_SHIPMENT_TRACKINGS,
     @Action(payloadType = AddOrderShipmentTrackingResponsePayload.class)
     ADDED_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = DeleteOrderShipmentTrackingResponsePayload.class)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -11,8 +11,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesPayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderNotesResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentTrackingsPayload;

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -44,8 +44,6 @@ public enum WCOrderAction implements IAction {
     FETCH_ORDERS_BY_IDS,
     @Action(payloadType = FetchOrdersCountPayload.class)
     FETCH_ORDERS_COUNT,
-    @Action(payloadType = FetchSingleOrderPayload.class)
-    FETCH_SINGLE_ORDER,
     @Action(payloadType = UpdateOrderStatusPayload.class)
     UPDATE_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesPayload.class)
@@ -76,8 +74,6 @@ public enum WCOrderAction implements IAction {
     FETCHED_ORDERS_BY_IDS,
     @Action(payloadType = FetchOrdersCountResponsePayload.class)
     FETCHED_ORDERS_COUNT,
-    @Action(payloadType = RemoteOrderPayload.class)
-    FETCHED_SINGLE_ORDER,
     @Action(payloadType = RemoteOrderPayload.class)
     UPDATED_ORDER_STATUS,
     @Action(payloadType = FetchOrderNotesResponsePayload.class)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -48,8 +48,6 @@ public enum WCOrderAction implements IAction {
     FETCH_SINGLE_ORDER,
     @Action(payloadType = UpdateOrderStatusPayload.class)
     UPDATE_ORDER_STATUS,
-    @Action(payloadType = FetchOrderNotesPayload.class)
-    FETCH_ORDER_NOTES,
     @Action(payloadType = PostOrderNotePayload.class)
     POST_ORDER_NOTE,
     @Action(payloadType = FetchHasOrdersPayload.class)
@@ -80,8 +78,6 @@ public enum WCOrderAction implements IAction {
     FETCHED_SINGLE_ORDER,
     @Action(payloadType = RemoteOrderPayload.class)
     UPDATED_ORDER_STATUS,
-    @Action(payloadType = FetchOrderNotesResponsePayload.class)
-    FETCHED_ORDER_NOTES,
     @Action(payloadType = RemoteOrderNotePayload.class)
     POSTED_ORDER_NOTE,
     @Action(payloadType = FetchHasOrdersResponsePayload.class)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchSingleOrderPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload;

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
@@ -1,10 +1,38 @@
 package org.wordpress.android.fluxc.model.pay
 
+import org.wordpress.android.fluxc.FluxCError
 import org.wordpress.android.fluxc.Payload
-import org.wordpress.android.fluxc.store.Store.OnChangedError
 
 data class WCTerminalStoreLocationResult(
-    val locationId: String
-) : Payload<WCTerminalStoreLocationError>()
+    val locationId: String?,
+    val displayName: String?,
+    val liveMode: Boolean?,
+    val address: StoreAddress?,
+) : Payload<WCTerminalStoreLocationError?>() {
+    constructor(
+        error: WCTerminalStoreLocationError,
+    ) : this(null, null, null, null) {
+        this.error = error
+    }
 
-class WCTerminalStoreLocationError : OnChangedError
+    data class StoreAddress(
+        val city: String?,
+        val country: String?,
+        val line1: String?,
+        val line2: String?,
+        val postalCode: String?,
+        val state: String?,
+    )
+}
+
+data class WCTerminalStoreLocationError(
+    val type: WCTerminalStoreLocationErrorType = WCTerminalStoreLocationErrorType.GENERIC_ERROR,
+    val message: String = ""
+) : FluxCError
+
+enum class WCTerminalStoreLocationErrorType {
+    GENERIC_ERROR,
+    MISSING_ADDRESS,
+    SERVER_ERROR,
+    NETWORK_ERROR
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.model.pay
+
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.store.Store.OnChangedError
+
+data class WCTerminalStoreLocationResult(
+    val locationId: String
+) : Payload<WCTerminalStoreLocationError>()
+
+class WCTerminalStoreLocationError : OnChangedError

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
@@ -7,10 +7,10 @@ data class WCTerminalStoreLocationResult(
     val locationId: String?,
     val displayName: String?,
     val liveMode: Boolean?,
-    val address: StoreAddress?,
+    val address: StoreAddress?
 ) : Payload<WCTerminalStoreLocationError?>() {
     constructor(
-        error: WCTerminalStoreLocationError,
+        error: WCTerminalStoreLocationError
     ) : this(null, null, null, null) {
         this.error = error
     }
@@ -21,7 +21,7 @@ data class WCTerminalStoreLocationResult(
         val line1: String?,
         val line2: String?,
         val postalCode: String?,
-        val state: String?,
+        val state: String?
     )
 }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -135,6 +135,24 @@ class PayRestClient @Inject constructor(
         }
     }
 
+    suspend fun getStoreLocationForSite(site: SiteModel): WooPayload<StoreLocationApiResponse> {
+        val url = WOOCOMMERCE.terminal.locations.store.pathV3
+        val params = mapOf("_fields" to STORE_LOCATION_FIELDS)
+
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                params,
+                StoreLocationApiResponse::class.java
+        )
+
+        return when (response) {
+            is JetpackSuccess -> WooPayload(response.data)
+            is JetpackError -> WooPayload(response.error.toWooError())
+        }
+    }
+
     private fun mapToCapturePaymentError(error: WPComGsonNetworkError?, message: String): WCCapturePaymentError {
         val type = when {
             error == null -> GENERIC_ERROR
@@ -154,5 +172,6 @@ class PayRestClient @Inject constructor(
         private const val ACCOUNT_REQUESTED_FIELDS: String =
                 "status,has_pending_requirements,has_overdue_requirements,current_deadline,statement_descriptor," +
                         "store_currencies,country,card_present_eligible,is_live,test_mode"
+        private const val STORE_LOCATION_FIELDS: String = "id,address,display_mode,livemode"
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -163,19 +163,19 @@ class PayRestClient @Inject constructor(
                                     line1 = data.address?.line1,
                                     line2 = data.address?.line2,
                                     postalCode = data.address?.postalCode,
-                                    state = data.address?.state,
+                                    state = data.address?.state
                             )
                     )
                 } ?: WCTerminalStoreLocationResult(
                         mapToStoreLocationForSiteError(
                                 error = null,
                                 message = "status field is null, but isError == false"
-                        ),
+                        )
                 )
             }
             is JetpackError -> {
                 WCTerminalStoreLocationResult(
-                        mapToStoreLocationForSiteError(response.error, response.error.message ?: "Unexpected error"),
+                        mapToStoreLocationForSiteError(response.error, response.error.message ?: "Unexpected error")
                 )
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/StoreLocationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/StoreLocationApiResponse.kt
@@ -6,7 +6,7 @@ data class StoreLocationApiResponse(
     @SerializedName("id") val id: String,
     @SerializedName("display_name") val displayName: String?,
     @SerializedName("livemode") val liveMode: Boolean?,
-    @SerializedName("address") val address: StoreAddress?,
+    @SerializedName("address") val address: StoreAddress?
 ) {
     data class StoreAddress(
         @SerializedName("city") val city: String?,
@@ -14,6 +14,6 @@ data class StoreLocationApiResponse(
         @SerializedName("line1") val line1: String?,
         @SerializedName("line2") val line2: String?,
         @SerializedName("postal_code") val postalCode: String?,
-        @SerializedName("state") val state: String?,
+        @SerializedName("state") val state: String?
     )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/StoreLocationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/StoreLocationApiResponse.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.pay
+
+import com.google.gson.annotations.SerializedName
+
+data class StoreLocationApiResponse(
+    @SerializedName("id") val id: String,
+    @SerializedName("display_name") val displayName: String?,
+    @SerializedName("livemode") val liveMode: Boolean?,
+    @SerializedName("address") val address: StoreAddress?,
+) {
+    data class StoreAddress(
+        @SerializedName("city") val city: String?,
+        @SerializedName("country") val country: String?,
+        @SerializedName("line1") val line1: String?,
+        @SerializedName("line2") val line2: String?,
+        @SerializedName("postal_code") val postalCode: String?,
+        @SerializedName("state") val state: String?,
+    )
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -504,24 +504,8 @@ class WCOrderStore @Inject constructor(
 
             val rowsAffected = if(!result.isError) OrderSqlUtils.insertOrUpdateOrder(result.order) else 0
 
-            emitLegacyOnOrderChangedEvent(result, rowsAffected)
-
             return@withDefaultContext if (!result.isError) result.order else null
         }
-    }
-
-    private fun emitLegacyOnOrderChangedEvent(
-        result: RemoteOrderPayload,
-        rowsAffected: Int,
-    ) {
-        val onOrderChanged: OnOrderChanged
-        if (result.isError) {
-            onOrderChanged = OnOrderChanged(rowsAffected).also { it.error = result.error }
-        } else {
-            onOrderChanged = OnOrderChanged(rowsAffected)
-        }
-        onOrderChanged.causeOfChange = FETCH_SINGLE_ORDER
-        emitChange(onOrderChanged)
     }
 
     private fun updateOrderStatus(payload: UpdateOrderStatusPayload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -38,7 +38,7 @@ class WCOrderStore @Inject constructor(
     dispatcher: Dispatcher,
     private val wcOrderRestClient: OrderRestClient,
     private val wcOrderFetcher: WCOrderFetcher,
-    private val coroutineEngine: CoroutineEngine,
+    private val coroutineEngine: CoroutineEngine
 ) : Store(dispatcher) {
     companion object {
         const val NUM_ORDERS_PER_FETCH = 15

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -502,9 +502,10 @@ class WCOrderStore @Inject constructor(
         return coroutineEngine.withDefaultContext(T.API, this, "fetchSingleOrder") {
             val result = wcOrderRestClient.fetchSingleOrder(site, remoteOrderId)
 
-            val rowsAffected = if(!result.isError) OrderSqlUtils.insertOrUpdateOrder(result.order) else 0
-
-            return@withDefaultContext if (!result.isError) result.order else null
+            return@withDefaultContext result.takeUnless { it.isError }?.let {
+                OrderSqlUtils.insertOrUpdateOrder(result.order)
+                result.order
+            }
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCPayStore.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.model.pay.WCCapturePaymentResponsePayload
 import org.wordpress.android.fluxc.model.pay.WCConnectionTokenResult
 import org.wordpress.android.fluxc.model.pay.WCPaymentAccountResult
 import org.wordpress.android.fluxc.model.pay.WCPaymentCreateCustomerByOrderIdResult
+import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationResult
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -53,6 +54,12 @@ class WCPayStore @Inject constructor(
     ): WooResult<WCPaymentCreateCustomerByOrderIdResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "createCustomerByOrderId") {
             restClient.createCustomerByOrderId(site, orderId).asWooResult()
+        }
+    }
+
+    suspend fun getStoreLocationForSite(site: SiteModel): WCTerminalStoreLocationResult {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "getStoreLocationForSite") {
+            restClient.getStoreLocationForSite(site)
         }
     }
 }


### PR DESCRIPTION
Releasing a [new stable version `1.27.0`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/releases/tag/1.27.0) for today's code freeze of WPAndroid 18.4.