### PR TITLE
Issue/woo 4806 suspendable add note

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsRes
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
-import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -320,7 +319,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderNotePostSuccess() {
+    fun testOrderNotePostSuccess() = runBlocking {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         val originalNote = WCOrderNoteModel().apply {
             localOrderId = 5
@@ -330,13 +329,8 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         }
 
         interceptor.respondWith("wc-order-note-post-response-success.json")
-        orderRestClient.postOrderNote(orderModel.id, orderModel.remoteOrderId, siteModel, originalNote)
+        val payload = orderRestClient.postOrderNote(orderModel.id, orderModel.remoteOrderId, siteModel, originalNote)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.POSTED_ORDER_NOTE, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteOrderNotePayload
         with(payload) {
             assertNull(error)
             assertEquals(originalNote.note, note.note)
@@ -348,7 +342,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderNotePostError() {
+    fun testOrderNotePostError() = runBlocking {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         val originalNote = WCOrderNoteModel().apply {
             localOrderId = 5
@@ -363,13 +357,8 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         }
 
         interceptor.respondWithError(errorJson, 400)
-        orderRestClient.postOrderNote(orderModel.id, orderModel.remoteOrderId, siteModel, originalNote)
+        val payload = orderRestClient.postOrderNote(orderModel.id, orderModel.remoteOrderId, siteModel, originalNote)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.POSTED_ORDER_NOTE, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteOrderNotePayload
         with(payload) {
             // Expecting a 'invalid id' error from the server
             assertNotNull(error)

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -19,8 +19,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderNotePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderStatusPayload;
@@ -39,8 +37,6 @@ public enum WCOrderAction implements IAction {
     @Action(payloadType = UpdateOrderStatusPayload.class)
     @Deprecated // Use suspendable WCOrderStore.updateOrderStatus(..) directly.
     UPDATE_ORDER_STATUS,
-    @Action(payloadType = PostOrderNotePayload.class)
-    POST_ORDER_NOTE,
     @Action(payloadType = FetchHasOrdersPayload.class)
     FETCH_HAS_ORDERS,
     @Action(payloadType = SearchOrdersPayload.class)
@@ -61,8 +57,6 @@ public enum WCOrderAction implements IAction {
     FETCHED_ORDERS_BY_IDS,
     @Action(payloadType = FetchOrdersCountResponsePayload.class)
     FETCHED_ORDERS_COUNT,
-    @Action(payloadType = RemoteOrderNotePayload.class)
-    POSTED_ORDER_NOTE,
     @Action(payloadType = FetchHasOrdersResponsePayload.class)
     FETCHED_HAS_ORDERS,
     @Action(payloadType = SearchOrdersResponsePayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -432,7 +432,6 @@ class WCOrderStore @Inject constructor(
             WCOrderAction.FETCH_ORDERS_COUNT -> fetchOrdersCount(action.payload as FetchOrdersCountPayload)
             WCOrderAction.UPDATE_ORDER_STATUS ->
                 throw IllegalStateException("Invalid action. Use suspendable updateOrderStatus(..) directly")
-            WCOrderAction.POST_ORDER_NOTE -> postOrderNote(action.payload as PostOrderNotePayload)
             WCOrderAction.FETCH_HAS_ORDERS -> fetchHasOrders(action.payload as FetchHasOrdersPayload)
             WCOrderAction.SEARCH_ORDERS -> searchOrders(action.payload as SearchOrdersPayload)
             WCOrderAction.FETCH_ORDER_STATUS_OPTIONS ->
@@ -450,7 +449,6 @@ class WCOrderStore @Inject constructor(
                 handleFetchOrderByIdsCompleted(action.payload as FetchOrdersByIdsResponsePayload)
             WCOrderAction.FETCHED_ORDERS_COUNT ->
                 handleFetchOrdersCountCompleted(action.payload as FetchOrdersCountResponsePayload)
-            WCOrderAction.POSTED_ORDER_NOTE -> handlePostOrderNoteCompleted(action.payload as RemoteOrderNotePayload)
             WCOrderAction.FETCHED_HAS_ORDERS -> handleFetchHasOrdersCompleted(
                     action.payload as FetchHasOrdersResponsePayload)
             WCOrderAction.SEARCHED_ORDERS -> handleSearchOrdersCompleted(action.payload as SearchOrdersResponsePayload)
@@ -566,8 +564,17 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    private fun postOrderNote(payload: PostOrderNotePayload) {
-        with(payload) { wcOrderRestClient.postOrderNote(localOrderId, remoteOrderId, site, note) }
+    suspend fun postOrderNote(payload: PostOrderNotePayload): OnOrderChanged {
+        return coroutineEngine.withDefaultContext(T.API, this, "postOrderNote") {
+            val result = with(payload) { wcOrderRestClient.postOrderNote(localOrderId, remoteOrderId, site, note) }
+
+            return@withDefaultContext if (payload.isError) {
+                OnOrderChanged(0).also { it.error = result.error }
+            } else {
+                val rowsAffected = OrderSqlUtils.insertOrIgnoreOrderNote(result.note)
+                OnOrderChanged(rowsAffected)
+            }
+        }
     }
 
     private fun fetchOrderStatusOptions(payload: FetchOrderStatusOptionsPayload) {
@@ -772,20 +779,6 @@ class WCOrderStore @Inject constructor(
     private fun revertOrderStatus(payload: RemoteOrderPayload): OnOrderChanged {
         val rowsAffected = updateOrderStatusLocally(LocalId(payload.order.id), payload.order.status)
         return OnOrderChanged(rowsAffected).also { it.error = payload.error }
-    }
-
-    private fun handlePostOrderNoteCompleted(payload: RemoteOrderNotePayload) {
-        val onOrderChanged: OnOrderChanged
-
-        if (payload.isError) {
-            onOrderChanged = OnOrderChanged(0).also { it.error = payload.error }
-        } else {
-            val rowsAffected = OrderSqlUtils.insertOrIgnoreOrderNote(payload.note)
-            onOrderChanged = OnOrderChanged(rowsAffected)
-        }
-
-        onOrderChanged.causeOfChange = WCOrderAction.POST_ORDER_NOTE
-        emitChange(onOrderChanged)
     }
 
     private fun handleFetchOrderStatusOptionsCompleted(payload: FetchOrderStatusOptionsResponsePayload) {


### PR DESCRIPTION
This PR refactors addOrderNote into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

Other changes
1. The app now returns an error response when the server returns success with an empty body - [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/34004e9927a505f3ad0a90126f217a34cdce9068/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt#L504) - instead of silently consuming the event.
2. The rest client now returns `newNote` instead of the `original/local` note - [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/34004e9927a505f3ad0a90126f217a34cdce9068/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt#L503) - I suspect this was a bug in the previous implementation, the note which the app received from the server was completely ignored in the previous implementation.

To Test:
1. Test addOrderNote action in the example app ( or test in WCAndroid ([PR](https://github.com/woocommerce/woocommerce-android/pull/5012)))
2. Check wpadmin if the note is visible in wpadmin
