### PR TITLE
Refactor StatsRepository into stateless repository. Mark III: fetchRevenueStats

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRe
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityResponsePayload
-import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchVisitorStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
@@ -555,8 +554,13 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     @Test
     fun testFetchRevenueStatsAvailabilitySuccess() {
         interceptor.respondWith("wc-revenue-stats-response-success.json")
-        val payload = orderStatsRestClient.fetchRevenueStatsAvailability(siteModel, "2019-07-30T00:00:00")
+        orderStatsRestClient.fetchRevenueStatsAvailability(siteModel, "2019-07-30T00:00:00")
 
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+        assertEquals(WCStatsAction.FETCHED_REVENUE_STATS_AVAILABILITY, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchRevenueStatsAvailabilityResponsePayload
         with(payload) {
             assertNull(error)
             assertEquals(siteModel, site)
@@ -572,8 +576,13 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
         }
 
         interceptor.respondWithError(errorJson)
-        val payload = orderStatsRestClient.fetchRevenueStatsAvailability(siteModel, "2019-07-30T00:00:00")
+        orderStatsRestClient.fetchRevenueStatsAvailability(siteModel, "2019-07-30T00:00:00")
 
+        countDownLatch = CountDownLatch(1)
+        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+
+        assertEquals(WCStatsAction.FETCHED_REVENUE_STATS_AVAILABILITY, lastAction!!.type)
+        val payload = lastAction!!.payload as FetchRevenueStatsAvailabilityResponsePayload
         with(payload) {
             assertNotNull(error)
             assertEquals(siteModel, site)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -451,65 +451,65 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
         }
     }
 
-//    @Test
-//    fun testRevenueStatsFetchCaching() = runBlocking {
-//        requestQueue.cache.clear()
-//
-//        // Make initial stats request
-//        interceptor.respondWith("wc-revenue-stats-response-success.json")
-//        orderStatsRestClient.fetchRevenueStats(
-//                site = siteModel, granularity = StatsGranularity.DAYS,
-//                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
-//                perPage = 35
-//        )
-//
-//        val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
-//
-//        assertNotNull(firstRequestCacheEntry)
-//
-//        // Make the same stats request - this should hit the cache
-//        interceptor.respondWith("wc-revenue-stats-response-success.json")
-//        orderStatsRestClient.fetchRevenueStats(
-//                site = siteModel, granularity = StatsGranularity.DAYS,
-//                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
-//                perPage = 35
-//        )
-//
-//        val secondRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
-//
-//        assertNotNull(secondRequestCacheEntry)
-//        // Verify that the cache has not been renewed,
-//        // which should mean that we read from it instead of making a network call
-//        assertEquals(firstRequestCacheEntry.ttl, secondRequestCacheEntry.ttl)
-//
-//        // Make the same stats request, but this time pass force=true to force a network request
-//        interceptor.respondWith("wc-revenue-stats-response-success.json")
-//        orderStatsRestClient.fetchRevenueStats(
-//                site = siteModel, granularity = StatsGranularity.DAYS,
-//                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
-//                perPage = 35, force = true
-//        )
-//
-//        val thirdRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
-//
-//        assertNotNull(thirdRequestCacheEntry)
-//        // The cache should have been renewed, since we ignored it and updated it with the results of a forced request
-//        assertNotEquals(secondRequestCacheEntry.ttl, thirdRequestCacheEntry.ttl)
-//
-//        // New day, cache should be ignored
-//        interceptor.respondWith("wc-revenue-stats-response-success.json")
-//        orderStatsRestClient.fetchRevenueStats(
-//                site = siteModel, granularity = StatsGranularity.DAYS,
-//                startDate = "2019-07-02T00:00:00", endDate = "2019-07-08T23:59:59",
-//                perPage = 35
-//        )
-//
-//        val newDayCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
-//
-//        assertNotNull(newDayCacheEntry)
-//        // This should be a separate cache entry from the previous day's
-//        assertNotEquals(thirdRequestCacheEntry.ttl, newDayCacheEntry.ttl)
-//    }
+    @Test
+    fun testRevenueStatsFetchCaching() = runBlocking {
+        requestQueue.cache.clear()
+
+        // Make initial stats request
+        interceptor.respondWith("wc-revenue-stats-response-success.json")
+        orderStatsRestClient.fetchRevenueStats(
+                site = siteModel, granularity = StatsGranularity.DAYS,
+                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
+                perPage = 35
+        )
+
+        val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(firstRequestCacheEntry)
+
+        // Make the same stats request - this should hit the cache
+        interceptor.respondWith("wc-revenue-stats-response-success.json")
+        orderStatsRestClient.fetchRevenueStats(
+                site = siteModel, granularity = StatsGranularity.DAYS,
+                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
+                perPage = 35
+        )
+
+        val secondRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(secondRequestCacheEntry)
+        // Verify that the cache has not been renewed,
+        // which should mean that we read from it instead of making a network call
+        assertEquals(firstRequestCacheEntry.ttl, secondRequestCacheEntry.ttl)
+
+        // Make the same stats request, but this time pass force=true to force a network request
+        interceptor.respondWith("wc-revenue-stats-response-success.json")
+        orderStatsRestClient.fetchRevenueStats(
+                site = siteModel, granularity = StatsGranularity.DAYS,
+                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
+                perPage = 35, force = true
+        )
+
+        val thirdRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(thirdRequestCacheEntry)
+        // The cache should have been renewed, since we ignored it and updated it with the results of a forced request
+        assertNotEquals(secondRequestCacheEntry.ttl, thirdRequestCacheEntry.ttl)
+
+        // New day, cache should be ignored
+        interceptor.respondWith("wc-revenue-stats-response-success.json")
+        orderStatsRestClient.fetchRevenueStats(
+                site = siteModel, granularity = StatsGranularity.DAYS,
+                startDate = "2019-07-02T00:00:00", endDate = "2019-07-08T23:59:59",
+                perPage = 35
+        )
+
+        val newDayCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+
+        assertNotNull(newDayCacheEntry)
+        // This should be a separate cache entry from the previous day's
+        assertNotEquals(thirdRequestCacheEntry.ttl, newDayCacheEntry.ttl)
+    }
 
     @Test
     fun testRevenueStatsFetchInvalidParamError() = runBlocking {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -451,65 +451,65 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
         }
     }
 
