### PR TITLE
Add support for `WCTracker`

### DIFF
--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -13,6 +13,8 @@ public class WCWPAPIEndpoint {
 
     private static final String WC_PREFIX_V1_ADDONS = "wc-product-add-ons/v1";
 
+    private static final String WC_PREFIX_TELEMETRY = "wc-telemetry";
+
     private final String mEndpoint;
 
     public WCWPAPIEndpoint(String endpoint) {
@@ -53,5 +55,9 @@ public class WCWPAPIEndpoint {
 
     public String getPathV1Addons() {
         return "/" + WC_PREFIX_V1_ADDONS + mEndpoint;
+    }
+
+    public String getPathWcTelemetry() {
+        return "/" + WC_PREFIX_TELEMETRY + mEndpoint;
     }
 }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -70,3 +70,5 @@
 
 /data/countries
 /system_status
+
+/tracker

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerRestClient.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.tracker
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+internal class TrackerRestClient @Inject constructor(
+    appContext: Context,
+    dispatcher: Dispatcher,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    private val requestBuilder: JetpackTunnelGsonRequestBuilder
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun sendTelemetry(appVersion: String, site: SiteModel): WooPayload<Unit> {
+        val url = WOOCOMMERCE.tracker.pathWcTelemetry
+
+        val response = requestBuilder.syncPostRequest(
+            restClient = this,
+            site = site,
+            url = url,
+            clazz = Unit::class.java,
+            body = mapOf(
+                "platform" to "android",
+                "version" to appVersion
+            )
+        )
+
+        return when (response) {
+            is JetpackSuccess -> WooPayload(Unit)
+            is JetpackError -> WooPayload(response.error.toWooError())
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.tracker
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TrackerStore @Inject internal constructor(private val restClient: TrackerRestClient) {
+    suspend fun sendTelemetry(appVersion: String, site: SiteModel): WooPayload<Unit> {
+        return restClient.sendTelemetry(appVersion, site)
+    }
+}


### PR DESCRIPTION
Relates to https://github.com/woocommerce/woocommerce-android/issues/5196

### Description
This PR adds an endpoint to send `WCTracker` telemetry. For test instructions please see WooCommerce PR.