### PR TITLE
Dashboard Cards: Introduce Skeleton Classes

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -5,8 +5,8 @@ import org.wordpress.android.fluxc.example.di.AppConfigModule;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.DatabaseModule;
 import org.wordpress.android.fluxc.module.MockedToolsModule;
-import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.OkHttpClientModule;
+import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
 
 import javax.inject.Singleton;
@@ -73,5 +73,8 @@ public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_XPostsTest test);
     void inject(ReleaseStack_NoRedirectsTest test);
     void inject(ReleaseStack_WCPayTest test);
+
     void inject(ReleaseStack_WPApiPluginTest test);
+
+    void inject(ReleaseStack_CardsTest test);
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CardsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CardsTest.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.release
+
+class ReleaseStack_CardsTest : ReleaseStack_Base() {
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        // Register
+        init()
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
@@ -1,0 +1,45 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.dashboard
+
+import com.android.volley.RequestQueue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.CardsResponse
+import org.wordpress.android.fluxc.store.dashboard.CardsStore.FetchedCardsPayload
+import org.wordpress.android.fluxc.test
+
+@RunWith(MockitoJUnitRunner::class)
+class CardsRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    @Mock private lateinit var site: SiteModel
+
+    private lateinit var restClient: CardsRestClient
+
+    @Before
+    fun setUp() {
+        restClient = CardsRestClient(
+                dispatcher,
+                null,
+                requestQueue,
+                accessToken,
+                userAgent
+        )
+    }
+
+    @Test
+    fun `skeleton test`() = test {
+        val result = restClient.fetchCards(site)
+
+        assertThat(result).isEqualTo(FetchedCardsPayload(CardsResponse()))
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.fluxc.store.dashboard
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.dashboard.CardsMapper
+import org.wordpress.android.fluxc.model.dashboard.CardsModel
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+
+@RunWith(MockitoJUnitRunner::class)
+class CardsStoreTest {
+    @Mock private lateinit var siteModel: SiteModel
+
+    private lateinit var cardsStore: CardsStore
+
+    @Before
+    fun setUp() {
+        cardsStore = CardsStore(
+                CardsMapper(),
+                initCoroutineEngine()
+        )
+    }
+
+    @Test
+    fun `skeleton test`() = test {
+        val result = cardsStore.fetchCards(siteModel)
+
+        assertThat(result.model).isEqualTo(CardsModel())
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardsMapper.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.fluxc.model.dashboard
+
+import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.CardsResponse
+import javax.inject.Inject
+
+class CardsMapper @Inject constructor() {
+    fun map(response: CardsResponse): CardsModel = CardsModel(response.todo)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardsModel.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.fluxc.model.dashboard
+
+data class CardsModel(
+    val todo: Int = 0
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import com.android.volley.RequestQueue
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.dashboard.CardsStore.FetchedCardsPayload
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -14,11 +16,14 @@ import javax.inject.Singleton
 @Singleton
 class CardsRestClient @Inject constructor(
     dispatcher: Dispatcher,
-    appContext: Context,
+    appContext: Context?,
     @Named("regular") requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    @Suppress("RedundantSuspendModifier", "UNUSED_PARAMETER")
+    suspend fun fetchCards(site: SiteModel) = FetchedCardsPayload(CardsResponse())
+
     data class CardsResponse(
         @SerializedName("todo") val todo: Int = 0
     )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.dashboard
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class CardsRestClient @Inject constructor(
+    dispatcher: Dispatcher,
+    appContext: Context,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    data class CardsResponse(
+        @SerializedName("todo") val todo: Int = 0
+    )
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/dashboard/CardsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/dashboard/CardsSqlUtils.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.fluxc.persistence.dashboard
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CardsSqlUtils @Inject constructor()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
@@ -1,0 +1,80 @@
+package org.wordpress.android.fluxc.store.dashboard
+
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.dashboard.CardsMapper
+import org.wordpress.android.fluxc.model.dashboard.CardsModel
+import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.CardsResponse
+import org.wordpress.android.fluxc.store.Store
+import org.wordpress.android.fluxc.store.Store.OnChangedError
+import org.wordpress.android.fluxc.store.dashboard.CardsStore.CardsErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CardsStore @Inject constructor(
+    private val mapper: CardsMapper,
+    private val coroutineEngine: CoroutineEngine
+) {
+    @Suppress("unused", "UNUSED_PARAMETER")
+    suspend fun fetchCards(
+        site: SiteModel
+    ) = coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchCards") {
+        // TODO: Fetch from rest.
+        return@withDefaultContext storeCards(FetchedCardsPayload(CardsResponse()))
+    }
+
+    private fun storeCards(
+        payload: FetchedCardsPayload<CardsResponse>
+    ): OnCardsFetched<CardsModel> {
+        return when {
+            payload.isError -> OnCardsFetched(payload.error)
+            payload.response != null -> {
+                // TODO: Store in db.
+                OnCardsFetched(mapper.map(payload.response))
+            }
+            else -> OnCardsFetched(CardsError(INVALID_RESPONSE))
+        }
+    }
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun getCards(
+        site: SiteModel
+    ) = coroutineEngine.run(AppLog.T.API, this, "getCards") {
+        // TODO: Get from db.
+    }
+
+    /* PAYLOADS */
+
+    data class FetchedCardsPayload<T>(
+        val response: T? = null
+    ) : Payload<CardsError>() {
+        @Suppress("unused")
+        constructor(error: CardsError) : this() {
+            this.error = error
+        }
+    }
+
+    /* ACTIONS */
+
+    data class OnCardsFetched<T>(
+        val model: T? = null,
+        val cached: Boolean = false
+    ) : Store.OnChanged<CardsError>() {
+        constructor(error: CardsError) : this() {
+            this.error = error
+        }
+    }
+
+    /* ERRORS */
+
+    enum class CardsErrorType {
+        GENERIC_ERROR,
+        AUTHORIZATION_REQUIRED,
+        INVALID_RESPONSE
+    }
+
+    class CardsError(var type: CardsErrorType, var message: String? = null) : OnChangedError
+}


### PR DESCRIPTION
Parent: [WordPress-Android#15498](https://github.com/wordpress-mobile/WordPress-Android/issues/15498)

This PR adds skeleton classes for the `CardsRestClient`, `CardsModel`, `CardsMapper`, `CardsSqlUtils`, `CardsStore` and the connected `ReleaseStack_CardsTest` test. Those will be used for the networking and persistence part of the `Dashboard Cards` feature.

-----

To test:

There is actually nothing to test in this PR, just review the basic skeleton classes and make sure that the structure is similar to other non-dispatcher related stores (ie. `PostDetailStore`, which doesn't extend from `Store`, and not `ScanStore`, which actually does).