### PR TITLE
Expose "temporary" parameter for cart creation

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
@@ -64,7 +64,8 @@ class TransactionsStoreTest {
                         siteModel,
                         TEST_DOMAIN_PRODUCT_ID,
                         TEST_DOMAIN_NAME,
-                        true
+                        isPrivacyProtectionEnabled = true,
+                        isTemporary = true
                 )
         ).thenReturn(
                 CreatedShoppingCartPayload(
@@ -75,7 +76,9 @@ class TransactionsStoreTest {
         val payload = CreateShoppingCartPayload(
                 siteModel,
                 TEST_DOMAIN_PRODUCT_ID,
-                TEST_DOMAIN_NAME, true
+                TEST_DOMAIN_NAME,
+                isPrivacyEnabled = true,
+                isTemporary = true
         )
 
         val action = TransactionActionBuilder.newCreateShoppingCartAction(payload)
@@ -85,7 +88,8 @@ class TransactionsStoreTest {
                 payload.site,
                 payload.productId,
                 payload.domainName,
-                payload.isPrivacyEnabled
+                payload.isPrivacyEnabled,
+                payload.isTemporary
         )
 
         val expectedEvent = TransactionsStore.OnShoppingCartCreated(CREATE_SHOPPING_CART_RESPONSE)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
@@ -58,7 +58,8 @@ class TransactionsRestClient @Inject constructor(
         site: SiteModel,
         productId: Int,
         domainName: String,
-        isPrivacyProtectionEnabled: Boolean
+        isPrivacyProtectionEnabled: Boolean,
+        isTemporary: Boolean
     ): CreatedShoppingCartPayload {
         val url = WPCOMREST.me.shopping_cart.site(site.siteId).urlV1_1
 
@@ -69,7 +70,7 @@ class TransactionsRestClient @Inject constructor(
         )
 
         val body = mapOf(
-                "temporary" to true,
+                "temporary" to isTemporary,
                 "products" to arrayOf(domainProduct)
         )
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
@@ -133,7 +133,8 @@ class TransactionsStore @Inject constructor(
         val site: SiteModel,
         val productId: Int,
         val domainName: String,
-        val isPrivacyEnabled: Boolean
+        val isPrivacyEnabled: Boolean,
+        val isTemporary: Boolean = true
     ) : Payload<BaseRequest.BaseNetworkError>()
 
     class RedeemShoppingCartPayload(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
@@ -74,7 +74,8 @@ class TransactionsStore @Inject constructor(
                 payload.site,
                 payload.productId,
                 payload.domainName,
-                payload.isPrivacyEnabled
+                payload.isPrivacyEnabled,
+                payload.isTemporary
         )
 
         return if (!createdShoppingCartPayload.isError) {


### PR DESCRIPTION
This PR exposes the "temporary" parameter in [`TransactionsRestClient::createShoppingCart`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/0fe3490b81e3b099f2329229dfc9a79c7422d48c/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt#L57-L62) and updates its related store method accordingly.

This is necessary in order to purchase domains through a persistent shopping cart.

There is no companion PR in WPAndroid for this change, but pulling this into a local FluxC build and building the app should be enough to make sure it isn't breaking anything.

