### PR TITLE
Refactor fetch order shipment providers

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -22,7 +22,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
@@ -493,16 +492,10 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderShipmentProvidersFetchSuccess() {
+    fun testOrderShipmentProvidersFetchSuccess() = runBlocking {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         interceptor.respondWith("wc-order-shipment-providers-success.json")
-        orderRestClient.fetchOrderShipmentProviders(siteModel, orderModel)
-
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_ORDER_SHIPMENT_PROVIDERS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchOrderShipmentProvidersResponsePayload
+        val payload = orderRestClient.fetchOrderShipmentProviders(siteModel, orderModel)
         assertNull(payload.error)
         assertEquals(54, payload.providers.size)
 
@@ -520,16 +513,10 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
      * situation and ensures we dispatch an error
      */
     @Test
-    fun testOrderShipmentProvidersFetchFailed() {
+    fun testOrderShipmentProvidersFetchFailed() = runBlocking {
         val orderModel = WCOrderModel(5).apply { localSiteId = siteModel.id }
         interceptor.respondWith("wc-order-shipment-providers-failed.json")
-        orderRestClient.fetchOrderShipmentProviders(siteModel, orderModel)
-
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCOrderAction.FETCHED_ORDER_SHIPMENT_PROVIDERS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchOrderShipmentProvidersResponsePayload
+        val payload = orderRestClient.fetchOrderShipmentProviders(siteModel, orderModel)
         assertNotNull(payload.error)
         assertEquals(payload.error.type, OrderErrorType.INVALID_RESPONSE)
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -10,7 +10,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.example.BuildConfig
-import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
@@ -23,8 +22,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderShipmentProvidersCh
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
 
 class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
@@ -236,18 +233,14 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
      */
     @Throws(InterruptedException::class)
     @Test
-    fun testFetchShipmentProviders() {
-        nextEvent = TestEvent.FETCHED_ORDER_SHIPMENT_PROVIDERS
-        mCountDownLatch = CountDownLatch(1)
-
+    fun testFetchShipmentProviders() = runBlocking {
         val orderModel = WCOrderModel().apply {
             id = 8
             remoteOrderId = BuildConfig.TEST_WC_ORDER_WITH_SHIPMENT_TRACKINGS_ID.toLong()
             localSiteId = sSite.id
         }
-        mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentProvidersAction(
-                FetchOrderShipmentProvidersPayload(sSite, orderModel)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        orderStore.fetchOrderShipmentProviders(FetchOrderShipmentProvidersPayload(sSite, orderModel))
 
         val providers = orderStore.getShipmentProvidersForSite(sSite)
         assertTrue(providers.isNotEmpty())

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderExtTest.kt
@@ -1,8 +1,6 @@
 package org.wordpress.android.fluxc.release
 
 import kotlinx.coroutines.runBlocking
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -13,31 +11,20 @@ import org.wordpress.android.fluxc.example.BuildConfig
 import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
-import org.wordpress.android.fluxc.store.Store.OnChanged
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderShipmentProvidersChanged
-import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import java.text.SimpleDateFormat
 import java.util.Date
 import javax.inject.Inject
 
 class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
-    internal enum class TestEvent {
-        NONE,
-        FETCHED_ORDER_SHIPMENT_PROVIDERS
-    }
-
     @Inject internal lateinit var orderStore: WCOrderStore
 
     override fun buildAuthenticatePayload() = AuthenticatePayload(
             BuildConfig.TEST_WPCOM_USERNAME_WOO_JETPACK_EXTENSIONS,
             BuildConfig.TEST_WPCOM_PASSWORD_WOO_JETPACK_EXTENSIONS)
-
-    private var nextEvent: TestEvent = TestEvent.NONE
-    private var lastEvent: OnChanged<OrderError>? = null
 
     @Throws(Exception::class)
     override fun setUp() {
@@ -45,8 +32,6 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
         mReleaseStackAppComponent.inject(this)
         // Register
         init()
-        // Reset expected test event
-        nextEvent = TestEvent.NONE
     }
 
     /**
@@ -244,18 +229,5 @@ class ReleaseStack_WCOrderExtTest : ReleaseStack_WCBase() {
 
         val providers = orderStore.getShipmentProvidersForSite(sSite)
         assertTrue(providers.isNotEmpty())
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onOrderShipmentProvidersChanged(event: OnOrderShipmentProvidersChanged) {
-        event.error?.let {
-            throw AssertionError("onOrderShipmentProvidersChanged has unexpected error: " + it.type)
-        }
-
-        lastEvent = event
-
-        assertEquals(TestEvent.FETCHED_ORDER_SHIPMENT_PROVIDERS, nextEvent)
-        mCountDownLatch.countDown()
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -40,7 +40,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPay
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
-import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderShipmentProvidersChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderStatusOptionsChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrdersSearched
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
@@ -307,8 +306,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     if (providers.isNullOrEmpty()) {
                         // Fetch providers for order
                         pendingOpenAddShipmentTracking = true
-                        val payload = FetchOrderShipmentProvidersPayload(site, order)
-                        dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentProvidersAction(payload))
+                        fetchOrderShipmentProviders(site, order)
                     } else {
                         val providerNames = mutableListOf<String>()
                         providers.forEach { providerNames.add(it.carrierName) }
@@ -358,9 +356,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                 // a list of providers, even though the providers are not order specific.
                 getFirstWCOrder()?.let { order ->
                     prependToLog("Fetching a list of providers from the API")
-
-                    val payload = FetchOrderShipmentProvidersPayload(site, order)
-                    dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderShipmentProvidersAction(payload))
+                    fetchOrderShipmentProviders(site, order)
                 } ?: prependToLog("No orders found in db to use as seed. Fetch orders first.")
             }
         }
@@ -374,6 +370,36 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
         }
     }
 
+    private fun fetchOrderShipmentProviders(
+        site: SiteModel,
+        order: WCOrderModel
+    ) {
+        coroutineScope.launch {
+            val payload = FetchOrderShipmentProvidersPayload(site, order)
+            val response = wcOrderStore.fetchOrderShipmentProviders(payload)
+            if (response.isError) {
+                prependToLog("Error fetching shipment providers - error: " + response.error.type)
+            } else {
+                selectedSite?.let { site ->
+                    if (pendingOpenAddShipmentTracking) {
+                        pendingOpenAddShipmentTracking = false
+                        getFirstWCOrder()?.let { order ->
+                            val providers = mutableListOf<String>()
+                            wcOrderStore.getShipmentProvidersForSite(site)
+                                    .forEach { providers.add(it.carrierName) }
+                            showAddTrackingDialog(site, order, providers)
+                        }
+                    } else {
+                        wcOrderStore.getShipmentProvidersForSite(site).forEach { provider ->
+                            prependToLog(" - ${provider.carrierName}")
+                        }
+                        prependToLog("[${response.rowsAffected}] shipment providers fetched successfully!")
+                    }
+                }
+            }
+        }
+    }
+
     override fun onStart() {
         super.onStart()
         dispatcher.register(this)
@@ -382,30 +408,6 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
     override fun onStop() {
         super.onStop()
         dispatcher.unregister(this)
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onOrderShipmentProviderChanged(event: OnOrderShipmentProvidersChanged) {
-        if (event.isError) {
-            prependToLog("Error fetching shipment providers - error: " + event.error.type)
-        } else {
-            selectedSite?.let { site ->
-                if (pendingOpenAddShipmentTracking) {
-                    pendingOpenAddShipmentTracking = false
-                    getFirstWCOrder()?.let { order ->
-                        val providers = mutableListOf<String>()
-                        wcOrderStore.getShipmentProvidersForSite(site).forEach { providers.add(it.carrierName) }
-                        showAddTrackingDialog(site, order, providers)
-                    }
-                } else {
-                    wcOrderStore.getShipmentProvidersForSite(site).forEach { provider ->
-                        prependToLog(" - ${provider.carrierName}")
-                    }
-                    prependToLog("[${event.rowsAffected}] shipment providers fetched successfully!")
-                }
-            }
-        }
     }
 
     @Suppress("unused")

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCOrderAction.java
@@ -7,8 +7,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersPayload;
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderShipmentProvidersResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload;
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersByIdsPayload;
@@ -41,8 +39,6 @@ public enum WCOrderAction implements IAction {
     SEARCH_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsPayload.class)
     FETCH_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = FetchOrderShipmentProvidersPayload.class)
-    FETCH_ORDER_SHIPMENT_PROVIDERS,
 
     // Remote responses
     @Action(payloadType = FetchOrdersResponsePayload.class)
@@ -59,6 +55,4 @@ public enum WCOrderAction implements IAction {
     SEARCHED_ORDERS,
     @Action(payloadType = FetchOrderStatusOptionsResponsePayload.class)
     FETCHED_ORDER_STATUS_OPTIONS,
-    @Action(payloadType = FetchOrderShipmentProvidersResponsePayload.class)
-    FETCHED_ORDER_SHIPMENT_PROVIDERS
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -437,8 +437,6 @@ class WCOrderStore @Inject constructor(
             WCOrderAction.SEARCH_ORDERS -> searchOrders(action.payload as SearchOrdersPayload)
             WCOrderAction.FETCH_ORDER_STATUS_OPTIONS ->
                 fetchOrderStatusOptions(action.payload as FetchOrderStatusOptionsPayload)
-            WCOrderAction.FETCH_ORDER_SHIPMENT_PROVIDERS ->
-                fetchOrderShipmentProviders(action.payload as FetchOrderShipmentProvidersPayload)
 
             // remote responses
             WCOrderAction.FETCHED_ORDERS -> handleFetchOrdersCompleted(action.payload as FetchOrdersResponsePayload)
@@ -453,9 +451,6 @@ class WCOrderStore @Inject constructor(
             WCOrderAction.SEARCHED_ORDERS -> handleSearchOrdersCompleted(action.payload as SearchOrdersResponsePayload)
             WCOrderAction.FETCHED_ORDER_STATUS_OPTIONS ->
                 handleFetchOrderStatusOptionsCompleted(action.payload as FetchOrderStatusOptionsResponsePayload)
-            WCOrderAction.FETCHED_ORDER_SHIPMENT_PROVIDERS ->
-                handleFetchOrderShipmentProvidersCompleted(
-                        action.payload as FetchOrderShipmentProvidersResponsePayload)
         }
     }
 
@@ -627,7 +622,7 @@ class WCOrderStore @Inject constructor(
     }
 
     suspend fun deleteOrderShipmentTracking(payload: DeleteOrderShipmentTrackingPayload): OnOrderChanged {
-        return coroutineEngine.withDefaultContext(T.API, this, "addOrderShipmentTracking") {
+        return coroutineEngine.withDefaultContext(T.API, this, "deleteOrderShipmentTracking") {
             val result = with(payload) {
                 wcOrderRestClient.deleteShipmentTrackingForOrder(site, localOrderId, remoteOrderId, tracking)
             }
@@ -849,24 +844,5 @@ class WCOrderStore @Inject constructor(
         }
 
         emitChange(onOrderStatusLabelsChanged)
-    }
-
-    private fun handleFetchOrderShipmentProvidersCompleted(
-        payload: FetchOrderShipmentProvidersResponsePayload
-    ) {
-        val onProviderChanged: OnOrderShipmentProvidersChanged
-
-        if (payload.isError) {
-            onProviderChanged = OnOrderShipmentProvidersChanged(0).also { it.error = payload.error }
-        } else {
-            // Delete all providers from the db
-            OrderSqlUtils.deleteOrderShipmentProvidersForSite(payload.site)
-
-            // Add new list to the database
-            val rowsAffected = payload.providers.sumBy { OrderSqlUtils.insertOrIgnoreOrderShipmentProvider(it) }
-            onProviderChanged = OnOrderShipmentProvidersChanged(rowsAffected)
-        }
-
-        emitChange(onProviderChanged)
     }
 }


### PR DESCRIPTION
### Issue
Resolves #2173 

### Description
Refactor FETCH_ORDER_SHIPMENT_PROVIDERS action to use coroutines and removes all legacy code referencing event bus code. In the WooCommerce app, this fetch action is called from the OrderShipmentProvidersRepository.