### PR TITLE
Woo: fetch site's metadata from the remote site for Jetpack CP sites

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonElement
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
 import org.wordpress.android.fluxc.network.UserAgent
@@ -99,6 +100,23 @@ class WooSystemRestClient @Inject constructor(
         }
     }
 
+    suspend fun fetchSiteSettings(site: SiteModel): WooPayload<WPSiteSettingsResponse> {
+        val url = WPAPI.settings.urlV2
+
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                this,
+                site,
+                url,
+                emptyMap(),
+                WPSiteSettingsResponse::class.java
+        )
+
+        return when (response) {
+            is JetpackSuccess -> WooPayload(response.data)
+            is JetpackError -> WooPayload(response.error.toWooError())
+        }
+    }
+
     data class ActivePluginsResponse(
         @SerializedName("active_plugins") private val activePlugins: List<SystemPluginModel>?,
         @SerializedName("inactive_plugins") private val inactivePlugins: List<SystemPluginModel>?
@@ -121,5 +139,13 @@ class WooSystemRestClient @Inject constructor(
         val settings: JsonElement? = null,
         val security: JsonElement? = null,
         val pages: JsonElement? = null
+    )
+
+    data class WPSiteSettingsResponse(
+        @SerializedName("title") val title: String?,
+        @SerializedName("description") val description: String?,
+        @SerializedName("url") val url: String?,
+        @SerializedName("show_on_front") val showOnFront: String?,
+        @SerializedName("page_on_front") val pageOnFront: Long?
     )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -142,10 +142,10 @@ class WooSystemRestClient @Inject constructor(
     )
 
     data class WPSiteSettingsResponse(
-        @SerializedName("title") val title: String?,
-        @SerializedName("description") val description: String?,
-        @SerializedName("url") val url: String?,
-        @SerializedName("show_on_front") val showOnFront: String?,
-        @SerializedName("page_on_front") val pageOnFront: Long?
+        @SerializedName("title") val title: String? = null,
+        @SerializedName("description") val description: String? = null,
+        @SerializedName("url") val url: String? = null,
+        @SerializedName("show_on_front") val showOnFront: String? = null,
+        @SerializedName("page_on_front") val pageOnFront: Long? = null
     )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -294,7 +294,9 @@ open class WooCommerceStore @Inject constructor(
             if (updateSettingsResult.isError) {
                 return@withDefaultContext updateSettingsResult
             }
-            return@withDefaultContext WooResult(updateSettingsResult.model!! or fetchAndUpdateWooCommerceAvailability(site))
+            return@withDefaultContext WooResult(
+                    updateSettingsResult.model!! or fetchAndUpdateWooCommerceAvailability(site)
+            )
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -159,8 +159,8 @@ open class WooCommerceStore @Inject constructor(
         // Fetch WooCommerce availability for jetpack cp sites
         siteStore.sites.filter { it.isJetpackCPConnected }
             .forEach { site ->
-                val isUpdated = fetchAndUpdateWooCommerceAvailability(site)
-                if (isUpdated && !fetchResult.updatedSites.contains(site)) {
+                val isUpdated = fetchUpdatedSiteMetaData(site)
+                if (isUpdated.model == true && !fetchResult.updatedSites.contains(site)) {
                     rowsAffected++
                 }
             }
@@ -172,38 +172,39 @@ open class WooCommerceStore @Inject constructor(
     }
 
     suspend fun fetchWooCommerceSite(site: SiteModel): WooResult<SiteModel> {
-        val fetchResult = if (!site.isJetpackCPConnected) {
-            siteStore.fetchSite(site)
-        } else {
-            // Individual fetching of sites is broken for Jetpack CP sites, so fallback to fetching all site
-            // TODO remove when the WordPress.com issue is fixed
-            siteStore.fetchSites(FetchSitesPayload())
-        }
-        if (fetchResult.isError) {
-            emitChange(fetchResult)
-
-            return WooResult(
-                    WooError(
-                            type = GENERIC_ERROR,
-                            message = fetchResult.error.message,
-                            original = UNKNOWN
+        if (!site.isJetpackCPConnected) {
+            siteStore.fetchSite(site).let {
+                if (it.isError) {
+                    return WooResult(
+                            WooError(
+                                    type = GENERIC_ERROR,
+                                    message = it.error.message,
+                                    original = UNKNOWN
+                            )
                     )
-            )
+                }
+            }
+        } else {
+            // The endpoint used by siteStore to fetch a single site is broken, so we'll update the metadata
+            // manually using the remote site directly
+            val isUpdated = fetchAndUpdateMetaDataFromSiteSettings(site).let {
+                if (it.isError) {
+                    return WooResult(
+                            WooError(
+                                    type = GENERIC_ERROR,
+                                    message = it.error.message,
+                                    original = UNKNOWN
+                            )
+                    )
+                }
+                it.model!!
+            }
+            if (isUpdated) {
+                emitChange(OnSiteChanged(1, listOf(site)))
+            }
         }
 
-        return if (!fetchResult.updatedSites.any { it.siteId == site.siteId }) {
-            // Nothing has changed for the site
-            emitChange(OnSiteChanged(0))
-            WooResult(site.takeIf { it.hasWooCommerce })
-        } else {
-            val updatedSite = fetchResult.updatedSites.first { it.siteId == site.siteId }
-            if (updatedSite.isJetpackCPConnected) {
-                fetchAndUpdateWooCommerceAvailability(updatedSite)
-            }
-            // Pass empty updated list to avoid a second fetch for WooCommerce availability
-            emitChange(OnSiteChanged(1, emptyList()))
-            WooResult(updatedSite.takeIf { it.hasWooCommerce })
-        }
+        return WooResult(siteStore.getSiteBySiteId(site.siteId))
     }
 
     fun getWooCommerceSites(): MutableList<SiteModel> =
@@ -285,6 +286,41 @@ open class WooCommerceStore @Inject constructor(
 
     fun observeSSRForSite(remoteSiteId: Long): Flow<WCSSRModel> {
         return ssrDao.observeSSRForSite(remoteSiteId)
+    }
+
+    private suspend fun fetchUpdatedSiteMetaData(site: SiteModel): WooResult<Boolean> {
+        return coroutineEngine.withDefaultContext(T.API, this, "fetchUpdatedSiteMetaData") {
+            val updateSettingsResult = fetchAndUpdateMetaDataFromSiteSettings(site)
+            if (updateSettingsResult.isError) {
+                return@withDefaultContext updateSettingsResult
+            }
+            return@withDefaultContext WooResult(updateSettingsResult.model!! or fetchAndUpdateWooCommerceAvailability(site))
+        }
+    }
+
+    private suspend fun fetchAndUpdateMetaDataFromSiteSettings(site: SiteModel): WooResult<Boolean> {
+        fun SiteModel.updateFromSiteSettings(response: WooSystemRestClient.WPSiteSettingsResponse) = apply {
+            name = response.title ?: name
+            description = response.description ?: description
+            url = response.url ?: url
+            showOnFront = response.showOnFront ?: showOnFront
+            pageOnFront = response.pageOnFront ?: pageOnFront
+        }
+
+        return coroutineEngine.withDefaultContext(T.API, this, "fetchAndUpdateMetaDataFromSiteSettings") {
+            val response = systemRestClient.fetchSiteSettings(site)
+            return@withDefaultContext when {
+                response.isError -> {
+                    AppLog.w(T.API, "fetching site settings  site ${site.siteId}")
+                    WooResult(response.error)
+                }
+                else -> {
+                    WooResult(response.result?.let {
+                        siteSqlUtils.insertOrUpdateSite(site.updateFromSiteSettings(it)) == 1
+                    } ?: false)
+                }
+            }
+        }
     }
 
     private suspend fun fetchAndUpdateWooCommerceAvailability(site: SiteModel): Boolean {


### PR DESCRIPTION
This PR implements what we discussed here: p91TBi-6lK-p2, as a summary, we run the following for every site that uses Jetpack Connection Pacakge updating it:
1. We use the endpoint `/wp/v2/settings` to fetch the updated site's metadata.
2. We use the endpoint `/wc/v3/settings` to see if WooCommerce is currently installed or not.

### Testing
1. You need at least one site that uses Jetpack Connection package connected to your account.
2. Open the example app.
3. Click on Woo.
4. Click on "Log sites".
5. Confirm that the list of sites is logged.
6. Go to the Jetpack CP site and update the site's title.
7. Go back to the example app, and click on "Log sites"
8. Confirm that the updated title is printed. 