### PR TITLE
Issue/woo 4806 suspendable delete shipment tracking

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
-import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
@@ -485,22 +484,17 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testDeleteOrderShipmentTrackingSuccess() {
+    fun testDeleteOrderShipmentTrackingSuccess() = runBlocking {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         val trackingModel = WCOrderShipmentTrackingModel().apply {
             remoteTrackingId = "95bb641d79d7c6974001d6a03fbdabc0"
         }
 
         interceptor.respondWith("wc-delete-order-shipment-tracking-success.json")
-        orderRestClient.deleteShipmentTrackingForOrder(
+        val payload = orderRestClient.deleteShipmentTrackingForOrder(
                 siteModel, orderModel.id, orderModel.remoteOrderId, trackingModel
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.DELETED_ORDER_SHIPMENT_TRACKING, lastAction!!.type)
-        val payload = lastAction!!.payload as DeleteOrderShipmentTrackingResponsePayload
         assertNull(payload.error)
         assertNotNull(payload.tracking)
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -4,11 +4,11 @@ import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
-import org.wordpress.android.fluxc.action.WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING
 import org.wordpress.android.fluxc.example.BuildConfig
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderModel
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderShipmentProvidersChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import java.text.SimpleDateFormat
@@ -31,7 +30,6 @@ import javax.inject.Inject
 class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
     internal enum class TestEvent {
         NONE,
-        DELETE_ORDER_SHIPMENT_TRACKING,
         FETCHED_ORDER_SHIPMENT_PROVIDERS
     }
 
@@ -149,13 +147,11 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
         /*
          * TEST 2: Delete the previously added shipment tracking record
          */
-        nextEvent = TestEvent.DELETE_ORDER_SHIPMENT_TRACKING
-        mCountDownLatch = CountDownLatch(1)
+        val onOrderChanged = orderStore.deleteOrderShipmentTracking(
+                DeleteOrderShipmentTrackingPayload(sSite, orderModel.id, orderModel.remoteOrderId, trackingResult!!)
+        )
 
-        mDispatcher.dispatch(WCOrderActionBuilder.newDeleteOrderShipmentTrackingAction(
-                DeleteOrderShipmentTrackingPayload(sSite, orderModel.id, orderModel.remoteOrderId, trackingResult!!)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
+        assertFalse(onOrderChanged.isError)
         // Verify the tracking record is no longer in the database
         var currentCount = trackings.size
         trackings = orderStore.getShipmentTrackingsForOrder(sSite, orderModel.id)
@@ -218,13 +214,11 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
         /*
          * TEST 2: Delete the previously added shipment tracking record
          */
-        nextEvent = TestEvent.DELETE_ORDER_SHIPMENT_TRACKING
-        mCountDownLatch = CountDownLatch(1)
+        val onOrderChanged = orderStore.deleteOrderShipmentTracking(
+                DeleteOrderShipmentTrackingPayload(sSite, orderModel.id, orderModel.remoteOrderId, trackingResult!!)
+        )
 
-        mDispatcher.dispatch(WCOrderActionBuilder.newDeleteOrderShipmentTrackingAction(
-                DeleteOrderShipmentTrackingPayload(sSite, orderModel.id, orderModel.remoteOrderId, trackingResult!!)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
+        assertFalse(onOrderChanged.isError)
         // Verify the tracking record is no longer in the database
         var currentCount = trackings.size
         trackings = orderStore.getShipmentTrackingsForOrder(sSite, orderModel.id)
@@ -257,24 +251,6 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
 
         val providers = orderStore.getShipmentProvidersForSite(sSite)
         assertTrue(providers.isNotEmpty())
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onOrderChanged(event: OnOrderChanged) {
-        event.error?.let {
-            throw AssertionError("OnOrderChanged has unexpected error: " + it.type)
-        }
-
-        lastEvent = event
-
-        when (event.causeOfChange) {
-            DELETE_ORDER_SHIPMENT_TRACKING -> {
-                assertEquals(TestEvent.DELETE_ORDER_SHIPMENT_TRACKING, nextEvent)
-                mCountDownLatch.countDown()
-            }
-            else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)
-        }
     }
 
     @Suppress("unused")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCOrderAction.DELETE_ORDER_SHIPMENT_TRACKING
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_HAS_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS_COUNT
@@ -61,7 +60,6 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
     private var pendingNotesOrderModel: WCOrderModel? = null
     private var pendingFetchOrdersFilter: List<String>? = null
     private var pendingFetchCompletedOrders: Boolean = false
-    private var pendingDeleteShipmentTracking: WCOrderShipmentTrackingModel? = null
     private var pendingOpenAddShipmentTracking: Boolean = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
@@ -323,11 +321,19 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                                     "remoteOrderId: ${order.remoteOrderId}")
 
                             wcOrderStore.getShipmentTrackingsForOrder(site, order.id).firstOrNull()?.let { tracking ->
-                                pendingDeleteShipmentTracking = tracking
-                                val payload = DeleteOrderShipmentTrackingPayload(
-                                        site, order.id, order.remoteOrderId, tracking
-                                )
-                                dispatcher.dispatch(WCOrderActionBuilder.newDeleteOrderShipmentTrackingAction(payload))
+                                coroutineScope.launch {
+                                    val onOrderChanged = wcOrderStore.deleteOrderShipmentTracking(
+                                            DeleteOrderShipmentTrackingPayload(
+                                                    site, order.id, order.remoteOrderId, tracking
+                                            )
+                                    )
+                                    onOrderChanged.takeUnless { it.isError }?.let {
+                                        prependToLog(
+                                                "Shipment tracking deleted successfully! " +
+                                                        "[${onOrderChanged.rowsAffected}] db rows affected."
+                                        )
+                                    } ?: prependToLog("Shipment tracking deletion FAILED!")
+                                }
                             } ?: prependToLog("No shipment trackings in the db for remoteOrderId: $remoteOrderId, " +
                                     "please fetch records first for this order")
                         } ?: prependToLog("No order found in the db for remoteOrderId: $remoteOrderId, " +
@@ -441,13 +447,6 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                             "Posted ${event.rowsAffected} " +
                                     "note to the api for order ${pendingNotesOrderModel!!.remoteOrderId}"
                     )
-                    DELETE_ORDER_SHIPMENT_TRACKING -> {
-                        pendingDeleteShipmentTracking?.let {
-                            prependToLog("Shipment tracking deleted successfully! [${event.rowsAffected}] db rows " +
-                                    "affected.")
-                            pendingDeleteShipmentTracking = null
-                        }
-                    }
                     else -> prependToLog("Order store was updated from a " + event.causeOfChange)
                 }
             }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -47,8 +47,6 @@ public enum WCOrderAction implements IAction {
     SEARCH_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsPayload.class)
     FETCH_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = DeleteOrderShipmentTrackingPayload.class)
-    DELETE_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = FetchOrderShipmentProvidersPayload.class)
     FETCH_ORDER_SHIPMENT_PROVIDERS,
 
@@ -69,8 +67,6 @@ public enum WCOrderAction implements IAction {
     SEARCHED_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsResponsePayload.class)
     FETCHED_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = DeleteOrderShipmentTrackingResponsePayload.class)
-    DELETED_ORDER_SHIPMENT_TRACKING,
     @Action(payloadType = FetchOrderShipmentProvidersResponsePayload.class)
     FETCHED_ORDER_SHIPMENT_PROVIDERS
 }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -3,8 +3,6 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
-import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListPayload;


### PR DESCRIPTION
This PR refactors deleteOrderShipmentTracking into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

- This PR also moves "AddOrderShipmentTracking" to a bg thread, using a coroutine engine

To Test:
1. Test deleteOrderShipmentTracking action in the example app  (you first need to fetch orders and fetch trackings for an order) or test in WCAndroid ([PR](https://github.com/woocommerce/woocommerce-android/pull/5008))
