### PR TITLE
Emit `empty billing email` order error

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -171,6 +171,10 @@ class OrderUpdateStore @Inject internal constructor(
             updateRemoteOrderPayload,
             initialOrder,
             mapError = { originalOrderError: OrderError? ->
+                /**
+                 * It's *likely* as INVALID_PARAM can be caused by probably other cases too and
+                 * empty billing address email in future releases of WooCommerce will be not relevant.
+                 */
                 val isLikelyEmptyBillingEmailError =
                         updateRemoteOrderPayload.error.type == OrderErrorType.INVALID_PARAM &&
                                 billingAddress.email.isBlank()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -72,7 +72,7 @@ class OrderUpdateStore @Inject internal constructor(
                 when (newAddress) {
                     is Billing -> {
                         val payload = wcOrderRestClient.updateBillingAddress(initialOrder, site, newAddress.toDto())
-                        emitRemoteUpdateOfUpdateContainingBillingAddress(payload, initialOrder, newAddress)
+                        emitRemoteUpdateContainingBillingAddress(payload, initialOrder, newAddress)
                     }
                     is Shipping -> {
                         val payload = wcOrderRestClient.updateShippingAddress(initialOrder, site, newAddress.toDto())
@@ -101,7 +101,7 @@ class OrderUpdateStore @Inject internal constructor(
                         site,
                         shippingAddress.toDto(),
                         billingAddress.toDto()
-                ).let { emitRemoteUpdateOfUpdateContainingBillingAddress(it, initialOrder, billingAddress) }
+                ).let { emitRemoteUpdateContainingBillingAddress(it, initialOrder, billingAddress) }
             }
         }
     }
@@ -163,7 +163,7 @@ class OrderUpdateStore @Inject internal constructor(
         this.billingPhone = newAddress.phone
     }
 
-    private suspend fun FlowCollector<UpdateOrderResult>.emitRemoteUpdateOfUpdateContainingBillingAddress(
+    private suspend fun FlowCollector<UpdateOrderResult>.emitRemoteUpdateContainingBillingAddress(
         updateRemoteOrderPayload: RemoteOrderPayload,
         initialOrder: WCOrderModel,
         billingAddress: Billing

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -307,7 +307,8 @@ class WCOrderStore @Inject constructor(
         ORDER_STATUS_NOT_FOUND,
         PLUGIN_NOT_ACTIVE,
         INVALID_RESPONSE,
-        GENERIC_ERROR;
+        GENERIC_ERROR,
+        EMPTY_BILLING_EMAIL;
 
         companion object {
             private val reverseMap = values().associateBy(OrderErrorType::name)


### PR DESCRIPTION
### Description

This PR will make `OrderUpdateStore` map `rest_invalid_param` to `EMPTY_BILLING_EMAIL` if update request contains empty billing email. 

For motivation and more context please see corresponding Woo PR: https://github.com/woocommerce/woocommerce-android/pull/5127