### PR TITLE
Add a column to expose active Jetpack connection plugins in the SiteModel table

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -133,6 +133,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     @Column private String mActiveModules;
     @Column private boolean mIsPublicizePermanentlyDisabled;
+    @Column private String mActiveJetpackConnectionPlugins;
 
     // Zendesk meta
     @Column private String mZendeskPlan;
@@ -744,6 +745,14 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setActiveModules(String activeModules) {
         mActiveModules = activeModules;
+    }
+
+    public String getActiveJetpackConnectionPlugins() {
+        return mActiveJetpackConnectionPlugins;
+    }
+
+    public void setActiveJetpackConnectionPlugins(String activeJetpackConnectionPlugins) {
+        mActiveJetpackConnectionPlugins = activeJetpackConnectionPlugins;
     }
 
     public boolean isActiveModuleEnabled(String moduleName) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -936,6 +936,9 @@ class SiteRestClient @Inject constructor(
             if (from.options.active_modules != null) {
                 site.activeModules = from.options.active_modules.joinToString(",")
             }
+            from.options.jetpack_connection_active_plugins?.let {
+                site.activeJetpackConnectionPlugins = it.joinToString(",")
+            }
             try {
                 site.maxUploadSize = java.lang.Long.valueOf(from.options.max_upload_size)
             } catch (e: NumberFormatException) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -32,6 +32,7 @@ public class SiteWPComRestResponse implements Response {
         public long page_for_posts;
         public boolean publicize_permanently_disabled;
         public List<String> active_modules;
+        public List<String> jetpack_connection_active_plugins;
     }
 
     public static class Plan {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 166
+        return 167
     }
 
     override fun getDbName(): String {
@@ -1825,6 +1825,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 165 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCOrderModel ADD SHIPPING_PHONE TEXT")
+                }
+                166 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD ACTIVE_JETPACK_CONNECTION_PLUGINS TEXT")
                 }
             }
         }


### PR DESCRIPTION
For the issue https://github.com/woocommerce/woocommerce-android/issues/5186, we need to pass the list of the currently active jetpack connection plugins of the selected site, this PR just adds a new column to the table, and fills it from the network response.

This doesn't bring any breaking changes, so it can be merged after the review directly.

#### Testing
I didn't add any new parts to the example app for this, as it seems not worth it, please use the database inspector from Android studio to confirm that the column has been added, and has the correct data (after forcing fetching sites from the example app)