### PR TITLE
Add support for fetching orders inside a date range

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
@@ -9,14 +9,22 @@ class WCOrderListDescriptor(
     val site: SiteModel,
     val statusFilter: String? = null,
     val searchQuery: String? = null,
-    val excludeFutureOrders: Boolean = false
+    val excludeFutureOrders: Boolean = false,
+    val beforeFilter: String? = null,
+    val afterFilter: String? = null
 ) : ListDescriptor {
     override val config: ListConfig = ListConfig.default
 
     override val uniqueIdentifier: ListDescriptorUniqueIdentifier by lazy {
         ListDescriptorUniqueIdentifier(
-                ("woo-site-order-list-${site.id}-sf${statusFilter.orEmpty()}-sq${searchQuery.orEmpty()}" +
-                        "-efo$excludeFutureOrders").hashCode())
+                ("woo-site-order-list-${site.id}" +
+                        "-sf${statusFilter.orEmpty()}" +
+                        "-sq${searchQuery.orEmpty()}" +
+                        "-bf${beforeFilter.orEmpty()}" +
+                        "-af${afterFilter.orEmpty()}" +
+                        "-efo$excludeFutureOrders"
+                        ).hashCode()
+        )
     }
 
     override val typeIdentifier: ListDescriptorTypeIdentifier by lazy {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -137,7 +137,11 @@ class OrderRestClient @Inject constructor(
                 "offset" to offset.toString(),
                 "status" to statusFilter,
                 "_fields" to "id,date_created_gmt,date_modified_gmt"
-        ).putIfNotEmpty("search" to listDescriptor.searchQuery)
+        ).putIfNotEmpty(
+            "search" to listDescriptor.searchQuery,
+                "before" to listDescriptor.beforeFilter,
+                "after" to listDescriptor.afterFilter
+        )
 
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, listDescriptor.site.siteId, params, responseType,
                 { response: List<OrderSummaryApiResponse>? ->


### PR DESCRIPTION
### Description
Changes needed to support new [order list filters ](https://github.com/woocommerce/woocommerce-android/issues/4934) 
These changes add support for fetching orders inside a date range. 

### Demo
Tested along with these [WIP changes ](https://github.com/woocommerce/woocommerce-android/pull/5104)


https://user-images.githubusercontent.com/2663464/139447801-32155a16-40b5-48b0-adc8-fdd1443b4519.mp4



