### PR TITLE
Allow to choose site for the `Orders` screen in example app

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.fluxc.example.ui
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
+import dagger.android.support.DaggerFragment
+import kotlinx.android.synthetic.main.fragment_woo_products.*
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
+import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
+import org.wordpress.android.fluxc.model.SiteModel
+
+abstract class StoreSelectingFragment : DaggerFragment() {
+    protected var selectedPos: Int = -1
+    protected var selectedSite: SiteModel? = null
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<LinearLayout>(R.id.buttonContainer).addView(
+                Button(context).apply {
+                    text = "Select Site"
+                    setOnClickListener {
+                        showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                            override fun onSiteSelected(site: SiteModel, pos: Int) {
+                                selectedSite = site
+                                selectedPos = pos
+                                buttonContainer.toggleSiteDependentButtons(true)
+                                text = site.name ?: site.displayName
+                            }
+                        })
+                    }
+                },
+                0
+        )
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/WooCustomersFragment.kt
@@ -1,12 +1,9 @@
 package org.wordpress.android.fluxc.example.ui.customer
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_customer.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,28 +12,17 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
-import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog.Listener
-import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.customer.creation.WooCustomerCreationFragment
 import org.wordpress.android.fluxc.example.ui.customer.search.WooCustomersSearchBuilderFragment
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
-import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCCustomerStore
 import javax.inject.Inject
 
-class WooCustomersFragment : Fragment() {
+class WooCustomersFragment : StoreSelectingFragment() {
     @Inject internal lateinit var wcCustomerStore: WCCustomerStore
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
-
-    private var selectedPos: Int = -1
-    private var selectedSite: SiteModel? = null
-
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_woo_customer, container, false)
@@ -44,7 +30,6 @@ class WooCustomersFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        btnCustomerSelectSite.setOnClickListener { selectStore() }
         btnPrintCutomer.setOnClickListener { printCustomerById() }
         btnFetchCustomerList.setOnClickListener {
             replaceFragment(WooCustomersSearchBuilderFragment.newInstance(selectedSite!!.id))
@@ -80,16 +65,5 @@ class WooCustomersFragment : Fragment() {
                 }
             }
         }
