### PR TITLE
Jetpack CP: Add Jetpack-tunneled plugins-related functionalities.

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -95,6 +95,7 @@ class MainFragment : Fragment() {
         reactnative.setOnClickListener(getOnClickListener(ReactNativeFragment()))
         editortheme.setOnClickListener(getOnClickListener(EditorThemeFragment()))
         experiments.setOnClickListener(getOnClickListener(ExperimentsFragment()))
+        plugins.setOnClickListener(getOnClickListener(PluginsFragment()))
     }
 
     // Private methods

--- a/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
@@ -84,12 +84,12 @@ class PluginsFragment : Fragment() {
         fetch_plugin.setOnClickListener {
             selectedSite?.let { site ->
 
-                showSingleLineDialog(activity, "Enter a plugin slug.") { pluginSlugText ->
-                    if (pluginSlugText.text.isEmpty()) {
-                        prependToLog("Slug is null so doing nothing")
+                showSingleLineDialog(activity, "Enter the plugin name.") { pluginNameText ->
+                    if (pluginNameText.text.isEmpty()) {
+                        prependToLog("Name is null so doing nothing")
                         return@showSingleLineDialog
                     }
-                    pluginSlugText.text.toString().apply {
+                    pluginNameText.text.toString().apply {
                         prependToLog("Fetching plugin: $this")
 
                         val payload = FetchJetpackSitePluginPayload(site, this)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
@@ -17,10 +17,10 @@ import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.PluginActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PluginStore
-import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginPayload
+import org.wordpress.android.fluxc.store.PluginStore.FetchJetpackSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload
+import org.wordpress.android.fluxc.store.PluginStore.OnJetpackSitePluginFetched
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginConfigured
-import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginFetched
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled
 import javax.inject.Inject
 
@@ -92,8 +92,8 @@ class PluginsFragment : Fragment() {
                     pluginSlugText.text.toString().apply {
                         prependToLog("Fetching plugin: $this")
 
-                        val payload = FetchSitePluginPayload(site, this)
-                        dispatcher.dispatch(PluginActionBuilder.newFetchSitePluginAction(payload))
+                        val payload = FetchJetpackSitePluginPayload(site, this)
+                        dispatcher.dispatch(PluginActionBuilder.newFetchJetpackSitePluginAction(payload))
                     }
                 }
             } ?: prependToLog("Please select a site first.")
@@ -114,7 +114,7 @@ class PluginsFragment : Fragment() {
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onSitePluginFetched(event: OnSitePluginFetched) {
+    fun onSitePluginFetched(event: OnJetpackSitePluginFetched) {
         if (!event.isError) {
             prependToLog("${event.plugin.displayName}: ${event.plugin.description}")
         } else {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
@@ -43,7 +43,7 @@ class PluginsFragment : StoreSelectingFragment() {
             selectedSite?.let { site ->
                 showSingleLineDialog(
                         activity,
-                        "Enter a plugin slug.\n(Note: If testing Jetpack CP sites, don't enter `jetpack`)"
+                        "Enter a plugin slug.\n(Hint: If testing Jetpack CP sites, don't use `jetpack`)"
                 ) { pluginSlugText ->
                     if (pluginSlugText.text.isEmpty()) {
                         prependToLog("Slug is null so doing nothing")
@@ -99,11 +99,11 @@ class PluginsFragment : StoreSelectingFragment() {
         }
     }
 
-    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onSitePluginConfigured(event: OnSitePluginConfigured) {
         if (!event.isError) {
-            prependToLog("${event.pluginName} is configured.")
+            // If there is no error, we can assume that the configuration (activating in our case) is successful.
+            prependToLog("${event.pluginName} is activated.")
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
@@ -1,0 +1,109 @@
+package org.wordpress.android.fluxc.example
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.fragment_plugins.*
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
+import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.generated.PluginActionBuilder
+import org.wordpress.android.fluxc.store.PluginStore
+import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginPayload
+import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginConfigured
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginFetched
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled
+import javax.inject.Inject
+
+class PluginsFragment : StoreSelectingFragment() {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var pluginStore: PluginStore
+
+    override fun onStart() {
+        super.onStart()
+        dispatcher.register(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        dispatcher.unregister(this)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_plugins, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        install_activate_plugin.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(
+                        activity,
+                        "Enter a plugin slug.\n(Note: If testing Jetpack CP sites, don't enter `jetpack`)"
+                ) { pluginSlugText ->
+                    if (pluginSlugText.text.isEmpty()) {
+                        prependToLog("Slug is null so doing nothing")
+                        return@showSingleLineDialog
+                    }
+                    pluginSlugText.text.toString().apply {
+                        prependToLog("Installing plugin: $this")
+                        val payload = InstallSitePluginPayload(site, this)
+                        dispatcher.dispatch(PluginActionBuilder.newInstallSitePluginAction(payload))
+                    }
+                }
+            } ?: prependToLog("Please select a site first.")
+        }
+
+        fetch_plugin.setOnClickListener {
+            selectedSite?.let { site ->
+
+                showSingleLineDialog(activity, "Enter a plugin slug.") { pluginSlugText ->
+                    if (pluginSlugText.text.isEmpty()) {
+                        prependToLog("Slug is null so doing nothing")
+                        return@showSingleLineDialog
+                    }
+                    pluginSlugText.text.toString().apply {
+                        prependToLog("Fetching plugin: $this")
+
+                        val payload = FetchSitePluginPayload(site, this)
+                        dispatcher.dispatch(PluginActionBuilder.newFetchSitePluginAction(payload))
+                    }
+                }
+            } ?: prependToLog("Please select a site first.")
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onSitePluginInstalled(event: OnSitePluginInstalled) {
+        if (!event.isError) {
+            prependToLog("${event.slug} is installed to ${event.site.name}.")
+        } else {
+            event.error.message?.let {
+                prependToLog("Installation failed: $it")
+            }
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onSitePluginFetched(event: OnSitePluginFetched) {
+        if (!event.isError) {
+            prependToLog("${event.plugin.displayName}: ${event.plugin.description}")
+        } else {
+            prependToLog("Fetching failed: ${event.error.type}")
+        }
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onSitePluginConfigured(event: OnSitePluginConfigured) {
+        if (!event.isError) {
+            prependToLog("${event.pluginName} is configured.")
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.example.SitesFragment
 import org.wordpress.android.fluxc.example.TaxonomiesFragment
 import org.wordpress.android.fluxc.example.ThemeFragment
 import org.wordpress.android.fluxc.example.UploadsFragment
+import org.wordpress.android.fluxc.example.PluginsFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
 import org.wordpress.android.fluxc.example.ui.customer.WooCustomersFragment
@@ -156,4 +157,7 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooHelpSupportFragment(): WooHelpSupportFragment
+
+    @ContributesAndroidInjector
+    abstract fun providePluginsFragment(): PluginsFragment
 }

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -138,6 +138,13 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="Experiments" />
+
+                <Button
+                    android:id="@+id/plugins"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Plugins" />
+
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>

--- a/example/src/main/res/layout/fragment_plugins.xml
+++ b/example/src/main/res/layout/fragment_plugins.xml
@@ -12,6 +12,29 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/plugins_select_site"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingEnd="@dimen/activity_start_end_half_margin"
+                android:text="Select Site" />
+
+            <TextView
+                android:id="@+id/plugins_selected_site"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="@dimen/activity_start_end_half_margin"
+                android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+                android:textColor="@android:color/holo_blue_bright" />
+        </LinearLayout>
+
         <View
             android:id="@+id/divider1"
             style="@style/Divider" />

--- a/example/src/main/res/layout/fragment_plugins.xml
+++ b/example/src/main/res/layout/fragment_plugins.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    tools:context="org.wordpress.android.fluxc.example.PluginsFragment"
+    tools:ignore="HardcodedText">
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <View
+            android:id="@+id/divider1"
+            style="@style/Divider" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:text="PluginStore tests:"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
+
+        <Button
+            android:id="@+id/install_activate_plugin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Install and activate a plugin" />
+
+        <Button
+            android:id="@+id/fetch_plugin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Fetch a plugin from site" />
+
+        <View
+            android:id="@+id/divider2"
+            style="@style/Divider" />
+
+    </LinearLayout>
+</ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPAPIEndpointTest.java
@@ -33,7 +33,7 @@ public class WPAPIEndpointTest {
 
         // Plugins
         assertEquals("/plugins/", WPAPI.plugins.getEndpoint());
-        assertEquals("/plugins/jetpack/jetpack/", WPAPI.plugins.slug("jetpack/jetpack").getEndpoint());
+        assertEquals("/plugins/jetpack/jetpack/", WPAPI.plugins.name("jetpack/jetpack").getEndpoint());
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPAPIEndpointTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/endpoints/WPAPIEndpointTest.java
@@ -30,6 +30,10 @@ public class WPAPIEndpointTest {
         // Users
         assertEquals("/users/", WPAPI.users.getEndpoint());
         assertEquals("/users/me/", WPAPI.users.me.getEndpoint());
+
+        // Plugins
+        assertEquals("/plugins/", WPAPI.plugins.getEndpoint());
+        assertEquals("/plugins/jetpack/jetpack/", WPAPI.plugins.slug("jetpack/jetpack").getEndpoint());
     }
 
     @Test
@@ -40,5 +44,6 @@ public class WPAPIEndpointTest {
         assertEquals("wp/v2/comments/", WPAPI.comments.getUrlV2());
         assertEquals("wp/v2/users/", WPAPI.users.getUrlV2());
         assertEquals("wp/v2/users/me/", WPAPI.users.me.getUrlV2());
+        assertEquals("wp/v2/plugins/", WPAPI.plugins.getUrlV2());
     }
 }

--- a/fluxc-processor/src/main/resources/wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-api-endpoints.txt
@@ -16,4 +16,4 @@
 /users/me/
 
 /plugins/
-/plugins/<slug>#String
+/plugins/<name>#String

--- a/fluxc-processor/src/main/resources/wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-api-endpoints.txt
@@ -14,3 +14,6 @@
 
 /users/
 /users/me/
+
+/plugins/
+/plugins/<slug>#String

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -9,7 +9,9 @@ import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginDirectoryPayload;
+import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginDirectoryPayload;
+import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedWPOrgPluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
@@ -29,6 +31,8 @@ public enum PluginAction implements IAction {
     FETCH_PLUGIN_DIRECTORY,
     @Action(payloadType = String.class)
     FETCH_WPORG_PLUGIN,
+    @Action(payloadType = FetchSitePluginPayload.class)
+    FETCH_SITE_PLUGIN,
     @Action(payloadType = InstallSitePluginPayload.class)
     INSTALL_SITE_PLUGIN,
     @Action(payloadType = SearchPluginDirectoryPayload.class)
@@ -45,6 +49,8 @@ public enum PluginAction implements IAction {
     FETCHED_PLUGIN_DIRECTORY,
     @Action(payloadType = FetchedWPOrgPluginPayload.class)
     FETCHED_WPORG_PLUGIN,
+    @Action(payloadType = FetchedSitePluginPayload.class)
+    FETCHED_SITE_PLUGIN,
     @Action(payloadType = InstalledSitePluginPayload.class)
     INSTALLED_SITE_PLUGIN,
     @Action(payloadType = SearchedPluginDirectoryPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -8,10 +8,10 @@ import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.FetchJetpackSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginDirectoryPayload;
-import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.FetchedJetpackSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginDirectoryPayload;
-import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedWPOrgPluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload;
@@ -31,8 +31,8 @@ public enum PluginAction implements IAction {
     FETCH_PLUGIN_DIRECTORY,
     @Action(payloadType = String.class)
     FETCH_WPORG_PLUGIN,
-    @Action(payloadType = FetchSitePluginPayload.class)
-    FETCH_SITE_PLUGIN,
+    @Action(payloadType = FetchJetpackSitePluginPayload.class)
+    FETCH_JETPACK_SITE_PLUGIN,
     @Action(payloadType = InstallSitePluginPayload.class)
     INSTALL_SITE_PLUGIN,
     @Action(payloadType = SearchPluginDirectoryPayload.class)
@@ -49,8 +49,8 @@ public enum PluginAction implements IAction {
     FETCHED_PLUGIN_DIRECTORY,
     @Action(payloadType = FetchedWPOrgPluginPayload.class)
     FETCHED_WPORG_PLUGIN,
-    @Action(payloadType = FetchedSitePluginPayload.class)
-    FETCHED_SITE_PLUGIN,
+    @Action(payloadType = FetchedJetpackSitePluginPayload.class)
+    FETCHED_JETPACK_SITE_PLUGIN,
     @Action(payloadType = InstalledSitePluginPayload.class)
     INSTALLED_SITE_PLUGIN,
     @Action(payloadType = SearchedPluginDirectoryPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginResponseModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginResponseModel.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.plugin
 
 import com.google.gson.annotations.SerializedName
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 
 data class PluginResponseModel(
     val plugin: String?,
@@ -22,6 +24,21 @@ data class PluginResponseModel(
     )
 }
 
+fun PluginResponseModel.toDomainModel(siteId: Int): SitePluginModel {
+    val model = SitePluginModel().apply {
+        localSiteId = siteId
+        name = this@toDomainModel.plugin
+        displayName = this@toDomainModel.name
+        authorName = StringEscapeUtils.unescapeHtml4(this@toDomainModel.author)
+        authorUrl = this@toDomainModel.authorUri
+        description = this@toDomainModel.description?.raw
+        pluginUrl = this@toDomainModel.pluginUri
+        slug = this@toDomainModel.textDomain
+        version = this@toDomainModel.version
+    }
+    model.setIsActive(this.status == "active")
+    return model
+}
 /**
  * [{"plugin":"akismet\/akismet",
  * "status":"inactive",

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
@@ -116,23 +116,8 @@ class PluginWPAPIRestClient @Inject constructor(
         }
     }
 
-    private fun PluginResponseModel.toDomainModel(siteId: Int): SitePluginModel {
-        val plugin = SitePluginModel()
-        plugin.authorUrl = this.authorUri
-        plugin.authorName = this.author
-        plugin.description = this.description?.raw
-        plugin.displayName = this.name
-        plugin.name = this.plugin
-        plugin.setIsActive(this.status == "active")
-        plugin.localSiteId = siteId
-        plugin.pluginUrl = this.pluginUri
-        plugin.version = this.version
-        plugin.slug = this.textDomain
-        return plugin
-    }
-
     /**
-     * POST /wp/v2/plugins { slug: "akismet" } installs the plugin with the slug aksimet from the WordPress.org plugin directory. The endpoint does not support uploading a plugin zip.
+     * POST /wp/v2/plugins { slug: "akismet" } installs the plugin with the slug akismet from the WordPress.org plugin directory. The endpoint does not support uploading a plugin zip.
     PUT /wp/v2/plugins/akismet/akismet { status: "active" } activates the selected plugin. The status can be set to network-active to network activate the plugin on Multisite. To deactivate the plugin set the status to inactive. There is not a separate network-inactive status, inactive will perform a network deactivation if the plugin was network activated.
     DELETE /wp/v2/plugins/akismet/akismet uninstalls the selected plugin. The plugin must be inactive before deleting it.
      */

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -38,6 +38,13 @@ class PluginJetpackTunnelRestClient @Inject constructor(
         private const val PLUGIN_ALREADY_EXISTS = "Destination folder already exists."
     }
 
+    /**
+     * Fetch a plugin's information from a site.
+     *
+     * @param [pluginSlug] Note that this is not the same as the WordPress.org plugin directory slug that can be used
+     * to install a plugin. Instead, it needs to be the value of the `plugin` key inside a plugin object as returned
+     * by the `GET wp/v2/plugins` endpoint. For example, for Jetpack, the correct value should be `jetpack/jetpack`.
+     */
     fun fetchPlugin(site: SiteModel, pluginSlug: String) {
         val url = "$PLUGINS_API_PATH/$pluginSlug"
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -35,6 +35,34 @@ class PluginJetpackTunnelRestClient @Inject constructor(
         private const val PLUGIN_ALREADY_EXISTS = "Destination folder already exists."
     }
 
+    suspend fun fetchPlugin(site: SiteModel, pluginSlug: String): InstalledSitePluginPayload {
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                restClient = this,
+                site = site,
+                url = "$PLUGINS_API_PATH/$pluginSlug",
+                params = emptyMap(),
+                PluginResponseModel::class.java
+        )
+
+        return when (response) {
+            is JetpackSuccess -> InstalledSitePluginPayload(
+                    site,
+                    sitePluginModelFromResponse(site, response.data!!)
+            )
+
+            is JetpackError -> {
+                InstalledSitePluginPayload(
+                        site,
+                        pluginSlug,
+                        InstallSitePluginError(
+                                InstallSitePluginErrorType.NOT_AVAILABLE,
+                                response.error.message
+                        )
+                )
+            }
+        }
+    }
+
     suspend fun installPlugin(site: SiteModel, pluginSlug: String): InstalledSitePluginPayload {
         val body = mapOf(
                 "slug" to pluginSlug

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginErrorType.PLUGIN_DOES_NOT_EXIST
-import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginPayload
+import org.wordpress.android.fluxc.store.PluginStore.FetchedJetpackSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType.PLUGIN_ALREADY_INSTALLED
@@ -54,14 +54,14 @@ class PluginJetpackTunnelRestClient @Inject constructor(
                 PluginResponseModel::class.java,
                 { response: PluginResponseModel? ->
                     response?.let {
-                        val payload = FetchedSitePluginPayload(it.toDomainModel(site.id))
-                        dispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginAction(payload))
+                        val payload = FetchedJetpackSitePluginPayload(it.toDomainModel(site.id))
+                        dispatcher.dispatch(PluginActionBuilder.newFetchedJetpackSitePluginAction(payload))
                     }
                 },
                 {
                     val fetchError = FetchSitePluginError(PLUGIN_DOES_NOT_EXIST)
-                    val payload = FetchedSitePluginPayload(pluginName, fetchError)
-                    dispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginAction(payload))
+                    val payload = FetchedJetpackSitePluginPayload(pluginName, fetchError)
+                    dispatcher.dispatch(PluginActionBuilder.newFetchedJetpackSitePluginAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) }
         )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -71,6 +71,12 @@ class PluginJetpackTunnelRestClient @Inject constructor(
         add(request)
     }
 
+    /**
+     * Install a plugin to a site.
+     *
+     * @param [pluginSlug] This can use the value of the plugin's URL slug on the plugin directory, in the form of
+     * https://wordpress.org/plugins/<slug>. For example, for Jetpack, the value should be 'jetpack'.
+     */
     fun installPlugin(site: SiteModel, pluginSlug: String) {
         val url = WPAPI.plugins.urlV2
         val body = mapOf(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -1,0 +1,95 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.plugin
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpapi.plugin.PluginResponseModel
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError
+import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType
+import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class PluginJetpackTunnelRestClient @Inject constructor(
+    dispatcher: Dispatcher,
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
+    appContext: Context?,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    companion object {
+        private const val PLUGINS_API_PATH = "/wp/v2/plugins"
+        private const val INACTIVE_STATUS = "inactive"
+        private const val PLUGIN_ALREADY_EXISTS = "Destination folder already exists."
+    }
+
+    suspend fun installPlugin(site: SiteModel, pluginSlug: String): InstalledSitePluginPayload {
+        val body = mapOf(
+                "slug" to pluginSlug
+        )
+
+        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
+                this,
+                site,
+                PLUGINS_API_PATH,
+                body,
+                PluginResponseModel::class.java
+        )
+        return when (response) {
+            is JetpackSuccess -> InstalledSitePluginPayload(
+                    site,
+                    sitePluginModelFromResponse(site, response.data!!)
+            )
+
+            is JetpackError -> {
+                val error = when (response.error.message) {
+                    PLUGIN_ALREADY_EXISTS -> {
+                        InstallSitePluginError(
+                                InstallSitePluginErrorType.PLUGIN_ALREADY_INSTALLED,
+                                response.error.message
+                        )
+                    }
+                    else -> {
+                        InstallSitePluginError(
+                                InstallSitePluginErrorType.GENERIC_ERROR,
+                                response.error.message
+                        )
+                    }
+                }
+                return InstalledSitePluginPayload(site, pluginSlug, error)
+            }
+        }
+    }
+
+    private fun sitePluginModelFromResponse(siteModel: SiteModel, response: PluginResponseModel): SitePluginModel {
+        val sitePluginModel = SitePluginModel().apply {
+            localSiteId = siteModel.id
+            name = response.name
+            displayName = response.name
+            authorName = StringEscapeUtils.unescapeHtml4(response.author)
+            authorUrl = response.authorUri
+            description = response.description?.raw
+            pluginUrl = response.pluginUri
+            slug = response.plugin
+            version = response.version
+        }
+        if (response.status == INACTIVE_STATUS) {
+            sitePluginModel.setIsActive(false)
+        } else {
+            sitePluginModel.setIsActive(true)
+        }
+        return sitePluginModel
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -43,12 +43,12 @@ class PluginJetpackTunnelRestClient @Inject constructor(
     /**
      * Fetch a plugin's information from a site.
      *
-     * @param [pluginSlug] Note that this is not the same as the WordPress.org plugin directory slug that can be used
+     * @param [pluginName] Note that this is not the same as the WordPress.org plugin directory slug that can be used
      * to install a plugin. Instead, it needs to be the value of the `plugin` key inside a plugin object as returned
      * by the `GET wp/v2/plugins` endpoint. For example, for Jetpack, the correct value should be `jetpack/jetpack`.
      */
-    fun fetchPlugin(site: SiteModel, pluginSlug: String) {
-        val url = WPAPI.plugins.slug(pluginSlug).urlV2
+    fun fetchPlugin(site: SiteModel, pluginName: String) {
+        val url = WPAPI.plugins.name(pluginName).urlV2
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(
                 url,
@@ -63,7 +63,7 @@ class PluginJetpackTunnelRestClient @Inject constructor(
                 },
                 { _ ->
                     val fetchError = FetchSitePluginError(PLUGIN_DOES_NOT_EXIST)
-                    val payload = FetchedSitePluginPayload(pluginSlug, fetchError)
+                    val payload = FetchedSitePluginPayload(pluginName, fetchError)
                     dispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) }
@@ -123,12 +123,12 @@ class PluginJetpackTunnelRestClient @Inject constructor(
      * Configure a plugin's status in a site. This supports making it 'active', or 'inactive'. The API also supports
      * the 'network-active' status, but it is not supported yet here.
      *
-     * @param [pluginSlug] Note that this is not the same as the WordPress.org plugin directory slug that can be used
+     * @param [pluginName] Note that this is not the same as the WordPress.org plugin directory slug that can be used
      * to install a plugin. Instead, it needs to be the value of the `plugin` key inside a plugin object as returned
      * by the `GET wp/v2/plugins` endpoint. For example, for Jetpack, the correct value should be `jetpack/jetpack`.
      */
-    fun configurePlugin(site: SiteModel, pluginSlug: String, active: Boolean) {
-        val url = WPAPI.plugins.slug(pluginSlug).urlV2
+    fun configurePlugin(site: SiteModel, pluginName: String, active: Boolean) {
+        val url = WPAPI.plugins.name(pluginName).urlV2
         val body = mapOf(
                 "status" to if (active) "active" else "inactive"
         )
@@ -153,7 +153,7 @@ class PluginJetpackTunnelRestClient @Inject constructor(
                             error.apiError, error.message
                     )
 
-                    val payload = ConfiguredSitePluginPayload(site, pluginSlug, pluginSlug, configurePluginError)
+                    val payload = ConfiguredSitePluginPayload(site, pluginName, configurePluginError)
                     dispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload))
                 }
         )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -41,9 +41,8 @@ class PluginJetpackTunnelRestClient @Inject constructor(
     /**
      * Fetch a plugin's information from a site.
      *
-     * @param [pluginName] Note that this is not the same as the WordPress.org plugin directory slug that can be used
-     * to install a plugin. Instead, it needs to be the value of the `plugin` key inside a plugin object as returned
-     * by the `GET wp/v2/plugins` endpoint. For example, for Jetpack, the correct value should be `jetpack/jetpack`.
+     * @param [pluginName] This should use the value of the `plugin` key inside a plugin object as returned
+     * by the `GET wp/v2/plugins` endpoint. For example, for Jetpack, the correct value is `jetpack/jetpack`.
      */
     fun fetchPlugin(site: SiteModel, pluginName: String) {
         val url = WPAPI.plugins.name(pluginName).urlV2
@@ -72,8 +71,8 @@ class PluginJetpackTunnelRestClient @Inject constructor(
     /**
      * Install a plugin to a site.
      *
-     * @param [pluginSlug] This can use the value of the plugin's URL slug on the plugin directory, in the form of
-     * https://wordpress.org/plugins/<slug>. For example, for Jetpack, the value should be 'jetpack'.
+     * @param [pluginSlug] This should use the value of the plugin's URL slug on the plugin directory, in the form of
+     * https://wordpress.org/plugins/<slug>. For example, for Jetpack, the value is 'jetpack'.
      */
     fun installPlugin(site: SiteModel, pluginSlug: String) {
         val url = WPAPI.plugins.urlV2
@@ -121,9 +120,8 @@ class PluginJetpackTunnelRestClient @Inject constructor(
      * Configure a plugin's status in a site. This supports making it 'active', or 'inactive'. The API also supports
      * the 'network-active' status, but it is not supported yet here.
      *
-     * @param [pluginName] Note that this is not the same as the WordPress.org plugin directory slug that can be used
-     * to install a plugin. Instead, it needs to be the value of the `plugin` key inside a plugin object as returned
-     * by the `GET wp/v2/plugins` endpoint. For example, for Jetpack, the correct value should be `jetpack/jetpack`.
+     * @param [pluginName] This should use the value of the `plugin` key inside a plugin object as returned
+     * by the `GET wp/v2/plugins` endpoint. For example, for Jetpack, the correct value is `jetpack/jetpack`.
      */
     fun configurePlugin(site: SiteModel, pluginName: String, active: Boolean) {
         val url = WPAPI.plugins.name(pluginName).urlV2

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -5,6 +5,7 @@ import com.android.volley.RequestQueue
 import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.PluginActionBuilder
+import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.network.UserAgent
@@ -33,7 +34,6 @@ class PluginJetpackTunnelRestClient @Inject constructor(
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     companion object {
-        private const val PLUGINS_API_PATH = "/wp/v2/plugins"
         private const val INACTIVE_STATUS = "inactive"
         private const val PLUGIN_ALREADY_EXISTS = "Destination folder already exists."
     }
@@ -46,7 +46,7 @@ class PluginJetpackTunnelRestClient @Inject constructor(
      * by the `GET wp/v2/plugins` endpoint. For example, for Jetpack, the correct value should be `jetpack/jetpack`.
      */
     fun fetchPlugin(site: SiteModel, pluginSlug: String) {
-        val url = "$PLUGINS_API_PATH/$pluginSlug"
+        val url = WPAPI.plugins.slug(pluginSlug).urlV2
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(
                 url,
@@ -70,12 +70,13 @@ class PluginJetpackTunnelRestClient @Inject constructor(
     }
 
     fun installPlugin(site: SiteModel, pluginSlug: String) {
+        val url = WPAPI.plugins.urlV2
         val body = mapOf(
                 "slug" to pluginSlug
         )
 
         val request = JetpackTunnelGsonRequest.buildPostRequest(
-                PLUGINS_API_PATH,
+                url,
                 site.siteId,
                 body,
                 PluginResponseModel::class.java,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -15,8 +15,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload
-import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginError
-import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginErrorType.PLUGIN_DOES_NOT_EXIST
+import org.wordpress.android.fluxc.store.PluginStore.FetchPluginForJetpackSiteError
+import org.wordpress.android.fluxc.store.PluginStore.FetchPluginForJetpackSiteErrorType.PLUGIN_DOES_NOT_EXIST
 import org.wordpress.android.fluxc.store.PluginStore.FetchedJetpackSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType.GENERIC_ERROR
@@ -59,7 +59,7 @@ class PluginJetpackTunnelRestClient @Inject constructor(
                     }
                 },
                 {
-                    val fetchError = FetchSitePluginError(PLUGIN_DOES_NOT_EXIST)
+                    val fetchError = FetchPluginForJetpackSiteError(PLUGIN_DOES_NOT_EXIST)
                     val payload = FetchedJetpackSitePluginPayload(pluginName, fetchError)
                     dispatcher.dispatch(PluginActionBuilder.newFetchedJetpackSitePluginAction(payload))
                 },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.model.plugin.SitePluginModel;
 import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType;
+import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginJetpackTunnelRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.plugin.PluginRestClient;
 import org.wordpress.android.fluxc.network.wporg.plugin.PluginWPOrgClient;
 import org.wordpress.android.fluxc.persistence.PluginSqlUtils;
@@ -721,15 +722,18 @@ public class PluginStore extends Store {
     private final PluginRestClient mPluginRestClient;
     private final PluginWPOrgClient mPluginWPOrgClient;
     private final PluginCoroutineStore mPluginCoroutineStore;
+    private final PluginJetpackTunnelRestClient mPluginJetpackTunnelRestClient;
 
     @Inject public PluginStore(Dispatcher dispatcher,
                                PluginRestClient pluginRestClient,
                                PluginWPOrgClient pluginWPOrgClient,
-                               PluginCoroutineStore pluginCoroutineStore) {
+                               PluginCoroutineStore pluginCoroutineStore,
+                               PluginJetpackTunnelRestClient pluginJetpackTunnelRestClient) {
         super(dispatcher);
         mPluginRestClient = pluginRestClient;
         mPluginWPOrgClient = pluginWPOrgClient;
         mPluginCoroutineStore = pluginCoroutineStore;
+        mPluginJetpackTunnelRestClient = pluginJetpackTunnelRestClient;
     }
 
     @Override
@@ -901,6 +905,8 @@ public class PluginStore extends Store {
             mPluginRestClient.installSitePlugin(payload.site, payload.slug);
         } else if (!payload.site.isUsingWpComRestApi()) {
             mPluginCoroutineStore.installSitePlugin(payload.site, payload.slug);
+        } else if (payload.site.isJetpackCPConnected()) {
+            mPluginJetpackTunnelRestClient.installPlugin(payload.site, payload.slug);
         } else {
             InstallSitePluginError error = new InstallSitePluginError(InstallSitePluginErrorType.NOT_AVAILABLE);
             InstalledSitePluginPayload errorPayload = new InstalledSitePluginPayload(payload.site,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -81,11 +81,11 @@ public class PluginStore extends Store {
     @SuppressWarnings("WeakerAccess")
     public static class FetchSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
-        public String slug;
+        public String pluginName;
 
-        public FetchSitePluginPayload(SiteModel site, String slug) {
+        public FetchSitePluginPayload(SiteModel site, String pluginName) {
             this.site = site;
-            this.slug = slug;
+            this.pluginName = pluginName;
         }
     }
 
@@ -140,6 +140,12 @@ public class PluginStore extends Store {
             this.plugin = plugin;
             this.pluginName = this.plugin.getName();
             this.slug = this.plugin.getSlug();
+        }
+
+        public ConfiguredSitePluginPayload(SiteModel site, String pluginName, ConfigureSitePluginError error) {
+            this.site = site;
+            this.pluginName = pluginName;
+            this.error = error;
         }
 
         public ConfiguredSitePluginPayload(SiteModel site, String pluginName, String slug,
@@ -219,14 +225,14 @@ public class PluginStore extends Store {
     @SuppressWarnings("WeakerAccess")
     public static class FetchedSitePluginPayload extends Payload<FetchSitePluginError> {
         public SitePluginModel plugin;
-        public String slug;
+        public String pluginName;
 
         public FetchedSitePluginPayload(SitePluginModel plugin) {
             this.plugin = plugin;
         }
 
-        public FetchedSitePluginPayload(String slug, FetchSitePluginError error) {
-            this.slug = slug;
+        public FetchedSitePluginPayload(String pluginName, FetchSitePluginError error) {
+            this.pluginName = pluginName;
             this.error = error;
         }
     }
@@ -710,11 +716,11 @@ public class PluginStore extends Store {
 
     public static class OnSitePluginFetched extends OnChanged<FetchSitePluginError> {
         public SitePluginModel plugin;
-        public String slug;
+        public String pluginName;
 
         public OnSitePluginFetched(FetchedSitePluginPayload payload) {
             this.plugin = payload.plugin;
-            this.slug = payload.slug;
+            this.pluginName = payload.pluginName;
         }
     }
 
@@ -919,7 +925,7 @@ public class PluginStore extends Store {
      */
     private void fetchSitePlugin(FetchSitePluginPayload payload) {
         if (payload.site.isJetpackCPConnected()) {
-            mPluginJetpackTunnelRestClient.fetchPlugin(payload.site, payload.slug);
+            mPluginJetpackTunnelRestClient.fetchPlugin(payload.site, payload.pluginName);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -925,7 +925,7 @@ public class PluginStore extends Store {
        Currently this is only supported on sites connected using Jetpack plugin or Jetpack Connection Package.
      */
     private void fetchPluginForJetpackSite(FetchJetpackSitePluginPayload payload) {
-        if (payload.site.isJetpackConnected()) {
+        if (payload.site.isJetpackConnected() || payload.site.isJetpackCPConnected()) {
             mPluginJetpackTunnelRestClient.fetchPlugin(payload.site, payload.pluginName);
         } else {
             FetchPluginForJetpackSiteError error = new FetchPluginForJetpackSiteError(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -79,11 +79,11 @@ public class PluginStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static class FetchSitePluginPayload extends Payload<BaseNetworkError> {
+    public static class FetchJetpackSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public String pluginName;
 
-        public FetchSitePluginPayload(SiteModel site, String pluginName) {
+        public FetchJetpackSitePluginPayload(SiteModel site, String pluginName) {
             this.site = site;
             this.pluginName = pluginName;
         }
@@ -223,15 +223,15 @@ public class PluginStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static class FetchedSitePluginPayload extends Payload<FetchSitePluginError> {
+    public static class FetchedJetpackSitePluginPayload extends Payload<FetchSitePluginError> {
         public SitePluginModel plugin;
         public String pluginName;
 
-        public FetchedSitePluginPayload(SitePluginModel plugin) {
+        public FetchedJetpackSitePluginPayload(SitePluginModel plugin) {
             this.plugin = plugin;
         }
 
-        public FetchedSitePluginPayload(String pluginName, FetchSitePluginError error) {
+        public FetchedJetpackSitePluginPayload(String pluginName, FetchSitePluginError error) {
             this.pluginName = pluginName;
             this.error = error;
         }
@@ -714,11 +714,11 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class OnSitePluginFetched extends OnChanged<FetchSitePluginError> {
+    public static class OnJetpackSitePluginFetched extends OnChanged<FetchSitePluginError> {
         public SitePluginModel plugin;
         public String pluginName;
 
-        public OnSitePluginFetched(FetchedSitePluginPayload payload) {
+        public OnJetpackSitePluginFetched(FetchedJetpackSitePluginPayload payload) {
             this.plugin = payload.plugin;
             this.pluginName = payload.pluginName;
         }
@@ -778,8 +778,8 @@ public class PluginStore extends Store {
             case FETCH_WPORG_PLUGIN:
                 fetchWPOrgPlugin((String) action.getPayload());
                 break;
-            case FETCH_SITE_PLUGIN:
-                fetchSitePlugin((FetchSitePluginPayload) action.getPayload());
+            case FETCH_JETPACK_SITE_PLUGIN:
+                fetchPluginForJetpackSite((FetchJetpackSitePluginPayload) action.getPayload());
                 break;
             case INSTALL_SITE_PLUGIN:
                 installSitePlugin((InstallSitePluginPayload) action.getPayload());
@@ -807,8 +807,8 @@ public class PluginStore extends Store {
             case FETCHED_WPORG_PLUGIN:
                 fetchedWPOrgPlugin((FetchedWPOrgPluginPayload) action.getPayload());
                 break;
-            case FETCHED_SITE_PLUGIN:
-                fetchedSitePlugin((FetchedSitePluginPayload) action.getPayload());
+            case FETCHED_JETPACK_SITE_PLUGIN:
+                fetchedJetpackSitePlugin((FetchedJetpackSitePluginPayload) action.getPayload());
                 break;
             case INSTALLED_SITE_PLUGIN:
                 installedSitePlugin((InstalledSitePluginPayload) action.getPayload());
@@ -921,10 +921,10 @@ public class PluginStore extends Store {
     }
 
     /* Fetch a single plugin from a site, to get its information and whether it exists or not.
-       Currently this is only supported on sites connected using Jetpack Connection Package.
+       Currently this is only supported on sites connected using Jetpack plugin or Jetpack Connection Package.
      */
-    private void fetchSitePlugin(FetchSitePluginPayload payload) {
-        if (payload.site.isJetpackCPConnected()) {
+    private void fetchPluginForJetpackSite(FetchJetpackSitePluginPayload payload) {
+        if (payload.site.isJetpackConnected()) {
             mPluginJetpackTunnelRestClient.fetchPlugin(payload.site, payload.pluginName);
         }
     }
@@ -1033,8 +1033,8 @@ public class PluginStore extends Store {
         emitChange(event);
     }
 
-    private void fetchedSitePlugin(FetchedSitePluginPayload payload) {
-        OnSitePluginFetched event = new OnSitePluginFetched(payload);
+    private void fetchedJetpackSitePlugin(FetchedJetpackSitePluginPayload payload) {
+        OnJetpackSitePluginFetched event = new OnJetpackSitePluginFetched(payload);
         if (payload.isError()) {
             event.error = payload.error;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -859,6 +859,8 @@ public class PluginStore extends Store {
                     payload.isAutoUpdateEnabled);
         } else if (!payload.site.isUsingWpComRestApi()) {
             mPluginCoroutineStore.configureSitePlugin(payload.site, payload.pluginName, payload.slug, payload.isActive);
+        } else if (payload.site.isJetpackCPConnected()) {
+            mPluginJetpackTunnelRestClient.configurePlugin(payload.site, payload.slug, payload.isActive);
         } else {
             ConfigureSitePluginError error = new ConfigureSitePluginError(ConfigureSitePluginErrorType.NOT_AVAILABLE);
             ConfiguredSitePluginPayload errorPayload = new ConfiguredSitePluginPayload(payload.site, payload.slug,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -223,7 +223,7 @@ public class PluginStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static class FetchedJetpackSitePluginPayload extends Payload<FetchSitePluginError> {
+    public static class FetchedJetpackSitePluginPayload extends Payload<FetchPluginForJetpackSiteError> {
         public SitePluginModel plugin;
         public String pluginName;
 
@@ -231,7 +231,7 @@ public class PluginStore extends Store {
             this.plugin = plugin;
         }
 
-        public FetchedJetpackSitePluginPayload(String pluginName, FetchSitePluginError error) {
+        public FetchedJetpackSitePluginPayload(String pluginName, FetchPluginForJetpackSiteError error) {
             this.pluginName = pluginName;
             this.error = error;
         }
@@ -361,10 +361,10 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class FetchSitePluginError implements OnChangedError {
-        public FetchSitePluginErrorType type;
+    public static class FetchPluginForJetpackSiteError implements OnChangedError {
+        public FetchPluginForJetpackSiteErrorType type;
 
-        public FetchSitePluginError(FetchSitePluginErrorType type) {
+        public FetchPluginForJetpackSiteError(FetchPluginForJetpackSiteErrorType type) {
             this.type = type;
         }
     }
@@ -553,7 +553,8 @@ public class PluginStore extends Store {
         PLUGIN_DOES_NOT_EXIST
     }
 
-    public enum FetchSitePluginErrorType {
+    public enum FetchPluginForJetpackSiteErrorType {
+        NOT_JETPACK_SITE,
         EMPTY_RESPONSE,
         GENERIC_ERROR,
         PLUGIN_DOES_NOT_EXIST
@@ -714,7 +715,7 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class OnJetpackSitePluginFetched extends OnChanged<FetchSitePluginError> {
+    public static class OnJetpackSitePluginFetched extends OnChanged<FetchPluginForJetpackSiteError> {
         public SitePluginModel plugin;
         public String pluginName;
 
@@ -926,6 +927,13 @@ public class PluginStore extends Store {
     private void fetchPluginForJetpackSite(FetchJetpackSitePluginPayload payload) {
         if (payload.site.isJetpackConnected()) {
             mPluginJetpackTunnelRestClient.fetchPlugin(payload.site, payload.pluginName);
+        } else {
+            FetchPluginForJetpackSiteError error = new FetchPluginForJetpackSiteError(
+                    FetchPluginForJetpackSiteErrorType.NOT_JETPACK_SITE
+            );
+            FetchedJetpackSitePluginPayload errorPayload =
+                    new FetchedJetpackSitePluginPayload(payload.pluginName, error);
+            mDispatcher.dispatch(PluginActionBuilder.newFetchedJetpackSitePluginAction(errorPayload));
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -708,6 +708,16 @@ public class PluginStore extends Store {
         }
     }
 
+    public static class OnSitePluginFetched extends OnChanged<FetchSitePluginError> {
+        public SitePluginModel plugin;
+        public String slug;
+
+        public OnSitePluginFetched(FetchedSitePluginPayload payload) {
+            this.plugin = payload.plugin;
+            this.slug = payload.slug;
+        }
+    }
+
     @SuppressWarnings("WeakerAccess")
     public static class OnSitePluginsRemoved extends OnChanged<RemoveSitePluginsError> {
         public SiteModel site;
@@ -792,7 +802,8 @@ public class PluginStore extends Store {
                 fetchedWPOrgPlugin((FetchedWPOrgPluginPayload) action.getPayload());
                 break;
             case FETCHED_SITE_PLUGIN:
-                // TODO
+                fetchedSitePlugin((FetchedSitePluginPayload) action.getPayload());
+                break;
             case INSTALLED_SITE_PLUGIN:
                 installedSitePlugin((InstalledSitePluginPayload) action.getPayload());
                 break;
@@ -1010,6 +1021,14 @@ public class PluginStore extends Store {
             event.error = payload.error;
         } else if (event.pluginSlug != null) {
             PluginSqlUtils.insertOrUpdateWPOrgPlugin(payload.wpOrgPlugin);
+        }
+        emitChange(event);
+    }
+
+    private void fetchedSitePlugin(FetchedSitePluginPayload payload) {
+        OnSitePluginFetched event = new OnSitePluginFetched(payload);
+        if (payload.isError()) {
+            event.error = payload.error;
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -345,6 +345,11 @@ public class PluginStore extends Store {
             this.type = InstallSitePluginErrorType.fromGenericErrorType(type);
             this.message = message;
         }
+
+        public InstallSitePluginError(InstallSitePluginErrorType type, @Nullable String message) {
+            this.type = type;
+            this.message = message;
+        }
     }
 
     public static class UpdateSitePluginError implements OnChangedError {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -763,7 +763,8 @@ public class PluginStore extends Store {
                 fetchWPOrgPlugin((String) action.getPayload());
                 break;
             case FETCH_SITE_PLUGIN:
-                // TODO
+                fetchSitePlugin((FetchSitePluginPayload) action.getPayload());
+                break;
             case INSTALL_SITE_PLUGIN:
                 installSitePlugin((InstallSitePluginPayload) action.getPayload());
                 break;
@@ -898,6 +899,15 @@ public class PluginStore extends Store {
 
     private void fetchWPOrgPlugin(String pluginSlug) {
         mPluginWPOrgClient.fetchWPOrgPlugin(pluginSlug);
+    }
+
+    /* Fetch a single plugin from a site, to get its information and whether it exists or not.
+       Currently this is only supported on sites connected using Jetpack Connection Package.
+     */
+    private void fetchSitePlugin(FetchSitePluginPayload payload) {
+        if (payload.site.isJetpackCPConnected()) {
+            mPluginJetpackTunnelRestClient.fetchPlugin(payload.site, payload.slug);
+        }
     }
 
     private void installSitePlugin(InstallSitePluginPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -865,7 +865,7 @@ public class PluginStore extends Store {
             mPluginRestClient.configureSitePlugin(payload.site, payload.pluginName, payload.slug, payload.isActive,
                     payload.isAutoUpdateEnabled);
         } else if (payload.site.isJetpackCPConnected()) {
-            mPluginJetpackTunnelRestClient.configurePlugin(payload.site, payload.slug, payload.isActive);
+            mPluginJetpackTunnelRestClient.configurePlugin(payload.site, payload.pluginName, payload.isActive);
         } else if (!payload.site.isUsingWpComRestApi()) {
             mPluginCoroutineStore.configureSitePlugin(payload.site, payload.pluginName, payload.slug, payload.isActive);
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -857,10 +857,10 @@ public class PluginStore extends Store {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
             mPluginRestClient.configureSitePlugin(payload.site, payload.pluginName, payload.slug, payload.isActive,
                     payload.isAutoUpdateEnabled);
-        } else if (!payload.site.isUsingWpComRestApi()) {
-            mPluginCoroutineStore.configureSitePlugin(payload.site, payload.pluginName, payload.slug, payload.isActive);
         } else if (payload.site.isJetpackCPConnected()) {
             mPluginJetpackTunnelRestClient.configurePlugin(payload.site, payload.slug, payload.isActive);
+        } else if (!payload.site.isUsingWpComRestApi()) {
+            mPluginCoroutineStore.configureSitePlugin(payload.site, payload.pluginName, payload.slug, payload.isActive);
         } else {
             ConfigureSitePluginError error = new ConfigureSitePluginError(ConfigureSitePluginErrorType.NOT_AVAILABLE);
             ConfiguredSitePluginPayload errorPayload = new ConfiguredSitePluginPayload(payload.site, payload.slug,
@@ -926,10 +926,10 @@ public class PluginStore extends Store {
     private void installSitePlugin(InstallSitePluginPayload payload) {
         if (payload.site.isUsingWpComRestApi() && payload.site.isJetpackConnected()) {
             mPluginRestClient.installSitePlugin(payload.site, payload.slug);
-        } else if (!payload.site.isUsingWpComRestApi()) {
-            mPluginCoroutineStore.installSitePlugin(payload.site, payload.slug);
         } else if (payload.site.isJetpackCPConnected()) {
             mPluginJetpackTunnelRestClient.installPlugin(payload.site, payload.slug);
+        } else if (!payload.site.isUsingWpComRestApi()) {
+            mPluginCoroutineStore.installSitePlugin(payload.site, payload.slug);
         } else {
             InstallSitePluginError error = new InstallSitePluginError(InstallSitePluginErrorType.NOT_AVAILABLE);
             InstalledSitePluginPayload errorPayload = new InstalledSitePluginPayload(payload.site,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -78,6 +78,17 @@ public class PluginStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
+    public static class FetchSitePluginPayload extends Payload<BaseNetworkError> {
+        public SiteModel site;
+        public String slug;
+
+        public FetchSitePluginPayload(SiteModel site, String slug) {
+            this.site = site;
+            this.slug = slug;
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")
     public static class InstallSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public String slug;
@@ -205,6 +216,21 @@ public class PluginStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
+    public static class FetchedSitePluginPayload extends Payload<FetchSitePluginError> {
+        public SitePluginModel plugin;
+        public String slug;
+
+        public FetchedSitePluginPayload(SitePluginModel plugin) {
+            this.plugin = plugin;
+        }
+
+        public FetchedSitePluginPayload(String slug, FetchSitePluginError error) {
+            this.slug = slug;
+            this.error = error;
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")
     public static class InstalledSitePluginPayload extends Payload<InstallSitePluginError> {
         public SiteModel site;
         public String slug;
@@ -324,6 +350,14 @@ public class PluginStore extends Store {
         public FetchWPOrgPluginErrorType type;
 
         public FetchWPOrgPluginError(FetchWPOrgPluginErrorType type) {
+            this.type = type;
+        }
+    }
+
+    public static class FetchSitePluginError implements OnChangedError {
+        public FetchSitePluginErrorType type;
+
+        public FetchSitePluginError(FetchSitePluginErrorType type) {
             this.type = type;
         }
     }
@@ -507,6 +541,12 @@ public class PluginStore extends Store {
     }
 
     public enum FetchWPOrgPluginErrorType {
+        EMPTY_RESPONSE,
+        GENERIC_ERROR,
+        PLUGIN_DOES_NOT_EXIST
+    }
+
+    public enum FetchSitePluginErrorType {
         EMPTY_RESPONSE,
         GENERIC_ERROR,
         PLUGIN_DOES_NOT_EXIST
@@ -718,6 +758,8 @@ public class PluginStore extends Store {
             case FETCH_WPORG_PLUGIN:
                 fetchWPOrgPlugin((String) action.getPayload());
                 break;
+            case FETCH_SITE_PLUGIN:
+                // TODO
             case INSTALL_SITE_PLUGIN:
                 installSitePlugin((InstallSitePluginPayload) action.getPayload());
                 break;
@@ -744,6 +786,8 @@ public class PluginStore extends Store {
             case FETCHED_WPORG_PLUGIN:
                 fetchedWPOrgPlugin((FetchedWPOrgPluginPayload) action.getPayload());
                 break;
+            case FETCHED_SITE_PLUGIN:
+                // TODO
             case INSTALLED_SITE_PLUGIN:
                 installedSitePlugin((InstalledSitePluginPayload) action.getPayload());
                 break;


### PR DESCRIPTION
## PR Description

This PR is adding functionalities to:
-  Install a plugin,
- Fetch a plugin's information
  
to .org sites that are connected using Jetpack Connection Package.

## To Test

1. Prepare a site connected with Jetpack CP. An easy way is to start a .org site, don't install Jetpack, and instead install Jetpack Backup plugin. Open the plugin's setting and connect it to your wpcom account.
2. Open Example app, then sign in to your wpcom account.
3. Go to "Plugins", then select the site created on step 1.
4. Use the "Install and activate a plugin" button and try installing a plugin. You will need to enter a plugin's slug, which is the `http://wordpress.org/support/plugin/<SLUG>` part on the Plugin Directory. Observe the log and ensure it says the plugin is installed and activated.
5. Use the "Fetch a plugin from site" button. Try fetching for `jetpack-backup/jetpack-backup`, and observe the log. It will show the plugin's name and description.

Extra: you can also use Flipper to observe the network calls on both buttons's action and check the request/response there.