### PR TITLE
Woo/2183 create quick order

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -534,6 +534,17 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         assertEquals(payload.error.type, OrderErrorType.INVALID_RESPONSE)
     }
 
+    @Test
+    fun testPushQuickOrder() = runBlocking {
+        interceptor.respondWith("wc-fetch-order-response-success.json")
+        val response = orderRestClient.postQuickOrder(siteModel, "10.00")
+
+        with(response) {
+            assertNull(error)
+            assertNotNull(order)
+        }
+    }
+
     @Suppress("unused")
     @Subscribe
     fun onAction(action: Action<*>) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -535,7 +535,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testPushQuickOrder() = runBlocking {
+    fun testPostQuickOrder() = runBlocking {
         interceptor.respondWith("wc-fetch-order-response-success.json")
         val response = orderRestClient.postQuickOrder(siteModel, "10.00")
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -386,7 +386,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                             if (result.isError) {
                                 prependToLog("Creating quick order failed.")
                             } else {
-                                prependToLog("Created quick order with remote ID ${result.remoteOrderId}.")
+                                prependToLog("Created quick order with remote ID ${result.order?.remoteOrderId}.")
                             }
                         } catch (e: NumberFormatException) {
                             prependToLog("Invalid amount.")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -386,7 +386,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                             if (result.isError) {
                                 prependToLog("Creating quick order failed.")
                             } else {
-                                prependToLog("Created quick order, ${result.rowsAffected} rows inserted.")
+                                prependToLog("Created quick order with remote ID ${result.remoteOrderId}.")
                             }
                         } catch (e: NumberFormatException) {
                             prependToLog("Invalid amount.")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -382,7 +382,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     coroutineScope.launch {
                         try {
                             val amount = editText.text.toString()
-                            val result = wcOrderStore.pushQuickOrder(site, amount)
+                            val result = wcOrderStore.postQuickOrder(site, amount)
                             if (result.isError) {
                                 prependToLog("Creating quick order failed.")
                             } else {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -47,7 +47,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.ToastUtils
-import java.math.BigDecimal
 import javax.inject.Inject
 
 class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDialog.Listener {
@@ -381,10 +380,17 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                         "Enter the amount:"
                 ) { editText ->
                     coroutineScope.launch {
-                        wcOrderStore.pushQuickOrder(site, BigDecimal(editText.text.toString())).takeUnless { it.isError }
-                                ?.let {
-                                    prependToLog("Created quick order, ${it.rowsAffected} rows inserted")
-                                } ?: prependToLog("Creating quick order failed.")
+                        try {
+                            val amount = editText.text.toString()
+                            val result = wcOrderStore.pushQuickOrder(site, amount)
+                            if (result.isError) {
+                                prependToLog("Creating quick order failed.")
+                            } else {
+                                prependToLog("Created quick order, ${result.rowsAffected} rows inserted.")
+                            }
+                        } catch (e: NumberFormatException) {
+                            prependToLog("Invalid amount.")
+                        }
                     }
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -47,6 +47,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.ToastUtils
+import java.math.BigDecimal
 import javax.inject.Inject
 
 class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDialog.Listener {
@@ -370,6 +371,22 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                 wcOrderStore.getOrdersForSite(site).firstOrNull()?.let { order ->
                     replaceFragment(AddressEditDialogFragment.newInstance(order))
                 } ?: showNoOrdersToast(site)
+            }
+        }
+
+        create_quick_order.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(
+                        activity,
+                        "Enter the amount:"
+                ) { editText ->
+                    coroutineScope.launch {
+                        wcOrderStore.pushQuickOrder(site, BigDecimal(editText.text.toString())).takeUnless { it.isError }
+                                ?.let {
+                                    prependToLog("Created quick order, ${it.rowsAffected} rows inserted")
+                                } ?: prependToLog("Creating quick order failed.")
+                    }
+                }
             }
         }
     }

--- a/example/src/main/res/layout/fragment_woo_orders.xml
+++ b/example/src/main/res/layout/fragment_woo_orders.xml
@@ -138,5 +138,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Update latest order billing address" />
+
+        <Button
+            android:id="@+id/create_quick_order"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Create quick order" />
     </LinearLayout>
 </ScrollView>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -52,7 +52,6 @@ import org.wordpress.android.fluxc.utils.DateUtils
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import java.math.BigDecimal
 import java.util.Calendar
 import javax.inject.Inject
 import javax.inject.Named
@@ -458,11 +457,12 @@ class OrderRestClient @Inject constructor(
     )
 
     /**
-     * Ccreates a "quick order," which is assigned the passed amount
+     * Creates a "quick order," which is an empty order assigned the passed amount
      */
-    suspend fun pushQuickOrder(site: SiteModel, amount: BigDecimal): RemoteOrderPayload {
+    suspend fun pushQuickOrder(site: SiteModel, amount: String): RemoteOrderPayload {
         val url = WOOCOMMERCE.orders.pathV3
-        val params = mapOf("fee_lines" to amount)
+        val feeLine = "[{ 'total', '$amount' }]"
+        val params = mapOf("fee_lines" to feeLine)
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -461,7 +461,7 @@ class OrderRestClient @Inject constructor(
     /**
      * Creates a "quick order," which is an empty order assigned the passed amount
      */
-    suspend fun pushQuickOrder(site: SiteModel, amount: String): RemoteOrderPayload {
+    suspend fun postQuickOrder(site: SiteModel, amount: String): RemoteOrderPayload {
         val jsonFee = JsonObject().also {
             it.addProperty("name", "Quick Order")
             it.addProperty("total", amount)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -2,7 +2,9 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import android.content.Context
 import com.android.volley.RequestQueue
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
+import com.google.gson.JsonObject
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction
@@ -461,8 +463,12 @@ class OrderRestClient @Inject constructor(
      */
     suspend fun pushQuickOrder(site: SiteModel, amount: String): RemoteOrderPayload {
         val url = WOOCOMMERCE.orders.pathV3
-        val feeLine = "[{ 'total', '$amount' }]"
-        val params = mapOf("fee_lines" to feeLine)
+        val jsonFee = JsonObject().also { it.addProperty("total", amount) }
+        val jsonArray = JsonArray().also { it.add(jsonFee) }
+        val params = mapOf(
+                "fee_lines" to jsonArray.toString(),
+                "_fields" to ORDER_FIELDS
+        )
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import android.content.Context
 import com.android.volley.RequestQueue
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.reflect.TypeToken
@@ -462,18 +463,13 @@ class OrderRestClient @Inject constructor(
      */
     suspend fun pushQuickOrder(site: SiteModel, amount: String): RemoteOrderPayload {
         val jsonFee = JsonObject().also {
-            it.addProperty("total", amount)
             it.addProperty("name", "Quick Order")
+            it.addProperty("total", amount)
             it.addProperty("tax_status", "none")
             it.addProperty("tax_class", "")
         }
-        val jsonFeeItems = JsonObject().also {
-            it.addProperty("items", jsonFee.toString())
-        }
-        val params = mapOf(
-                "fee_lines" to jsonFeeItems.toString(),
-                "_fields" to ORDER_FIELDS
-        )
+        val jsonFeeItems = JsonArray().also { it.add(jsonFee) }
+        val params = mapOf( "fee_lines" to jsonFeeItems )
 
         val url = WOOCOMMERCE.orders.pathV3
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import android.content.Context
 import com.android.volley.RequestQueue
-import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.reflect.TypeToken
@@ -464,15 +463,15 @@ class OrderRestClient @Inject constructor(
     suspend fun pushQuickOrder(site: SiteModel, amount: String): RemoteOrderPayload {
         val jsonFee = JsonObject().also {
             it.addProperty("total", amount)
+            it.addProperty("name", "Quick Order")
+            it.addProperty("tax_status", "none")
+            it.addProperty("tax_class", "")
         }
         val jsonFeeItems = JsonObject().also {
             it.addProperty("items", jsonFee.toString())
         }
-        val jsonFeeLines = JsonArray().also {
-            it.add(jsonFeeItems)
-        }
         val params = mapOf(
-                "fee_lines" to jsonFeeLines.toString(),
+                "fee_lines" to jsonFeeItems.toString(),
                 "_fields" to ORDER_FIELDS
         )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -462,14 +462,21 @@ class OrderRestClient @Inject constructor(
      * Creates a "quick order," which is an empty order assigned the passed amount
      */
     suspend fun pushQuickOrder(site: SiteModel, amount: String): RemoteOrderPayload {
-        val url = WOOCOMMERCE.orders.pathV3
-        val jsonFee = JsonObject().also { it.addProperty("total", amount) }
-        val jsonArray = JsonArray().also { it.add(jsonFee) }
+        val jsonFee = JsonObject().also {
+            it.addProperty("total", amount)
+        }
+        val jsonFeeItems = JsonObject().also {
+            it.addProperty("items", jsonFee.toString())
+        }
+        val jsonFeeLines = JsonArray().also {
+            it.add(jsonFeeItems)
+        }
         val params = mapOf(
-                "fee_lines" to jsonArray.toString(),
+                "fee_lines" to jsonFeeLines.toString(),
                 "_fields" to ORDER_FIELDS
         )
 
+        val url = WOOCOMMERCE.orders.pathV3
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this,
                 site,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -469,7 +469,10 @@ class OrderRestClient @Inject constructor(
             it.addProperty("tax_class", "")
         }
         val jsonFeeItems = JsonArray().also { it.add(jsonFee) }
-        val params = mapOf( "fee_lines" to jsonFeeItems )
+        val params = mapOf(
+                "fee_lines" to jsonFeeItems,
+                "_fields" to ORDER_FIELDS
+        )
 
         val url = WOOCOMMERCE.orders.pathV3
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -509,7 +509,7 @@ class WCOrderStore @Inject constructor(
     }
 
     suspend fun pushQuickOrder(site: SiteModel, amount: BigDecimal): OnOrderChanged {
-        return coroutineEngine.withDefaultContext(T.API, this, "fetchSingleOrder") {
+        return coroutineEngine.withDefaultContext(T.API, this, "pushQuickOrder") {
             val result = wcOrderRestClient.pushQuickOrder(site, amount)
 
             return@withDefaultContext if (result.isError) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -508,9 +508,9 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    suspend fun pushQuickOrder(site: SiteModel, amount: String): OnOrderChanged {
+    suspend fun postQuickOrder(site: SiteModel, amount: String): OnOrderChanged {
         return coroutineEngine.withDefaultContext(T.API, this, "pushQuickOrder") {
-            val result = wcOrderRestClient.pushQuickOrder(site, amount)
+            val result = wcOrderRestClient.postQuickOrder(site, amount)
 
             return@withDefaultContext if (result.isError) {
                 OnOrderChanged(0).also { it.error = result.error }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -508,7 +508,7 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    suspend fun pushQuickOrder(site: SiteModel, amount: BigDecimal): OnOrderChanged {
+    suspend fun pushQuickOrder(site: SiteModel, amount: String): OnOrderChanged {
         return coroutineEngine.withDefaultContext(T.API, this, "pushQuickOrder") {
             val result = wcOrderRestClient.pushQuickOrder(site, amount)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -32,7 +32,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUp
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import java.math.BigDecimal
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUp
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import java.math.BigDecimal
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
@@ -497,6 +498,19 @@ class WCOrderStore @Inject constructor(
     suspend fun fetchSingleOrder(site: SiteModel, remoteOrderId: Long): OnOrderChanged {
         return coroutineEngine.withDefaultContext(T.API, this, "fetchSingleOrder") {
             val result = wcOrderRestClient.fetchSingleOrder(site, remoteOrderId)
+
+            return@withDefaultContext if (result.isError) {
+                OnOrderChanged(0).also { it.error = result.error }
+            } else {
+                val rowsAffected = OrderSqlUtils.insertOrUpdateOrder(result.order)
+                OnOrderChanged(rowsAffected)
+            }
+        }
+    }
+
+    suspend fun pushQuickOrder(site: SiteModel, amount: BigDecimal): OnOrderChanged {
+        return coroutineEngine.withDefaultContext(T.API, this, "fetchSingleOrder") {
+            val result = wcOrderRestClient.pushQuickOrder(site, amount)
 
             return@withDefaultContext if (result.isError) {
                 OnOrderChanged(0).also { it.error = result.error }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -326,7 +326,7 @@ class WCOrderStore @Inject constructor(
     }
 
     data class OnQuickOrderResult(
-        var remoteOrderId: Long
+        var order: WCOrderModel? = null
     ) : OnChanged<OrderError>()
 
     /**
@@ -516,10 +516,10 @@ class WCOrderStore @Inject constructor(
             val result = wcOrderRestClient.postQuickOrder(site, amount)
 
             return@withDefaultContext if (result.isError) {
-                OnQuickOrderResult(0).also { it.error = result.error }
+                OnQuickOrderResult().also { it.error = result.error }
             } else {
                 OrderSqlUtils.insertOrUpdateOrder(result.order)
-                OnQuickOrderResult(result.order.remoteOrderId)
+                OnQuickOrderResult(result.order)
             }
         }
     }


### PR DESCRIPTION
Closes #2183 by adding the ability to create a "quick order," which is an empty order with an amount attached. To test, visit Woo > Orders in the example app and tap "Create quick order" at the bottom.

You can test this functionality with [this WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/5211).