### PR TITLE
Throw exception on null `type` or `title format` in Add-on DTO.

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/addons/RemoteAddonDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/addons/RemoteAddonDto.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class RemoteAddonDto(
     @SerializedName("title_format")
-    val titleFormat: RemoteTitleFormat,
+    val titleFormat: RemoteTitleFormat?,
     @SerializedName("description_enable")
     val descriptionEnabled: Int,
     @SerializedName("restrictions_type")
@@ -14,7 +14,7 @@ data class RemoteAddonDto(
     @SerializedName("price_type")
     val priceType: RemotePriceType? = null,
 
-    val type: RemoteType,
+    val type: RemoteType?,
     val display: RemoteDisplay? = null,
     val name: String,
     val description: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteAddonMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteAddonMapper.kt
@@ -29,7 +29,7 @@ object RemoteAddonMapper {
                     position = dto.position,
                     options = dto.mapOptions(),
                     display = dto.display?.toDomainModel() ?: throw MappingRemoteException(
-                                    "Can't map ${dto.name}. MultipleChoice add-on type has to have `display` defined."
+                                    "MultipleChoice add-on type has to have `display` defined."
                             )
             )
             Checkbox -> Addon.Checkbox(
@@ -137,7 +137,7 @@ object RemoteAddonMapper {
                 RemoteRestrictionsType.Email -> Addon.CustomText.Restrictions.Email
             }
         } else {
-            throw MappingRemoteException("Can't map $name. CustomText Add-on has to have restrictions defined.")
+            throw MappingRemoteException("CustomText Add-on has to have restrictions defined.")
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteAddonMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteAddonMapper.kt
@@ -92,6 +92,7 @@ object RemoteAddonMapper {
                     required = dto.required.asBoolean(),
                     position = dto.position
             )
+            else -> throw MappingRemoteException("Add-on has to have type")
         }
     }
 
@@ -109,11 +110,12 @@ object RemoteAddonMapper {
         }.orEmpty()
     }
 
