### PR TITLE
Issue/woo 4806 suspendable add order shipment tracking

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
-import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
@@ -433,7 +432,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testAddOrderShipmentTrackingSuccess() {
+    fun testAddOrderShipmentTrackingSuccess() = runBlocking {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         val trackingModel = WCOrderShipmentTrackingModel().apply {
             trackingProvider = "TNT Express (consignment)"
@@ -441,15 +440,10 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             dateShipped = "2019-04-18"
         }
         interceptor.respondWith("wc-post-order-shipment-tracking-success.json")
-        orderRestClient.addOrderShipmentTrackingForOrder(
+        val payload = orderRestClient.addOrderShipmentTrackingForOrder(
                 siteModel, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = false
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.ADDED_ORDER_SHIPMENT_TRACKING, lastAction!!.type)
-        val payload = lastAction!!.payload as AddOrderShipmentTrackingResponsePayload
         assertNull(payload.error)
         assertNotNull(payload.tracking)
 
@@ -465,7 +459,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testAddOrderShipmentTrackingCustomProviderSuccess() {
+    fun testAddOrderShipmentTrackingCustomProviderSuccess() = runBlocking {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         val trackingModel = WCOrderShipmentTrackingModel().apply {
             trackingProvider = "Amanda Test Provider"
@@ -474,15 +468,10 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             dateShipped = "2019-04-19"
         }
         interceptor.respondWith("wc-post-order-shipment-tracking-custom-success.json")
-        orderRestClient.addOrderShipmentTrackingForOrder(
+        val payload = orderRestClient.addOrderShipmentTrackingForOrder(
                 siteModel, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = true
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.ADDED_ORDER_SHIPMENT_TRACKING, lastAction!!.type)
-        val payload = lastAction!!.payload as AddOrderShipmentTrackingResponsePayload
         assertNull(payload.error)
         assertNotNull(payload.tracking)
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -8,7 +8,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
-import org.wordpress.android.fluxc.action.WCOrderAction.ADD_ORDER_SHIPMENT_TRACKING
 import org.wordpress.android.fluxc.action.WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING
 import org.wordpress.android.fluxc.example.BuildConfig
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
@@ -32,7 +31,6 @@ import javax.inject.Inject
 class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
     internal enum class TestEvent {
         NONE,
-        ADD_ORDER_SHIPMENT_TRACKING,
         DELETE_ORDER_SHIPMENT_TRACKING,
         FETCHED_ORDER_SHIPMENT_PROVIDERS
     }
@@ -106,13 +104,10 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
      */
     @Throws(InterruptedException::class)
     @Test
-    fun testAddAndDeleteShipmentTrackingForOrder_standardProvider() {
+    fun testAddAndDeleteShipmentTrackingForOrder_standardProvider() = runBlocking {
         /*
          * TEST 1: Add an order shipment tracking for an order
          */
-        nextEvent = TestEvent.ADD_ORDER_SHIPMENT_TRACKING
-        mCountDownLatch = CountDownLatch(1)
-
         val orderModel = WCOrderModel().apply {
             id = 8
             remoteOrderId = BuildConfig.TEST_WC_ORDER_WITH_SHIPMENT_TRACKINGS_ID.toLong()
@@ -128,11 +123,9 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
             trackingNumber = testTrackingNumber
             dateShipped = testDateShipped
         }
-        mDispatcher.dispatch(WCOrderActionBuilder.newAddOrderShipmentTrackingAction(
-                AddOrderShipmentTrackingPayload(
-                        sSite, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = false))
+        orderStore.addOrderShipmentTracking(AddOrderShipmentTrackingPayload(
+                sSite, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = false)
         )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         var trackings = orderStore.getShipmentTrackingsForOrder(
                 sSite, orderModel.id
@@ -176,13 +169,10 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
      */
     @Throws(InterruptedException::class)
     @Test
-    fun testAddShipmentTrackingForOrder_customProvider() {
+    fun testAddShipmentTrackingForOrder_customProvider() = runBlocking {
         /*
          * TEST 1: Add a tracking record using a custom provider
          */
-        nextEvent = TestEvent.ADD_ORDER_SHIPMENT_TRACKING
-        mCountDownLatch = CountDownLatch(1)
-
         val orderModel = WCOrderModel().apply {
             id = 8
             remoteOrderId = BuildConfig.TEST_WC_ORDER_WITH_SHIPMENT_TRACKINGS_ID.toLong()
@@ -200,12 +190,11 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
             dateShipped = testDateShipped
             trackingLink = testTrackingLink
         }
-        mDispatcher.dispatch(WCOrderActionBuilder.newAddOrderShipmentTrackingAction(
+        orderStore.addOrderShipmentTracking(
                 AddOrderShipmentTrackingPayload(
-                        sSite, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = true))
+                        sSite, orderModel.id, orderModel.remoteOrderId, trackingModel, isCustomProvider = true
+                )
         )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
         var trackings = orderStore.getShipmentTrackingsForOrder(
                 sSite, orderModel.id
         )
@@ -280,10 +269,6 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
         lastEvent = event
 
         when (event.causeOfChange) {
-            ADD_ORDER_SHIPMENT_TRACKING -> {
-                assertEquals(TestEvent.ADD_ORDER_SHIPMENT_TRACKING, nextEvent)
-                mCountDownLatch.countDown()
-            }
             DELETE_ORDER_SHIPMENT_TRACKING -> {
                 assertEquals(TestEvent.DELETE_ORDER_SHIPMENT_TRACKING, nextEvent)
                 mCountDownLatch.countDown()

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -49,8 +49,6 @@ public enum WCOrderAction implements IAction {
     SEARCH_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsPayload.class)
     FETCH_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = AddOrderShipmentTrackingPayload.class)
-    ADD_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = DeleteOrderShipmentTrackingPayload.class)
     DELETE_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = FetchOrderShipmentProvidersPayload.class)
@@ -73,8 +71,6 @@ public enum WCOrderAction implements IAction {
     SEARCHED_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsResponsePayload.class)
     FETCHED_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = AddOrderShipmentTrackingResponsePayload.class)
-    ADDED_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = DeleteOrderShipmentTrackingResponsePayload.class)
     DELETED_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = FetchOrderShipmentProvidersResponsePayload.class)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -3,8 +3,6 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
-import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload;

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -585,13 +585,19 @@ class OrderRestClient @Inject constructor(
 
         return when (response) {
             is JetpackSuccess -> {
-                val trackingResponse = response.data?.let {
-                    orderShipmentTrackingResponseToModel(it).apply {
+                response.data?.let {
+                    val trackingModel = orderShipmentTrackingResponseToModel(it).apply {
                         this.localOrderId = localOrderId
                         localSiteId = site.id
                     }
-                }
-                AddOrderShipmentTrackingResponsePayload(site, localOrderId, remoteOrderId, trackingResponse)
+                    AddOrderShipmentTrackingResponsePayload(site, localOrderId, remoteOrderId, trackingModel)
+                } ?: AddOrderShipmentTrackingResponsePayload(
+                        OrderError(type = GENERIC_ERROR, message = "Success response with empty data"),
+                        site,
+                        localOrderId,
+                        remoteOrderId,
+                        tracking
+                )
             }
             is JetpackError -> {
                 val trackingsError = networkErrorToOrderError(response.error)


### PR DESCRIPTION
"Not ready for merge" - Should be merged together with a PR in WCAndroid

This PR refactors addOrderShipmentTracking into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

To Test:
1. Test addOrderShipmentTracking action in the example app or test in WCAndroid ([PR](https://github.com/woocommerce/woocommerce-android/pull/5005))