-    }
-
-    private fun selectStore() {
-        showStoreSelectorDialog(selectedPos, object : Listener {
-            override fun onSiteSelected(site: SiteModel, pos: Int) {
-                selectedSite = site
-                selectedPos = pos
-                llButtonContainer.toggleSiteDependentButtons(true)
-                tvCustomerSelectedSite.text = site.name ?: site.displayName
-            }
-        })
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/helpsupport/WooHelpSupportFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/helpsupport/WooHelpSupportFragment.kt
@@ -1,12 +1,9 @@
 package org.wordpress.android.fluxc.example.ui.helpsupport
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_help_support.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,44 +12,21 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
-import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
-import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
-import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
-import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
-class WooHelpSupportFragment : Fragment() {
+class WooHelpSupportFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
 
-    private var selectedPos: Int = -1
-    private var selectedSite: SiteModel? = null
-
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
-
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_woo_help_support, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        help_support_select_site.setOnClickListener {
-            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
-                override fun onSiteSelected(site: SiteModel, pos: Int) {
-                    selectedSite = site
-                    selectedPos = pos
-                    buttonContainer.toggleSiteDependentButtons(true)
-                    help_support_selected_site.text = site.name ?: site.displayName
-                }
-            })
-        }
-
         fetch_ssr.setOnClickListener {
             selectedSite?.let { site ->
                 coroutineScope.launch {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
@@ -1,12 +1,9 @@
 package org.wordpress.android.fluxc.example.ui.leaderboards
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_leaderboards.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,8 +12,7 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
-import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
-import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.leaderboards.WCTopPerformerProductModel
 import org.wordpress.android.fluxc.store.WCLeaderboardsStore
@@ -28,28 +24,18 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
-class WooLeaderboardsFragment : Fragment(), StoreSelectorDialog.Listener {
+class WooLeaderboardsFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
     @Inject internal lateinit var wcLeaderboardsStore: WCLeaderboardsStore
 
-    private var selectedPos: Int = -1
-    private var selectedSite: SiteModel? = null
-
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
-
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_woo_leaderboards, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        leaderboards_select_site.setOnClickListener(::onLeaderboardsSelectSiteButtonClicked)
         setupFetchButtons()
         bindCacheRetrievalButtons()
     }
@@ -84,13 +70,6 @@ class WooLeaderboardsFragment : Fragment(), StoreSelectorDialog.Listener {
         }
     }
 
-    private fun onLeaderboardsSelectSiteButtonClicked(view: View) {
-        fragmentManager?.let { fm ->
-            StoreSelectorDialog.newInstance(this, selectedPos)
-                    .show(fm, "StoreSelectorDialog")
-        }
-    }
-
     private fun launchProductLeaderboardsRequest(unit: StatsGranularity) {
         coroutineScope.launch {
             try {
@@ -115,13 +94,6 @@ class WooLeaderboardsFragment : Fragment(), StoreSelectorDialog.Listener {
                 prependToLog("Couldn't fetch Products Leaderboards. Error: ${ex.message}")
             }
         }
-    }
-
-    override fun onSiteSelected(site: SiteModel, pos: Int) {
-        selectedSite = site
-        selectedPos = pos
-        buttonContainer.toggleSiteDependentButtons()
-        leaderboards_selected_site.text = site.name ?: site.displayName
     }
 
     private fun logLeaderboardResponse(model: List<WCTopPerformerProductModel>, unit: StatsGranularity) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -1,13 +1,10 @@
 package org.wordpress.android.fluxc.example.ui.orders
 
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_orders.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -26,6 +23,7 @@ import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.WCAddOrderShipmentTrackingDialog
 import org.wordpress.android.fluxc.example.WCOrderListActivity
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
@@ -52,7 +50,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
-class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener {
+class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDialog.Listener {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wcOrderStore: WCOrderStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
@@ -68,11 +66,6 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
     private var pendingOpenAddShipmentTracking: Boolean = false
     private var pendingAddShipmentTrackingRemoteOrderID: Long? = null
 
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(layout.fragment_woo_orders, container, false)
 
@@ -80,21 +73,21 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         super.onViewCreated(view, savedInstanceState)
 
         fetch_orders.setOnClickListener {
-            getFirstWCSite()?.let {
+            selectedSite?.let {
                 val payload = FetchOrdersPayload(it, loadMore = false)
                 dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(payload))
             }
         }
 
         fetch_order_list.setOnClickListener {
-            getFirstWCSite()?.let {
+            selectedSite?.let {
                 val intent = Intent(activity, WCOrderListActivity::class.java)
                 startActivity(intent)
             }
         }
 
         fetch_orders_count.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(
                         activity,
                         "Enter a single order status to filter by:"
@@ -114,7 +107,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         search_orders.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(
                         activity,
                         "Enter a search query:"
@@ -131,7 +124,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         fetch_single_order.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter the remoteOrderId of order to fetch:") { editText ->
                     val enteredRemoteId = editText.text.toString().toLongOrNull()
                     coroutineScope.launch {
@@ -147,14 +140,14 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         fetch_has_orders.setOnClickListener {
-            getFirstWCSite()?.let {
+            selectedSite?.let {
                 val payload = FetchHasOrdersPayload(it)
                 dispatcher.dispatch(WCOrderActionBuilder.newFetchHasOrdersAction(payload))
             }
         }
 
         fetch_orders_by_status.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter comma-separated list of statuses to filter by:") { editText ->
                     pendingFetchOrdersFilter = editText.text.toString()
                             .takeIf { it.trim().isNotEmpty() }
@@ -179,7 +172,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         fetch_orders_by_status_api.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 prependToLog("Submitting request to fetch only completed orders from the api")
                 pendingFetchCompletedOrders = true
                 val payload = FetchOrdersPayload(site, loadMore = false, statusFilter = "completed")
@@ -188,14 +181,14 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         fetch_order_status_options.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 dispatcher.dispatch(WCOrderActionBuilder
                         .newFetchOrderStatusOptionsAction(FetchOrderStatusOptionsPayload(site)))
             }
         }
 
         fetch_order_notes.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 getFirstWCOrder()?.let { order ->
                     coroutineScope.launch {
                         wcOrderStore.fetchOrderNotes(order.id, order.remoteOrderId, site).takeUnless { it.isError }
@@ -211,7 +204,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         post_order_note.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 getFirstWCOrder()?.let { order ->
                     pendingNotesOrderModel = order
                     showSingleLineDialog(activity, "Enter note") { editText ->
@@ -226,7 +219,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         update_latest_order_status.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 wcOrderStore.getOrdersForSite(site).firstOrNull()?.let { order ->
                     showSingleLineDialog(activity, "Enter new order status") { editText ->
                         val status = editText.text.toString()
@@ -238,7 +231,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         fetch_shipment_trackings.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(
                         activity,
                         "Enter the remoteOrderId to fetch shipment trackings:"
@@ -274,7 +267,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         add_shipment_tracking.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 getFirstWCOrder()?.let { order ->
                     val providers = wcOrderStore.getShipmentProvidersForSite(site)
                     if (providers.isNullOrEmpty()) {
@@ -292,7 +285,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         delete_shipment_tracking.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(
                         activity,
                         "Enter the remoteOrderId to delete the first shipment tracking for:"
@@ -318,7 +311,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         }
 
         fetch_shipment_providers.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 // Just use the first order, the shipment trackings api oddly requires an order_id for fetching
                 // a list of providers, even though the providers are not order specific.
                 getFirstWCOrder()?.let { order ->
@@ -347,7 +340,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
         if (event.isError) {
             prependToLog("Error fetching shipment providers - error: " + event.error.type)
         } else {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 if (pendingOpenAddShipmentTracking) {
                     pendingOpenAddShipmentTracking = false
                     getFirstWCOrder()?.let { order ->
@@ -373,7 +366,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
             return
         }
 
-        getFirstWCSite()?.let { site ->
+        selectedSite?.let { site ->
             wcOrderStore.getOrdersForSite(site).let { orderList ->
                 // We check if the rowsAffected value is zero because not all events will causes data to be
                 // saved to the orders table (such as the FETCH-ORDERS-COUNT...so the orderList would always
@@ -386,7 +379,7 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
                 when (event.causeOfChange) {
                     FETCH_ORDERS -> {
                         pendingFetchOrdersFilter?.let { filter ->
-                            getFirstWCSite()?.let { site ->
+                            selectedSite?.let { site ->
                                 // get orders and group by order.status
                                 val orders = wcOrderStore.getOrdersForSite(site, *filter.toTypedArray())
                                         .groupBy { order -> order.status }
@@ -466,22 +459,20 @@ class WooOrdersFragment : Fragment(), WCAddOrderShipmentTrackingDialog.Listener 
             return
         }
 
-        val orderStatusOptions = getFirstWCSite()?.let {
+        val orderStatusOptions = selectedSite?.let {
             wcOrderStore.getOrderStatusOptionsForSite(it)
         }?.map { it.label to it.statusCount }?.toMap()
         prependToLog("Fetched order status options from the api: $orderStatusOptions " +
                 "- updated ${event.rowsAffected} in the db")
     }
 
-    private fun getFirstWCOrder() = getFirstWCSite()?.let {
+    private fun getFirstWCOrder() = selectedSite?.let {
         wcOrderStore.getOrdersForSite(it).getOrNull(0)
     }
 
     private fun showNoOrdersToast(site: SiteModel) {
         ToastUtils.showToast(activity, "No orders found for site: " + site.name)
     }
-
-    private fun getFirstWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(0)
 
     private fun showAddTrackingDialog(site: SiteModel, order: WCOrderModel, providers: List<String>) {
         fragmentManager?.let { fm ->

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
@@ -1,13 +1,9 @@
 package org.wordpress.android.fluxc.example.ui.products
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.fragment_woo_leaderboards.buttonContainer
 import kotlinx.android.synthetic.main.fragment_woo_product_attribute.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,42 +11,25 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
-import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
-import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.attribute.WCGlobalAttributeModel
 import org.wordpress.android.fluxc.model.attribute.terms.WCAttributeTermModel
 import org.wordpress.android.fluxc.store.WCGlobalAttributeStore
 import javax.inject.Inject
 
-class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
+class WooProductAttributeFragment : StoreSelectingFragment() {
     @Inject internal lateinit var wcAttributesStore: WCGlobalAttributeStore
-
-    private var selectedPos: Int = -1
-    private var selectedSite: SiteModel? = null
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
-
-    override fun onSiteSelected(site: SiteModel, pos: Int) {
-        selectedSite = site
-        selectedPos = pos
-        buttonContainer.toggleSiteDependentButtons()
-        attributes_selected_site.text = site.name ?: site.displayName
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
             inflater.inflate(R.layout.fragment_woo_product_attribute, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        attributes_select_site.setOnClickListener(::onProductAttributesSelectSiteButtonClicked)
         fetch_product_attributes.setOnClickListener(::onFetchAttributesListClicked)
         fetch_product_attributes_from_db.setOnClickListener(::onFetchCachedAttributesListClicked)
         create_product_attributes.setOnClickListener(::onCreateAttributeButtonClicked)
@@ -59,13 +38,6 @@ class WooProductAttributeFragment : Fragment(), StoreSelectorDialog.Listener {
         fetch_product_single_attribute.setOnClickListener(::onFetchAttributeButtonClicked)
         fetch_term_for_attribute.setOnClickListener(::onFetchAttributeTermsButtonClicked)
         create_term_for_attribute.setOnClickListener(::onCreateAttributeTermButtonClicked)
-    }
-
-    private fun onProductAttributesSelectSiteButtonClicked(view: View) {
-        fragmentManager?.let { fm ->
-            StoreSelectorDialog.newInstance(this, selectedPos)
-                    .show(fm, "StoreSelectorDialog")
-        }
     }
 
     private fun onCreateAttributeButtonClicked(view: View) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -1,12 +1,9 @@
 package org.wordpress.android.fluxc.example.ui.products
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_products.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -29,12 +26,9 @@ import org.wordpress.android.fluxc.action.WCProductAction.UPDATE_PRODUCT_REVIEW_
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
-import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
-import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
-import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.store.MediaStore
@@ -67,15 +61,13 @@ import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPaylo
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
-class WooProductsFragment : Fragment() {
+class WooProductsFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wcProductStore: WCProductStore
     @Inject lateinit var addonsStore: WCAddonsStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
     @Inject internal lateinit var mediaStore: MediaStore
 
-    private var selectedPos: Int = -1
-    private var selectedSite: SiteModel? = null
     private var pendingFetchSingleProductRemoteId: Long? = null
     private var pendingFetchSingleVariationRemoteId: Long? = null
     private var pendingFetchSingleProductShippingClassRemoteId: Long? = null
@@ -92,27 +84,11 @@ class WooProductsFragment : Fragment() {
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(layout.fragment_woo_products, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        stats_select_site.setOnClickListener {
-            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
-                override fun onSiteSelected(site: SiteModel, pos: Int) {
-                    selectedSite = site
-                    selectedPos = pos
-                    buttonContainer.toggleSiteDependentButtons(true)
-                    stats_select_site.text = site.name ?: site.displayName
-                }
-            })
-        }
 
         fetch_single_product.setOnClickListener {
             selectedSite?.let { site ->

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -14,8 +14,6 @@ import android.widget.EditText
 import android.widget.Spinner
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
-import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_shippinglabels.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -26,21 +24,19 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
-import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
-import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
-import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.generated.WCCoreActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
-import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.CustomPackage
-import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.PredefinedOption
 import org.wordpress.android.fluxc.model.shippinglabels.WCContentType
 import org.wordpress.android.fluxc.model.shippinglabels.WCCustomsItem
 import org.wordpress.android.fluxc.model.shippinglabels.WCNonDeliveryOption
+import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.CustomPackage
+import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.PredefinedOption
 import org.wordpress.android.fluxc.model.shippinglabels.WCRestrictionType
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingAccountSettings
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel
@@ -65,38 +61,19 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.ceil
 
-class WooShippingLabelFragment : Fragment() {
+class WooShippingLabelFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
     @Inject internal lateinit var wcShippingLabelStore: WCShippingLabelStore
     @Inject internal lateinit var wcOrderStore: WCOrderStore
 
-    private var selectedPos: Int = -1
-    private var selectedSite: SiteModel? = null
-
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
-
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_woo_shippinglabels, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        shipping_labels_select_site.setOnClickListener {
-            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
-                override fun onSiteSelected(site: SiteModel, pos: Int) {
-                    selectedSite = site
-                    selectedPos = pos
-                    buttonContainer.toggleSiteDependentButtons(true)
-                    shipping_labels_selected_site.text = site.name ?: site.displayName
-                }
-            })
-        }
 
         fetch_shipping_labels.setOnClickListener {
             selectedSite?.let { site ->

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -1,12 +1,9 @@
 package org.wordpress.android.fluxc.example.ui.stats
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_revenue_stats.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -14,11 +11,8 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCStatsAction
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
-import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
-import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
-import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCStatsStore
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchNewVisitorStatsPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityPayload
@@ -29,35 +23,16 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
-class WooRevenueStatsFragment : Fragment() {
+class WooRevenueStatsFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wcStatsStore: WCStatsStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
-
-    private var selectedSite: SiteModel? = null
-    private var selectedPos: Int = -1
-
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_woo_revenue_stats, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        stats_select_site.setOnClickListener {
-            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
-                override fun onSiteSelected(site: SiteModel, pos: Int) {
-                    selectedSite = site
-                    selectedPos = pos
-                    buttonContainer.toggleSiteDependentButtons(true)
-                    stats_select_site.text = site.name ?: site.displayName
-                }
-            })
-        }
 
         fetch_revenue_stats_availability.setOnClickListener {
             selectedSite?.let {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/taxes/WooTaxFragment.kt
@@ -1,12 +1,9 @@
 package org.wordpress.android.fluxc.example.ui.taxes
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
-import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_taxes.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -16,43 +13,21 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
-import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
-import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
-import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
-import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.store.WCTaxStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
-class WooTaxFragment : Fragment() {
+class WooTaxFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wcTaxStore: WCTaxStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
-
-    private var selectedPos: Int = -1
-    private var selectedSite: SiteModel? = null
-
-    override fun onAttach(context: Context) {
-        AndroidSupportInjection.inject(this)
-        super.onAttach(context)
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_woo_taxes, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        taxes_select_site.setOnClickListener {
-            showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
-                override fun onSiteSelected(site: SiteModel, pos: Int) {
-                    selectedSite = site
-                    selectedPos = pos
-                    buttonContainer.toggleSiteDependentButtons(true)
-                    taxes_selected_site.text = site.name ?: site.displayName
-                }
-            })
-        }
 
         fetch_tax_class.setOnClickListener {
             selectedSite?.let { site ->

--- a/example/src/main/res/layout/fragment_woo_customer.xml
+++ b/example/src/main/res/layout/fragment_woo_customer.xml
@@ -7,41 +7,11 @@
     tools:ignore="HardcodedText">
 
     <LinearLayout
-        android:id="@+id/llButtonContainer"
+        android:id="@+id/buttonContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:paddingHorizontal="16dp">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="Perform actions on a selected site:"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/btnCustomerSelectSite"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Select Site" />
-
-            <TextView
-                android:id="@+id/tvCustomerSelectedSite"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="8dp"
-                android:layout_weight="1"
-                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-                android:textColor="@android:color/holo_blue_bright" />
-        </LinearLayout>
 
         <Button
             android:id="@+id/btnFetchCustomerList"

--- a/example/src/main/res/layout/fragment_woo_help_support.xml
+++ b/example/src/main/res/layout/fragment_woo_help_support.xml
@@ -12,36 +12,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="Perform actions on a selected site:"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/help_support_select_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Select Site" />
-
-            <TextView
-                android:id="@+id/help_support_selected_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:paddingStart="10dp"
-                android:paddingLeft="10dp"
-                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-                android:textColor="@android:color/holo_blue_bright" />
-        </LinearLayout>
-
         <Button
             android:id="@+id/fetch_ssr"
             android:layout_width="match_parent"

--- a/example/src/main/res/layout/fragment_woo_leaderboards.xml
+++ b/example/src/main/res/layout/fragment_woo_leaderboards.xml
@@ -12,36 +12,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="Perform actions on a selected site:"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/leaderboards_select_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Select Site" />
-
-            <TextView
-                android:id="@+id/leaderboards_selected_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:paddingStart="10dp"
-                android:paddingLeft="10dp"
-                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-                android:textColor="@android:color/holo_blue_bright" />
-        </LinearLayout>
-
         <Button
             android:id="@+id/fetch_product_leaderboards_of_day"
             android:layout_width="match_parent"

--- a/example/src/main/res/layout/fragment_woo_orders.xml
+++ b/example/src/main/res/layout/fragment_woo_orders.xml
@@ -8,6 +8,7 @@
     tools:context="org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment">
 
     <LinearLayout
+        android:id="@+id/buttonContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">

--- a/example/src/main/res/layout/fragment_woo_orders.xml
+++ b/example/src/main/res/layout/fragment_woo_orders.xml
@@ -1,11 +1,10 @@
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_margin="@dimen/activity_start_end_margin"
-    tools:ignore="HardcodedText"
-    tools:context="org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment">
+    tools:context="org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment"
+    tools:ignore="HardcodedText">
 
     <LinearLayout
         android:id="@+id/buttonContainer"
@@ -17,96 +16,113 @@
             android:id="@+id/fetch_orders"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Orders"/>
+            android:enabled="false"
+            android:text="Fetch Orders" />
 
         <Button
             android:id="@+id/fetch_order_list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Order List"/>
+            android:enabled="false"
+            android:text="Fetch Order List" />
 
         <Button
             android:id="@+id/fetch_orders_count"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Orders Count"/>
+            android:enabled="false"
+            android:text="Fetch Orders Count" />
 
         <Button
             android:id="@+id/fetch_single_order"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Single Order"/>
+            android:enabled="false"
+            android:text="Fetch Single Order" />
 
         <Button
             android:id="@+id/fetch_has_orders"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Has Orders"/>
+            android:enabled="false"
+            android:text="Fetch Has Orders" />
 
         <Button
             android:id="@+id/fetch_orders_by_status"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Load Orders Filtered By Status (DB)"/>
+            android:enabled="false"
+            android:text="Load Orders Filtered By Status (DB)" />
 
         <Button
             android:id="@+id/fetch_orders_by_status_api"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Completed Orders (API)"/>
+            android:enabled="false"
+            android:text="Fetch Completed Orders (API)" />
 
         <Button
             android:id="@+id/fetch_order_status_options"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Order Status Options"/>
+            android:enabled="false"
+            android:text="Fetch Order Status Options" />
 
         <Button
             android:id="@+id/search_orders"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Search Orders"/>
+            android:enabled="false"
+
+            android:text="Search Orders" />
 
         <Button
             android:id="@+id/fetch_order_notes"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Order Notes"/>
+            android:enabled="false"
+            android:text="Fetch Order Notes" />
 
         <Button
             android:id="@+id/post_order_note"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Post Order Note"/>
+            android:enabled="false"
+            android:text="Post Order Note" />
 
         <Button
             android:id="@+id/fetch_shipment_trackings"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Order Shipment Trackings"/>
+            android:enabled="false"
+            android:text="Fetch Order Shipment Trackings" />
 
         <Button
             android:id="@+id/add_shipment_tracking"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Add Shipment Tracking To First Order"/>
+            android:enabled="false"
+            android:text="Add Shipment Tracking To First Order" />
 
         <Button
             android:id="@+id/delete_shipment_tracking"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Delete First Shipment Tracking For Order"/>
+            android:enabled="false"
+            android:text="Delete First Shipment Tracking For Order" />
 
         <Button
             android:id="@+id/fetch_shipment_providers"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch Order Shipment Providers"/>
+            android:enabled="false"
+            android:text="Fetch Order Shipment Providers" />
 
         <Button
             android:id="@+id/update_latest_order_status"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Update Latest Order Status"/>
+            android:enabled="false"
+            android:text="Update Latest Order Status" />
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/fragment_woo_product_attribute.xml
+++ b/example/src/main/res/layout/fragment_woo_product_attribute.xml
@@ -12,36 +12,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="Perform actions on a selected site:"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/attributes_select_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Select Site" />
-
-            <TextView
-                android:id="@+id/attributes_selected_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:paddingStart="10dp"
-                android:paddingLeft="10dp"
-                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-                android:textColor="@android:color/holo_blue_bright" />
-        </LinearLayout>
-
         <Button
             android:id="@+id/fetch_product_attributes"
             android:layout_width="match_parent"

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -13,34 +13,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="Perform actions on a selected site:"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"/>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/stats_select_site"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Select Site"/>
-
-            <TextView
-                android:id="@+id/stats_selected_site"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
-                android:paddingStart="10dp"
-                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-                android:textColor="@android:color/holo_blue_bright"/>
-        </LinearLayout>
-
         <Button
             android:id="@+id/fetch_single_product"
             android:layout_width="match_parent"

--- a/example/src/main/res/layout/fragment_woo_revenue_stats.xml
+++ b/example/src/main/res/layout/fragment_woo_revenue_stats.xml
@@ -12,34 +12,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="Perform actions on a selected site:"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/stats_select_site"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Select Site" />
-
-            <TextView
-                android:id="@+id/stats_selected_site"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingStart="10dp"
-                android:paddingLeft="10dp"
-                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-                android:textColor="@android:color/holo_blue_bright" />
-        </LinearLayout>
-
         <Button
             android:id="@+id/fetch_revenue_stats_availability"
             android:layout_width="match_parent"

--- a/example/src/main/res/layout/fragment_woo_shippinglabels.xml
+++ b/example/src/main/res/layout/fragment_woo_shippinglabels.xml
@@ -12,36 +12,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="Perform actions on a selected site:"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/shipping_labels_select_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Select Site" />
-
-            <TextView
-                android:id="@+id/shipping_labels_selected_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:paddingStart="10dp"
-                android:paddingLeft="10dp"
-                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-                android:textColor="@android:color/holo_blue_bright" />
-        </LinearLayout>
-
         <Button
             android:id="@+id/fetch_shipping_labels"
             android:layout_width="match_parent"

--- a/example/src/main/res/layout/fragment_woo_taxes.xml
+++ b/example/src/main/res/layout/fragment_woo_taxes.xml
@@ -12,36 +12,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:text="Perform actions on a selected site:"
-            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/taxes_select_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Select Site" />
-
-            <TextView
-                android:id="@+id/taxes_selected_site"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:paddingStart="10dp"
-                android:paddingLeft="10dp"
-                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
-                android:textColor="@android:color/holo_blue_bright" />
-        </LinearLayout>
-
         <Button
             android:id="@+id/fetch_tax_class"
             android:layout_width="match_parent"


### PR DESCRIPTION
Closes #2033 

### Description

This PR adds possibility to select a site in `Orders` screen.

While adding this change I've realised that we have this feature in many other screens and its implemented separately so I unified logic and UI for that in every screen.

As you can see it came with a nice codebase reduction (+117/−513).

### Demo

| Before | After |
| ---- | ---- |
| <img width="721" alt="Screenshot 2021-10-05 at 16 03 15" src="https://user-images.githubusercontent.com/5845095/136038709-6be84d94-6f94-45ce-b4e8-56411934926a.png"> | <img width="721" alt="Screenshot 2021-10-05 at 16 08 02" src="https://user-images.githubusercontent.com/5845095/136039637-3f4278f9-ab85-41f2-bb78-29ab0ff2c67a.png"> | 
| <img width="721" alt="Screenshot 2021-10-05 at 16 04 03" src="https://user-images.githubusercontent.com/5845095/136038883-bef5690a-177d-4941-b0db-9e242eccc2d3.png"> | <img width="721" alt="Screenshot 2021-10-05 at 16 05 00" src="https://user-images.githubusercontent.com/5845095/136039054-4aa78a39-d9e4-43f4-b782-2904a1436f0f.png"> |

### How to test

#### TC1 Order screen
1. Sign in
2. Go to `Woo`
3. Click on `Orders`
4. **Assert that action buttons are disabled**
5. Click on `Select site` and select something
6. **Smoke test actions to make sure that correct site has been selected**

#### TC2 Other screens
As some other screens has been updated to use shared logic with site selection, please smoke test:
- Customers
- Help & Support
- Leaderboards
- Attributes
- Products
- Revenue stats
- Shipping labels
- Taxes

Nothing should really change but maybe I've missed something.