-    private fun RemoteTitleFormat.toDomainModel(): Addon.TitleFormat {
+    private fun RemoteTitleFormat?.toDomainModel(): Addon.TitleFormat {
         return when (this) {
             Label -> Addon.TitleFormat.Label
             RemoteTitleFormat.Heading -> Addon.TitleFormat.Heading
             Hide -> Addon.TitleFormat.Hide
+            null -> throw MappingRemoteException("Add-on has to have title")
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteGlobalAddonGroupMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteGlobalAddonGroupMapper.kt
@@ -19,7 +19,7 @@ internal class RemoteGlobalAddonGroupMapper @Inject constructor(private val appL
                     try {
                         RemoteAddonMapper.toDomain(dtoAddon)
                     } catch (exception: MappingRemoteException) {
-                        appLogWrapper.e(API, exception.message)
+                        appLogWrapper.e(API, "Exception while parsing $dtoAddon: ${exception.message}")
                         null
                     }
                 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1077,7 +1077,7 @@ class WCProductStore @Inject constructor(
                     try {
                         RemoteAddonMapper.toDomain(remoteAddonDto)
                     } catch (exception: MappingRemoteException) {
-                        logger.e(API, exception.message)
+                        logger.e(API, "Exception while parsing $remoteAddonDto: ${exception.message}")
                         null
                     }
                 }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteAddonMapperTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteAddonMapperTest.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.mappers
+
+import org.junit.Test
+import org.wordpress.android.fluxc.model.addons.RemoteAddonDto
+
+class RemoteAddonMapperTest {
+
+    val sut = RemoteAddonMapper
+
+    @Test
+    fun `should not throw exception for a valid dto`() {
+        sut.toDomain(VALID_ADDON_DTO)
+    }
+
+    @Test(expected = MappingRemoteException::class)
+    fun `should throw exception when type of addon dto is null`() {
+        sut.toDomain(
+            VALID_ADDON_DTO.copy(type = null)
+        )
+    }
+
+    @Test(expected = MappingRemoteException::class)
+    fun `should throw exception when title format of addon dto is null`() {
+        sut.toDomain(
+            VALID_ADDON_DTO.copy(titleFormat = null)
+        )
+    }
+
+    private companion object {
+        val VALID_ADDON_DTO = RemoteAddonDto(
+            titleFormat = RemoteAddonDto.RemoteTitleFormat.Hide,
+            descriptionEnabled = 1,
+            restrictionsType = null,
+            adjustPrice = 0,
+            priceType = null,
+            type = RemoteAddonDto.RemoteType.MultipleChoice,
+            display = RemoteAddonDto.RemoteDisplay.RadioButton,
+            name = "Add-on",
+            description = "This is a test add-on",
+            required = 1,
+            position = 0,
+            price = null,
+            min = 0,
+            max = 0,
+            options = listOf(
+                RemoteAddonDto.RemoteOption(
+                    priceType = RemoteAddonDto.RemotePriceType.FlatFee,
+                    label = "First checkbox option",
+                    price = "10"
+                ),
+                RemoteAddonDto.RemoteOption(
+                    priceType = RemoteAddonDto.RemotePriceType.FlatFee,
+                    label = "Second checkbox option",
+                    price = "20"
+                )
+            )
+        )
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteAddonMapperTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/addons/mappers/RemoteAddonMapperTest.kt
@@ -4,7 +4,6 @@ import org.junit.Test
 import org.wordpress.android.fluxc.model.addons.RemoteAddonDto
 
 class RemoteAddonMapperTest {
-
     val sut = RemoteAddonMapper
 
     @Test

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/ProvideAddonsIntegrationTests.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/ProvideAddonsIntegrationTests.kt
@@ -454,29 +454,30 @@ class ProvideAddonsIntegrationTests {
     @Test
     fun `should not allow to map MultipleChoice Add-on without display property`() {
         runBlocking {
+            val testedDto = RemoteAddonDto(
+                titleFormat = Label,
+                descriptionEnabled = 1,
+                adjustPrice = 0,
+                type = MultipleChoice,
+                name = "sample",
+                description = "Description",
+                required = 1,
+                position = 0,
+                min = 0,
+                max = 10,
+                price = "100$",
+                options = listOf(
+                    RemoteAddonDto.RemoteOption(
+                        priceType = FlatFee,
+                        label = "Test option",
+                        price = "10"
+                    )
+                )
+            )
             whenever(restClient.fetchGlobalAddOnGroups(any())).thenReturn(
                     WooPayload(
                             result = groupWith(
-                                    RemoteAddonDto(
-                                            titleFormat = Label,
-                                            descriptionEnabled = 1,
-                                            adjustPrice = 0,
-                                            type = MultipleChoice,
-                                            name = "sample",
-                                            description = "Description",
-                                            required = 1,
-                                            position = 0,
-                                            min = 0,
-                                            max = 10,
-                                            price = "100$",
-                                            options = listOf(
-                                                    RemoteAddonDto.RemoteOption(
-                                                            priceType = FlatFee,
-                                                            label = "Test option",
-                                                            price = "10"
-                                                    )
-                                            )
-                                    )
+                                testedDto
                             )
                     )
             )
@@ -484,31 +485,35 @@ class ProvideAddonsIntegrationTests {
             sut.fetchAllGlobalAddonsGroups(siteModel)
 
             assertThat(sut.observeAllAddonsForProduct(siteModel.siteId, product).first()).isEmpty()
-            verify(logger).e(API, "Can't map sample. MultipleChoice add-on type has to have `display` defined.")
+            verify(logger).e(
+                API,
+                "Exception while parsing $testedDto: MultipleChoice add-on type has to have `display` defined."
+            )
         }
     }
 
     @Test
     fun `should not allow to map CustomText Add-on without restrictions property`() {
         runBlocking {
+            val testedDto = RemoteAddonDto(
+                titleFormat = Heading,
+                descriptionEnabled = 0,
+                restrictionsType = null,
+                adjustPrice = 1,
+                priceType = FlatFee,
+                type = CustomText,
+                name = "sample",
+                description = "",
+                required = 1,
+                position = 5,
+                min = 2,
+                max = 5,
+                price = "100$"
+            )
             whenever(restClient.fetchGlobalAddOnGroups(any())).thenReturn(
                     WooPayload(
                             result = groupWith(
-                                    RemoteAddonDto(
-                                            titleFormat = Heading,
-                                            descriptionEnabled = 0,
-                                            restrictionsType = null,
-                                            adjustPrice = 1,
-                                            priceType = FlatFee,
-                                            type = CustomText,
-                                            name = "sample",
-                                            description = "",
-                                            required = 1,
-                                            position = 5,
-                                            min = 2,
-                                            max = 5,
-                                            price = "100$"
-                                    )
+                                testedDto
                             )
                     )
             )
@@ -516,7 +521,10 @@ class ProvideAddonsIntegrationTests {
             sut.fetchAllGlobalAddonsGroups(siteModel)
 
             assertThat(sut.observeAllAddonsForProduct(siteModel.siteId, product).first()).isEmpty()
-            verify(logger).e(API, "Can't map sample. CustomText Add-on has to have restrictions defined.")
+            verify(logger).e(
+                API,
+                "Exception while parsing $testedDto: CustomText Add-on has to have restrictions defined."
+            )
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-android/issues/4941

### Description

This PR is about dropping invalid Add-on DTOs and not consider it for passing outside network layer. Invalid add-on DTO is one that does not meet requirements described in API specification: `type` and `title format` are required parameters.

### How to test

I couldn't replicate behaviour so I had to SSP into malformed site. The best way would be to firstly:
1. Log-in to site with app based on `develop` of FluxC and see that app crashes
2. Then build app based on this PR and run app again - it should not crash anymore

### Logging events

Those exceptions are consumed in the callers of the mapper and logged via `AppLog`. I've decided to not send Sentry issues when this happens ([what I suggested in discussion](https://github.com/woocommerce/woocommerce-android/issues/4941#issuecomment-936562181)) as I've realised that those malformed add-ons are completely empty and won't give us any information on how to fix things. Even site [seems to not have add-ons plug-in enabled](https://github.com/woocommerce/woocommerce-android/issues/4941#issuecomment-937605856) (maybe had in the past?).

I've added some more context to thrown exception so it might be easier in the future to spot malformed DTO right away.