### PR TITLE
Fix NPE and set consumerProguardFiles to propagate rules to client apps

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -22,6 +22,7 @@ android {
                         "room.expandProjection":"true"]
             }
         }
+        consumerProguardFiles 'proguard-rules.pro'
     }
     buildTypes {
         release {

--- a/fluxc/proguard-rules.pro
+++ b/fluxc/proguard-rules.pro
@@ -36,6 +36,7 @@
 
 # Application classes that will be serialized/deserialized over Gson
 -keep class org.wordpress.android.fluxc.model.** { <fields>; }
+-keep class org.wordpress.android.fluxc.network.** { <fields>; }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)

--- a/fluxc/proguard-rules.pro
+++ b/fluxc/proguard-rules.pro
@@ -21,3 +21,36 @@
 -keep class com.sun.jna.* { *; }
 -keepclassmembers class * extends com.sun.jna.* { public *; }
 ## Encrypted Logging End
+
+##---------------Begin: proguard configuration for Gson  ----------
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-dontwarn sun.misc.**
+#-keep class com.google.gson.stream.** { *; }
+
+# Application classes that will be serialized/deserialized over Gson
+-keep class org.wordpress.android.fluxc.model.** { <fields>; }
+
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+# Prevent R8 from leaving Data object members always null
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+
+# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+
+##---------------End: proguard configuration for Gson  ----------

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequest.kt
@@ -244,7 +244,7 @@ object JetpackTunnelGsonRequest {
             put("path", "$path&_method=get")
             put("json", "true")
             if (params.isNotEmpty()) {
-                put("query", gson.toJson(params))
+                put("query", gson.toJson(params, object : TypeToken<Map<String, String>>() {}.type))
             }
         }
         return finalParams
@@ -260,7 +260,7 @@ object JetpackTunnelGsonRequest {
             put("path", "$path&_method=$method")
             put("json", "true")
             if (body.isNotEmpty()) {
-                put("body", gson.toJson(body))
+                put("body", gson.toJson(body, object : TypeToken<Map<String, Any>>() {}.type))
             }
         }
         return finalBody

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -11,6 +11,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
+        consumerProguardFiles 'proguard-rules.pro'
     }
     buildTypes {
         release {


### PR DESCRIPTION
Review from one reviewer should be enough.

This PR is an attempt at fixing https://github.com/woocommerce/woocommerce-android/issues/4868, which we are not able reproduce. I've left [some comments](https://github.com/woocommerce/woocommerce-android/issues/4868#issuecomment-957273359) on the issue. 

This PR:
1. Sets proguard rules for client/consumer apps
2. Updates proguard rules to include [rules recommended for gson library](https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg)
3. Explicitly specifies type for generic type passed to `toJson` method

To test:
Test in WCAndroid