### PR TITLE
Update customer notes

### DIFF
--- a/example/src/main/res/layout/fragment_woo_orders.xml
+++ b/example/src/main/res/layout/fragment_woo_orders.xml
@@ -124,5 +124,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Update Latest Order Status" />
+
+        <Button
+            android:id="@+id/update_latest_order_notes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Update Latest Order Customer Notes" />
     </LinearLayout>
 </ScrollView>

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -22,6 +22,15 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }
 
 dependencies {
@@ -64,6 +73,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
 }
 
 project.afterEvaluate {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/wrappers/OrderSqlDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/wrappers/OrderSqlDao.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.persistence.wrappers
+
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.persistence.OrderSqlUtils
+import javax.inject.Inject
+
+typealias RowAffected = Int
+
+internal class OrderSqlDao @Inject constructor() {
+    fun insertOrUpdateOrder(order: WCOrderModel): RowAffected = OrderSqlUtils.insertOrUpdateOrder(order)
+
+    fun updateLocalOrder(localOrderId: Int, updateOrder: WCOrderModel.() -> Unit): RowAffected {
+        val updatedOrder = OrderSqlUtils.getOrderByLocalId(localOrderId)
+                .apply(updateOrder)
+        return OrderSqlUtils.insertOrUpdateOrder(updatedOrder)
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.fluxc.store
+
+import kotlinx.coroutines.flow.Flow
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.persistence.wrappers.OrderSqlDao
+import org.wordpress.android.fluxc.persistence.wrappers.RowAffected
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog.T
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class OrderUpdateStore @Inject internal constructor(
+    private val coroutineEngine: CoroutineEngine,
+    private val wcOrderRestClient: OrderRestClient,
+    private val orderSqlDao: OrderSqlDao
+) {
+    suspend fun updateOrderNotes(
+        initialOrder: WCOrderModel,
+        site: SiteModel,
+        newNotes: String
+    ): Flow<UpdateOrderResult> {
+        return coroutineEngine.flowWithDefaultContext(T.API, this, "updateOrderNotes") {
+            val optimisticUpdateRowsAffected: RowAffected = orderSqlDao.updateLocalOrder(initialOrder.id) {
+                customerNote = newNotes
+            }
+            emit(UpdateOrderResult.OptimisticUpdateResult(OnOrderChanged(optimisticUpdateRowsAffected)))
+
+            val updateRemoteOrderPayload = wcOrderRestClient.updateCustomerOrderNote(
+                    initialOrder,
+                    site,
+                    newNotes
+            )
+            val remoteUpdateResult = if (updateRemoteOrderPayload.isError) {
+                OnOrderChanged(orderSqlDao.insertOrUpdateOrder(initialOrder)).apply {
+                    error = updateRemoteOrderPayload.error
+                }
+            } else {
+                OnOrderChanged(orderSqlDao.insertOrUpdateOrder(updateRemoteOrderPayload.order))
+            }
+            emit(RemoteUpdateResult(remoteUpdateResult))
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -314,7 +314,7 @@ class WCOrderStore @Inject constructor(
     }
 
     // OnChanged events
-    class OnOrderChanged(
+    data class OnOrderChanged(
         var rowsAffected: Int,
         var statusFilter: String? = null,
         var canLoadMore: Boolean = false

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -1,0 +1,141 @@
+package org.wordpress.android.fluxc.store
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.persistence.wrappers.OrderSqlDao
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+
+@ExperimentalCoroutinesApi
+class OrderUpdateStoreTest {
+    private lateinit var sut: OrderUpdateStore
+    private lateinit var orderRestClient: OrderRestClient
+
+    private val orderSqlDao: OrderSqlDao = mock {
+        on { insertOrUpdateOrder(any()) } doReturn ROW_AFFECTED
+        on { updateLocalOrder(any(), any()) } doReturn ROW_AFFECTED
+    }
+
+    fun setUp(setMocks: () -> Unit) {
+        setMocks.invoke()
+        sut = OrderUpdateStore(
+                coroutineEngine = CoroutineEngine(
+                        TestCoroutineScope().coroutineContext,
+                        mock()
+                ),
+                orderRestClient,
+                orderSqlDao
+        )
+    }
+
+    @Test
+    fun `should optimistically update order customer notes`(): Unit = runBlocking {
+        // given
+        val initialOrder = WCOrderModel().apply {
+            customerNote = "original customer note"
+        }
+        val updatedNote = "updated customer note"
+        val updatedOrder = WCOrderModel().apply {
+            customerNote = updatedNote
+        }
+        val site = SiteModel()
+
+        setUp {
+            orderRestClient = mock {
+                onBlocking { updateCustomerOrderNote(initialOrder, site, updatedNote) }.doReturn(
+                        RemoteOrderPayload(
+                                updatedOrder,
+                                site
+                        )
+                )
+            }
+        }
+
+        // when
+        val results = sut.updateOrderNotes(
+                initialOrder = initialOrder,
+                site = site,
+                newNotes = updatedNote
+        ).toList()
+
+        // then
+        assertThat(results).hasSize(2).containsExactly(
+                OptimisticUpdateResult(
+                        OnOrderChanged(ROW_AFFECTED)
+                ),
+                RemoteUpdateResult(
+                        OnOrderChanged(ROW_AFFECTED)
+                )
+        )
+        verify(orderSqlDao).insertOrUpdateOrder(argThat {
+            customerNote == updatedNote
+        })
+    }
+
+    @Test
+    fun `should revert local customer notes update if remote update failed`(): Unit = runBlocking {
+        // given
+        val originalNote = "original customer note"
+        val initialOrder = WCOrderModel().apply {
+            customerNote = originalNote
+        }
+        val updatedNote = "updated customer note"
+        val site = SiteModel()
+
+        setUp {
+            orderRestClient = mock {
+                onBlocking { updateCustomerOrderNote(initialOrder, site, updatedNote) }.doReturn(
+                        RemoteOrderPayload(
+                                error = WCOrderStore.OrderError(),
+                                initialOrder,
+                                site
+                        )
+                )
+            }
+        }
+
+        // when
+        val results = sut.updateOrderNotes(
+                initialOrder = initialOrder,
+                site = site,
+                newNotes = updatedNote
+        ).toList()
+
+        // then
+        assertThat(results).hasSize(2).containsExactly(
+                OptimisticUpdateResult(
+                        OnOrderChanged(ROW_AFFECTED)
+                ),
+                RemoteUpdateResult(
+                        OnOrderChanged(ROW_AFFECTED)
+                )
+        )
+
+        val remoteUpdateResult = results[1]
+        assertThat(remoteUpdateResult.event.error.type).isEqualTo(GENERIC_ERROR)
+
+        verify(orderSqlDao).insertOrUpdateOrder(argThat {
+            customerNote == originalNote
+        })
+    }
+
+    private companion object {
+        const val ROW_AFFECTED = 1
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/4888

### Description

This PR introduces API to optimistically update customer notes 

### Demo 

https://user-images.githubusercontent.com/5845095/136543030-78bd353c-9d18-489d-9907-cb987876fd8f.mov

### Test

1. Run example app
2. Go to Woo > Orders > Scroll down > `Update Latest Order Customer Notes`
3. Enter some custom text
4. **Assert there's optimistic and remote update results in logs**
5. Go to admin panel and see the order 
6. **Assert the customer note is updated**

