### PR TITLE
Fix phone info order shipping address

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
@@ -64,7 +64,7 @@ class AddressEditDialogFragment : DaggerFragment() {
                         binding.city.setText(order?.shippingCity)
                         binding.state.setText(order?.shippingState)
                         binding.postcode.setText(order?.shippingPostcode)
-                        binding.phone.setText(order?.billingPhone)
+                        binding.phone.setText(order?.shippingPhone)
                         binding.email.visibility = View.INVISIBLE
                     }
                     BILLING -> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
@@ -28,7 +28,8 @@ class OrderDto : Response {
         val city: String? = null,
         val state: String? = null,
         val postcode: String? = null,
-        val country: String? = null
+        val country: String? = null,
+        val phone: String? = null
     )
 
     class CouponLine {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -26,6 +26,7 @@ object OrderDtoMapper {
             city = this.city,
             state = this.state,
             postcode = this.postcode,
-            country = this.country
+            country = this.country,
+            phone = this.phone
     )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -791,6 +791,7 @@ class OrderRestClient @Inject constructor(
             shippingState = response.shipping?.state ?: ""
             shippingPostcode = response.shipping?.postcode ?: ""
             shippingCountry = response.shipping?.country ?: ""
+            shippingPhone = response.shipping?.phone.orEmpty()
 
             lineItems = response.line_items.toString()
             shippingLines = response.shipping_lines.toString()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -141,6 +141,7 @@ class OrderUpdateStore @Inject internal constructor(
         this.shippingState = newAddress.state
         this.shippingPostcode = newAddress.postcode
         this.shippingCountry = newAddress.country
+        this.shippingPhone = newAddress.phone
     }
 
     private fun WCOrderModel.updateLocalBillingAddress(newAddress: Billing) {

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -352,7 +352,7 @@ class OrderUpdateStoreTest {
 
         val emptyShipping = OrderAddress.Shipping("", "", "", "", "", "", "", "", "", "")
         val emptyBilling = OrderAddress.Billing("", "", "", "", "", "", "", "", "", "", "")
-        val emptyShippingDto = Shipping("", "", "", "", "", "", "", "", "")
+        val emptyShippingDto = Shipping("", "", "", "", "", "", "", "", "", "")
         val emptyBillingDto = Billing("", "", "", "", "", "", "", "", "", "", "")
     }
 }


### PR DESCRIPTION
Summary
==========
This is a quick fix to allow the Shipping Address models to support Phone information since the update was missing some parts to effectively update the info at the site side.

How to Test
==========
1. Go to the Order Address update section
2. Update the Shipping Address phone
3. Verify if the latest order in the Woo Site got updated with the inserted information
