### PR TITLE
API for submiting billing and shipping addresses updates

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -61,6 +61,8 @@ android {
         }
     }
 
+    buildFeatures.viewBinding true
+
     sourceSets {
         // Adds exported schema location as test app assets.
         getByName("androidTest").assets.srcDirs += "$projectDir/../fluxc/schemas"

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.example.ui.customer.search.WooCustomersSearch
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.helpsupport.WooHelpSupportFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooAddonsTestFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductAttributeFragment
@@ -156,4 +157,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooHelpSupportFragment(): WooHelpSupportFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooAddressEditDialogFragment(): AddressEditDialogFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
@@ -61,8 +61,8 @@ class AddressEditDialogFragment : DaggerFragment() {
                         binding.city.setText(order?.shippingCity)
                         binding.state.setText(order?.shippingState)
                         binding.postcode.setText(order?.shippingPostcode)
+                        binding.phone.setText(order?.billingPhone)
                         binding.email.visibility = View.INVISIBLE
-                        binding.phone.visibility = View.INVISIBLE
                     }
                     BILLING -> {
                         binding.addressTypeSwitch.text = "Edit billing address for order ${order?.remoteOrderId}"
@@ -74,13 +74,9 @@ class AddressEditDialogFragment : DaggerFragment() {
                         binding.city.setText(order?.billingCity)
                         binding.state.setText(order?.billingState)
                         binding.postcode.setText(order?.billingPostcode)
-
+                        binding.phone.setText(order?.billingPhone)
                         binding.email.apply {
                             setText(order?.billingEmail)
-                            visibility = View.VISIBLE
-                        }
-                        binding.phone.apply {
-                            setText(order?.billingPhone)
                             visibility = View.VISIBLE
                         }
                     }
@@ -101,7 +97,8 @@ class AddressEditDialogFragment : DaggerFragment() {
                                 city = binding.city.text.toString(),
                                 state = binding.state.text.toString(),
                                 postcode = binding.postcode.text.toString(),
-                                country = binding.country.text.toString()
+                                country = binding.country.text.toString(),
+                                phone = binding.phone.text.toString()
                         )
                         BILLING -> OrderAddress.Billing(
                                 firstName = binding.firstName.text.toString(),

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
@@ -1,0 +1,142 @@
+package org.wordpress.android.fluxc.example.ui.orders
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import dagger.android.support.DaggerFragment
+import kotlinx.android.synthetic.main.fragment_address_edit_dialog.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.example.databinding.FragmentAddressEditDialogBinding
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.EditTypeState.BILLING
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.EditTypeState.SHIPPING
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.order.OrderAddress
+import org.wordpress.android.fluxc.store.OrderUpdateStore
+import javax.inject.Inject
+
+class AddressEditDialogFragment : DaggerFragment() {
+    @Inject lateinit var orderUpdateStore: OrderUpdateStore
+
+    enum class EditTypeState {
+        SHIPPING, BILLING
+    }
+
+    private var currentAddressType = MutableStateFlow(SHIPPING)
+    private lateinit var binding: FragmentAddressEditDialogBinding
+
+    var selectedOrder = MutableStateFlow<WCOrderModel?>(null)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = FragmentAddressEditDialogBinding.inflate(inflater).apply {
+        binding = this
+        addressTypeSwitch.setOnCheckedChangeListener { _, isChecked ->
+            currentAddressType.value = if (isChecked) BILLING else SHIPPING
+        }
+    }.root
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        CoroutineScope(Dispatchers.Main).launch {
+            currentAddressType.combine(selectedOrder) { addressType, order ->
+                when (addressType) {
+                    SHIPPING -> {
+                        binding.addressTypeSwitch.text = "Edit shipping address for order ${order?.remoteOrderId}"
+                        binding.firstName.setText(order?.shippingFirstName)
+                        binding.lastName.setText(order?.shippingLastName)
+                        binding.company.setText(order?.shippingCompany)
+                        binding.address1.setText(order?.shippingAddress1)
+                        binding.address2.setText(order?.shippingAddress2)
+                        binding.city.setText(order?.shippingCity)
+                        binding.state.setText(order?.shippingState)
+                        binding.postcode.setText(order?.shippingPostcode)
+                        binding.email.visibility = View.INVISIBLE
+                        binding.phone.visibility = View.INVISIBLE
+                    }
+                    BILLING -> {
+                        binding.addressTypeSwitch.text = "Edit billing address for order ${order?.remoteOrderId}"
+                        binding.firstName.setText(order?.billingFirstName)
+                        binding.lastName.setText(order?.billingLastName)
+                        binding.company.setText(order?.billingCompany)
+                        binding.address1.setText(order?.billingAddress1)
+                        binding.address2.setText(order?.billingAddress2)
+                        binding.city.setText(order?.billingCity)
+                        binding.state.setText(order?.billingState)
+                        binding.postcode.setText(order?.billingPostcode)
+
+                        binding.email.apply {
+                            setText(order?.billingEmail)
+                            visibility = View.VISIBLE
+                        }
+                        binding.phone.apply {
+                            setText(order?.billingPhone)
+                            visibility = View.VISIBLE
+                        }
+                    }
+                }
+            }.collect()
+        }
+
+        sendUpdate.setOnClickListener {
+            selectedOrder.value?.let { order ->
+                CoroutineScope(Dispatchers.IO).launch {
+                    val newAddress = when (currentAddressType.value) {
+                        SHIPPING -> OrderAddress.Shipping(
+                                firstName = binding.firstName.text.toString(),
+                                lastName = binding.lastName.text.toString(),
+                                company = binding.company.text.toString(),
+                                address1 = binding.address1.text.toString(),
+                                address2 = binding.address2.text.toString(),
+                                city = binding.city.text.toString(),
+                                state = binding.state.text.toString(),
+                                postcode = binding.postcode.text.toString(),
+                                country = binding.country.text.toString()
+                        )
+                        BILLING -> OrderAddress.Billing(
+                                firstName = binding.firstName.text.toString(),
+                                lastName = binding.lastName.text.toString(),
+                                company = binding.company.text.toString(),
+                                address1 = binding.address1.text.toString(),
+                                address2 = binding.address2.text.toString(),
+                                city = binding.city.text.toString(),
+                                state = binding.state.text.toString(),
+                                postcode = binding.postcode.text.toString(),
+                                country = binding.country.text.toString(),
+                                phone = binding.phone.text.toString(),
+                                email = binding.email.text.toString()
+                        )
+                    }
+
+                    orderUpdateStore.updateOrderAddress(
+                            orderLocalId = LocalId(order.id),
+                            newAddress = newAddress
+                    ).collect {
+                        CoroutineScope(Dispatchers.Main).launch {
+                            prependToLog("${it::class.simpleName} - Error: ${it.event.error?.message}")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun newInstance(order: WCOrderModel) = AddressEditDialogFragment().also { fragment ->
+            CoroutineScope(Dispatchers.IO).launch {
+                fragment.selectedOrder.value = order
+            }
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.WCAddOrderShipmentTrackingDialog
 import org.wordpress.android.fluxc.example.WCOrderListActivity
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
@@ -361,6 +362,14 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     val payload = FetchOrderShipmentProvidersPayload(site, order)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentProvidersAction(payload))
                 } ?: prependToLog("No orders found in db to use as seed. Fetch orders first.")
+            }
+        }
+
+        update_latest_order_billing_address.setOnClickListener {
+            selectedSite?.let { site ->
+                wcOrderStore.getOrdersForSite(site).firstOrNull()?.let { order ->
+                    replaceFragment(AddressEditDialogFragment.newInstance(order))
+                } ?: showNoOrdersToast(site)
             }
         }
     }

--- a/example/src/main/res/layout/fragment_address_edit_dialog.xml
+++ b/example/src/main/res/layout/fragment_address_edit_dialog.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:columnCount="2"
+    android:padding="16dp"
+    android:rowCount="8"
+    android:stretchMode="columnWidth"
+    tools:context=".ui.orders.AddressEditDialogFragment">
+
+    <Switch
+        android:id="@+id/addressTypeSwitch"
+        android:layout_width="match_parent"
+        android:layout_row="0"
+        android:layout_column="0"
+        android:layout_columnSpan="2"
+        android:text="Update Shipping Address"
+        android:textSize="16sp" />
+
+    <EditText
+        android:id="@+id/firstName"
+        android:layout_width="0dp"
+        android:layout_row="1"
+        android:layout_column="0"
+        android:layout_columnWeight="1"
+        android:hint="First name" />
+
+    <EditText
+        android:id="@+id/lastName"
+        android:layout_width="0dp"
+        android:layout_row="1"
+        android:layout_column="1"
+        android:layout_columnWeight="1"
+        android:hint="Last name" />
+
+    <EditText
+        android:id="@+id/company"
+        android:layout_width="0dp"
+        android:layout_row="2"
+        android:layout_column="0"
+        android:layout_columnWeight="1"
+        android:hint="Company" />
+
+    <EditText
+        android:id="@+id/address1"
+        android:layout_width="0dp"
+        android:layout_row="2"
+        android:layout_column="1"
+        android:layout_columnWeight="1"
+        android:hint="Address 1" />
+
+    <EditText
+        android:id="@+id/address2"
+        android:layout_width="0dp"
+        android:layout_row="3"
+        android:layout_column="0"
+        android:layout_columnWeight="1"
+        android:hint="Address 2" />
+
+    <EditText
+        android:id="@+id/city"
+        android:layout_width="0dp"
+        android:layout_row="3"
+        android:layout_column="1"
+        android:layout_columnWeight="1"
+        android:hint="City" />
+
+    <EditText
+        android:id="@+id/state"
+        android:layout_width="0dp"
+        android:layout_row="4"
+        android:layout_column="0"
+        android:layout_columnWeight="1"
+        android:hint="State" />
+
+    <EditText
+        android:id="@+id/postcode"
+        android:layout_width="0dp"
+        android:layout_row="4"
+        android:layout_column="1"
+        android:layout_columnWeight="1"
+        android:hint="Post code" />
+
+    <EditText
+        android:id="@+id/country"
+        android:layout_width="match_parent"
+        android:layout_row="5"
+        android:layout_column="0"
+        android:layout_columnSpan="2"
+        android:hint="Country" />
+
+    <EditText
+        android:id="@+id/email"
+        android:layout_width="0dp"
+        android:layout_row="6"
+        android:layout_column="0"
+        android:layout_columnWeight="1"
+        android:hint="Email" />
+
+    <EditText
+        android:id="@+id/phone"
+        android:layout_width="0dp"
+        android:layout_row="6"
+        android:layout_column="1"
+        android:layout_columnWeight="1"
+        android:hint="Phone" />
+
+    <Button
+        android:id="@+id/sendUpdate"
+        android:layout_width="match_parent"
+        android:layout_row="7"
+        android:layout_column="0"
+        android:layout_columnSpan="2"
+        android:text="Send update" />
+
+</GridLayout>

--- a/example/src/main/res/layout/fragment_address_edit_dialog.xml
+++ b/example/src/main/res/layout/fragment_address_edit_dialog.xml
@@ -84,27 +84,27 @@
 
     <EditText
         android:id="@+id/country"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_row="5"
         android:layout_column="0"
-        android:layout_columnSpan="2"
-        android:hint="Country" />
-
-    <EditText
-        android:id="@+id/email"
-        android:layout_width="0dp"
-        android:layout_row="6"
-        android:layout_column="0"
         android:layout_columnWeight="1"
-        android:hint="Email" />
+        android:hint="Country" />
 
     <EditText
         android:id="@+id/phone"
         android:layout_width="0dp"
-        android:layout_row="6"
+        android:layout_row="5"
         android:layout_column="1"
         android:layout_columnWeight="1"
         android:hint="Phone" />
+
+    <EditText
+        android:id="@+id/email"
+        android:layout_width="match_parent"
+        android:layout_row="6"
+        android:layout_column="0"
+        android:layout_columnSpan="2"
+        android:hint="Email" />
 
     <Button
         android:id="@+id/sendUpdate"

--- a/example/src/main/res/layout/fragment_woo_orders.xml
+++ b/example/src/main/res/layout/fragment_woo_orders.xml
@@ -131,5 +131,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Update Latest Order Customer Notes" />
+
+        <Button
+            android:id="@+id/update_latest_order_billing_address"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Update latest order billing address" />
     </LinearLayout>
 </ScrollView>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
@@ -13,6 +13,7 @@ import com.wellsql.generated.SiteModelTable
 import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostFormatModel
 import org.wordpress.android.fluxc.model.RoleModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -36,6 +37,13 @@ class SiteSqlUtils
     object DuplicateSiteException : Exception() {
         private const val serialVersionUID = -224883903136726226L
     }
+
+    fun getSiteWithLocalId(id: LocalId): SiteModel? = WellSql.select(SiteModel::class.java)
+            .where()
+            .equals(SiteModelTable.ID, id.value)
+            .endWhere()
+            .asModel
+            .firstOrNull()
 
     fun getSitesWithLocalId(id: Int): List<SiteModel> {
         return WellSql.select(SiteModel::class.java)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1823,6 +1823,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 164 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD IS_JETPACK_CP_CONNECTED BOOLEAN")
                 }
+                165 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCOrderModel ADD SHIPPING_PHONE TEXT")
+                }
             }
         }
         db.setTransactionSuccessful()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -58,6 +58,7 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     @Column var shippingState = ""
     @Column var shippingPostcode = ""
     @Column var shippingCountry = ""
+    @Column var shippingPhone = ""
 
     @Column var lineItems = ""
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -8,7 +8,6 @@ import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.model.order.OrderAddress
-import org.wordpress.android.fluxc.model.order.OrderAddress.AddressType
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
@@ -149,12 +148,12 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
     /**
      * Returns the billing details wrapped in a [OrderAddress].
      */
-    fun getBillingAddress() = OrderAddress(this, AddressType.BILLING)
+    fun getBillingAddress() = OrderAddress.Billing(this)
 
     /**
      * Returns the shipping details wrapped in a [OrderAddress].
      */
-    fun getShippingAddress() = OrderAddress(this, AddressType.SHIPPING)
+    fun getShippingAddress() = OrderAddress.Shipping(this)
 
     /**
      * Deserializes the JSON contained in [lineItems] into a list of [LineItem] objects.

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderAddress.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderAddress.kt
@@ -2,45 +2,66 @@ package org.wordpress.android.fluxc.model.order
 
 import org.wordpress.android.fluxc.model.WCOrderModel
 
-class OrderAddress(orderModel: WCOrderModel, type: AddressType) {
-    enum class AddressType {
-        SHIPPING, BILLING
+sealed class OrderAddress {
+    abstract val firstName: String
+    abstract val lastName: String
+    abstract val company: String
+    abstract val address1: String
+    abstract val address2: String
+    abstract val city: String
+    abstract val state: String
+    abstract val postcode: String
+    abstract val country: String
+
+    data class Shipping(
+        override val firstName: String,
+        override val lastName: String,
+        override val company: String,
+        override val address1: String,
+        override val address2: String,
+        override val city: String,
+        override val state: String,
+        override val postcode: String,
+        override val country: String
+    ) : OrderAddress() {
+        constructor(orderModel: WCOrderModel) : this(
+                firstName = orderModel.shippingFirstName,
+                lastName = orderModel.shippingLastName,
+                company = orderModel.shippingCompany,
+                address1 = orderModel.shippingAddress1,
+                address2 = orderModel.shippingAddress2,
+                city = orderModel.shippingCity,
+                state = orderModel.shippingState,
+                postcode = orderModel.shippingPostcode,
+                country = orderModel.shippingCountry
+        )
     }
 
-    val firstName: String
-    val lastName: String
-    val company: String
-    val address1: String
-    val address2: String
-    val city: String
-    val state: String
-    val postcode: String
-    val country: String
-
-    init {
-        when (type) {
-            AddressType.BILLING -> {
-                firstName = orderModel.billingFirstName
-                lastName = orderModel.billingLastName
-                company = orderModel.billingCompany
-                address1 = orderModel.billingAddress1
-                address2 = orderModel.billingAddress2
-                city = orderModel.billingCity
-                state = orderModel.billingState
-                postcode = orderModel.billingPostcode
+    data class Billing(
+        val phone: String,
+        val email: String,
+        override val firstName: String,
+        override val lastName: String,
+        override val company: String,
+        override val address1: String,
+        override val address2: String,
+        override val city: String,
+        override val state: String,
+        override val postcode: String,
+        override val country: String
+    ) : OrderAddress() {
+        constructor(orderModel: WCOrderModel) : this(
+                phone = orderModel.billingPhone,
+                email = orderModel.billingEmail,
+                firstName = orderModel.billingFirstName,
+                lastName = orderModel.billingLastName,
+                company = orderModel.billingCompany,
+                address1 = orderModel.billingAddress1,
+                address2 = orderModel.billingAddress2,
+                city = orderModel.billingCity,
+                state = orderModel.billingState,
+                postcode = orderModel.billingPostcode,
                 country = orderModel.billingCountry
-            }
-            AddressType.SHIPPING -> {
-                firstName = orderModel.shippingFirstName
-                lastName = orderModel.shippingLastName
-                company = orderModel.shippingCompany
-                address1 = orderModel.shippingAddress1
-                address2 = orderModel.shippingAddress2
-                city = orderModel.shippingCity
-                state = orderModel.shippingState
-                postcode = orderModel.shippingPostcode
-                country = orderModel.shippingCountry
-            }
-        }
+        )
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderAddress.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/OrderAddress.kt
@@ -12,6 +12,7 @@ sealed class OrderAddress {
     abstract val state: String
     abstract val postcode: String
     abstract val country: String
+    abstract val phone: String
 
     data class Shipping(
         override val firstName: String,
@@ -22,7 +23,8 @@ sealed class OrderAddress {
         override val city: String,
         override val state: String,
         override val postcode: String,
-        override val country: String
+        override val country: String,
+        override val phone: String
     ) : OrderAddress() {
         constructor(orderModel: WCOrderModel) : this(
                 firstName = orderModel.shippingFirstName,
@@ -33,12 +35,12 @@ sealed class OrderAddress {
                 city = orderModel.shippingCity,
                 state = orderModel.shippingState,
                 postcode = orderModel.shippingPostcode,
-                country = orderModel.shippingCountry
+                country = orderModel.shippingCountry,
+                phone = orderModel.shippingPhone
         )
     }
 
     data class Billing(
-        val phone: String,
         val email: String,
         override val firstName: String,
         override val lastName: String,
@@ -48,10 +50,10 @@ sealed class OrderAddress {
         override val city: String,
         override val state: String,
         override val postcode: String,
-        override val country: String
+        override val country: String,
+        override val phone: String
     ) : OrderAddress() {
         constructor(orderModel: WCOrderModel) : this(
-                phone = orderModel.billingPhone,
                 email = orderModel.billingEmail,
                 firstName = orderModel.billingFirstName,
                 lastName = orderModel.billingLastName,
@@ -61,7 +63,8 @@ sealed class OrderAddress {
                 city = orderModel.billingCity,
                 state = orderModel.billingState,
                 postcode = orderModel.billingPostcode,
-                country = orderModel.billingCountry
+                country = orderModel.billingCountry,
+                phone = orderModel.billingPhone
         )
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
@@ -4,32 +4,32 @@ import com.google.gson.JsonElement
 import org.wordpress.android.fluxc.network.Response
 
 @Suppress("PropertyName")
-class OrderApiResponse : Response {
-    class Billing {
-        val first_name: String? = null
-        val last_name: String? = null
-        val company: String? = null
-        val address_1: String? = null
-        val address_2: String? = null
-        val city: String? = null
-        val state: String? = null
-        val postcode: String? = null
-        val country: String? = null
-        val email: String? = null
+class OrderDto : Response {
+    data class Billing(
+        val first_name: String? = null,
+        val last_name: String? = null,
+        val company: String? = null,
+        val address_1: String? = null,
+        val address_2: String? = null,
+        val city: String? = null,
+        val state: String? = null,
+        val postcode: String? = null,
+        val country: String? = null,
+        val email: String? = null,
         val phone: String? = null
-    }
+    )
 
-    class Shipping {
-        val first_name: String? = null
-        val last_name: String? = null
-        val company: String? = null
-        val address_1: String? = null
-        val address_2: String? = null
-        val city: String? = null
-        val state: String? = null
-        val postcode: String? = null
+    data class Shipping(
+        val first_name: String? = null,
+        val last_name: String? = null,
+        val company: String? = null,
+        val address_1: String? = null,
+        val address_2: String? = null,
+        val city: String? = null,
+        val state: String? = null,
+        val postcode: String? = null,
         val country: String? = null
-    }
+    )
 
     class CouponLine {
         val code: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -1,0 +1,31 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
+
+import org.wordpress.android.fluxc.model.order.OrderAddress
+
+object OrderDtoMapper {
+    fun OrderAddress.Billing.toDto() = OrderDto.Billing(
+            first_name = this.firstName,
+            last_name = this.lastName,
+            company = this.company,
+            address_1 = this.address1,
+            address_2 = this.address2,
+            city = this.city,
+            state = this.state,
+            postcode = this.postcode,
+            country = this.country,
+            email = this.email,
+            phone = this.phone
+    )
+
+    fun OrderAddress.Shipping.toDto() = OrderDto.Shipping(
+            first_name = this.firstName,
+            last_name = this.lastName,
+            company = this.company,
+            address_1 = this.address1,
+            address_2 = this.address2,
+            city = this.city,
+            state = this.state,
+            postcode = this.postcode,
+            country = this.country
+    )
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -27,6 +27,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Shipping
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingResponsePayload
@@ -81,14 +83,14 @@ class OrderRestClient @Inject constructor(
         val statusFilter = filterByStatus.takeUnless { it.isNullOrBlank() } ?: WCOrderStore.DEFAULT_ORDER_STATUS
 
         val url = WOOCOMMERCE.orders.pathV3
-        val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
+        val responseType = object : TypeToken<List<OrderDto>>() {}.type
         val params = mapOf(
                 "per_page" to WCOrderStore.NUM_ORDERS_PER_FETCH.toString(),
                 "offset" to offset.toString(),
                 "status" to statusFilter,
                 "_fields" to ORDER_FIELDS)
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
-                { response: List<OrderApiResponse>? ->
+                { response: List<OrderDto>? ->
                     val orderModels = response?.map {
                         orderResponseToOrderModel(it).apply { localSiteId = site.id }
                     }.orEmpty()
@@ -178,13 +180,13 @@ class OrderRestClient @Inject constructor(
      */
     fun fetchOrdersByIds(site: SiteModel, remoteOrderIds: List<RemoteId>) {
         val url = WOOCOMMERCE.orders.pathV3
-        val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
+        val responseType = object : TypeToken<List<OrderDto>>() {}.type
         val params = mapOf(
                 "per_page" to remoteOrderIds.size.toString(),
                 "include" to remoteOrderIds.map { it.value }.joinToString(),
                 "_fields" to ORDER_FIELDS)
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
-                { response: List<OrderApiResponse>? ->
+                { response: List<OrderDto>? ->
                     val orderModels = response?.map {
                         orderResponseToOrderModel(it).apply { localSiteId = site.id }
                     }.orEmpty()
@@ -245,7 +247,7 @@ class OrderRestClient @Inject constructor(
      */
     fun searchOrders(site: SiteModel, searchQuery: String, offset: Int) {
         val url = WOOCOMMERCE.orders.pathV3
-        val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
+        val responseType = object : TypeToken<List<OrderDto>>() {}.type
         val params = mutableMapOf(
                 "per_page" to WCOrderStore.NUM_ORDERS_PER_FETCH.toString(),
                 "offset" to offset.toString(),
@@ -254,7 +256,7 @@ class OrderRestClient @Inject constructor(
         ).putIfNotEmpty("search" to searchQuery)
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
-                { response: List<OrderApiResponse>? ->
+                { response: List<OrderDto>? ->
                     val orderModels = response?.map {
                         orderResponseToOrderModel(it).apply { localSiteId = site.id }
                     }.orEmpty()
@@ -287,7 +289,7 @@ class OrderRestClient @Inject constructor(
                 site,
                 url,
                 params,
-                OrderApiResponse::class.java
+                OrderDto::class.java
         )
 
         return when (response) {
@@ -360,13 +362,13 @@ class OrderRestClient @Inject constructor(
         val statusFilter = if (filterByStatus.isNullOrBlank()) { "any" } else { filterByStatus }
 
         val url = WOOCOMMERCE.orders.pathV3
-        val responseType = object : TypeToken<List<OrderApiResponse>>() {}.type
+        val responseType = object : TypeToken<List<OrderDto>>() {}.type
         val params = mapOf(
                 "per_page" to "1",
                 "offset" to "0",
                 "status" to statusFilter)
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
-                { response: List<OrderApiResponse>? ->
+                { response: List<OrderDto>? ->
                     val orderModels = response?.map {
                         orderResponseToOrderModel(it).apply { localSiteId = site.id }
                     }.orEmpty()
@@ -400,7 +402,7 @@ class OrderRestClient @Inject constructor(
             site = site,
             url = url,
             body = updatePayload.plus("_fields" to ORDER_FIELDS),
-            clazz = OrderApiResponse::class.java
+            clazz = OrderDto::class.java
         )
 
         return when (response) {
@@ -720,7 +722,7 @@ class OrderRestClient @Inject constructor(
         }
     }
 
-    private fun orderResponseToOrderModel(response: OrderApiResponse): WCOrderModel {
+    private fun orderResponseToOrderModel(response: OrderDto): WCOrderModel {
         return WCOrderModel().apply {
             remoteOrderId = response.id ?: 0
             number = response.number ?: remoteOrderId.toString()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -393,7 +393,7 @@ class OrderRestClient @Inject constructor(
     private suspend fun updateOrder(
         orderToUpdate: WCOrderModel,
         site: SiteModel,
-        updatePayload: Map<String, String>
+        updatePayload: Map<String, Any>
     ): RemoteOrderPayload {
         val url = WOOCOMMERCE.orders.id(orderToUpdate.remoteOrderId).pathV3
 
@@ -435,6 +435,12 @@ class OrderRestClient @Inject constructor(
 
     suspend fun updateCustomerOrderNote(orderToUpdate: WCOrderModel, site: SiteModel, newNotes: String) =
             updateOrder(orderToUpdate, site, mapOf("customer_note" to newNotes))
+
+    suspend fun updateBillingAddress(orderToUpdate: WCOrderModel, site: SiteModel, billing: Billing) =
+            updateOrder(orderToUpdate, site, mapOf("billing" to billing))
+
+    suspend fun updateShippingAddress(orderToUpdate: WCOrderModel, site: SiteModel, shipping: Shipping) =
+            updateOrder(orderToUpdate, site, mapOf("shipping" to shipping))
 
     /**
      * Makes a GET call to `/wc/v3/orders/<id>/notes` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/wrappers/OrderSqlDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/wrappers/OrderSqlDao.kt
@@ -5,12 +5,12 @@ import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import javax.inject.Inject
 
-typealias RowAffected = Int
+typealias RowsAffected = Int
 
 internal class OrderSqlDao @Inject constructor() {
-    fun insertOrUpdateOrder(order: WCOrderModel): RowAffected = OrderSqlUtils.insertOrUpdateOrder(order)
+    fun insertOrUpdateOrder(order: WCOrderModel): RowsAffected = OrderSqlUtils.insertOrUpdateOrder(order)
 
-    fun updateLocalOrder(localOrderId: Int, updateOrder: WCOrderModel.() -> Unit): RowAffected {
+    fun updateLocalOrder(localOrderId: Int, updateOrder: WCOrderModel.() -> Unit): RowsAffected {
         val updatedOrder = OrderSqlUtils.getOrderByLocalId(localOrderId)
                 .apply(updateOrder)
         return OrderSqlUtils.insertOrUpdateOrder(updatedOrder)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -1,12 +1,20 @@
 package org.wordpress.android.fluxc.store
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.order.OrderAddress
+import org.wordpress.android.fluxc.model.order.OrderAddress.Billing
+import org.wordpress.android.fluxc.model.order.OrderAddress.Shipping
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDtoMapper.toDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.wrappers.OrderSqlDao
-import org.wordpress.android.fluxc.persistence.wrappers.RowAffected
+import org.wordpress.android.fluxc.persistence.wrappers.RowsAffected
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -18,10 +26,12 @@ import javax.inject.Singleton
 class OrderUpdateStore @Inject internal constructor(
     private val coroutineEngine: CoroutineEngine,
     private val wcOrderRestClient: OrderRestClient,
-    private val orderSqlDao: OrderSqlDao
+    private val orderSqlDao: OrderSqlDao,
+    private val siteSqlUtils: SiteSqlUtils
 ) {
     suspend fun updateCustomerOrderNote(
         orderLocalId: LocalId,
+            // todo wzieba: Remove site argument. As we have local order id we can get site from database. No need to bother client with that.
         site: SiteModel,
         newCustomerNote: String
     ): Flow<UpdateOrderResult> {
@@ -29,15 +39,9 @@ class OrderUpdateStore @Inject internal constructor(
             val initialOrder = orderSqlDao.getOrderByLocalId(orderLocalId)
 
             if (initialOrder == null) {
-                emit(UpdateOrderResult.OptimisticUpdateResult(
-                        OnOrderChanged(NO_ROWS_AFFECTED).apply {
-                            error = WCOrderStore.OrderError(
-                                    message = "Order with id ${orderLocalId.value} not found"
-                            )
-                        }
-                ))
+                emitNoEntityFound("Order with id ${orderLocalId.value} not found")
             } else {
-                val optimisticUpdateRowsAffected: RowAffected = orderSqlDao.updateLocalOrder(initialOrder.id) {
+                val optimisticUpdateRowsAffected: RowsAffected = orderSqlDao.updateLocalOrder(initialOrder.id) {
                     customerNote = newCustomerNote
                 }
                 emit(UpdateOrderResult.OptimisticUpdateResult(OnOrderChanged(optimisticUpdateRowsAffected)))
@@ -47,16 +51,92 @@ class OrderUpdateStore @Inject internal constructor(
                         site,
                         newCustomerNote
                 )
-                val remoteUpdateResult = if (updateRemoteOrderPayload.isError) {
-                    OnOrderChanged(orderSqlDao.insertOrUpdateOrder(initialOrder)).apply {
-                        error = updateRemoteOrderPayload.error
-                    }
-                } else {
-                    OnOrderChanged(orderSqlDao.insertOrUpdateOrder(updateRemoteOrderPayload.order))
-                }
-                emit(RemoteUpdateResult(remoteUpdateResult))
+
+                emitRemoteUpdateResultOrRevertOnError(updateRemoteOrderPayload, initialOrder)
             }
         }
+    }
+
+    suspend fun updateOrderAddress(
+        orderLocalId: LocalId,
+        newAddress: OrderAddress
+    ): Flow<UpdateOrderResult> {
+        return coroutineEngine.flowWithDefaultContext(T.API, this, "updateOrderAddress") {
+            val initialOrder = orderSqlDao.getOrderByLocalId(orderLocalId)
+            if (initialOrder == null) {
+                emitNoEntityFound("Order with id ${orderLocalId.value} not found")
+            } else {
+                val site = siteSqlUtils.getSiteWithLocalId(LocalId(initialOrder.localSiteId))
+                if (site == null) {
+                    emitNoEntityFound("Site with local id ${initialOrder.localSiteId} not found")
+                } else {
+                    val optimisticUpdateRowsAffected: RowsAffected = updateLocalOrderAddress(initialOrder, newAddress)
+                    emit(UpdateOrderResult.OptimisticUpdateResult(OnOrderChanged(optimisticUpdateRowsAffected)))
+
+                    val updateRemoteOrderPayload = when (newAddress) {
+                        is Billing -> wcOrderRestClient.updateBillingAddress(initialOrder, site, newAddress.toDto())
+                        is Shipping -> wcOrderRestClient.updateShippingAddress(initialOrder, site, newAddress.toDto())
+                    }
+
+                    emitRemoteUpdateResultOrRevertOnError(updateRemoteOrderPayload, initialOrder)
+                }
+            }
+        }
+    }
+
+    private fun updateLocalOrderAddress(
+        initialOrder: WCOrderModel,
+        newAddress: OrderAddress
+    ) = orderSqlDao.updateLocalOrder(initialOrder.id) {
+        when (newAddress) {
+            is Billing -> {
+                this.billingFirstName = newAddress.firstName
+                this.billingLastName = newAddress.lastName
+                this.billingCompany = newAddress.company
+                this.billingAddress1 = newAddress.address1
+                this.billingAddress2 = newAddress.address2
+                this.billingCity = newAddress.city
+                this.billingState = newAddress.state
+                this.billingPostcode = newAddress.postcode
+                this.billingCountry = newAddress.country
+                this.billingEmail = newAddress.email
+                this.billingPhone = newAddress.phone
+            }
+            is Shipping -> {
+                this.shippingFirstName = newAddress.firstName
+                this.shippingLastName = newAddress.lastName
+                this.shippingCompany = newAddress.company
+                this.shippingAddress1 = newAddress.address1
+                this.shippingAddress2 = newAddress.address2
+                this.shippingCity = newAddress.city
+                this.shippingState = newAddress.state
+                this.shippingPostcode = newAddress.postcode
+                this.shippingCountry = newAddress.country
+            }
+        }
+    }
+
+    private suspend fun FlowCollector<UpdateOrderResult>.emitRemoteUpdateResultOrRevertOnError(
+        updateRemoteOrderPayload: RemoteOrderPayload,
+        initialOrder: WCOrderModel
+    ) {
+        val remoteUpdateResult = if (updateRemoteOrderPayload.isError) {
+            OnOrderChanged(orderSqlDao.insertOrUpdateOrder(initialOrder)).apply {
+                error = updateRemoteOrderPayload.error
+            }
+        } else {
+            OnOrderChanged(orderSqlDao.insertOrUpdateOrder(updateRemoteOrderPayload.order))
+        }
+
+        emit(RemoteUpdateResult(remoteUpdateResult))
+    }
+
+    private suspend fun FlowCollector<UpdateOrderResult>.emitNoEntityFound(message: String) {
+        emit(UpdateOrderResult.OptimisticUpdateResult(
+                OnOrderChanged(NO_ROWS_AFFECTED).apply {
+                    error = WCOrderStore.OrderError(message = message)
+                }
+        ))
     }
 
     private companion object {

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -310,7 +310,7 @@ class OrderUpdateStoreTest {
             id = TEST_LOCAL_SITE_ID
         }
 
-        val emptyShipping = OrderAddress.Shipping("", "", "", "", "", "", "", "", "")
+        val emptyShipping = OrderAddress.Shipping("", "", "", "", "", "", "", "", "", "")
         val emptyShippingDto = Shipping("", "", "", "", "", "", "", "", "")
     }
 }


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/4897
Closes https://github.com/woocommerce/woocommerce-android/issues/4902

### Description

This PR:
- adds API for updating (optimistically + remotely) billing and shipping addresses
- adds support for `phone` field in `shipping` address
- adds sample app test view

### Demo

https://user-images.githubusercontent.com/5845095/137497374-c513ba4b-ef44-4392-af8f-274d0e6689c4.mov

### How to test

#### TC1 Successful update

1. In example app, go to `Woo` > `Order` > `Update latest order billing address`
2. Edit some fields of either billing or shipping addresses
3. Click on `Send update`
4. **Assert there are two results for update (optimistic and remote) and both of them have `null` error**
5. **Assert that order has been updated on web**

#### TC2 Unsuccessful update 

As currently API doesn't support empty email for billing address, you can see how the app behaves on failed request

1. In example app, go to `Woo` > `Order` > `Update latest order billing address`
2. Select billing address, update email to empty value
3. Click on `Send update`
4. **Assert there are two results for update (optimistic and remote) and remote has an error**
5. Go back to `Orders`
6. Click on `Select site` again (there's a bug - you shouldn't have to. I plan to fix it).
7. Go to back to `Update latest order billing address`
8. Select billing address edit
9. **Assert there's old email (not blank one)**