### PR TITLE
Jetpack CP: add support for uploading media using the WPCom's `/wp/v2` API

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.example;
 
+import static android.app.Activity.RESULT_OK;
+
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
@@ -20,6 +22,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.action.MediaAction;
+import org.wordpress.android.fluxc.example.ui.common.FragmentExtKt;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -41,8 +44,6 @@ import java.util.List;
 import javax.inject.Inject;
 
 import dagger.android.support.AndroidSupportInjection;
-
-import static android.app.Activity.RESULT_OK;
 
 public class MediaFragment extends Fragment {
     private static final int RESULT_PICK_MEDIA = 1;
@@ -75,6 +76,11 @@ public class MediaFragment extends Fragment {
         View view = inflater.inflate(R.layout.fragment_media, container, false);
 
         mMediaList = (Spinner) view.findViewById(R.id.media_list);
+
+        view.findViewById(R.id.media_select_site).setOnClickListener(v -> FragmentExtKt.showSiteSelectorDialog(
+                MediaFragment.this,
+                mSiteStore.getSites().indexOf(mSite),
+                (site, pos) -> mSite = site));
 
         mCancelButton = view.findViewById(R.id.cancel_upload);
         mCancelButton.setOnClickListener(new View.OnClickListener() {

--- a/example/src/main/res/layout/fragment_media.xml
+++ b/example/src/main/res/layout/fragment_media.xml
@@ -9,6 +9,12 @@
     tools:context="org.wordpress.android.fluxc.example.MediaFragment">
 
     <Button
+        android:id="@+id/media_select_site"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Select Site" />
+
+    <Button
         android:id="@+id/fetch_media_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPV2MediaRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.MediaSqlUtils;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
@@ -41,7 +42,9 @@ import static org.wordpress.android.fluxc.media.MediaTestUtils.insertRandomMedia
 @RunWith(RobolectricTestRunner.class)
 public class MediaStoreTest {
     private MediaStore mMediaStore = new MediaStore(new Dispatcher(),
-            Mockito.mock(MediaRestClient.class), Mockito.mock(MediaXMLRPCClient.class));
+            Mockito.mock(MediaRestClient.class),
+            Mockito.mock(MediaXMLRPCClient.class),
+            Mockito.mock(WPV2MediaRestClient.class));
 
     @Before
     public void setUp() {

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClientTest.kt
@@ -1,0 +1,146 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
+
+import com.android.volley.RequestQueue
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.IOException
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.UnitTestUtils
+import org.wordpress.android.fluxc.action.UploadAction.UPLOADED_MEDIA
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.media.MediaTestUtils
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import java.io.File
+import java.util.concurrent.CountDownLatch
+
+@RunWith(RobolectricTestRunner::class)
+class WPV2MediaRestClientTest {
+    private val accessToken: AccessToken = mock()
+    private val requestQueue: RequestQueue = mock()
+    private val okHttpClient: OkHttpClient = mock()
+    private val dispatcher: Dispatcher = mock()
+    private val userAgent: UserAgent = mock()
+    private val mockedCall: Call = mock()
+    private lateinit var countDownLatch: CountDownLatch
+    private lateinit var restClient: WPV2MediaRestClient
+
+    private lateinit var dispatchedPayload: ProgressPayload
+
+    @Before
+    fun setup() {
+        restClient = WPV2MediaRestClient(
+                dispatcher = dispatcher,
+                appContext = null,
+                coroutineEngine = initCoroutineEngine(),
+                okHttpClient = okHttpClient,
+                requestQueue = requestQueue,
+                accessToken = accessToken,
+                userAgent = userAgent,
+        )
+        EventBus.getDefault().register(this)
+    }
+
+    @Test
+    fun `emit success action when upload finishes`() {
+        val file = File("./image.jpg")
+        file.createNewFile()
+        whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
+        whenever(mockedCall.enqueue(any())).then {
+            (it.arguments.first() as Callback).onResponse(
+                    mockedCall,
+                    mock {
+                        on { body } doReturn UnitTestUtils.getStringFromResourceFile(
+                                this::class.java,
+                                "media/media-upload-wp-api-success.json"
+                        ).toResponseBody("application/json".toMediaType())
+                        on { isSuccessful } doReturn true
+                    }
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch = CountDownLatch(1)
+        restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+
+        countDownLatch.await()
+        file.delete()
+
+        verify(dispatcher).dispatch(argThat {
+            type == UPLOADED_MEDIA && (payload as ProgressPayload).completed
+        })
+    }
+
+    @Test
+    fun `emit failure action when upload fails`() {
+        val file = File("./image.jpg")
+        file.createNewFile()
+        whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
+        whenever(mockedCall.enqueue(any())).then {
+            (it.arguments.first() as Callback).onFailure(mock(), IOException())
+            countDownLatch.countDown()
+        }
+
+        countDownLatch = CountDownLatch(1)
+        restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+
+        countDownLatch.await()
+        file.delete()
+
+        verify(dispatcher).dispatch(argThat {
+            type == UPLOADED_MEDIA && (payload as ProgressPayload).error != null
+        })
+    }
+
+    @Test
+    fun `emit failure action when we can't parse the response`() {
+        val file = File("./image.jpg")
+        file.createNewFile()
+        whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
+        whenever(mockedCall.enqueue(any())).then {
+            (it.arguments.first() as Callback).onResponse(
+                    mockedCall,
+                    mock {
+                        on { body } doReturn "".toResponseBody("application/json".toMediaType())
+                        on { isSuccessful } doReturn true
+                    }
+            )
+            countDownLatch.countDown()
+        }
+
+        countDownLatch = CountDownLatch(1)
+        restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+
+        countDownLatch.await()
+        file.delete()
+
+        verify(dispatcher).dispatch(argThat {
+            type == UPLOADED_MEDIA && (payload as ProgressPayload).error != null
+        })
+    }
+
+    @Subscribe
+    fun onAction(action: Action<*>) {
+        if (action.type == UPLOADED_MEDIA) {
+            dispatchedPayload = action.payload as ProgressPayload
+        }
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClientTest.kt
@@ -54,7 +54,7 @@ class WPV2MediaRestClientTest {
                 okHttpClient = okHttpClient,
                 requestQueue = requestQueue,
                 accessToken = accessToken,
-                userAgent = userAgent,
+                userAgent = userAgent
         )
         EventBus.getDefault().register(this)
     }

--- a/example/src/test/resources/media/media-upload-wp-api-success.json
+++ b/example/src/test/resources/media/media-upload-wp-api-success.json
@@ -1,0 +1,207 @@
+{
+  "id": 44,
+  "date": "2021-10-25T11:45:28",
+  "date_gmt": "2021-10-25T11:45:28",
+  "guid": {
+    "rendered": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png",
+    "raw": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png"
+  },
+  "modified": "2021-10-25T11:45:28",
+  "modified_gmt": "2021-10-25T11:45:28",
+  "slug": "screenshot_1634547293",
+  "status": "inherit",
+  "type": "attachment",
+  "link": "https://suspicious-beetle.jurassic.ninja/screenshot_1634547293/",
+  "title": {
+    "raw": "Screenshot_1634547293",
+    "rendered": "Screenshot_1634547293"
+  },
+  "author": 1,
+  "comment_status": "open",
+  "ping_status": "closed",
+  "template": "",
+  "meta": [],
+  "permalink_template": "https://suspicious-beetle.jurassic.ninja/?attachment_id=44",
+  "generated_slug": "screenshot_1634547293",
+  "description": {
+    "raw": "",
+    "rendered": "<p class=\"attachment\"><a href='https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png'><img width=\"300\" height=\"211\" src=\"https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-300x211.png\" class=\"attachment-medium size-medium\" alt=\"\" loading=\"lazy\" srcset=\"https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-300x211.png 300w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1024x720.png 1024w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-768x540.png 768w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1536x1080.png 1536w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-2048x1440.png 2048w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1568x1103.png 1568w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-600x422.png 600w\" sizes=\"(max-width: 300px) 100vw, 300px\" style=\"width:100%;height:70.31%;max-width:2560px;\" /></a></p>\n"
+  },
+  "caption": {
+    "raw": "",
+    "rendered": ""
+  },
+  "alt_text": "",
+  "media_type": "image",
+  "mime_type": "image/png",
+  "media_details": {
+    "width": 2560,
+    "height": 1800,
+    "file": "2021/10/Screenshot_1634547293.png",
+    "sizes": {
+      "medium": {
+        "file": "Screenshot_1634547293-300x211.png",
+        "width": 300,
+        "height": 211,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-300x211.png"
+      },
+      "large": {
+        "file": "Screenshot_1634547293-1024x720.png",
+        "width": 1024,
+        "height": 720,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1024x720.png"
+      },
+      "thumbnail": {
+        "file": "Screenshot_1634547293-150x150.png",
+        "width": 150,
+        "height": 150,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-150x150.png"
+      },
+      "medium_large": {
+        "file": "Screenshot_1634547293-768x540.png",
+        "width": 768,
+        "height": 540,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-768x540.png"
+      },
+      "1536x1536": {
+        "file": "Screenshot_1634547293-1536x1080.png",
+        "width": 1536,
+        "height": 1080,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1536x1080.png"
+      },
+      "2048x2048": {
+        "file": "Screenshot_1634547293-2048x1440.png",
+        "width": 2048,
+        "height": 1440,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-2048x1440.png"
+      },
+      "post-thumbnail": {
+        "file": "Screenshot_1634547293-1568x1103.png",
+        "width": 1568,
+        "height": 1103,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1568x1103.png"
+      },
+      "woocommerce_thumbnail": {
+        "file": "Screenshot_1634547293-450x450.png",
+        "width": 450,
+        "height": 450,
+        "uncropped": false,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-450x450.png"
+      },
+      "woocommerce_single": {
+        "file": "Screenshot_1634547293-600x422.png",
+        "width": 600,
+        "height": 422,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-600x422.png"
+      },
+      "woocommerce_gallery_thumbnail": {
+        "file": "Screenshot_1634547293-100x100.png",
+        "width": 100,
+        "height": 100,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-100x100.png"
+      },
+      "shop_catalog": {
+        "file": "Screenshot_1634547293-450x450.png",
+        "width": 450,
+        "height": 450,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-450x450.png"
+      },
+      "shop_single": {
+        "file": "Screenshot_1634547293-600x422.png",
+        "width": 600,
+        "height": 422,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-600x422.png"
+      },
+      "shop_thumbnail": {
+        "file": "Screenshot_1634547293-100x100.png",
+        "width": 100,
+        "height": 100,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-100x100.png"
+      },
+      "full": {
+        "file": "Screenshot_1634547293.png",
+        "width": 2560,
+        "height": 1800,
+        "mime_type": "image/png",
+        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png"
+      }
+    },
+    "image_meta": {
+      "aperture": "0",
+      "credit": "",
+      "camera": "",
+      "caption": "",
+      "created_timestamp": "0",
+      "copyright": "",
+      "focal_length": "0",
+      "iso": "0",
+      "shutter_speed": "0",
+      "title": "",
+      "orientation": "0",
+      "keywords": []
+    }
+  },
+  "post": null,
+  "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png",
+  "missing_image_sizes": [],
+  "_links": {
+    "self": [
+      {
+        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/media/44"
+      }
+    ],
+    "collection": [
+      {
+        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/media"
+      }
+    ],
+    "about": [
+      {
+        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/types/attachment"
+      }
+    ],
+    "author": [
+      {
+        "embeddable": true,
+        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/users/1"
+      }
+    ],
+    "replies": [
+      {
+        "embeddable": true,
+        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/comments?post=44"
+      }
+    ],
+    "wp:action-unfiltered-html": [
+      {
+        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/media/44?post=44"
+      }
+    ],
+    "wp:action-assign-author": [
+      {
+        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/media/44?post=44"
+      }
+    ],
+    "curies": [
+      {
+        "name": "wp",
+        "href": "https://api.w.org/{rel}",
+        "templated": true
+      }
+    ]
+  },
+  "author_wpcom": 191289149
+}

--- a/example/src/test/resources/media/media-upload-wp-api-success.json
+++ b/example/src/test/resources/media/media-upload-wp-api-success.json
@@ -3,29 +3,29 @@
   "date": "2021-10-25T11:45:28",
   "date_gmt": "2021-10-25T11:45:28",
   "guid": {
-    "rendered": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png",
-    "raw": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png"
+    "rendered": "https://siteurl.com/wp-content/uploads/2021/10/file_name.png",
+    "raw": "https://siteurl.com/wp-content/uploads/2021/10/file_name.png"
   },
   "modified": "2021-10-25T11:45:28",
   "modified_gmt": "2021-10-25T11:45:28",
-  "slug": "screenshot_1634547293",
+  "slug": "file_name",
   "status": "inherit",
   "type": "attachment",
-  "link": "https://suspicious-beetle.jurassic.ninja/screenshot_1634547293/",
+  "link": "https://siteurl.com/file_name/",
   "title": {
-    "raw": "Screenshot_1634547293",
-    "rendered": "Screenshot_1634547293"
+    "raw": "file_name",
+    "rendered": "file_name"
   },
   "author": 1,
   "comment_status": "open",
   "ping_status": "closed",
   "template": "",
   "meta": [],
-  "permalink_template": "https://suspicious-beetle.jurassic.ninja/?attachment_id=44",
-  "generated_slug": "screenshot_1634547293",
+  "permalink_template": "https://siteurl.com/?attachment_id=44",
+  "generated_slug": "file_name",
   "description": {
     "raw": "",
-    "rendered": "<p class=\"attachment\"><a href='https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png'><img width=\"300\" height=\"211\" src=\"https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-300x211.png\" class=\"attachment-medium size-medium\" alt=\"\" loading=\"lazy\" srcset=\"https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-300x211.png 300w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1024x720.png 1024w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-768x540.png 768w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1536x1080.png 1536w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-2048x1440.png 2048w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1568x1103.png 1568w, https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-600x422.png 600w\" sizes=\"(max-width: 300px) 100vw, 300px\" style=\"width:100%;height:70.31%;max-width:2560px;\" /></a></p>\n"
+    "rendered": "<p class=\"attachment\"><a href='https://siteurl.com/wp-content/uploads/2021/10/file_name.png'><img width=\"300\" height=\"211\" src=\"https://siteurl.com/wp-content/uploads/2021/10/file_name-300x211.png\" class=\"attachment-medium size-medium\" alt=\"\" loading=\"lazy\" srcset=\"https://siteurl.com/wp-content/uploads/2021/10/file_name-300x211.png 300w, https://siteurl.com/wp-content/uploads/2021/10/file_name-1024x720.png 1024w, https://siteurl.com/wp-content/uploads/2021/10/file_name-768x540.png 768w, https://siteurl.com/wp-content/uploads/2021/10/file_name-1536x1080.png 1536w, https://siteurl.com/wp-content/uploads/2021/10/file_name-2048x1440.png 2048w, https://siteurl.com/wp-content/uploads/2021/10/file_name-1568x1103.png 1568w, https://siteurl.com/wp-content/uploads/2021/10/file_name-600x422.png 600w\" sizes=\"(max-width: 300px) 100vw, 300px\" style=\"width:100%;height:70.31%;max-width:2560px;\" /></a></p>\n"
   },
   "caption": {
     "raw": "",
@@ -37,106 +37,106 @@
   "media_details": {
     "width": 2560,
     "height": 1800,
-    "file": "2021/10/Screenshot_1634547293.png",
+    "file": "2021/10/file_name.png",
     "sizes": {
       "medium": {
-        "file": "Screenshot_1634547293-300x211.png",
+        "file": "file_name-300x211.png",
         "width": 300,
         "height": 211,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-300x211.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-300x211.png"
       },
       "large": {
-        "file": "Screenshot_1634547293-1024x720.png",
+        "file": "file_name-1024x720.png",
         "width": 1024,
         "height": 720,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1024x720.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-1024x720.png"
       },
       "thumbnail": {
-        "file": "Screenshot_1634547293-150x150.png",
+        "file": "file_name-150x150.png",
         "width": 150,
         "height": 150,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-150x150.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-150x150.png"
       },
       "medium_large": {
-        "file": "Screenshot_1634547293-768x540.png",
+        "file": "file_name-768x540.png",
         "width": 768,
         "height": 540,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-768x540.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-768x540.png"
       },
       "1536x1536": {
-        "file": "Screenshot_1634547293-1536x1080.png",
+        "file": "file_name-1536x1080.png",
         "width": 1536,
         "height": 1080,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1536x1080.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-1536x1080.png"
       },
       "2048x2048": {
-        "file": "Screenshot_1634547293-2048x1440.png",
+        "file": "file_name-2048x1440.png",
         "width": 2048,
         "height": 1440,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-2048x1440.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-2048x1440.png"
       },
       "post-thumbnail": {
-        "file": "Screenshot_1634547293-1568x1103.png",
+        "file": "file_name-1568x1103.png",
         "width": 1568,
         "height": 1103,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-1568x1103.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-1568x1103.png"
       },
       "woocommerce_thumbnail": {
-        "file": "Screenshot_1634547293-450x450.png",
+        "file": "file_name-450x450.png",
         "width": 450,
         "height": 450,
         "uncropped": false,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-450x450.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-450x450.png"
       },
       "woocommerce_single": {
-        "file": "Screenshot_1634547293-600x422.png",
+        "file": "file_name-600x422.png",
         "width": 600,
         "height": 422,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-600x422.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-600x422.png"
       },
       "woocommerce_gallery_thumbnail": {
-        "file": "Screenshot_1634547293-100x100.png",
+        "file": "file_name-100x100.png",
         "width": 100,
         "height": 100,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-100x100.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-100x100.png"
       },
       "shop_catalog": {
-        "file": "Screenshot_1634547293-450x450.png",
+        "file": "file_name-450x450.png",
         "width": 450,
         "height": 450,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-450x450.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-450x450.png"
       },
       "shop_single": {
-        "file": "Screenshot_1634547293-600x422.png",
+        "file": "file_name-600x422.png",
         "width": 600,
         "height": 422,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-600x422.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-600x422.png"
       },
       "shop_thumbnail": {
-        "file": "Screenshot_1634547293-100x100.png",
+        "file": "file_name-100x100.png",
         "width": 100,
         "height": 100,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293-100x100.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name-100x100.png"
       },
       "full": {
-        "file": "Screenshot_1634547293.png",
+        "file": "file_name.png",
         "width": 2560,
         "height": 1800,
         "mime_type": "image/png",
-        "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png"
+        "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name.png"
       }
     },
     "image_meta": {
@@ -155,44 +155,44 @@
     }
   },
   "post": null,
-  "source_url": "https://suspicious-beetle.jurassic.ninja/wp-content/uploads/2021/10/Screenshot_1634547293.png",
+  "source_url": "https://siteurl.com/wp-content/uploads/2021/10/file_name.png",
   "missing_image_sizes": [],
   "_links": {
     "self": [
       {
-        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/media/44"
+        "href": "https://public-api.wordpress.com/wp/v2/sites/[site_id]/media/44"
       }
     ],
     "collection": [
       {
-        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/media"
+        "href": "https://public-api.wordpress.com/wp/v2/sites/[site_id]/media"
       }
     ],
     "about": [
       {
-        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/types/attachment"
+        "href": "https://public-api.wordpress.com/wp/v2/sites/[site_id]/types/attachment"
       }
     ],
     "author": [
       {
         "embeddable": true,
-        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/users/1"
+        "href": "https://public-api.wordpress.com/wp/v2/sites/[site_id]/users/1"
       }
     ],
     "replies": [
       {
         "embeddable": true,
-        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/comments?post=44"
+        "href": "https://public-api.wordpress.com/wp/v2/sites/[site_id]/comments?post=44"
       }
     ],
     "wp:action-unfiltered-html": [
       {
-        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/media/44?post=44"
+        "href": "https://public-api.wordpress.com/wp/v2/sites/[site_id]/media/44?post=44"
       }
     ],
     "wp:action-assign-author": [
       {
-        "href": "https://public-api.wordpress.com/wp/v2/sites/198991431/media/44?post=44"
+        "href": "https://public-api.wordpress.com/wp/v2/sites/[site_id]/media/44?post=44"
       }
     ],
     "curies": [

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPAPIEndpoint.java
@@ -1,7 +1,9 @@
 package org.wordpress.android.fluxc.annotations.endpoint;
 
 public class WPAPIEndpoint {
+    private static final String WPCOM_REST_PREFIX = "https://public-api.wordpress.com";
     private static final String WPAPI_PREFIX_V2 = "wp/v2";
+    private static final String WPCOM_WPAPI_PREFIX = WPCOM_REST_PREFIX + "/wp/v2/sites/";
 
     private final String mEndpoint;
 
@@ -23,5 +25,9 @@ public class WPAPIEndpoint {
 
     public String getUrlV2() {
         return WPAPI_PREFIX_V2 + mEndpoint;
+    }
+
+    public String getWPComUrl(long siteId) {
+        return WPCOM_WPAPI_PREFIX + siteId + mEndpoint;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
@@ -1,0 +1,107 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
+
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.DELETED
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.UPLOADED
+
+private const val DELETED_STATUS = "deleted"
+
+data class MediaWPRESTResponse(
+    val id: Long,
+    val date: String,
+    val guid: Attribute,
+    val slug: String,
+    val status: String,
+    val type: String,
+    val link: String,
+    val title: Attribute,
+    val author: Long,
+    val post: Long? = null,
+    val description: Attribute,
+    val caption: Attribute,
+    val altText: String,
+    val mediaType: String,
+    val mimeType: String,
+    val mediaDetails: MediaDetails,
+    val sourceURL: String
+) {
+    data class Attribute(
+        val rendered: String
+    )
+
+    data class MediaDetails(
+        val width: Int,
+        val height: Int,
+        val file: String,
+        val sizes: Sizes?,
+        val imageMeta: ImageMeta
+    )
+
+    data class ImageMeta(
+        val aperture: String,
+        val credit: String,
+        val camera: String,
+        val caption: String,
+        val createdTimestamp: String,
+        val copyright: String,
+        val focalLength: String,
+        val iso: String,
+        val shutterSpeed: String,
+        val title: String,
+        val orientation: String,
+        val keywords: List<Any?>
+    )
+
+    data class Sizes(
+        val medium: ImageSize?,
+        val thumbnail: ImageSize?,
+        val newspackArticleBlockLandscapeSmall: ImageSize?,
+        val newspackArticleBlockPortraitSmall: ImageSize?,
+        val newspackArticleBlockSquareSmall: ImageSize?,
+        val newspackArticleBlockLandscapeTiny: ImageSize?,
+        val newspackArticleBlockPortraitTiny: ImageSize?,
+        val newspackArticleBlockSquareTiny: ImageSize?,
+        val woocommerceThumbnail: ImageSize?,
+        val woocommerceSingle: ImageSize?,
+        val woocommerceGalleryThumbnail: ImageSize?,
+        val shopCatalog: ImageSize?,
+        val shopSingle: ImageSize?,
+        val shopThumbnail: ImageSize?,
+        val full: ImageSize?
+    )
+
+    data class ImageSize(
+        val path: String?,
+        val file: String?,
+        val width: Long,
+        val height: Long,
+        val virtual: Boolean?,
+        val mimeType: String,
+        val sourceURL: String,
+        val uncropped: Boolean? = null
+    )
+}
+
+fun MediaWPRESTResponse.toMediaModel(): MediaModel {
+    val mediaModel = MediaModel()
+    mediaModel.mediaId = id
+    mediaModel.uploadDate = date
+    mediaModel.postId = post ?: 0L
+    mediaModel.authorId = author
+    mediaModel.url = sourceURL
+    mediaModel.guid = guid.rendered
+    mediaModel.fileName = mediaDetails.file
+    mediaModel.fileExtension = mediaDetails.file.substringAfterLast('.', "")
+    mediaModel.mimeType = mimeType
+    mediaModel.title = StringEscapeUtils.unescapeHtml4(title.rendered)
+    mediaModel.caption = StringEscapeUtils.unescapeHtml4(caption.rendered)
+    mediaModel.description = StringEscapeUtils.unescapeHtml4(description.rendered)
+    mediaModel.alt = StringEscapeUtils.unescapeHtml4(altText)
+    mediaModel.thumbnailUrl = mediaDetails.sizes?.thumbnail?.sourceURL
+    mediaModel.height = mediaDetails.height
+    mediaModel.width = mediaDetails.width
+    mediaModel.deleted = DELETED_STATUS == status
+    mediaModel.setUploadState(if (mediaModel.deleted) DELETED else UPLOADED)
+    return mediaModel
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
 
+import com.google.gson.annotations.SerializedName
 import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.DELETED
@@ -20,11 +21,11 @@ data class MediaWPRESTResponse(
     val post: Long? = null,
     val description: Attribute,
     val caption: Attribute,
-    val altText: String,
-    val mediaType: String,
-    val mimeType: String,
-    val mediaDetails: MediaDetails,
-    val sourceURL: String
+    @SerializedName("alt_text") val altText: String,
+    @SerializedName("media_type") val mediaType: String,
+    @SerializedName("mime_type") val mimeType: String,
+    @SerializedName("media_details") val mediaDetails: MediaDetails,
+    @SerializedName("source_url") val sourceURL: String
 ) {
     data class Attribute(
         val rendered: String
@@ -34,40 +35,12 @@ data class MediaWPRESTResponse(
         val width: Int,
         val height: Int,
         val file: String,
-        val sizes: Sizes?,
-        val imageMeta: ImageMeta
-    )
-
-    data class ImageMeta(
-        val aperture: String,
-        val credit: String,
-        val camera: String,
-        val caption: String,
-        val createdTimestamp: String,
-        val copyright: String,
-        val focalLength: String,
-        val iso: String,
-        val shutterSpeed: String,
-        val title: String,
-        val orientation: String,
-        val keywords: List<Any?>
+        val sizes: Sizes?
     )
 
     data class Sizes(
         val medium: ImageSize?,
         val thumbnail: ImageSize?,
-        val newspackArticleBlockLandscapeSmall: ImageSize?,
-        val newspackArticleBlockPortraitSmall: ImageSize?,
-        val newspackArticleBlockSquareSmall: ImageSize?,
-        val newspackArticleBlockLandscapeTiny: ImageSize?,
-        val newspackArticleBlockPortraitTiny: ImageSize?,
-        val newspackArticleBlockSquareTiny: ImageSize?,
-        val woocommerceThumbnail: ImageSize?,
-        val woocommerceSingle: ImageSize?,
-        val woocommerceGalleryThumbnail: ImageSize?,
-        val shopCatalog: ImageSize?,
-        val shopSingle: ImageSize?,
-        val shopThumbnail: ImageSize?,
         val full: ImageSize?
     )
 
@@ -77,8 +50,8 @@ data class MediaWPRESTResponse(
         val width: Long,
         val height: Long,
         val virtual: Boolean?,
-        val mimeType: String,
-        val sourceURL: String,
+        @SerializedName("media_type") val mimeType: String,
+        @SerializedName("source_url") val sourceURL: String,
         val uncropped: Boolean? = null
     )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
@@ -7,7 +7,7 @@ import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.DELETED
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.UPLOADED
 import org.wordpress.android.util.DateTimeUtils
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Locale
 
 private const val DELETED_STATUS = "deleted"
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
@@ -5,12 +5,15 @@ import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.DELETED
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.UPLOADED
+import org.wordpress.android.util.DateTimeUtils
+import java.text.SimpleDateFormat
+import java.util.*
 
 private const val DELETED_STATUS = "deleted"
 
 data class MediaWPRESTResponse(
     val id: Long,
-    val date: String,
+    @SerializedName("date_gmt") val dateGmt: String,
     val guid: Attribute,
     val slug: String,
     val status: String,
@@ -59,7 +62,8 @@ data class MediaWPRESTResponse(
 fun MediaWPRESTResponse.toMediaModel(): MediaModel {
     val mediaModel = MediaModel()
     mediaModel.mediaId = id
-    mediaModel.uploadDate = date
+    val date = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT).parse(dateGmt)
+    mediaModel.uploadDate = DateTimeUtils.iso8601FromDate(date)
     mediaModel.postId = post ?: 0L
     mediaModel.authorId = author
     mediaModel.url = sourceURL

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPRestUploadRequestBody.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPRestUploadRequestBody.kt
@@ -13,7 +13,7 @@ import java.io.File
 import java.io.IOException
 import java.net.URLEncoder
 
-private const val FILE_DATA_KEY = "file[0]"
+private const val FILE_DATA_KEY = "file"
 
 class WPRestUploadRequestBody(
     media: MediaModel,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPRestUploadRequestBody.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPRestUploadRequestBody.kt
@@ -13,7 +13,12 @@ import java.io.File
 import java.io.IOException
 import java.net.URLEncoder
 
-private const val FILE_DATA_KEY = "file"
+private const val FILE_FORM_KEY = "file"
+private const val TITLE_FORM_KEY = "title"
+private const val DESCRIPTION_FORM_KEY = "description"
+private const val CAPTION_FORM_KEY = "caption"
+private const val ALT_FORM_KEY = "alt_text"
+private const val POST_ID_FORM_KEY = "post"
 
 class WPRestUploadRequestBody(
     media: MediaModel,
@@ -40,12 +45,12 @@ class WPRestUploadRequestBody(
 
         val builder: MultipartBody.Builder = MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
-                .addFormDataPart(FILE_DATA_KEY, fileName, body)
-                .addParamIfNotEmpty("title", media.title)
-                .addParamIfNotEmpty("description", media.description)
-                .addParamIfNotEmpty("caption", media.caption)
-                .addParamIfNotEmpty("alt_text", media.alt)
-                .addParamIfNotEmpty("post", media.postId.takeIf { it > 0L }?.toString())
+                .addFormDataPart(FILE_FORM_KEY, fileName, body)
+                .addParamIfNotEmpty(TITLE_FORM_KEY, media.title)
+                .addParamIfNotEmpty(DESCRIPTION_FORM_KEY, media.description)
+                .addParamIfNotEmpty(CAPTION_FORM_KEY, media.caption)
+                .addParamIfNotEmpty(ALT_FORM_KEY, media.alt)
+                .addParamIfNotEmpty(POST_ID_FORM_KEY, media.postId.takeIf { it > 0L }?.toString())
 
         return builder.build()
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPRestUploadRequestBody.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPRestUploadRequestBody.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
+
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okio.BufferedSink
+import okio.buffer
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.network.BaseUploadRequestBody
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.MEDIA
+import java.io.File
+import java.io.IOException
+import java.net.URLEncoder
+
+private const val FILE_DATA_KEY = "file[0]"
+
+class WPRestUploadRequestBody(
+    media: MediaModel,
+    progressListener: ProgressListener
+) : BaseUploadRequestBody(media, progressListener) {
+    private val multipartBody: MultipartBody
+
+    init {
+        multipartBody = buildMultipartBody()
+    }
+
+    private fun buildMultipartBody(): MultipartBody {
+        val mediaFile = File(media.filePath)
+        val body = mediaFile.asRequestBody(media.mimeType.toMediaType())
+        val fileName = URLEncoder.encode(media.fileName, "UTF-8")
+
+        val builder: MultipartBody.Builder = MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart(FILE_DATA_KEY, fileName, body)
+
+        return builder.build()
+    }
+
+    override fun contentLength(): Long {
+        return try {
+            multipartBody.contentLength()
+        } catch (e: IOException) {
+            AppLog.w(MEDIA, "Error determining mMultipartBody content length: $e")
+            -1L
+        }
+    }
+
+    override fun contentType(): MediaType = multipartBody.contentType()
+
+    override fun writeTo(sink: BufferedSink) {
+        val countingSink = CountingSink(sink)
+        val bufferedSink = countingSink.buffer()
+        multipartBody.writeTo(bufferedSink)
+        bufferedSink.flush()
+    }
+
+    override fun getProgress(bytesWritten: Long): Float = bytesWritten.toFloat() / contentLength()
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPRestUploadRequestBody.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPRestUploadRequestBody.kt
@@ -26,6 +26,14 @@ class WPRestUploadRequestBody(
     }
 
     private fun buildMultipartBody(): MultipartBody {
+        fun MultipartBody.Builder.addParamIfNotEmpty(key: String, attribute: String?): MultipartBody.Builder {
+            return apply {
+                attribute?.takeIf { it.isNotEmpty() }?.let {
+                    addFormDataPart(key, it)
+                }
+            }
+        }
+
         val mediaFile = File(media.filePath)
         val body = mediaFile.asRequestBody(media.mimeType.toMediaType())
         val fileName = URLEncoder.encode(media.fileName, "UTF-8")
@@ -33,6 +41,11 @@ class WPRestUploadRequestBody(
         val builder: MultipartBody.Builder = MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
                 .addFormDataPart(FILE_DATA_KEY, fileName, body)
+                .addParamIfNotEmpty("title", media.title)
+                .addParamIfNotEmpty("description", media.description)
+                .addParamIfNotEmpty("caption", media.caption)
+                .addParamIfNotEmpty("alt_text", media.alt)
+                .addParamIfNotEmpty("post", media.postId.takeIf { it > 0L }?.toString())
 
         return builder.build()
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import okhttp3.OkHttpClient
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog.T
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class WPV2MediaRestClient @Inject constructor(
+    dispatcher: Dispatcher,
+    private val coroutineEngine: CoroutineEngine,
+    private val okHttpClient: OkHttpClient,
+    appContext: Context?,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    fun uploadMedia(site: SiteModel, media: MediaModel) {
+        coroutineEngine.launch(T.MEDIA, this, "Upload Media using WPCom's /wp/v2 API") {
+            syncUploadMedia(site, media)
+        }
+    }
+
+    suspend fun syncUploadMedia(site: SiteModel, media: MediaModel) {
+
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -4,18 +4,17 @@ import android.content.Context
 import com.android.volley.RequestQueue
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
-import kotlinx.coroutines.CancellableContinuation
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.OkHttpClient
@@ -24,6 +23,7 @@ import okhttp3.Response
 import org.json.JSONException
 import org.json.JSONObject
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.generated.UploadActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.MediaModel
@@ -40,13 +40,12 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.REQUEST_TOO_L
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.AppLog.T.MEDIA
 import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
-import kotlin.coroutines.resume
 
 @Singleton
 class WPV2MediaRestClient @Inject constructor(
@@ -60,22 +59,42 @@ class WPV2MediaRestClient @Inject constructor(
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     private val gson: Gson by lazy { Gson() }
 
+    private val currentUploads = ConcurrentHashMap<Int, CoroutineScope>()
+
     fun uploadMedia(site: SiteModel, media: MediaModel) {
-        coroutineEngine.launch(MEDIA, this, "Upload Media using WPCom's /wp/v2 API") {
+        coroutineEngine.launch(MEDIA, this, "Upload Media using WPCom's v2 API") {
             syncUploadMedia(site, media)
+                    .onStart {
+                        currentUploads[media.id] = this@launch
+                    }
+                    .onCompletion {
+                        currentUploads.remove(media.id)
+                    }
                     .collect { payload ->
                         mDispatcher.dispatch(UploadActionBuilder.newUploadedMediaAction(payload))
                     }
         }
     }
 
-    fun syncUploadMedia(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
+    fun cancelUpload(media: MediaModel) {
+        currentUploads[media.id]?.let { scope ->
+            scope.cancel()
+            val payload = ProgressPayload(media, 0f, false, true)
+            mDispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload))
+        }
+    }
+
+    private fun syncUploadMedia(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
         return callbackFlow {
             val url = WPAPI.media.getWPComUrl(site.siteId)
             val body = WPRestUploadRequestBody(media) { media, progress ->
                 if (!isClosedForSend) {
                     val payload = ProgressPayload(media, progress, false, null)
-                    offer(payload)
+                    try {
+                        offer(payload)
+                    } catch (e: CancellationException) {
+                        // the flow has been cancelled
+                    }
                 }
             }
 
@@ -89,7 +108,7 @@ class WPV2MediaRestClient @Inject constructor(
 
             call.enqueue(object : Callback {
                 override fun onFailure(call: Call, e: IOException) {
-                    // If the continuation has been canceled, then ignore errors
+                    // If the upload has been canceled, then ignore errors
                     if (!isClosedForSend) {
                         val message = "media upload failed: $e"
                         AppLog.w(MEDIA, message)
@@ -106,8 +125,12 @@ class WPV2MediaRestClient @Inject constructor(
                             val res = gson.fromJson(response.body!!.string(), MediaWPRESTResponse::class.java)
                             val uploadedMedia = res.toMediaModel()
                             val payload = ProgressPayload(uploadedMedia, 1f, true, false)
-                            sendBlocking(payload)
-                            close()
+                            try {
+                                sendBlocking(payload)
+                                close()
+                            } catch (e: CancellationException) {
+                                // the flow has been cancelled
+                            }
                         } catch (e: JsonSyntaxException) {
                             AppLog.e(MEDIA, e)
                             val error = MediaError(PARSE_ERROR)
@@ -133,8 +156,12 @@ class WPV2MediaRestClient @Inject constructor(
     private fun ProducerScope<ProgressPayload>.handleFailure(media: MediaModel, error: MediaError) {
         media.setUploadState(FAILED)
         val payload = ProgressPayload(media, 1f, false, error)
-        sendBlocking(payload)
-        close()
+        try {
+            sendBlocking(payload)
+            close()
+        } catch (e: CancellationException) {
+            // the flow has been cancelled
+        }
     }
 
     private fun Response.parseError(): MediaError {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -2,18 +2,35 @@ package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
 
 import android.content.Context
 import com.android.volley.RequestQueue
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.FAILED
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.PARSE_ERROR
+import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.AppLog.T.MEDIA
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
+import kotlin.coroutines.resume
 
 @Singleton
 class WPV2MediaRestClient @Inject constructor(
@@ -25,13 +42,68 @@ class WPV2MediaRestClient @Inject constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    private val gson: Gson by lazy { Gson() }
+
     fun uploadMedia(site: SiteModel, media: MediaModel) {
         coroutineEngine.launch(T.MEDIA, this, "Upload Media using WPCom's /wp/v2 API") {
             syncUploadMedia(site, media)
         }
     }
 
-    suspend fun syncUploadMedia(site: SiteModel, media: MediaModel) {
+    suspend fun syncUploadMedia(site: SiteModel, media: MediaModel): ProgressPayload {
+        return suspendCancellableCoroutine { cont ->
+            val url = WPAPI.media.getWPComUrl(site.siteId)
+            val body = TODO()
 
+            val request = Request.Builder()
+                    .url(url)
+                    .post(body = body)
+                    .header(WPComGsonRequest.REST_AUTHORIZATION_HEADER, accessToken.get())
+                    .build()
+
+            val call = okHttpClient.newCall(request)
+
+            call.enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    // If the continuation has been canceled, then ignore errors
+                    if (cont.isActive) {
+                        val message = "media upload failed: $e"
+                        AppLog.w(MEDIA, message)
+                        val error = MediaError.fromIOException(e)
+                        error.logMessage = message
+                        cont.handleFailure(media, error)
+                    }
+                }
+
+                override fun onResponse(call: Call, response: okhttp3.Response) {
+                    if (response.isSuccessful) {
+                        try {
+                            val res = gson.fromJson(response.body!!.string(), MediaWPRESTResponse::class.java)
+                            val media = res.toMediaModel()
+                            cont.resume(ProgressPayload(media, 1f, true, false))
+                        } catch (e: JsonSyntaxException) {
+                            val error = MediaError(PARSE_ERROR)
+                            cont.handleFailure(media, error)
+                        } catch (e: NullPointerException) {
+                            val error = MediaError(PARSE_ERROR)
+                            cont.handleFailure(media, error)
+                        }
+                    } else {
+                        TODO()
+                    }
+                }
+            })
+
+            cont.invokeOnCancellation {
+                call.cancel()
+            }
+        }
+    }
+
+    private fun CancellableContinuation<ProgressPayload>.handleFailure(media: MediaModel, error: MediaError) {
+        media.setUploadState(FAILED)
+        val payload = ProgressPayload(media, 1f, false, error)
+        mDispatcher.emitChange(payload)
+        resume(payload)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1007,7 +1007,7 @@ class SiteRestClient @Inject constructor(
                     ?.let { TextUtils.join(",", from.zendesk_site_meta.addon) } ?: ""
         }
         // Only set the isWPCom flag for "pure" WPCom sites
-        if (!from.jetpack) {
+        if (!from.jetpack_connection) {
             site.setIsWPCom(true)
         }
         site.origin = SiteModel.ORIGIN_WPCOM_REST

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -864,6 +864,8 @@ public class MediaStore extends Store {
 
         if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.cancelUpload(media);
+        } else if (payload.site.isJetpackCPConnected()) {
+            mWPV2MediaRestClient.cancelUpload(media);
         } else {
             mMediaXmlrpcClient.cancelUpload(media);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -797,7 +797,7 @@ public class MediaStore extends Store {
         if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.uploadMedia(payload.site, payload.media);
         } else if (payload.site.isJetpackCPConnected()) {
-            mMediaRestClient.uploadMedia(payload.site, payload.media);
+            mWPV2MediaRestClient.uploadMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.uploadMedia(payload.site, payload.media);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPV2MediaRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.MediaSqlUtils;
 import org.wordpress.android.fluxc.store.media.MediaErrorSubType;
@@ -467,15 +468,21 @@ public class MediaStore extends Store {
 
     private final MediaRestClient mMediaRestClient;
     private final MediaXMLRPCClient mMediaXmlrpcClient;
+    private final WPV2MediaRestClient mWPV2MediaRestClient;
     // Ensures that the UploadStore is initialized whenever the MediaStore is,
     // to ensure actions are shadowed and repeated by the UploadStore
     @SuppressWarnings("unused")
     @Inject UploadStore mUploadStore;
 
-    @Inject public MediaStore(Dispatcher dispatcher, MediaRestClient restClient, MediaXMLRPCClient xmlrpcClient) {
+    @Inject public MediaStore(
+            Dispatcher dispatcher,
+            MediaRestClient restClient,
+            MediaXMLRPCClient xmlrpcClient,
+            WPV2MediaRestClient wpv2MediaRestClient) {
         super(dispatcher);
         mMediaRestClient = restClient;
         mMediaXmlrpcClient = xmlrpcClient;
+        mWPV2MediaRestClient = wpv2MediaRestClient;
     }
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
@@ -788,6 +795,8 @@ public class MediaStore extends Store {
         }
 
         if (payload.site.isUsingWpComRestApi()) {
+            mMediaRestClient.uploadMedia(payload.site, payload.media);
+        } else if (payload.site.isJetpackCPConnected()) {
             mMediaRestClient.uploadMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.uploadMedia(payload.site, payload.media);


### PR DESCRIPTION
Jetpack CP sites can't access the regular WPCom APIs that rely on syncing from Jetpack, we need to rely instead on the mirrored `/wp/v2` APIs (more details: p91TBi-67H-p2), this PR adds support for this by adding a new `RestClient` that use this API.

The PR is long because of the tests and the json sample file.

#### Testing
1. You need a site that uses a Jetpack CP plugin (WCPay or Backup) and doesn't have full Jetpack.
2. Open the example app, and login.
3. Click on Media.
4. Select the Jetpack CP site.
5. Test media upload and confirm that it works as expected.

You can also use the WCAndroid's PR for testing: https://github.com/woocommerce/woocommerce-android/pull/5071