-    @Test
-    fun testRevenueStatsFetchCaching() = runBlocking {
-        requestQueue.cache.clear()
-
-        // Make initial stats request
-        interceptor.respondWith("wc-revenue-stats-response-success.json")
-        orderStatsRestClient.fetchRevenueStats(
-                site = siteModel, granularity = StatsGranularity.DAYS,
-                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
-                perPage = 35
-        )
-
-        val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
-
-        assertNotNull(firstRequestCacheEntry)
-
-        // Make the same stats request - this should hit the cache
-        interceptor.respondWith("wc-revenue-stats-response-success.json")
-        orderStatsRestClient.fetchRevenueStats(
-                site = siteModel, granularity = StatsGranularity.DAYS,
-                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
-                perPage = 35
-        )
-
-        val secondRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
-
-        assertNotNull(secondRequestCacheEntry)
-        // Verify that the cache has not been renewed,
-        // which should mean that we read from it instead of making a network call
-        assertEquals(firstRequestCacheEntry.ttl, secondRequestCacheEntry.ttl)
-
-        // Make the same stats request, but this time pass force=true to force a network request
-        interceptor.respondWith("wc-revenue-stats-response-success.json")
-        orderStatsRestClient.fetchRevenueStats(
-                site = siteModel, granularity = StatsGranularity.DAYS,
-                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
-                perPage = 35, force = true
-        )
-
-        val thirdRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
-
-        assertNotNull(thirdRequestCacheEntry)
-        // The cache should have been renewed, since we ignored it and updated it with the results of a forced request
-        assertNotEquals(secondRequestCacheEntry.ttl, thirdRequestCacheEntry.ttl)
-
-        // New day, cache should be ignored
-        interceptor.respondWith("wc-revenue-stats-response-success.json")
-        orderStatsRestClient.fetchRevenueStats(
-                site = siteModel, granularity = StatsGranularity.DAYS,
-                startDate = "2019-07-02T00:00:00", endDate = "2019-07-08T23:59:59",
-                perPage = 35
-        )
-
-        val newDayCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
-
-        assertNotNull(newDayCacheEntry)
-        // This should be a separate cache entry from the previous day's
-        assertNotEquals(thirdRequestCacheEntry.ttl, newDayCacheEntry.ttl)
-    }
+//    @Test
+//    fun testRevenueStatsFetchCaching() = runBlocking {
+//        requestQueue.cache.clear()
+//
+//        // Make initial stats request
+//        interceptor.respondWith("wc-revenue-stats-response-success.json")
+//        orderStatsRestClient.fetchRevenueStats(
+//                site = siteModel, granularity = StatsGranularity.DAYS,
+//                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
+//                perPage = 35
+//        )
+//
+//        val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+//
+//        assertNotNull(firstRequestCacheEntry)
+//
+//        // Make the same stats request - this should hit the cache
+//        interceptor.respondWith("wc-revenue-stats-response-success.json")
+//        orderStatsRestClient.fetchRevenueStats(
+//                site = siteModel, granularity = StatsGranularity.DAYS,
+//                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
+//                perPage = 35
+//        )
+//
+//        val secondRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+//
+//        assertNotNull(secondRequestCacheEntry)
+//        // Verify that the cache has not been renewed,
+//        // which should mean that we read from it instead of making a network call
+//        assertEquals(firstRequestCacheEntry.ttl, secondRequestCacheEntry.ttl)
+//
+//        // Make the same stats request, but this time pass force=true to force a network request
+//        interceptor.respondWith("wc-revenue-stats-response-success.json")
+//        orderStatsRestClient.fetchRevenueStats(
+//                site = siteModel, granularity = StatsGranularity.DAYS,
+//                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
+//                perPage = 35, force = true
+//        )
+//
+//        val thirdRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+//
+//        assertNotNull(thirdRequestCacheEntry)
+//        // The cache should have been renewed, since we ignored it and updated it with the results of a forced request
+//        assertNotEquals(secondRequestCacheEntry.ttl, thirdRequestCacheEntry.ttl)
+//
+//        // New day, cache should be ignored
+//        interceptor.respondWith("wc-revenue-stats-response-success.json")
+//        orderStatsRestClient.fetchRevenueStats(
+//                site = siteModel, granularity = StatsGranularity.DAYS,
+//                startDate = "2019-07-02T00:00:00", endDate = "2019-07-08T23:59:59",
+//                perPage = 35
+//        )
+//
+//        val newDayCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
+//
+//        assertNotNull(newDayCacheEntry)
+//        // This should be a separate cache entry from the previous day's
+//        assertNotEquals(thirdRequestCacheEntry.ttl, newDayCacheEntry.ttl)
+//    }
 
     @Test
     fun testRevenueStatsFetchInvalidParamError() = runBlocking {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -397,25 +397,20 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testRevenueStatsDayFetchSuccess() {
+    fun testRevenueStatsDayFetchSuccess() = runBlocking {
         interceptor.respondWith("wc-revenue-stats-response-success.json")
-        orderStatsRestClient.fetchRevenueStats(
+        val payload = orderStatsRestClient.fetchRevenueStats(
                 site = siteModel, granularity = StatsGranularity.DAYS,
                 startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
                 perPage = 35
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCStatsAction.FETCHED_REVENUE_STATS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchRevenueStatsResponsePayload
         assertNull(payload.error)
         assertEquals(siteModel, payload.site)
         assertEquals(StatsGranularity.DAYS, payload.granularity)
         assertNotNull(payload.stats)
 
-        with(payload.stats!!) {
+        with (payload.stats!!) {
             assertEquals(siteModel.id, localSiteId)
             assertEquals(StatsGranularity.DAYS.toString(), interval)
 
@@ -433,19 +428,14 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testRevenueStatsDayFetchJsonError() {
+    fun testRevenueStatsDayFetchJsonError() = runBlocking {
         interceptor.respondWith("wc-revenue-stats-response-empty.json")
-        orderStatsRestClient.fetchRevenueStats(
+        val payload = orderStatsRestClient.fetchRevenueStats(
                 site = siteModel, granularity = StatsGranularity.DAYS,
                 startDate = "2019-07-07T00:00:00", endDate = "2019-07-01T23:59:59",
                 perPage = 35
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCStatsAction.FETCHED_REVENUE_STATS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchRevenueStatsResponsePayload
         assertNull(payload.error)
         assertEquals(siteModel, payload.site)
         assertEquals(StatsGranularity.DAYS, payload.granularity)
@@ -463,7 +453,7 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testRevenueStatsFetchCaching() {
+    fun testRevenueStatsFetchCaching() = runBlocking {
         requestQueue.cache.clear()
 
         // Make initial stats request
@@ -473,9 +463,6 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
                 startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
                 perPage = 35
         )
-
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         val firstRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
 
@@ -488,9 +475,6 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
                 startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
                 perPage = 35
         )
-
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
 
         val secondRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
 
@@ -507,9 +491,6 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
                 perPage = 35, force = true
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
         val thirdRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
 
         assertNotNull(thirdRequestCacheEntry)
@@ -524,9 +505,6 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
                 perPage = 35
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
         val newDayCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)
 
         assertNotNull(newDayCacheEntry)
@@ -535,23 +513,18 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testRevenueStatsFetchInvalidParamError() {
+    fun testRevenueStatsFetchInvalidParamError() = runBlocking {
         val errorJson = JsonObject().apply {
             addProperty("error", "rest_invalid_param")
             addProperty("message", "Invalid parameter(s): after")
         }
 
         interceptor.respondWithError(errorJson)
-        orderStatsRestClient.fetchRevenueStats(
+        val payload = orderStatsRestClient.fetchRevenueStats(
                 site = siteModel, granularity = StatsGranularity.DAYS,
                 startDate = "invalid", endDate = "2019-07-07T23:59:59", perPage = 35
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCStatsAction.FETCHED_REVENUE_STATS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchRevenueStatsResponsePayload
         assertNotNull(payload.error)
         assertEquals(siteModel, payload.site)
         assertEquals(StatsGranularity.DAYS, payload.granularity)
@@ -560,23 +533,18 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testRevenueStatsFetchResponseNullError() {
+    fun testRevenueStatsFetchResponseNullError() = runBlocking {
         val errorJson = JsonObject().apply {
             addProperty("error", OrderStatsErrorType.RESPONSE_NULL.name)
             addProperty("message", "Response object is null")
         }
 
         interceptor.respondWithError(errorJson)
-        orderStatsRestClient.fetchRevenueStats(
+        val payload = orderStatsRestClient.fetchRevenueStats(
                 site = siteModel, granularity = StatsGranularity.DAYS,
                 startDate = "invalid", endDate = "2019-07-07T23:59:59", perPage = 35
         )
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCStatsAction.FETCHED_REVENUE_STATS, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchRevenueStatsResponsePayload
         assertNotNull(payload.error)
         assertEquals(siteModel, payload.site)
         assertEquals(StatsGranularity.DAYS, payload.granularity)
@@ -587,13 +555,8 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     @Test
     fun testFetchRevenueStatsAvailabilitySuccess() {
         interceptor.respondWith("wc-revenue-stats-response-success.json")
-        orderStatsRestClient.fetchRevenueStatsAvailability(siteModel, "2019-07-30T00:00:00")
+        val payload = orderStatsRestClient.fetchRevenueStatsAvailability(siteModel, "2019-07-30T00:00:00")
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
-
-        assertEquals(WCStatsAction.FETCHED_REVENUE_STATS_AVAILABILITY, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchRevenueStatsAvailabilityResponsePayload
         with(payload) {
             assertNull(error)
             assertEquals(siteModel, site)
@@ -609,13 +572,8 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
         }
 
         interceptor.respondWithError(errorJson)
-        orderStatsRestClient.fetchRevenueStatsAvailability(siteModel, "2019-07-30T00:00:00")
+        val payload = orderStatsRestClient.fetchRevenueStatsAvailability(siteModel, "2019-07-30T00:00:00")
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCStatsAction.FETCHED_REVENUE_STATS_AVAILABILITY, lastAction!!.type)
-        val payload = lastAction!!.payload as FetchRevenueStatsAvailabilityResponsePayload
         with(payload) {
             assertNotNull(error)
             assertEquals(siteModel, site)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -409,7 +409,7 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
         assertEquals(StatsGranularity.DAYS, payload.granularity)
         assertNotNull(payload.stats)
 
-        with (payload.stats!!) {
+        with(payload.stats!!) {
             assertEquals(siteModel.id, localSiteId)
             assertEquals(StatsGranularity.DAYS.toString(), interval)
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -5,6 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.fragment_woo_revenue_stats.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -28,6 +31,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
     @Inject internal lateinit var wcStatsStore: WCStatsStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
 
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_woo_revenue_stats, container, false)
 
@@ -43,57 +48,97 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
 
         fetch_current_day_revenue_stats.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS)
-                dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+                coroutineScope.launch {
+                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS)
+                    wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
+                        prependToLog("Revenue stats ${it.rowsAffected != 0}")
+                        onFetchRevenueStatsLoaded(it)
+                    } ?: prependToLog("Fetching revenueStats failed.")
+                }
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_day_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, forced = true)
-                dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+                coroutineScope.launch {
+                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, forced = true)
+                    wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.DAYS} : ${it.rowsAffected != 0}")
+                        onFetchRevenueStatsLoaded(it)
+                    } ?: prependToLog("Fetching revenueStats failed.")
+                }
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_week_revenue_stats.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchRevenueStatsPayload(it, StatsGranularity.WEEKS)
-                dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+                coroutineScope.launch {
+                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.WEEKS)
+                    wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.WEEKS} : ${it.rowsAffected != 0}")
+                        onFetchRevenueStatsLoaded(it)
+                    } ?: prependToLog("Fetching revenueStats failed.")
+                }
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_week_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.WEEKS, forced = true)
-                dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+                coroutineScope.launch {
+                    val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.WEEKS, forced = true)
+                    wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
+                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.WEEKS} : ${it.rowsAffected != 0}")
+                        onFetchRevenueStatsLoaded(it)
+                    } ?: prependToLog("Fetching revenueStats failed.")
+                }
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_month_revenue_stats.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchRevenueStatsPayload(it, StatsGranularity.MONTHS)
-                dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+                coroutineScope.launch {
+                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.MONTHS)
+                    wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.MONTHS} : ${it.rowsAffected != 0}")
+                        onFetchRevenueStatsLoaded(it)
+                    } ?: prependToLog("Fetching revenueStats failed.")
+                }
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_month_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.MONTHS, forced = true)
-                dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+                coroutineScope.launch {
+                    val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.MONTHS, forced = true)
+                    wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
+                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.MONTHS} : ${it.rowsAffected != 0}")
+                        onFetchRevenueStatsLoaded(it)
+                    } ?: prependToLog("Fetching revenueStats failed.")
+                }
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_year_revenue_stats.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchRevenueStatsPayload(it, StatsGranularity.YEARS)
-                dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+                coroutineScope.launch {
+                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.YEARS)
+                    wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.YEARS} : ${it.rowsAffected != 0}")
+                        onFetchRevenueStatsLoaded(it)
+                    } ?: prependToLog("Fetching revenueStats failed.")
+                }
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_year_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.YEARS, forced = true)
-                dispatcher.dispatch(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+                coroutineScope.launch {
+                    val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.YEARS, forced = true)
+                    wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
+                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.YEARS} : ${it.rowsAffected != 0}")
+                        onFetchRevenueStatsLoaded(it)
+                    } ?: prependToLog("Fetching revenueStats failed.")
+                }
             } ?: prependToLog("No site selected!")
         }
 
