### PR TITLE
Crash tests when api.properties is not setup

### DIFF
--- a/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
+++ b/instaflux/src/main/java/org/wordpress/android/fluxc/instaflux/AppConfigModule.java
@@ -35,7 +35,8 @@ public class AppConfigModule {
         String appId = getStringBuildConfigValue("OAUTH_APP_ID");
         String appSecret = getStringBuildConfigValue("OAUTH_APP_SECRET");
         if (TextUtils.isEmpty(appId) || TextUtils.isEmpty(appSecret)) {
-            AppLog.e(T.API, "OAUTH_APP_ID or OAUTH_APP_SECRET is empty, check your gradle.properties");
+            AppLog.e(T.API, "OAUTH_APP_ID or OAUTH_APP_SECRET is empty, check your api.properties");
+            throw new RuntimeException("OAUTH_APP_ID or OAUTH_APP_SECRET is empty, check your api.properties");
         }
         return new AppSecrets(appId, appSecret);
     }


### PR DESCRIPTION
This PR crashes tests when `api.properties` file is not correctly setup. Original, the app would fail with `The required "client_id" parameter is missing` later and figuring out what is wrong took unnecessary time.

No need to test anything, but if you really wanted, you can
1. Remove content of `api.properties`
2. Run eg `ReleaseStack_WCPayTest`
3. Notice that they fail with `OAUTH_APP_ID or OAUTH_APP_SECRET is empty, check your api.properties` error