### PR TITLE
Convert FetchProductReviews into suspendable method

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked
 
 import com.google.gson.JsonArray
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -22,7 +23,6 @@ import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
-import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
@@ -452,15 +452,10 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchProductReviewsSuccess() {
+    fun testFetchProductReviewsSuccess() = runBlocking {
         interceptor.respondWith("wc-fetch-product-reviews-response-success.json")
-        productRestClient.fetchProductReviews(siteModel, 0)
+        val payload = productRestClient.fetchProductReviews(siteModel, 0)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCProductAction.FETCHED_PRODUCT_REVIEWS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchProductReviewsResponsePayload
         assertFalse(payload.isError)
         assertEquals(siteModel.id, payload.site.id)
         assertEquals(25, payload.reviews.size)
@@ -478,15 +473,10 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchProductReviewsFailed() {
+    fun testFetchProductReviewsFailed() = runBlocking {
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
-        productRestClient.fetchProductReviews(siteModel, 0)
+        val payload = productRestClient.fetchProductReviews(siteModel, 0)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCProductAction.FETCHED_PRODUCT_REVIEWS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchProductReviewsResponsePayload
         assertTrue(payload.isError)
         assertEquals(ProductErrorType.GENERIC_ERROR, payload.error.type)
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.release
 
 import com.google.gson.JsonArray
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.junit.Assert.assertEquals
@@ -69,7 +70,6 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         FETCHED_SINGLE_PRODUCT,
         FETCHED_PRODUCTS,
         FETCHED_PRODUCT_VARIATIONS,
-        FETCHED_PRODUCT_REVIEWS,
         FETCHED_SINGLE_PRODUCT_REVIEW,
         FETCHED_PRODUCT_SHIPPING_CLASS_LIST,
         FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS,
@@ -339,7 +339,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
     @Throws(InterruptedException::class)
     @Test
-    fun testFetchProductReviews() {
+    fun testFetchProductReviews() = runBlocking {
         /*
          * TEST 1: Fetch product reviews for site
          */
@@ -347,12 +347,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         productStore.deleteAllProductReviews()
         assertEquals(0, ProductSqlUtils.getProductReviewsForSite(sSite).size)
 
-        nextEvent = TestEvent.FETCHED_PRODUCT_REVIEWS
-        mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(
-                WCProductActionBuilder.newFetchProductReviewsAction(FetchProductReviewsPayload(sSite, offset = 0))
-        )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        productStore.fetchProductReviews(FetchProductReviewsPayload(sSite, offset = 0))
 
         // Verify results
         val fetchedReviewsAll = productStore.getProductReviewsForSite(sSite)
@@ -368,14 +363,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         productStore.deleteAllProductReviews()
         assertEquals(0, ProductSqlUtils.getProductReviewsForSite(sSite).size)
 
-        nextEvent = TestEvent.FETCHED_PRODUCT_REVIEWS
-        mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(
-                WCProductActionBuilder.newFetchProductReviewsAction(
-                        FetchProductReviewsPayload(sSite, reviewIds = idsToFetch, offset = 0)
-                )
-        )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        productStore.fetchProductReviews(FetchProductReviewsPayload(sSite, reviewIds = idsToFetch, offset = 0))
 
         // Verify results
         val fetchReviewsId = productStore.getProductReviewsForSite(sSite)
@@ -395,14 +383,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         productStore.deleteAllProductReviews()
         assertEquals(0, ProductSqlUtils.getProductReviewsForSite(sSite).size)
 
-        nextEvent = TestEvent.FETCHED_PRODUCT_REVIEWS
-        mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(
-                WCProductActionBuilder.newFetchProductReviewsAction(
-                        FetchProductReviewsPayload(sSite, productIds = productIdsToFetch, offset = 0)
-                )
-        )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        productStore.fetchProductReviews(FetchProductReviewsPayload(sSite, productIds = productIdsToFetch, offset = 0))
 
         // Verify results
         val fetchedReviewsForProduct = productStore.getProductReviewsForSite(sSite)
@@ -863,10 +844,6 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         when (event.causeOfChange) {
             WCProductAction.FETCH_SINGLE_PRODUCT_REVIEW -> {
                 assertEquals(TestEvent.FETCHED_SINGLE_PRODUCT_REVIEW, nextEvent)
-                mCountDownLatch.countDown()
-            }
-            WCProductAction.FETCH_PRODUCT_REVIEWS -> {
-                assertEquals(TestEvent.FETCHED_PRODUCT_REVIEWS, nextEvent)
                 mCountDownLatch.countDown()
             }
             WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS -> {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import kotlinx.android.synthetic.main.fragment_woo_products.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -15,7 +16,6 @@ import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_TAGS
 import org.wordpress.android.fluxc.action.WCProductAction.DELETED_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_CATEGORIES
-import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_REVIEWS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_TAGS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_VARIATIONS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
@@ -200,9 +200,16 @@ class WooProductsFragment : StoreSelectingFragment() {
                 ) { editText ->
                     val remoteProductId = editText.text.toString().toLongOrNull()
                     remoteProductId?.let { id ->
-                        prependToLog("Submitting request to fetch product reviews for remoteProductID $id")
-                        val payload = FetchProductReviewsPayload(site, productIds = listOf(remoteProductId))
-                        dispatcher.dispatch(WCProductActionBuilder.newFetchProductReviewsAction(payload))
+                        coroutineScope.launch {
+                            prependToLog("Submitting request to fetch product reviews for remoteProductID $id")
+                            val result = wcProductStore.fetchProductReviews(
+                                    FetchProductReviewsPayload(
+                                            site,
+                                            productIds = listOf(remoteProductId)
+                                    )
+                            )
+                            prependToLog("Fetched ${result.rowsAffected} product reviews")
+                        }
                     } ?: prependToLog("No valid remoteProductId defined...doing nothing")
                 }
             }
@@ -210,9 +217,12 @@ class WooProductsFragment : StoreSelectingFragment() {
 
         fetch_all_reviews.setOnClickListener {
             selectedSite?.let { site ->
-                prependToLog("Submitting request to fetch product reviews for site ${site.id}")
-                val payload = FetchProductReviewsPayload(site)
-                dispatcher.dispatch(WCProductActionBuilder.newFetchProductReviewsAction(payload))
+                coroutineScope.launch {
+                    prependToLog("Submitting request to fetch product reviews for site ${site.id}")
+                    val payload = FetchProductReviewsPayload(site)
+                    val result = wcProductStore.fetchProductReviews(payload)
+                    prependToLog("Fetched ${result.rowsAffected} product reviews")
+                }
             }
         }
 
@@ -470,9 +480,6 @@ class WooProductsFragment : StoreSelectingFragment() {
                         pendingFetchSingleProductVariationOffset = 0
                         load_more_product_variations.isEnabled = false
                     }
-                }
-                FETCH_PRODUCT_REVIEWS -> {
-                    prependToLog("Fetched ${event.rowsAffected} product reviews")
                 }
                 FETCH_SINGLE_PRODUCT_REVIEW -> {
                     prependToLog("Fetched ${event.rowsAffected} single product review")

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPayload
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -29,7 +30,13 @@ import kotlin.test.assertTrue
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
 class WCProductStoreTest {
-    private val productStore = WCProductStore(Dispatcher(), mock(), addonsDao = mock(), logger = mock())
+    private val productStore = WCProductStore(
+            Dispatcher(),
+            mock(),
+            addonsDao = mock(),
+            logger = mock(),
+            coroutineEngine = initCoroutineEngine()
+    )
 
     @Before
     fun setUp() {

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -9,8 +9,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.DeleteProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductTagsPayload;

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -64,8 +64,6 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = FetchSingleProductShippingClassPayload.class)
     FETCH_SINGLE_PRODUCT_SHIPPING_CLASS,
-    @Action(payloadType = FetchProductReviewsPayload.class)
-    FETCH_PRODUCT_REVIEWS,
     @Action(payloadType = FetchSingleProductReviewPayload.class)
     FETCH_SINGLE_PRODUCT_REVIEW,
     @Action(payloadType = UpdateProductReviewStatusPayload.class)
@@ -110,8 +108,6 @@ public enum WCProductAction implements IAction {
     FETCHED_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = RemoteProductShippingClassPayload.class)
     FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS,
-    @Action(payloadType = FetchProductReviewsResponsePayload.class)
-    FETCHED_PRODUCT_REVIEWS,
     @Action(payloadType = RemoteProductReviewPayload.class)
     FETCHED_SINGLE_PRODUCT_REVIEW,
     @Action(payloadType = RemoteProductReviewPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -85,7 +85,7 @@ class ProductRestClient @Inject constructor(
     @Named("regular") requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder? = null
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     /**
      * Makes a GET request to `/wp-json/wc/v3/products/shipping_classes/[remoteShippingClassId]`
@@ -442,7 +442,7 @@ class ProductRestClient @Inject constructor(
     private suspend fun String.requestTo(
         site: SiteModel,
         params: Map<String, String>
-    ) = jetpackTunnelGsonRequestBuilder?.syncGetRequest(
+    ) = jetpackTunnelGsonRequestBuilder.syncGetRequest(
             this@ProductRestClient,
             site,
             this,
@@ -731,7 +731,7 @@ class ProductRestClient @Inject constructor(
         attributesJson: String
     ) = WOOCOMMERCE.products.id(productId).variations.pathV3
             .let { url ->
-                jetpackTunnelGsonRequestBuilder?.syncPostRequest(
+                jetpackTunnelGsonRequestBuilder.syncPostRequest(
                         this@ProductRestClient,
                         site,
                         url,
@@ -755,7 +755,7 @@ class ProductRestClient @Inject constructor(
         variationId: Long
     ) = WOOCOMMERCE.products.id(productId).variations.variation(variationId).pathV3
             .let { url ->
-                jetpackTunnelGsonRequestBuilder?.syncDeleteRequest(
+                jetpackTunnelGsonRequestBuilder.syncDeleteRequest(
                         this@ProductRestClient,
                         site,
                         url,
@@ -781,7 +781,7 @@ class ProductRestClient @Inject constructor(
         attributesJson: String
     ) = WOOCOMMERCE.products.id(productId).variations.variation(variationId).pathV3
                 .let { url ->
-                    jetpackTunnelGsonRequestBuilder?.syncPutRequest(
+                    jetpackTunnelGsonRequestBuilder.syncPutRequest(
                             this@ProductRestClient,
                             site,
                             url,
@@ -806,13 +806,13 @@ class ProductRestClient @Inject constructor(
         attributesJson: String
     ) = WOOCOMMERCE.products.id(productId).pathV3
             .let { url ->
-                jetpackTunnelGsonRequestBuilder?.syncPutRequest(
+                jetpackTunnelGsonRequestBuilder.syncPutRequest(
                         this,
                         site,
                         url,
                         mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray),
                         ProductApiResponse::class.java
-                )?.handleResult()
+                ).handleResult()
             }
 
     /**


### PR DESCRIPTION
Merge Instructions:
1. Review this PR
2. [Review PR in WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/5207)
3. Merge this PR
4. Update FluxC hash in WCAndroid
5. Merge WCAndroid PR

This PR refactors fetchProductReviews into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

Other changes
1. The app now returns an error response when the server returns success with an empty body - [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/fb2de0803654d74bf1c0b5395ae23bd0e944694f/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt#L1009) - instead of silently consuming the event => the main benefit of this approach is that the client app always receives a result and doesn't need to manually implement timeout behavior.
2. Makes JetpackTunnelGsonRequestBuilder and CoroutineEngine non-nullable => I didn't find any reason why they were nullable

To Test:
1. Test fetch reviews for specific product and fetch reviews for site actions in the example app ( or test in WCAndroid ([PR](https://github.com/woocommerce/woocommerce-android/pull/5207)))