@@ -136,30 +181,32 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         dispatcher.unregister(this)
     }
 
+    private fun onFetchRevenueStatsLoaded(event: OnWCRevenueStatsChanged) {
+        selectedSite?.let { site ->
+            if (event.isError) {
+                prependToLog("Error fetching order status options from the api: ${event.error.message}")
+                return
+            }
+
+            val wcRevenueStatsModel = wcStatsStore.getRawRevenueStats(
+                    site,
+                    event.granularity,
+                    event.startDate!!,
+                    event.endDate!!)
+            wcRevenueStatsModel?.let {
+                val revenueSum = it.parseTotal()?.totalSales
+                prependToLog("Fetched stats with total " + revenueSum + " for granularity " +
+                        event.granularity.toString().toLowerCase() + " from " + site.name +
+                        " between " + event.startDate + " and " + event.endDate)
+            } ?: prependToLog("No stats were stored for site " + site.name + " =(")
+        } ?: prependToLog("No stats were stored for site " + selectedSite?.name + " =(")
+    }
+
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onWCRevenueStatsChanged(event: OnWCRevenueStatsChanged) {
         val site = selectedSite
         when (event.causeOfChange) {
-            WCStatsAction.FETCH_REVENUE_STATS -> {
-                if (event.isError) {
-                    prependToLog("Error from " + event.causeOfChange + " - error: " + event.error.type)
-                    return
-                }
-
-                val wcRevenueStatsModel = wcStatsStore.getRawRevenueStats(
-                        site!!,
-                        event.granularity,
-                        event.startDate!!,
-                        event.endDate!!)
-                wcRevenueStatsModel?.let {
-                    val revenueSum = it.parseTotal()?.totalSales
-                    prependToLog("Fetched stats with total " + revenueSum + " for granularity " +
-                            event.granularity.toString().toLowerCase() + " from " + site.name +
-                            " between " + event.startDate + " and " + event.endDate)
-                } ?: prependToLog("No stats were stored for site " + site.name + " =(")
-            }
-
             WCStatsAction.FETCH_REVENUE_STATS_AVAILABILITY -> {
                 prependToLog("Revenue stats available for site ${site?.name}: ${event.availability}")
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -63,7 +63,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, forced = true)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.DAYS} : ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.DAYS} "
+                                + ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -75,7 +76,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(it, StatsGranularity.WEEKS)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.WEEKS} : ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.WEEKS} "
+                                + ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -87,7 +89,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.WEEKS, forced = true)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.WEEKS} : ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.WEEKS} "
+                                + ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -99,7 +102,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(it, StatsGranularity.MONTHS)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.MONTHS} : ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.MONTHS} "
+                                + ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -109,9 +113,13 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_month_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.MONTHS, forced = true)
+                    val payload = FetchRevenueStatsPayload(site = it,
+                            granularity = StatsGranularity.MONTHS,
+                            forced = true
+                    )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.MONTHS} : ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.MONTHS} "
+                                + ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -123,7 +131,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(it, StatsGranularity.YEARS)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.YEARS} : ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.YEARS} "
+                                + ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -133,9 +142,13 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_year_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.YEARS, forced = true)
+                    val payload = FetchRevenueStatsPayload(site = it,
+                            granularity = StatsGranularity.YEARS,
+                            forced = true
+                    )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.YEARS} : ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.YEARS} "
+                                + ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -63,8 +63,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, forced = true)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.DAYS} "
-                                + ": ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.DAYS} " +
+                                ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -76,8 +76,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(it, StatsGranularity.WEEKS)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.WEEKS} "
-                                + ": ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.WEEKS} " +
+                                ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -89,8 +89,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.WEEKS, forced = true)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.WEEKS} "
-                                + ": ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.WEEKS} " +
+                                ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -102,8 +102,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(it, StatsGranularity.MONTHS)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.MONTHS} "
-                                + ": ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.MONTHS} " +
+                                ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -118,8 +118,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                             forced = true
                     )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.MONTHS} "
