### PR TITLE
Migrate fetchSingleProductReview to suspendable function

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -482,20 +482,14 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchProductReviewByReviewIdSuccess() {
+    fun testFetchProductReviewByReviewIdSuccess() = runBlocking {
         interceptor.respondWith("wc-fetch-product-review-response-success.json")
-        productRestClient.fetchProductReviewById(siteModel, 5499)
-
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCProductAction.FETCHED_SINGLE_PRODUCT_REVIEW, lastAction!!.type)
+        val result = productRestClient.fetchProductReviewById(siteModel, 5499)
 
         // Verify payload and product review properties
-        val payload = lastAction!!.payload as RemoteProductReviewPayload
-        assertFalse(payload.isError)
-        assertEquals(siteModel.id, payload.site.id)
-        payload.productReview?.let {
+        assertFalse(result.isError)
+        assertEquals(siteModel.id, result.site.id)
+        result.productReview?.let {
             with(it) {
                 assertEquals(5499, remoteProductReviewId)
                 assertEquals("2019-07-09T15:48:07Z", dateCreated)
@@ -512,17 +506,12 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchProductReviewByReviewIdFailed() {
+    fun testFetchProductReviewByReviewIdFailed() = runBlocking {
         interceptor.respondWithError("wc-product-review-response-failure-invalid-id.json")
-        productRestClient.fetchProductReviewById(siteModel, 5499)
+        val result = productRestClient.fetchProductReviewById(siteModel, 5499)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCProductAction.FETCHED_SINGLE_PRODUCT_REVIEW, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteProductReviewPayload
-        assertTrue(payload.isError)
-        assertEquals(ProductErrorType.INVALID_REVIEW_ID, payload.error.type)
+        assertTrue(result.isError)
+        assertEquals(ProductErrorType.INVALID_REVIEW_ID, result.error.type)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -503,6 +503,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
                 assertEquals(3, reviewerAvatarUrlBySize.size)
             }
         }
+        Unit
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -70,6 +70,18 @@ object ProductTestUtils {
         }
     }
 
+    fun generateSampleProductReview(
+        remoteProductId: Long = 1L,
+        remoteProductReviewId: Long = 2L,
+        siteId: Int = 6
+    ): WCProductReviewModel {
+        return WCProductReviewModel(1).apply {
+            this.remoteProductId = remoteProductId
+            this.remoteProductReviewId = remoteProductReviewId
+            this.localSiteId = siteId
+        }
+    }
+
     fun generateProductList(siteId: Int = 6): List<WCProductShippingClassModel> {
         with(ArrayList<WCProductShippingClassModel>()) {
             add(generateSampleProductShippingClass(1, siteId = siteId))

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/utils/SiteTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/utils/SiteTestUtils.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.wc.utils
+
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.AccountSqlUtils
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+
+object SiteTestUtils {
+    fun insertTestAccountAndSiteIntoDb(): SiteModel {
+        val account = AccountModel().apply { userId = 412 }
+        AccountSqlUtils.insertOrUpdateAccount(account, 5124)
+
+        val site = SiteModel()
+        site.siteId = 6347
+
+        SiteSqlUtils().insertOrUpdateSite(site)
+        return site
+    }
+}

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -15,7 +15,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductTagsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleVariationPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
@@ -62,8 +61,6 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = FetchSingleProductShippingClassPayload.class)
     FETCH_SINGLE_PRODUCT_SHIPPING_CLASS,
-    @Action(payloadType = FetchSingleProductReviewPayload.class)
-    FETCH_SINGLE_PRODUCT_REVIEW,
     @Action(payloadType = UpdateProductReviewStatusPayload.class)
     UPDATE_PRODUCT_REVIEW_STATUS,
     @Action(payloadType = UpdateProductImagesPayload.class)
@@ -106,8 +103,6 @@ public enum WCProductAction implements IAction {
     FETCHED_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = RemoteProductShippingClassPayload.class)
     FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS,
-    @Action(payloadType = RemoteProductReviewPayload.class)
-    FETCHED_SINGLE_PRODUCT_REVIEW,
     @Action(payloadType = RemoteProductReviewPayload.class)
     UPDATED_PRODUCT_REVIEW_STATUS,
     @Action(payloadType = RemoteUpdateProductImagesPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1027,7 +1027,7 @@ class ProductRestClient @Inject constructor(
      * @param [site] The site to fetch product reviews for
      * @param [remoteReviewId] The remote id of the review to fetch
      */
-    fun fetchProductReviewById(site: SiteModel, remoteReviewId: Long) {
+    suspend fun fetchProductReviewById(site: SiteModel, remoteReviewId: Long): RemoteProductReviewPayload {
         val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
                 this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
@@ -110,7 +109,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newFetchedSingleProductShippingClassAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteProductShippingClassPayload(
                             productError,
@@ -156,7 +155,7 @@ class ProductRestClient @Inject constructor(
                     )
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductShippingClassListAction(payload))
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteProductShippingClassListPayload(productError, site)
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductShippingClassListAction(payload))
@@ -199,7 +198,7 @@ class ProductRestClient @Inject constructor(
                     val payload = RemoteProductTagsPayload(site, tags, offset, loadedMore, canLoadMore, searchQuery)
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductTagsAction(payload))
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteProductTagsPayload(productError, site)
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductTagsAction(payload))
@@ -236,7 +235,7 @@ class ProductRestClient @Inject constructor(
                     val payload = RemoteAddProductTagsResponsePayload(site, addedTags)
                     dispatcher.dispatch(WCProductActionBuilder.newAddedProductTagsAction(payload))
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteAddProductTagsResponsePayload(productError, site)
                     dispatcher.dispatch(WCProductActionBuilder.newAddedProductTagsAction(payload))
@@ -265,7 +264,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newFetchedSingleProductAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteProductPayload(
                             productError,
@@ -302,7 +301,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newFetchedSingleVariationAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteVariationPayload(
                             productError,
@@ -334,7 +333,7 @@ class ProductRestClient @Inject constructor(
         filterOptions: Map<ProductFilterOption, String>? = null,
         excludedProductIds: List<Long>? = null
     ) {
-        // orderby (string) Options: date, id, include, title and slug. Default is date.
+        // orderBy (string) Options: date, id, include, title and slug. Default is date.
         val orderBy = when (sortType) {
             TITLE_ASC, TITLE_DESC -> "title"
             DATE_ASC, DATE_DESC -> "date"
@@ -396,7 +395,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newSearchedProductsAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     if (searchQuery == null) {
                         val payload = RemoteProductListPayload(productError, site)
@@ -438,7 +437,7 @@ class ProductRestClient @Inject constructor(
             .let {
                 WOOCOMMERCE.products.pathV3
                         .requestTo(site, it)
-            }?.handleResultFrom(site)
+            }.handleResultFrom(site)
 
     private suspend fun String.requestTo(
         site: SiteModel,
@@ -513,7 +512,7 @@ class ProductRestClient @Inject constructor(
                     val payload = RemoteProductSkuAvailabilityPayload(site, sku, available)
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductSkuAvailabilityAction(payload))
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     // If there is a network error of some sort that prevents us from knowing if a sku is available
                     // then just consider sku as available
@@ -619,7 +618,7 @@ class ProductRestClient @Inject constructor(
                     )
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductVariationsAction(payload))
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteProductVariationsPayload(
                             productError,
@@ -661,7 +660,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteUpdateProductPayload(
                             productError,
@@ -679,8 +678,8 @@ class ProductRestClient @Inject constructor(
      * Dispatches a WCProductAction.UPDATED_PRODUCT action with the result
      *
      * @param [site] The site to fetch product reviews for
-     * @param [storedWCProductModel] the stored model to compare with the [updatedProductModel]
-     * @param [updatedProductModel] the product model that contains the update
+     * @param [storedWCProductVariationModel] the stored model to compare with the [updatedProductVariationModel]
+     * @param [updatedProductVariationModel] the product model that contains the update
      */
     fun updateVariation(
         site: SiteModel,
@@ -704,7 +703,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newUpdatedVariationAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteUpdateVariationPayload(
                             productError,
@@ -738,7 +737,7 @@ class ProductRestClient @Inject constructor(
                         url,
                         mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray),
                         ProductVariationApiResponse::class.java
-                )?.handleResult()
+                ).handleResult()
             }
 
     /**
@@ -761,7 +760,7 @@ class ProductRestClient @Inject constructor(
                         site,
                         url,
                         ProductVariationApiResponse::class.java
-                )?.handleResult()
+                ).handleResult()
             }
 
     /**
@@ -772,7 +771,7 @@ class ProductRestClient @Inject constructor(
      * Returns a WooPayload with the Api response as result
      *
      * @param [site] The site to update the given variation attributes
-     * @param [variation] Locally updated product variation to be sent
+     * @param [attributesJson] Locally updated product variation to be sent
      */
 
     suspend fun updateVariationAttributes(
@@ -788,7 +787,7 @@ class ProductRestClient @Inject constructor(
                             url,
                             mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray),
                             ProductVariationApiResponse::class.java
-                    )?.handleResult()
+                    ).handleResult()
                 }
 
     /**
@@ -798,7 +797,6 @@ class ProductRestClient @Inject constructor(
      * Returns a WooPayload with the Api response as result
      *
      * @param [site] The site to update the given product attributes
-     * @param [product] Locally updated product to be sent
      */
 
     suspend fun updateProductAttributes(
@@ -849,7 +847,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductImagesAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteUpdateProductImagesPayload(
                             productError,
@@ -907,7 +905,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newFetchedProductCategoriesAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productCategoryError = networkErrorToProductError(networkError)
                     val payload = RemoteProductCategoriesPayload(productCategoryError, site)
                     dispatcher.dispatch(WCProductActionBuilder.newFetchedProductCategoriesAction(payload))
@@ -945,7 +943,7 @@ class ProductRestClient @Inject constructor(
                     val payload = RemoteAddProductCategoryResponsePayload(site, categoryResponse)
                     dispatcher.dispatch(WCProductActionBuilder.newAddedProductCategoryAction(payload))
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productCategorySaveError = networkErrorToProductError(networkError)
                     val payload = RemoteAddProductCategoryResponsePayload(productCategorySaveError, site, category)
                     dispatcher.dispatch(WCProductActionBuilder.newAddedProductCategoryAction(payload))
@@ -1009,7 +1007,7 @@ class ProductRestClient @Inject constructor(
                     )
                 } ?: FetchProductReviewsResponsePayload(
                         ProductError(
-                                ProductErrorType.GENERIC_ERROR,
+                                GENERIC_ERROR,
                                 "Success response with empty data"
                         ), site
                 )
@@ -1082,7 +1080,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductReviewStatusAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productReviewError = networkErrorToProductError(networkError)
                     val payload = RemoteProductReviewPayload(productReviewError, site)
                     dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductReviewStatusAction(payload))
@@ -1096,7 +1094,7 @@ class ProductRestClient @Inject constructor(
      * Dispatches a [WCProductAction.ADDED_PRODUCT] action with the result
      *
      * @param [site] The site to fetch product reviews for
-     * @param [newModel] the new product model
+     * @param [productModel] the new product model
      */
     fun addProduct(
         site: SiteModel,
@@ -1122,7 +1120,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newAddedProductAction(payload))
                     }
                 },
-                errorListener = WPComErrorListener { networkError ->
+                errorListener = { networkError ->
                     // error
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteAddProductPayload(
@@ -1160,7 +1158,7 @@ class ProductRestClient @Inject constructor(
                         dispatcher.dispatch(WCProductActionBuilder.newDeletedProductAction(payload))
                     }
                 },
-                WPComErrorListener { networkError ->
+                { networkError ->
                     val productError = networkErrorToProductError(networkError)
                     val payload = RemoteDeleteProductPayload(
                             productError,


### PR DESCRIPTION
Merge Instructions:
1. Review this PR
2. Review [PR in WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/5259)
3. Remove "Not ready for merge" label and merge this PR
4. Update FluxC hash in WCAndroid
5. Merge WCAndroid PR

This PR refactors fetchSingleProductReview into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

Other changes
1. The app now returns an error response when the server returns success with an empty body instead of silently consuming the event => the main benefit of this approach is that the client app always receives a result and doesn't need to manually implement timeout behavior.

To Test:
1. Test fetch product review by id in the example app ( or test in [WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/5259))
