### PR TITLE
Jetpack CP: use /wp/v2 endpoint for fetching media

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/MediaWPRestResponse.kt
@@ -59,8 +59,9 @@ data class MediaWPRESTResponse(
     )
 }
 
-fun MediaWPRESTResponse.toMediaModel(): MediaModel {
+fun MediaWPRESTResponse.toMediaModel(localSiteId: Int): MediaModel {
     val mediaModel = MediaModel()
+    mediaModel.localSiteId = localSiteId
     mediaModel.mediaId = id
     val date = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT).parse(dateGmt)
     mediaModel.uploadDate = DateTimeUtils.iso8601FromDate(date)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -184,7 +184,7 @@ class WPV2MediaRestClient @Inject constructor(
     ): FetchMediaListResponsePayload {
         val url = WPAPI.media.getWPComUrl(site.siteId)
         val params = mutableMapOf(
-                "per_page" to perPage.toString(),
+                "per_page" to perPage.toString()
         )
         if (offset > 0) {
             params["offset"] = offset.toString()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -146,7 +146,7 @@ class WPV2MediaRestClient @Inject constructor(
                     if (response.isSuccessful) {
                         try {
                             val res = gson.fromJson(response.body!!.string(), MediaWPRESTResponse::class.java)
-                            val uploadedMedia = res.toMediaModel()
+                            val uploadedMedia = res.toMediaModel(site.id)
                             val payload = ProgressPayload(uploadedMedia, 1f, true, false)
                             try {
                                 sendBlocking(payload)
@@ -208,7 +208,7 @@ class WPV2MediaRestClient @Inject constructor(
                 FetchMediaListResponsePayload(site, error, mimeType)
             }
             is Success -> {
-                val mediaList = response.data.map { it.toMediaModel() }
+                val mediaList = response.data.map { it.toMediaModel(site.id) }
                 AppLog.v(MEDIA, "Fetched media list for site with size: " + mediaList.size)
                 val canLoadMore = mediaList.size == perPage
                 FetchMediaListResponsePayload(site, mediaList, offset > 0, canLoadMore, mimeType)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -32,13 +32,18 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload
 import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.PARSE_ERROR
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.REQUEST_TOO_LARGE
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.MimeType
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MEDIA
 import java.io.IOException
@@ -85,6 +90,17 @@ class WPV2MediaRestClient @Inject constructor(
     }
 
     private fun syncUploadMedia(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
+        fun ProducerScope<ProgressPayload>.handleFailure(media: MediaModel, error: MediaError) {
+            media.setUploadState(FAILED)
+            val payload = ProgressPayload(media, 1f, false, error)
+            try {
+                sendBlocking(payload)
+                close()
+            } catch (e: CancellationException) {
+                // the flow has been cancelled
+            }
+        }
+
         return callbackFlow {
             val url = WPAPI.media.getWPComUrl(site.siteId)
             val body = WPRestUploadRequestBody(media) { media, progress ->
@@ -141,7 +157,7 @@ class WPV2MediaRestClient @Inject constructor(
                             handleFailure(media, error)
                         }
                     } else {
-                        val error = response.parseError()
+                        val error = response.parseUploadError()
                         handleFailure(media, error)
                     }
                 }
@@ -153,18 +169,7 @@ class WPV2MediaRestClient @Inject constructor(
         }
     }
 
-    private fun ProducerScope<ProgressPayload>.handleFailure(media: MediaModel, error: MediaError) {
-        media.setUploadState(FAILED)
-        val payload = ProgressPayload(media, 1f, false, error)
-        try {
-            sendBlocking(payload)
-            close()
-        } catch (e: CancellationException) {
-            // the flow has been cancelled
-        }
-    }
-
-    private fun Response.parseError(): MediaError {
+    private fun Response.parseUploadError(): MediaError {
         val mediaError = MediaError(MediaErrorType.fromHttpStatusCode(code))
         mediaError.statusCode = code
         mediaError.logMessage = message

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -817,6 +817,8 @@ public class MediaStore extends Store {
         }
         if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
+        } else if (payload.site.isJetpackCPConnected()) {
+            mWPV2MediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
         } else {
             mMediaXmlrpcClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
         }


### PR DESCRIPTION
This PR is needed for the task https://github.com/woocommerce/woocommerce-android/issues/5305, it adds handling of fetching media for Jetpack CP sites.

#### Testing
Either use the Media screen for fetching, or refer to the WCAndroid's PR https://github.com/woocommerce/woocommerce-android/pull/5308