### PR TITLE
Convert markReviewAsRead into suspendable function

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_NotificationTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.mocked
 
 import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -22,7 +23,6 @@ import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationHash
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload
-import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadResponsePayload
 import org.wordpress.android.fluxc.store.NotificationStore.NotificationAppKey
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload
 import org.wordpress.android.fluxc.store.SiteStore
@@ -222,38 +222,32 @@ class MockedStack_NotificationTest : MockedStack_Base() {
     }
 
     @Test
-    fun testMarkSingleNotificationReadSuccess() {
+    fun testMarkSingleNotificationReadSuccess() = runBlocking {
         val testNoteIdSet = NoteIdSet(0, 22L, 2L)
 
         interceptor.respondWith("mark-notification-read-response-success.json")
-        notificationRestClient.markNotificationRead(
+        val result = notificationRestClient.markNotificationRead(
                 listOf(NotificationModel(
                         remoteNoteId = testNoteIdSet.remoteNoteId,
                         remoteSiteId = testNoteIdSet.remoteSiteId)))
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(NotificationAction.MARKED_NOTIFICATIONS_READ, lastAction!!.type)
-        val payload = lastAction!!.payload as MarkNotificationsReadResponsePayload
-
-        assertNotNull(payload)
-        assertEquals(payload.success, true)
-        assertNotNull(payload.notifications)
-        assertEquals(1, payload.notifications!!.size)
-        with(payload.notifications!![0]) {
+        assertNotNull(result)
+        assertEquals(result.success, true)
+        assertNotNull(result.notifications)
+        assertEquals(1, result.notifications!!.size)
+        with(result.notifications!![0]) {
             assertEquals(remoteNoteId, testNoteIdSet.remoteNoteId)
         }
     }
 
     @Test
-    fun testMarkMultipleNotificationsReadSuccess() {
+    fun testMarkMultipleNotificationsReadSuccess() = runBlocking {
         val testNoteIdSet1 = NoteIdSet(0, 22L, 2L)
         val testNoteIdSet2 = NoteIdSet(0, 33L, 3L)
         val testNoteIdSet3 = NoteIdSet(0, 44L, 4L)
 
         interceptor.respondWith("mark-notification-read-response-success.json")
-        notificationRestClient.markNotificationRead(listOf(
+        val result = notificationRestClient.markNotificationRead(listOf(
                 NotificationModel(
                         remoteNoteId = testNoteIdSet1.remoteNoteId,
                         remoteSiteId = testNoteIdSet1.remoteSiteId),
@@ -264,25 +258,19 @@ class MockedStack_NotificationTest : MockedStack_Base() {
                         remoteNoteId = testNoteIdSet3.remoteNoteId,
                         remoteSiteId = testNoteIdSet3.remoteSiteId)))
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(NotificationAction.MARKED_NOTIFICATIONS_READ, lastAction!!.type)
-        val payload = lastAction!!.payload as MarkNotificationsReadResponsePayload
-
-        assertNotNull(payload)
-        assertEquals(payload.success, true)
-        assertNotNull(payload.notifications)
-        assertEquals(3, payload.notifications!!.size)
-        with(payload.notifications!![0]) {
+        assertNotNull(result)
+        assertEquals(result.success, true)
+        assertNotNull(result.notifications)
+        assertEquals(3, result.notifications!!.size)
+        with(result.notifications!![0]) {
             assertEquals(remoteNoteId, testNoteIdSet1.remoteNoteId)
             assertEquals(remoteSiteId, testNoteIdSet1.remoteSiteId)
         }
-        with(payload.notifications!![1]) {
+        with(result.notifications!![1]) {
             assertEquals(remoteNoteId, testNoteIdSet2.remoteNoteId)
             assertEquals(remoteSiteId, testNoteIdSet2.remoteSiteId)
         }
-        with(payload.notifications!![2]) {
+        with(result.notifications!![2]) {
             assertEquals(remoteNoteId, testNoteIdSet3.remoteNoteId)
             assertEquals(remoteSiteId, testNoteIdSet3.remoteSiteId)
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NotificationTest.kt
@@ -257,9 +257,6 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
                 assertEquals(TestEvent.MARKED_NOTIFS_SEEN, nextEvent)
                 mCountDownLatch.countDown()
             }
-            NotificationAction.MARK_NOTIFICATIONS_READ -> {
-                // noop
-            }
             else -> throw AssertionError("Unexpected cause of change: ${event.causeOfChange}")
         }
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NotificationTest.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsSeen
 import org.wordpress.android.fluxc.store.NotificationStore.OnNotificationChanged
 import java.util.Date
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
 import kotlin.properties.Delegates

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NotificationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_NotificationTest.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.release
 
+import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -36,7 +36,6 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
         NONE,
         FETCHED_NOTIFS,
         MARKED_NOTIFS_SEEN,
-        MARKED_NOTIFS_READ
     }
 
     @Inject internal lateinit var notificationStore: NotificationStore
@@ -71,7 +70,7 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
         mDispatcher.dispatch(NotificationActionBuilder
                 .newFetchNotificationsAction(FetchNotificationsPayload()))
 
-        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         val fetchedNotifs = notificationStore.getNotifications().size
         assertTrue(fetchedNotifs > 0 && fetchedNotifs <= NotificationRestClient.NOTIFICATION_DEFAULT_NUMBER)
@@ -89,7 +88,7 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
                 .newFetchNotificationsAction(FetchNotificationsPayload()))
 
         // Verify expected dispatch actions
-        assertTrue(actionCountdownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(actionCountdownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
         assertEquals(lastAction!!.type, nextAction)
         assertEquals(incomingActions[0].type, NotificationAction.FETCH_NOTIFICATIONS)
         assertEquals(incomingActions[1].type, NotificationAction.FETCHED_NOTIFICATIONS)
@@ -100,7 +99,7 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
         assertTrue(payload.notifs.isNotEmpty())
 
         // Now wait for full event completion
-        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         val fetchedNotifs = notificationStore.getNotifications().size
         assertTrue(fetchedNotifs > 0 && fetchedNotifs <= NotificationRestClient.NOTIFICATION_DEFAULT_NUMBER)
@@ -120,7 +119,7 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
         mDispatcher.dispatch(NotificationActionBuilder
                 .newFetchNotificationsAction(FetchNotificationsPayload()))
 
-        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         val totalInitialNotifs = notificationStore.getNotifications().size
         assertTrue(totalInitialNotifs > 0 && totalInitialNotifs <= NotificationRestClient.NOTIFICATION_DEFAULT_NUMBER)
@@ -166,7 +165,7 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
                 .newFetchNotificationsAction(FetchNotificationsPayload()))
 
         // Wait for our expected next action
-        assertTrue(actionCountdownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(actionCountdownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         // Verify fetch hashes action and payload
         assertEquals(lastAction!!.type, nextAction)
@@ -181,8 +180,8 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
         // Finally, wait for full fetch notifications event completion, and verify results
         //
 
-        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-        Assert.assertNotNull(lastEvent)
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertNotNull(lastEvent)
         assertEquals(lastEvent!!.causeOfChange, NotificationAction.FETCH_NOTIFICATIONS)
 
         // Fetch fresh list of cached notifications from the db
@@ -206,13 +205,13 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
         mDispatcher.dispatch(NotificationActionBuilder
                 .newMarkNotificationsSeenAction(MarkNotificationsSeenPayload(lastSeenTime)))
 
-        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
         assertNotNull(lastEvent?.lastSeenTime)
     }
 
     @Throws(InterruptedException::class)
     @Test
-    fun testMarkNotificationsRead() {
+    fun testMarkNotificationsRead() = runBlocking {
         // First, fetch notifications and store in database.
         nextEvent = TestEvent.FETCHED_NOTIFS
         mCountDownLatch = CountDownLatch(1)
@@ -220,7 +219,7 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
         mDispatcher.dispatch(NotificationActionBuilder
                 .newFetchNotificationsAction(FetchNotificationsPayload()))
 
-        Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         val fetchedNotifs = notificationStore.getNotifications()
 
@@ -228,20 +227,14 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
         if (fetchedNotifs.isNotEmpty()) {
             val requestList = fetchedNotifs.take(3)
             val requestListSize = requestList.size
-
-            nextEvent = TestEvent.MARKED_NOTIFS_READ
-            mCountDownLatch = CountDownLatch(1)
-
-            mDispatcher.dispatch(NotificationActionBuilder
-                    .newMarkNotificationsReadAction(MarkNotificationsReadPayload(requestList)))
-            Assert.assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+            val result = notificationStore.markNotificationsRead(MarkNotificationsReadPayload(requestList))
 
             // Verify
-            Assert.assertNotNull(lastEvent)
-            Assert.assertTrue(lastEvent!!.success)
-            Assert.assertEquals(lastEvent!!.changedNotificationLocalIds.size, requestListSize)
-            with(lastEvent!!.changedNotificationLocalIds) {
-                requestList.forEach { Assert.assertTrue(contains(it.noteId)) }
+            assertNotNull(result)
+            assertTrue(result.success)
+            assertEquals(result.changedNotificationLocalIds.size, requestListSize)
+            with(result.changedNotificationLocalIds) {
+                requestList.forEach { assertTrue(contains(it.noteId)) }
             }
         } else {
             throw AssertionError("No notifications fetched to run test with!")
@@ -266,8 +259,7 @@ class ReleaseStack_NotificationTest : ReleaseStack_WPComBase() {
                 mCountDownLatch.countDown()
             }
             NotificationAction.MARK_NOTIFICATIONS_READ -> {
-                assertEquals(TestEvent.MARKED_NOTIFS_READ, nextEvent)
-                mCountDownLatch.countDown()
+                // noop
             }
             else -> throw AssertionError("Unexpected cause of change: ${event.causeOfChange}")
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/NotificationsFragment.kt
@@ -8,15 +8,16 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_notifications.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.NotificationAction.FETCH_NOTIFICATION
 import org.wordpress.android.fluxc.action.NotificationAction.FETCH_NOTIFICATIONS
-import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_READ
 import org.wordpress.android.fluxc.action.NotificationAction.MARK_NOTIFICATIONS_SEEN
 import org.wordpress.android.fluxc.action.NotificationAction.UPDATE_NOTIFICATION
-import org.wordpress.android.fluxc.example.NotificationTypeSubtypeDialog.Listener
 import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
@@ -43,6 +44,8 @@ class NotificationsFragment : Fragment() {
     private var selectedSite: SiteModel? = null
     private var selectedPos: Int = -1
 
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)
@@ -68,7 +71,7 @@ class NotificationsFragment : Fragment() {
         }
 
         notifs_by_type_subtype.setOnClickListener {
-            showNotificationTypeSubtypeDialog(object : Listener {
+            showNotificationTypeSubtypeDialog(object : NotificationTypeSubtypeDialog.Listener {
                 override fun onSubmitted(type: String, subtype: String) {
                     prependToLog("Fetching notifications matching $type or $subtype...\n")
                     val notifs = notificationStore.getNotifications(listOf(type), listOf(subtype))
@@ -85,7 +88,7 @@ class NotificationsFragment : Fragment() {
             if (selectedSite == null) {
                 prependToLog("No site selected")
             } else {
-                showNotificationTypeSubtypeDialog(object : Listener {
+                showNotificationTypeSubtypeDialog(object : NotificationTypeSubtypeDialog.Listener {
                     override fun onSubmitted(type: String, subtype: String) {
                         prependToLog("Checking unread notifications matching $type or $subtype...\n")
                         val hasUnread = notificationStore.hasUnreadNotificationsForSite(
@@ -119,8 +122,14 @@ class NotificationsFragment : Fragment() {
             selectedSite?.let { site ->
                 notificationStore.getNotificationsForSite(site).firstOrNull()?.let { note ->
                     prependToLog("Setting notification with remoteNoteId of ${note.remoteNoteId} as read\n")
-                    dispatcher.dispatch(NotificationActionBuilder
-                            .newMarkNotificationsReadAction(MarkNotificationsReadPayload(listOf(note))))
+                    coroutineScope.launch {
+                        val result = notificationStore.markNotificationsRead(MarkNotificationsReadPayload(listOf(note)))
+                        result.changedNotificationLocalIds.forEach {
+                            notificationStore.getNotificationByLocalId(it)?.let { notif ->
+                                prependToLog("SUCCESS! ${notif.toLogString()}")
+                            }
+                        }
+                    }
                 } ?: prependToLog("No notifications found for selected site!")
             } ?: prependToLog("No site selected!")
         }
@@ -208,13 +217,6 @@ class NotificationsFragment : Fragment() {
                 val localNoteId = event.changedNotificationLocalIds[0]
                 notificationStore.getNotificationByLocalId(localNoteId)?.let {
                     prependToLog("SUCCESS! ${it.toLogString()}")
-                }
-            }
-            MARK_NOTIFICATIONS_READ -> {
-                event.changedNotificationLocalIds.forEach {
-                    notificationStore.getNotificationByLocalId(it)?.let { notif ->
-                        prependToLog("SUCCESS! ${notif.toLogString()}")
-                    }
                 }
             }
             MARK_NOTIFICATIONS_SEEN -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -11,7 +11,6 @@ import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsPay
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadPayload;
-import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsSeenPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDevicePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload;
@@ -31,6 +30,7 @@ public enum NotificationAction implements IAction {
     @Action(payloadType = MarkNotificationsSeenPayload.class)
     MARK_NOTIFICATIONS_SEEN, // Submit the time notifications were last seen
     @Action(payloadType = MarkNotificationsReadPayload.class)
+    @Deprecated // Use suspendable markNotificationsRead directly
     MARK_NOTIFICATIONS_READ, // Mark one or more notifications as read by user
 
     // Remote responses
@@ -46,8 +46,6 @@ public enum NotificationAction implements IAction {
     FETCHED_NOTIFICATION, // Response to fetching a single notification
     @Action(payloadType = MarkNotificationSeenResponsePayload.class)
     MARKED_NOTIFICATIONS_SEEN, // Response to submitting the time notifications were last seen
-    @Action(payloadType = MarkNotificationsReadResponsePayload.class)
-    MARKED_NOTIFICATIONS_READ, // Response to marking one or more notifications as read
 
     // Local actions
     @Action(payloadType = NotificationModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -29,9 +29,6 @@ public enum NotificationAction implements IAction {
     FETCH_NOTIFICATION, // Fetch a single notification
     @Action(payloadType = MarkNotificationsSeenPayload.class)
     MARK_NOTIFICATIONS_SEEN, // Submit the time notifications were last seen
-    @Action(payloadType = MarkNotificationsReadPayload.class)
-    @Deprecated // Use suspendable markNotificationsRead directly
-    MARK_NOTIFICATIONS_READ, // Mark one or more notifications as read by user
 
     // Remote responses
     @Action(payloadType = RegisterDeviceResponsePayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/NotificationAction.java
@@ -10,7 +10,6 @@ import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationResp
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationsResponsePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationSeenResponsePayload;
-import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsReadPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.MarkNotificationsSeenPayload;
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDevicePayload;
 import org.wordpress.android.fluxc.store.NotificationStore.RegisterDeviceResponsePayload;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.notifications.NotificationRestClient
 import org.wordpress.android.fluxc.persistence.NotificationSqlUtils
+import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.PreferenceUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -29,7 +30,8 @@ class NotificationStore @Inject constructor(
     dispatcher: Dispatcher,
     private val context: Context,
     private val notificationRestClient: NotificationRestClient,
-    private val notificationSqlUtils: NotificationSqlUtils
+    private val notificationSqlUtils: NotificationSqlUtils,
+    private val coroutineEngine: CoroutineEngine
 ) : Store(dispatcher) {
     companion object {
         const val WPCOM_PUSH_DEVICE_UUID = "NOTIFICATIONS_UUID_PREF_KEY"
@@ -173,8 +175,9 @@ class NotificationStore @Inject constructor(
             NotificationAction.MARK_NOTIFICATIONS_SEEN ->
                 markNotificationSeen(action.payload as MarkNotificationsSeenPayload)
             NotificationAction.MARK_NOTIFICATIONS_READ ->
-                markNotificationsRead(action.payload as MarkNotificationsReadPayload)
-
+                coroutineEngine.launch(T.API, this, "markNotificationsRead") {
+                    markNotificationsRead(action.payload as MarkNotificationsReadPayload)
+                }
             // remote responses
             NotificationAction.REGISTERED_DEVICE ->
                 handleRegisteredDevice(action.payload as RegisterDeviceResponsePayload)
@@ -188,9 +191,6 @@ class NotificationStore @Inject constructor(
                 handleFetchNotificationCompleted(action.payload as FetchNotificationResponsePayload)
             NotificationAction.MARKED_NOTIFICATIONS_SEEN ->
                 handleMarkedNotificationSeen(action.payload as MarkNotificationSeenResponsePayload)
-            NotificationAction.MARKED_NOTIFICATIONS_READ ->
-                handleMarkedNotificationsRead(action.payload as MarkNotificationsReadResponsePayload)
-
             // local actions
             NotificationAction.UPDATE_NOTIFICATION -> updateNotification(action.payload as NotificationModel)
         }
@@ -460,37 +460,39 @@ class NotificationStore @Inject constructor(
         emitChange(onNotificationChanged)
     }
 
-    private fun markNotificationsRead(payload: MarkNotificationsReadPayload) {
-        notificationRestClient.markNotificationRead(payload.notifications)
-    }
+    @Suppress("MemberVisibilityCanBePrivate")
+    suspend fun markNotificationsRead(payload: MarkNotificationsReadPayload): OnNotificationChanged {
+        return coroutineEngine.withDefaultContext(T.API, this, "markNotificationsRead") {
+            val result = notificationRestClient.markNotificationRead(payload.notifications)
+            // Update the notification in the database
+            var rowsAffected = 0
+            if (result.success) {
+                result.notifications?.forEach {
+                    it.read = true // Just in case it wasn't set by the calling client
+                    rowsAffected += notificationSqlUtils.insertOrUpdateNotification(it)
+                }
+            }
 
-    private fun handleMarkedNotificationsRead(payload: MarkNotificationsReadResponsePayload) {
-        // Update the notification in the database
-        var rowsAffected = 0
-        if (payload.success) {
-            payload.notifications?.forEach {
-                it.read = true // Just in case it wasn't set by the calling client
-                rowsAffected += notificationSqlUtils.insertOrUpdateNotification(it)
+            // Create and dispatch result
+            val onNotificationChanged = if (result.isError) {
+                OnNotificationChanged(rowsAffected).apply {
+                    error = result.error
+                    success = false
+                }
+            } else {
+                OnNotificationChanged(rowsAffected).apply {
+                    success = true
+                }
+            }.apply {
+                result.notifications?.forEach {
+                    changedNotificationLocalIds.add(it.noteId)
+                }
+                causeOfChange = NotificationAction.MARK_NOTIFICATIONS_READ
             }
+            // Legacy client code still expects the event in event bus
+            emitChange(onNotificationChanged)
+            onNotificationChanged
         }
-
-        // Create and dispatch result
-        val onNotificationChanged = if (payload.isError) {
-            OnNotificationChanged(rowsAffected).apply {
-                error = payload.error
-                success = false
-            }
-        } else {
-            OnNotificationChanged(rowsAffected).apply {
-                success = true
-            }
-        }.apply {
-            payload.notifications?.forEach {
-                changedNotificationLocalIds.add(it.noteId)
-            }
-            causeOfChange = NotificationAction.MARK_NOTIFICATIONS_READ
-        }
-        emitChange(onNotificationChanged)
     }
 
     private fun updateNotification(payload: NotificationModel) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -174,10 +174,6 @@ class NotificationStore @Inject constructor(
             NotificationAction.FETCH_NOTIFICATION -> fetchNotification(action.payload as FetchNotificationPayload)
             NotificationAction.MARK_NOTIFICATIONS_SEEN ->
                 markNotificationSeen(action.payload as MarkNotificationsSeenPayload)
-            NotificationAction.MARK_NOTIFICATIONS_READ ->
-                coroutineEngine.launch(T.API, this, "markNotificationsRead") {
-                    markNotificationsRead(action.payload as MarkNotificationsReadPayload)
-                }
             // remote responses
             NotificationAction.REGISTERED_DEVICE ->
                 handleRegisteredDevice(action.payload as RegisterDeviceResponsePayload)
@@ -487,10 +483,7 @@ class NotificationStore @Inject constructor(
                 result.notifications?.forEach {
                     changedNotificationLocalIds.add(it.noteId)
                 }
-                causeOfChange = NotificationAction.MARK_NOTIFICATIONS_READ
             }
-            // Legacy client code still expects the event in event bus
-            emitChange(onNotificationChanged)
             onNotificationChanged
         }
     }


### PR DESCRIPTION
Merge Instructions:
1. Review this PR
2. Review [PR in WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/5349)
3. Remove "Not ready for merge" label and merge this PR
4. Update FluxC hash in WCAndroid
5. Merge WCAndroid PR

This PR refactors markReviewAsRead into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

To Test:
1. Test markReviewAsRead action in the example app or test the feature in WCAndroid