-                                + ": ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.MONTHS} " +
+                                ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -131,8 +131,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     val payload = FetchRevenueStatsPayload(it, StatsGranularity.YEARS)
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.YEARS} "
-                                + ": ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats with granularity ${StatsGranularity.YEARS} " +
+                                ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -147,8 +147,8 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                             forced = true
                     )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.YEARS} "
-                                + ": ${it.rowsAffected != 0}")
+                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.YEARS} " +
+                                ": ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -87,7 +87,10 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_week_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(site = it, granularity = StatsGranularity.WEEKS, forced = true)
+                    val payload = FetchRevenueStatsPayload(site = it,
+                            granularity = StatsGranularity.WEEKS,
+                            forced = true
+                    )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
                         prependToLog("Revenue stats forced with granularity ${StatsGranularity.WEEKS} " +
                                 ": ${it.rowsAffected != 0}")

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -6,7 +6,9 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import com.yarolegovich.wellsql.WellSql
+import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.anyOf
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
@@ -34,6 +36,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
@@ -1241,11 +1244,13 @@ class WCStatsStoreTest {
     }
 
     @Test
-    fun testFetchCurrentDayRevenueStatsDate() {
+    fun testFetchCurrentDayRevenueStatsDate() = runBlocking {
         val plus12SiteDate = SiteModel().apply { timezone = "12" }.let {
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
+            ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.formatDate("yyyy-MM-dd", Date())
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
-            wcStatsStore.onAction(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+            wcStatsStore.fetchRevenueStats(payload)
 
             val timeOnSite = getCurrentDateTimeForSite(it, "yyyy-MM-dd'T'00:00:00")
 
@@ -1261,9 +1266,11 @@ class WCStatsStoreTest {
         reset(mockOrderStatsRestClient)
 
         val minus12SiteDate = SiteModel().apply { timezone = "-12" }.let {
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
+            ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.formatDate("yyyy-MM-dd", Date())
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
-            wcStatsStore.onAction(WCStatsActionBuilder.newFetchRevenueStatsAction(payload))
+            wcStatsStore.fetchRevenueStats(payload)
 
             val timeOnSite = getCurrentDateTimeForSite(it, "yyyy-MM-dd'T'00:00:00")
 
@@ -1284,14 +1291,27 @@ class WCStatsStoreTest {
     }
 
     @Test
-    fun testGetRevenueAndOrderStatsForSite() {
+    fun testGetRevenueAndOrderStatsForSite() = runBlocking {
         // revenue stats model for current day
         val currentDayStatsModel = WCStatsTestUtils.generateSampleRevenueStatsModel()
         val site = SiteModel().apply { id = currentDayStatsModel.localSiteId }
-        val currentDayPayload = FetchRevenueStatsResponsePayload(
-                site, StatsGranularity.valueOf(currentDayStatsModel.interval.toUpperCase()), currentDayStatsModel
+        val currentDayGranularity = StatsGranularity.valueOf(currentDayStatsModel.interval.toUpperCase())
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+                .thenReturn(
+                        FetchRevenueStatsResponsePayload(
+                                site,
+                                currentDayGranularity,
+                                currentDayStatsModel
+                        )
+                )
+        wcStatsStore.fetchRevenueStats(
+                FetchRevenueStatsPayload(
+                        site,
+                        currentDayGranularity,
+                        currentDayStatsModel.startDate,
+                        currentDayStatsModel.endDate
+                )
         )
-        wcStatsStore.onAction(WCStatsActionBuilder.newFetchedRevenueStatsAction(currentDayPayload))
 
         // verify that the revenue stats & order count is not empty
         val currentDayRevenueStats = wcStatsStore.getGrossRevenueStats(
@@ -1311,10 +1331,20 @@ class WCStatsStoreTest {
                 WCStatsTestUtils.generateSampleRevenueStatsModel(
                         interval = StatsGranularity.WEEKS.toString(), startDate = "2019-07-07", endDate = "2019-07-09"
                 )
+        val curretnWeekGranularity = StatsGranularity.valueOf(currentWeekStatsModel.interval.toUpperCase())
         val currentWeekPayload = FetchRevenueStatsResponsePayload(
-                site, StatsGranularity.valueOf(currentWeekStatsModel.interval.toUpperCase()), currentWeekStatsModel
+                site, curretnWeekGranularity, currentWeekStatsModel
         )
-        wcStatsStore.onAction(WCStatsActionBuilder.newFetchedRevenueStatsAction(currentWeekPayload))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+                .thenReturn(currentWeekPayload)
+        wcStatsStore.fetchRevenueStats(
+                FetchRevenueStatsPayload(
+                        site,
+                        curretnWeekGranularity,
+                        currentWeekStatsModel.startDate,
+                        currentWeekStatsModel.endDate
+                )
+        )
 
         // verify that the revenue stats & order count is not empty
         val currentWeekRevenueStats = wcStatsStore.getGrossRevenueStats(
@@ -1334,10 +1364,20 @@ class WCStatsStoreTest {
                 WCStatsTestUtils.generateSampleRevenueStatsModel(
                         interval = StatsGranularity.MONTHS.toString(), startDate = "2019-07-01", endDate = "2019-07-09"
                 )
+        val currentMonthGranularity = StatsGranularity.valueOf(currentMonthStatsModel.interval.toUpperCase())
         val currentMonthPayload = FetchRevenueStatsResponsePayload(
-                site, StatsGranularity.valueOf(currentMonthStatsModel.interval.toUpperCase()), currentMonthStatsModel
+                site, currentMonthGranularity, currentMonthStatsModel
         )
-        wcStatsStore.onAction(WCStatsActionBuilder.newFetchedRevenueStatsAction(currentMonthPayload))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+                .thenReturn(currentMonthPayload)
+        wcStatsStore.fetchRevenueStats(
+                FetchRevenueStatsPayload(
+                        site,
+                        currentMonthGranularity,
+                        currentMonthStatsModel.startDate,
+                        currentMonthStatsModel.endDate
+                )
+        )
 
         // verify that the revenue stats & order count is not empty
         val currentMonthRevenueStats = wcStatsStore.getGrossRevenueStats(
@@ -1357,10 +1397,20 @@ class WCStatsStoreTest {
         val altSiteOrderStatsModel = WCStatsTestUtils.generateSampleRevenueStatsModel(
                 localSiteId = site2.id, interval = StatsGranularity.DAYS.toString()
         )
-        val altSiteCurrentDayPayload = FetchRevenueStatsResponsePayload(
-                site, StatsGranularity.valueOf(altSiteOrderStatsModel.interval.toUpperCase()), altSiteOrderStatsModel
+        val allSiteCurrentDayGranularity = StatsGranularity.valueOf(altSiteOrderStatsModel.interval.toUpperCase())
+        val allSiteCurrentDayPayload = FetchRevenueStatsResponsePayload(
+                site, allSiteCurrentDayGranularity, altSiteOrderStatsModel
         )
-        wcStatsStore.onAction(WCStatsActionBuilder.newFetchedRevenueStatsAction(altSiteCurrentDayPayload))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+                .thenReturn(allSiteCurrentDayPayload)
+        wcStatsStore.fetchRevenueStats(
+                FetchRevenueStatsPayload(
+                        site,
+                        allSiteCurrentDayGranularity,
+                        altSiteOrderStatsModel.startDate,
+                        altSiteOrderStatsModel.endDate
+                )
+        )
 
         // verify that the revenue stats & order count is not empty
         val altSiteCurrentDayRevenueStats = wcStatsStore.getGrossRevenueStats(
@@ -1377,10 +1427,20 @@ class WCStatsStoreTest {
 
         // non existentSite
         val nonExistentSite = SiteModel().apply { id = 88 }
+        val nonExistentSiteGranularity = StatsGranularity.valueOf(altSiteOrderStatsModel.interval)
         val nonExistentPayload = FetchRevenueStatsResponsePayload(
-                nonExistentSite, StatsGranularity.valueOf(altSiteOrderStatsModel.interval), altSiteOrderStatsModel
+                nonExistentSite, nonExistentSiteGranularity, altSiteOrderStatsModel
         )
-        wcStatsStore.onAction(WCStatsActionBuilder.newFetchedRevenueStatsAction(nonExistentPayload))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+                .thenReturn(nonExistentPayload)
+        wcStatsStore.fetchRevenueStats(
+                FetchRevenueStatsPayload(
+                        site,
+                        nonExistentSiteGranularity,
+                        altSiteOrderStatsModel.startDate,
+                        altSiteOrderStatsModel.endDate
+                )
+        )
 
         // verify that the revenue stats & order count is empty
         val nonExistentRevenueStats = wcStatsStore.getGrossRevenueStats(
@@ -1397,7 +1457,14 @@ class WCStatsStoreTest {
 
         // missing data
         val missingDataPayload = FetchRevenueStatsResponsePayload(site, StatsGranularity.YEARS, null)
-        wcStatsStore.onAction(WCStatsActionBuilder.newFetchedRevenueStatsAction(missingDataPayload))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+                .thenReturn(nonExistentPayload)
+        wcStatsStore.fetchRevenueStats(
+                FetchRevenueStatsPayload(
+                        site,
+                        StatsGranularity.YEARS
+                )
+        )
 
         // verify that the revenue stats & order count is empty
         val missingRevenueStats = wcStatsStore.getGrossRevenueStats(

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
@@ -8,7 +8,6 @@ import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityResponsePayload;
-import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsResponsePayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsResponsePayload;
@@ -20,9 +19,6 @@ public enum WCStatsAction implements IAction {
     // Remote actions
     @Action(payloadType = FetchOrderStatsPayload.class)
     FETCH_ORDER_STATS,
-
-    @Action(payloadType = FetchRevenueStatsPayload.class)
-    FETCH_REVENUE_STATS,
 
     @Action(payloadType = FetchRevenueStatsAvailabilityPayload.class)
     FETCH_REVENUE_STATS_AVAILABILITY,

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCStatsAction.java
@@ -8,7 +8,6 @@ import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityResponsePayload;
-import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsResponsePayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsPayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchTopEarnersStatsResponsePayload;
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchVisitorStatsPayload;
@@ -35,9 +34,6 @@ public enum WCStatsAction implements IAction {
     // Remote responses
     @Action(payloadType = FetchOrderStatsResponsePayload.class)
     FETCHED_ORDER_STATS,
-
-    @Action(payloadType = FetchRevenueStatsResponsePayload.class)
-    FETCHED_REVENUE_STATS,
 
     @Action(payloadType = FetchRevenueStatsAvailabilityResponsePayload.class)
     FETCHED_REVENUE_STATS_AVAILABILITY,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -201,10 +201,11 @@ class OrderStatsRestClient @Inject constructor(
 
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
                 this,
-                site,
-                url,
-                params,
-                RevenueStatsApiResponse::class.java,
+                site = site,
+                url = url,
+                params = params,
+                clazz = RevenueStatsApiResponse::class.java,
+                enableCaching = !force,
                 forced = force
         )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -205,7 +205,7 @@ class OrderStatsRestClient @Inject constructor(
                 url = url,
                 params = params,
                 clazz = RevenueStatsApiResponse::class.java,
-                enableCaching = !force,
+                enableCaching = true,
                 forced = force
         )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -45,13 +45,13 @@ import javax.inject.Singleton
 
 @Singleton
 class OrderStatsRestClient @Inject constructor(
-        appContext: Context,
-        dispatcher: Dispatcher,
-        @Named("regular") requestQueue: RequestQueue,
-        private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
-        private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-        accessToken: AccessToken,
-        userAgent: UserAgent
+    appContext: Context,
+    dispatcher: Dispatcher,
+    @Named("regular") requestQueue: RequestQueue,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
+    accessToken: AccessToken,
+    userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     enum class OrderStatsApiUnit {
         HOUR, DAY, WEEK, MONTH, YEAR;
@@ -222,7 +222,9 @@ class OrderStatsRestClient @Inject constructor(
 
                     FetchRevenueStatsResponsePayload(site, granularity, model)
                 } ?: FetchRevenueStatsResponsePayload(
-                        OrderStatsError(type = OrderStatsErrorType.GENERIC_ERROR, message = "Success response with empty data"),
+                        OrderStatsError(type = OrderStatsErrorType.GENERIC_ERROR,
+                                message = "Success response with empty data"
+                        ),
                         site,
                         granularity
                 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -653,7 +653,7 @@ class WCStatsStore @Inject constructor(
         val endDate = getEndDateForRevenueStatsGranularity(payload.site, payload.granularity)
         val perPage = getRandomPageIntForRevenueStats(payload.forced)
         return coroutineEngine.withDefaultContext(T.API, this, "fetchRevenueStats") {
-            var result = wcOrderStatsClient.fetchRevenueStats(
+            val result = wcOrderStatsClient.fetchRevenueStats(
                 site = payload.site,
                 granularity = payload.granularity,
                 startDate = startDate,


### PR DESCRIPTION
Implements  https://github.com/woocommerce/woocommerce-android/issues/5090 partially

This PR refactors fetchVisitorStats into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.

## Changes
* Refactored fetchNewVisitorStats in OrderStatsRestClient to a suspendible function
* Updated WooRevenueStatsFragment
* Updated fetchRevenueStats in WCStatsStore
* Updated tests

## How to test
1. Test fetchNewVisitorStats action in the example app ( or test in WCAndroid ([PR](https://github.com/woocommerce/woocommerce-android/pull/5351)))