### PR TITLE
Issue 5174. Handling of postal_code_invalid error

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCPayTest.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.pay.WCCapturePaymentErrorType.PAYMENT_A
 import org.wordpress.android.fluxc.model.pay.WCCapturePaymentErrorType.SERVER_ERROR
 import org.wordpress.android.fluxc.model.pay.WCPaymentAccountResult.WCPayAccountStatusEnum
 import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationErrorType.GenericError
+import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationErrorType.InvalidPostalCode
 import org.wordpress.android.fluxc.model.pay.WCTerminalStoreLocationErrorType.MissingAddress
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.pay.PayRestClient
@@ -162,5 +163,15 @@ class MockedStack_WCPayTest : MockedStack_Base() {
 
         assertTrue(result.isError)
         assertTrue(result.error?.type is GenericError)
+    }
+
+    @Test
+    fun whenGetStoreLocationForSiteWithInvalidPostalCodeError() = runBlocking {
+        interceptor.respondWithError("wc-pay-store-location-for-site-invalid-postal-code-error.json", 500)
+
+        val result = payRestClient.getStoreLocationForSite(SiteModel().apply { siteId = 123L })
+
+        assertTrue(result.isError)
+        assertTrue(result.error?.type is InvalidPostalCode)
     }
 }

--- a/example/src/androidTest/resources/wc-pay-store-location-for-site-invalid-postal-code-error.json
+++ b/example/src/androidTest/resources/wc-pay-store-location-for-site-invalid-postal-code-error.json
@@ -1,0 +1,4 @@
+{
+  "error": "postal_code_invalid",
+  "message": "Error: Invalid US postal code"
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/pay/WCTerminalStoreLocationResult.kt
@@ -33,6 +33,7 @@ data class WCTerminalStoreLocationError(
 sealed class WCTerminalStoreLocationErrorType {
     object GenericError : WCTerminalStoreLocationErrorType()
     data class MissingAddress(val addressEditingUrl: String) : WCTerminalStoreLocationErrorType()
+    object InvalidPostalCode : WCTerminalStoreLocationErrorType()
     object ServerError : WCTerminalStoreLocationErrorType()
     object NetworkError : WCTerminalStoreLocationErrorType()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pay/PayRestClient.kt
@@ -204,6 +204,7 @@ class PayRestClient @Inject constructor(
                 if (error.message.isNullOrBlank()) WCTerminalStoreLocationErrorType.GenericError
                 else WCTerminalStoreLocationErrorType.MissingAddress(error.message)
             }
+            error.apiError == "postal_code_invalid" -> WCTerminalStoreLocationErrorType.InvalidPostalCode
             error.type == GenericErrorType.TIMEOUT -> WCTerminalStoreLocationErrorType.NetworkError
             error.type == GenericErrorType.NO_CONNECTION -> WCTerminalStoreLocationErrorType.NetworkError
             error.type == GenericErrorType.NETWORK_ERROR -> WCTerminalStoreLocationErrorType.NetworkError


### PR DESCRIPTION
The PR ads handling of 

```
{
	"error": "postal_code_invalid",
	"message": "Error: Invalid US postal code"
}
```

So we can handle this properly in the app