### PR TITLE
Publish sources jar to S3

### DIFF
--- a/fluxc-annotations/build.gradle
+++ b/fluxc-annotations/build.gradle
@@ -24,8 +24,3 @@ project.afterEvaluate {
         }
    }
 }
-
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress.fluxc"
-    mavenPublishArtifactId "fluxc-annotations"
-}

--- a/fluxc-annotations/build.gradle
+++ b/fluxc-annotations/build.gradle
@@ -3,6 +3,11 @@ plugins {
     id "com.automattic.android.publish-to-s3"
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -33,8 +33,3 @@ project.afterEvaluate {
         }
    }
 }
-
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress.fluxc"
-    mavenPublishArtifactId "fluxc-processor"
-}

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -5,6 +5,11 @@ plugins {
     id "com.automattic.android.publish-to-s3"
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -111,6 +111,7 @@ project.afterEvaluate {
 
                 groupId "org.wordpress"
                 artifactId "fluxc"
+                artifact tasks.named("androidSourcesJar") // This task is added by 'publish-to-s3' plugin
                 // version is set by 'publish-to-s3' plugin
             }
         }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -117,8 +117,3 @@ project.afterEvaluate {
         }
    }
 }
-
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress"
-    mavenPublishArtifactId "fluxc"
-}

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -90,8 +90,3 @@ project.afterEvaluate {
         }
    }
 }
-
-publishToS3Plugin {
-    mavenPublishGroupId "org.wordpress.fluxc.plugins"
-    mavenPublishArtifactId "woocommerce"
-}

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -84,6 +84,7 @@ project.afterEvaluate {
 
                 groupId "org.wordpress.fluxc.plugins"
                 artifactId "woocommerce"
+                artifact tasks.named("androidSourcesJar") // This task is added by 'publish-to-s3' plugin
                 // version is set by 'publish-to-s3' plugin
             }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
         id "org.jetbrains.kotlin.kapt" version gradle.ext.kotlinVersion
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
-        id "com.automattic.android.publish-to-s3" version "0.6.1"
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
     }
     repositories {
         maven {


### PR DESCRIPTION
This PR updates `publish-to-s3` Gradle plugin to `0.7.0` and uses the newly introduced `androidSourcesJar` task to upload the `-sources.jar` file so it can be used by developers to access the source code from their IDEs. More details can be found in: https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/29

Note that `fluxc-annotations` & `fluxc-processor` are not Android library projects, so the `androidSourcesJar` task can not be used. `java` Gradle plugin has `withSourcesJar()` & `withJavadocJar()` options for this purpose, so they are used for these modules instead.

**To test:**
* Follow the test instructions in https://github.com/wordpress-mobile/WordPress-Android/pull/15492