### PR TITLE
Remove legacy isCardPresentEligible flag

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCPayTest.kt
@@ -45,7 +45,6 @@ class ReleaseStack_WCPayTest : ReleaseStack_WCBase() {
         assertEquals(false, result.model?.hasOverdueRequirements)
         assertEquals("DO.WPMT.CO", result.model?.statementDescriptor)
         assertEquals("US", result.model?.country)
-        assertEquals(true, result.model?.isCardPresentEligible)
         assertEquals("usd", result.model?.storeCurrencies?.default)
         assertEquals(listOf("usd"), result.model?.storeCurrencies?.supportedCurrencies)
         assertEquals(WCPayAccountStatusEnum.COMPLETE, result.model?.status)

--- a/example/src/androidTest/resources/wc-pay-load-account-response-current-deadline.json
+++ b/example/src/androidTest/resources/wc-pay-load-account-response-current-deadline.json
@@ -9,7 +9,6 @@
       "default": "usd",
       "supported": ["usd"]
     },
-    "country": "US",
-    "card_present_eligible": false
+    "country": "US"
   }
 }

--- a/example/src/androidTest/resources/wc-pay-load-account-response-empty-status.json
+++ b/example/src/androidTest/resources/wc-pay-load-account-response-empty-status.json
@@ -9,7 +9,6 @@
       "default": "usd",
       "supported": ["usd"]
     },
-    "country": "US",
-    "card_present_eligible": false
+    "country": "US"
   }
 }

--- a/example/src/androidTest/resources/wc-pay-load-account-response-is-live-account.json
+++ b/example/src/androidTest/resources/wc-pay-load-account-response-is-live-account.json
@@ -10,7 +10,6 @@
       "default": "usd",
       "supported": ["usd"]
     },
-    "country": "US",
-    "card_present_eligible": false
+    "country": "US"
   }
 }

--- a/example/src/androidTest/resources/wc-pay-load-account-response-new-status.json
+++ b/example/src/androidTest/resources/wc-pay-load-account-response-new-status.json
@@ -9,7 +9,6 @@
       "default": "usd",
       "supported": ["usd"]
     },
-    "country": "US",
-    "card_present_eligible": false
+    "country": "US"
   }
 }

--- a/example/src/androidTest/resources/wc-pay-load-account-response-restricted-soon-status.json
+++ b/example/src/androidTest/resources/wc-pay-load-account-response-restricted-soon-status.json
@@ -9,7 +9,6 @@
       "default": "usd",
       "supported": ["usd"]
     },
-    "country": "US",
-    "card_present_eligible": false
+    "country": "US"
   }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCPaymentAccountResult.kt
@@ -33,11 +33,6 @@ data class WCPaymentAccountResult(
     @SerializedName("country")
     val country: String,
     /**
-     * A boolean flag indicating if this Account is eligible for card present payments
-     */
-    @SerializedName("card_present_eligible")
-    val isCardPresentEligible: Boolean,
-    /**
      * A boolean flag indicating if this Account is test/live.
      */
     @SerializedName("is_live")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -215,6 +215,6 @@ class PayRestClient @Inject constructor(
     companion object {
         private const val ACCOUNT_REQUESTED_FIELDS: String =
                 "status,has_pending_requirements,has_overdue_requirements,current_deadline,statement_descriptor," +
-                        "store_currencies,country,card_present_eligible,is_live,test_mode"
+                        "store_currencies,country,is_live,test_mode"
     }
 }


### PR DESCRIPTION
The `isCardPresentEligible` feature flag is not used anymore in the apps. The IPP feature is released to all users now. The server always returns `isCardPresentEligible=false` for mobile clients and uses the flag internal for a different purpose. 