### PR TITLE
Enable updating both order addresses on the same request

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
@@ -34,6 +34,7 @@ class AddressEditDialogFragment : DaggerFragment() {
     private lateinit var binding: FragmentAddressEditDialogBinding
 
     var selectedOrder = MutableStateFlow<WCOrderModel?>(null)
+    var originalBillingEmail = ""
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -51,6 +52,7 @@ class AddressEditDialogFragment : DaggerFragment() {
 
         CoroutineScope(Dispatchers.Main).launch {
             currentAddressType.combine(selectedOrder) { addressType, order ->
+                originalBillingEmail = order?.billingEmail.orEmpty()
                 when (addressType) {
                     SHIPPING -> {
                         binding.addressTypeSwitch.text = "Edit shipping address for order ${order?.remoteOrderId}"
@@ -134,6 +136,8 @@ class AddressEditDialogFragment : DaggerFragment() {
             country = binding.country.text.toString(),
             phone = binding.phone.text.toString(),
             email = binding.email.text.toString()
+                    .takeIf { it.isNotEmpty() }
+                    ?: originalBillingEmail
     )
 
     private fun generateShippingAddressModel() = Shipping(

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
@@ -18,7 +18,8 @@ import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.E
 import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.EditTypeState.SHIPPING
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.order.OrderAddress
+import org.wordpress.android.fluxc.model.order.OrderAddress.Billing
+import org.wordpress.android.fluxc.model.order.OrderAddress.Shipping
 import org.wordpress.android.fluxc.store.OrderUpdateStore
 import javax.inject.Inject
 
@@ -88,31 +89,8 @@ class AddressEditDialogFragment : DaggerFragment() {
             selectedOrder.value?.let { order ->
                 CoroutineScope(Dispatchers.IO).launch {
                     val newAddress = when (currentAddressType.value) {
-                        SHIPPING -> OrderAddress.Shipping(
-                                firstName = binding.firstName.text.toString(),
-                                lastName = binding.lastName.text.toString(),
-                                company = binding.company.text.toString(),
-                                address1 = binding.address1.text.toString(),
-                                address2 = binding.address2.text.toString(),
-                                city = binding.city.text.toString(),
-                                state = binding.state.text.toString(),
-                                postcode = binding.postcode.text.toString(),
-                                country = binding.country.text.toString(),
-                                phone = binding.phone.text.toString()
-                        )
-                        BILLING -> OrderAddress.Billing(
-                                firstName = binding.firstName.text.toString(),
-                                lastName = binding.lastName.text.toString(),
-                                company = binding.company.text.toString(),
-                                address1 = binding.address1.text.toString(),
-                                address2 = binding.address2.text.toString(),
-                                city = binding.city.text.toString(),
-                                state = binding.state.text.toString(),
-                                postcode = binding.postcode.text.toString(),
-                                country = binding.country.text.toString(),
-                                phone = binding.phone.text.toString(),
-                                email = binding.email.text.toString()
-                        )
+                        SHIPPING -> generateShippingAddressModel()
+                        BILLING -> generateBillingAddressModel()
                     }
 
                     orderUpdateStore.updateOrderAddress(
@@ -126,7 +104,50 @@ class AddressEditDialogFragment : DaggerFragment() {
                 }
             }
         }
+
+        sendBothAddressesUpdate.setOnClickListener {
+            selectedOrder.value?.let { order ->
+                CoroutineScope(Dispatchers.IO).launch {
+                    orderUpdateStore.updateBothOrderAddresses(
+                            orderLocalId = LocalId(order.id),
+                            shippingAddress = generateShippingAddressModel(),
+                            billingAddress = generateBillingAddressModel()
+                    ).collect {
+                        CoroutineScope(Dispatchers.Main).launch {
+                            prependToLog("${it::class.simpleName} - Error: ${it.event.error?.message}")
+                        }
+                    }
+                }
+            }
+        }
     }
+
+    private fun generateBillingAddressModel() = Billing(
+            firstName = binding.firstName.text.toString(),
+            lastName = binding.lastName.text.toString(),
+            company = binding.company.text.toString(),
+            address1 = binding.address1.text.toString(),
+            address2 = binding.address2.text.toString(),
+            city = binding.city.text.toString(),
+            state = binding.state.text.toString(),
+            postcode = binding.postcode.text.toString(),
+            country = binding.country.text.toString(),
+            phone = binding.phone.text.toString(),
+            email = binding.email.text.toString()
+    )
+
+    private fun generateShippingAddressModel() = Shipping(
+            firstName = binding.firstName.text.toString(),
+            lastName = binding.lastName.text.toString(),
+            company = binding.company.text.toString(),
+            address1 = binding.address1.text.toString(),
+            address2 = binding.address2.text.toString(),
+            city = binding.city.text.toString(),
+            state = binding.state.text.toString(),
+            postcode = binding.postcode.text.toString(),
+            country = binding.country.text.toString(),
+            phone = binding.phone.text.toString()
+    )
 
     companion object {
         @JvmStatic

--- a/example/src/main/res/layout/fragment_address_edit_dialog.xml
+++ b/example/src/main/res/layout/fragment_address_edit_dialog.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:columnCount="2"
     android:padding="16dp"
-    android:rowCount="8"
+    android:rowCount="9"
     android:stretchMode="columnWidth"
     tools:context=".ui.orders.AddressEditDialogFragment">
 
@@ -113,5 +113,13 @@
         android:layout_column="0"
         android:layout_columnSpan="2"
         android:text="Send update" />
+
+    <Button
+        android:id="@+id/sendUpdateToBoth"
+        android:layout_width="match_parent"
+        android:layout_row="8"
+        android:layout_column="0"
+        android:layout_columnSpan="2"
+        android:text="Send update to both addresses" />
 
 </GridLayout>

--- a/example/src/main/res/layout/fragment_address_edit_dialog.xml
+++ b/example/src/main/res/layout/fragment_address_edit_dialog.xml
@@ -120,6 +120,6 @@
         android:layout_row="8"
         android:layout_column="0"
         android:layout_columnSpan="2"
-        android:text="Send both addresses to update" />
+        android:text="Send update replicating both addresses" />
 
 </GridLayout>

--- a/example/src/main/res/layout/fragment_address_edit_dialog.xml
+++ b/example/src/main/res/layout/fragment_address_edit_dialog.xml
@@ -115,11 +115,11 @@
         android:text="Send update" />
 
     <Button
-        android:id="@+id/sendUpdateToBoth"
+        android:id="@+id/sendBothAddressesUpdate"
         android:layout_width="match_parent"
         android:layout_row="8"
         android:layout_column="0"
         android:layout_columnSpan="2"
-        android:text="Send update to both addresses" />
+        android:text="Send both addresses to update" />
 
 </GridLayout>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 165
+        return 166
     }
 
     override fun getDbName(): String {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -442,7 +442,7 @@ class OrderRestClient @Inject constructor(
     suspend fun updateShippingAddress(orderToUpdate: WCOrderModel, site: SiteModel, shipping: Shipping) =
             updateOrder(orderToUpdate, site, mapOf("shipping" to shipping))
 
-    suspend fun updateAllAddresses(
+    suspend fun updateBothOrderAddresses(
         orderToUpdate: WCOrderModel,
         site: SiteModel,
         shipping: Shipping,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -442,6 +442,16 @@ class OrderRestClient @Inject constructor(
     suspend fun updateShippingAddress(orderToUpdate: WCOrderModel, site: SiteModel, shipping: Shipping) =
             updateOrder(orderToUpdate, site, mapOf("shipping" to shipping))
 
+    suspend fun updateAllAddresses(
+        orderToUpdate: WCOrderModel,
+        site: SiteModel,
+        shipping: Shipping,
+        billing: Billing
+    ) = updateOrder(
+            orderToUpdate, site,
+            mapOf("shipping" to shipping, "billing" to billing)
+    )
+
     /**
      * Makes a GET call to `/wc/v3/orders/<id>/notes` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * retrieving a list of notes for the given WooCommerce [SiteModel] and [WCOrderModel].

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -91,7 +91,7 @@ class OrderUpdateStore @Inject internal constructor(
                         billingAddress
                 ).let { emit(UpdateOrderResult.OptimisticUpdateResult(OnOrderChanged(it))) }
 
-                wcOrderRestClient.updateAllAddresses(
+                wcOrderRestClient.updateBothOrderAddresses(
                         initialOrder,
                         site,
                         shippingAddress.toDto(),

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Shipping
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.wrappers.OrderSqlDao
@@ -165,6 +166,45 @@ class OrderUpdateStoreTest {
     }
 
 //    Updating addresses
+@Test
+fun `should optimistically update shipping and billing addresses`(): Unit = runBlocking {
+    // given
+    val updatedOrder = WCOrderModel().apply {
+        shippingFirstName = UPDATED_SHIPPING_FIRST_NAME
+        billingFirstName = UPDATED_BILLING_FIRST_NAME
+    }
+
+    setUp {
+        orderRestClient = mock {
+            onBlocking {
+                updateAllAddresses(
+                        initialOrder,
+                        site,
+                        emptyShippingDto.copy(first_name = UPDATED_SHIPPING_FIRST_NAME),
+                        emptyBillingDto.copy(first_name = UPDATED_BILLING_FIRST_NAME)
+                )
+            } doReturn (RemoteOrderPayload(updatedOrder, site))
+        }
+    }
+
+    // when
+    val results = sut.updateBothOrderAddresses(
+            orderLocalId = LocalId(initialOrder.id),
+            shippingAddress = emptyShipping.copy(firstName = UPDATED_SHIPPING_FIRST_NAME),
+            billingAddress = emptyBilling.copy(firstName = UPDATED_BILLING_FIRST_NAME)
+    ).toList()
+
+    // then
+    assertThat(results).hasSize(2).containsExactly(
+            OptimisticUpdateResult(OnOrderChanged(ROWS_AFFECTED)),
+            RemoteUpdateResult(OnOrderChanged(ROWS_AFFECTED))
+    )
+    verify(orderSqlDao).insertOrUpdateOrder(argThat {
+        shippingFirstName == UPDATED_SHIPPING_FIRST_NAME &&
+        billingFirstName == UPDATED_BILLING_FIRST_NAME
+    })
+}
+
 
     @Test
     fun `should optimistically update shipping address`(): Unit = runBlocking {
@@ -298,6 +338,7 @@ class OrderUpdateStoreTest {
         const val UPDATED_CUSTOMER_NOTE = "updated customer note"
         const val INITIAL_SHIPPING_FIRST_NAME = "original shipping first name"
         const val UPDATED_SHIPPING_FIRST_NAME = "updated shipping first name"
+        const val UPDATED_BILLING_FIRST_NAME = "updated billing first name"
 
         val initialOrder = WCOrderModel().apply {
             id = TEST_LOCAL_ORDER_ID
@@ -311,6 +352,8 @@ class OrderUpdateStoreTest {
         }
 
         val emptyShipping = OrderAddress.Shipping("", "", "", "", "", "", "", "", "", "")
+        val emptyBilling = OrderAddress.Billing("", "", "", "", "", "", "", "", "", "", "")
         val emptyShippingDto = Shipping("", "", "", "", "", "", "", "", "")
+        val emptyBillingDto = Billing("", "", "", "", "", "", "", "", "", "", "")
     }
 }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -177,7 +177,7 @@ fun `should optimistically update shipping and billing addresses`(): Unit = runB
     setUp {
         orderRestClient = mock {
             onBlocking {
-                updateAllAddresses(
+                updateBothOrderAddresses(
                         initialOrder,
                         site,
                         emptyShippingDto.copy(first_name = UPDATED_SHIPPING_FIRST_NAME),


### PR DESCRIPTION
Summary
==========
Fixes issue https://github.com/woocommerce/woocommerce-android/issues/4978 by creating a way to update both Shipping and Billing Addresses of a given Order on a single request. Because of the `use as` toggle inside the Address editing form, we need a way to update both addresses meanwhile avoiding creating duplicated optimistic requests for something that should be a single updating operation.

How to Test
==========
1. Go to the latest store Order on your test site wp-admin dashboard and leave the Billing and Shipping Addresses with different information from each other
![image](https://user-images.githubusercontent.com/5920403/138117170-5ba2ab95-991f-4ce8-87e7-2f8519abdbea.png)

2. Go to the example app and select to update the Billing and Shipping address and hit the `send update replicating both addresses`
<img src="https://user-images.githubusercontent.com/5920403/138115765-dad9ad03-2e59-43d6-8509-878cb37f0b9d.png" width="280" height="585" />

3. Go back to your latest store Order on your test site wp-admin dashboard and verify if the Shipping and Billing Addresses are now the same

<img width="919" alt="Screen Shot 2021-10-20 at 11 42 31" src="https://user-images.githubusercontent.com/5920403/138115812-0b201bbd-e28a-4b77-9bc5-cfa4cdd04964.png">
