### PR TITLE
Woo: create order

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.0.2'
     implementation "androidx.arch.core:core-common:$arch_core_version"
     implementation "androidx.arch.core:core-runtime:$arch_core_version"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
     implementation 'org.apache.commons:commons-lang3:3.7'
 
     // WordPress libs

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
@@ -4,127 +4,163 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.fragment_address_edit_dialog.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.example.databinding.FragmentAddressEditDialogBinding
 import org.wordpress.android.fluxc.example.prependToLog
-import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.EditTypeState.BILLING
-import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.EditTypeState.SHIPPING
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.AddressType.BILLING
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.AddressType.SHIPPING
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.Mode.Add
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.Mode.Edit
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.OrderAddress.Billing
 import org.wordpress.android.fluxc.model.order.OrderAddress.Shipping
 import org.wordpress.android.fluxc.store.OrderUpdateStore
 import javax.inject.Inject
 
 class AddressEditDialogFragment : DaggerFragment() {
-    @Inject lateinit var orderUpdateStore: OrderUpdateStore
+    companion object {
+        @JvmStatic
+        fun newInstanceForEditing(order: WCOrderModel): AddressEditDialogFragment =
+                AddressEditDialogFragment().apply {
+                    this.selectedOrder = order
+                    this.mode = Edit
+                }
 
-    enum class EditTypeState {
-        SHIPPING, BILLING
+        @JvmStatic
+        fun newInstanceForCreation(addressType: AddressType, listener: (OrderAddress) -> Unit): AddressEditDialogFragment =
+                AddressEditDialogFragment().apply {
+                    this.selectedOrder = WCOrderModel()
+                    this.mode = Add
+                    this.addressListener = listener
+                    this.currentAddressType.value = addressType
+                }
     }
 
-    private var currentAddressType = MutableStateFlow(SHIPPING)
-    private lateinit var binding: FragmentAddressEditDialogBinding
+    @Inject lateinit var orderUpdateStore: OrderUpdateStore
 
-    var selectedOrder = MutableStateFlow<WCOrderModel?>(null)
+    enum class AddressType {
+        SHIPPING, BILLING
+    }
+    enum class Mode {
+        Edit, Add
+    }
+
+    private lateinit var mode: Mode
+    private var currentAddressType = MutableStateFlow(SHIPPING)
+
+    private lateinit var selectedOrder: WCOrderModel
     var originalBillingEmail = ""
+
+    private var addressListener: ((OrderAddress) -> Unit)? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View = FragmentAddressEditDialogBinding.inflate(inflater).apply {
-        binding = this
-        addressTypeSwitch.setOnCheckedChangeListener { _, isChecked ->
-            currentAddressType.value = if (isChecked) BILLING else SHIPPING
-        }
-    }.root
+    ): View = FragmentAddressEditDialogBinding.inflate(inflater).root
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentAddressEditDialogBinding.bind(view)
 
-        CoroutineScope(Dispatchers.Main).launch {
-            currentAddressType.combine(selectedOrder) { addressType, order ->
-                originalBillingEmail = order?.billingEmail.orEmpty()
+        if (mode == Add) {
+            binding.addressTypeSwitch.visibility = View.GONE
+            binding.sendBothAddressesUpdate.visibility = View.GONE
+            binding.sendUpdate.text = "Save"
+            binding.addressTypeTitle.visibility = View.VISIBLE
+            binding.addressTypeTitle.text = if (currentAddressType.value == BILLING) {
+                "Enter a billing address"
+            } else {
+                "Enter a shipping address"
+            }
+        }
+
+        binding.addressTypeSwitch.setOnCheckedChangeListener { _, isChecked ->
+            currentAddressType.value = if (isChecked) BILLING else SHIPPING
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            currentAddressType.collect { addressType ->
+                originalBillingEmail = selectedOrder.billingEmail
                 when (addressType) {
                     SHIPPING -> {
-                        binding.addressTypeSwitch.text = "Edit shipping address for order ${order?.remoteOrderId}"
-                        binding.firstName.setText(order?.shippingFirstName)
-                        binding.lastName.setText(order?.shippingLastName)
-                        binding.company.setText(order?.shippingCompany)
-                        binding.address1.setText(order?.shippingAddress1)
-                        binding.address2.setText(order?.shippingAddress2)
-                        binding.city.setText(order?.shippingCity)
-                        binding.state.setText(order?.shippingState)
-                        binding.postcode.setText(order?.shippingPostcode)
-                        binding.phone.setText(order?.shippingPhone)
+                        binding.addressTypeSwitch.text = "Edit shipping address for order ${selectedOrder.remoteOrderId}"
+                        binding.firstName.setText(selectedOrder.shippingFirstName)
+                        binding.lastName.setText(selectedOrder.shippingLastName)
+                        binding.company.setText(selectedOrder.shippingCompany)
+                        binding.address1.setText(selectedOrder.shippingAddress1)
+                        binding.address2.setText(selectedOrder.shippingAddress2)
+                        binding.city.setText(selectedOrder.shippingCity)
+                        binding.state.setText(selectedOrder.shippingState)
+                        binding.postcode.setText(selectedOrder.shippingPostcode)
+                        binding.phone.setText(selectedOrder.shippingPhone)
                         binding.email.visibility = View.INVISIBLE
                     }
                     BILLING -> {
-                        binding.addressTypeSwitch.text = "Edit billing address for order ${order?.remoteOrderId}"
-                        binding.firstName.setText(order?.billingFirstName)
-                        binding.lastName.setText(order?.billingLastName)
-                        binding.company.setText(order?.billingCompany)
-                        binding.address1.setText(order?.billingAddress1)
-                        binding.address2.setText(order?.billingAddress2)
-                        binding.city.setText(order?.billingCity)
-                        binding.state.setText(order?.billingState)
-                        binding.postcode.setText(order?.billingPostcode)
-                        binding.phone.setText(order?.billingPhone)
+                        binding.addressTypeSwitch.text = "Edit billing address for order ${selectedOrder.remoteOrderId}"
+                        binding.firstName.setText(selectedOrder.billingFirstName)
+                        binding.lastName.setText(selectedOrder.billingLastName)
+                        binding.company.setText(selectedOrder.billingCompany)
+                        binding.address1.setText(selectedOrder.billingAddress1)
+                        binding.address2.setText(selectedOrder.billingAddress2)
+                        binding.city.setText(selectedOrder.billingCity)
+                        binding.state.setText(selectedOrder.billingState)
+                        binding.postcode.setText(selectedOrder.billingPostcode)
+                        binding.phone.setText(selectedOrder.billingPhone)
                         binding.email.apply {
-                            setText(order?.billingEmail)
+                            setText(selectedOrder.billingEmail)
                             visibility = View.VISIBLE
                         }
                     }
                 }
-            }.collect()
+            }
         }
 
         sendUpdate.setOnClickListener {
-            selectedOrder.value?.let { order ->
-                CoroutineScope(Dispatchers.IO).launch {
-                    val newAddress = when (currentAddressType.value) {
-                        SHIPPING -> generateShippingAddressModel()
-                        BILLING -> generateBillingAddressModel()
-                    }
+            val newAddress = when (currentAddressType.value) {
+                SHIPPING -> generateShippingAddressModel(binding)
+                BILLING -> generateBillingAddressModel(binding)
+            }
 
-                    orderUpdateStore.updateOrderAddress(
-                            orderLocalId = LocalId(order.id),
-                            newAddress = newAddress
-                    ).collect {
-                        CoroutineScope(Dispatchers.Main).launch {
+            when(mode) {
+                Edit -> {
+                    lifecycleScope.launch {
+                        orderUpdateStore.updateOrderAddress(
+                                orderLocalId = LocalId(selectedOrder.id),
+                                newAddress = newAddress
+                        ).collect {
                             prependToLog("${it::class.simpleName} - Error: ${it.event.error?.message}")
                         }
                     }
+                }
+                Add -> {
+                    parentFragmentManager.popBackStack()
+                    addressListener?.invoke(newAddress)
                 }
             }
         }
 
         sendBothAddressesUpdate.setOnClickListener {
-            selectedOrder.value?.let { order ->
-                CoroutineScope(Dispatchers.IO).launch {
-                    orderUpdateStore.updateBothOrderAddresses(
-                            orderLocalId = LocalId(order.id),
-                            shippingAddress = generateShippingAddressModel(),
-                            billingAddress = generateBillingAddressModel()
-                    ).collect {
-                        CoroutineScope(Dispatchers.Main).launch {
-                            prependToLog("${it::class.simpleName} - Error: ${it.event.error?.message}")
-                        }
-                    }
+            lifecycleScope.launch {
+                orderUpdateStore.updateBothOrderAddresses(
+                        orderLocalId = LocalId(selectedOrder.id),
+                        shippingAddress = generateShippingAddressModel(binding),
+                        billingAddress = generateBillingAddressModel(binding)
+                ).collect {
+                    prependToLog("${it::class.simpleName} - Error: ${it.event.error?.message}")
                 }
             }
         }
     }
 
-    private fun generateBillingAddressModel() = Billing(
+    private fun generateBillingAddressModel(binding: FragmentAddressEditDialogBinding) = Billing(
             firstName = binding.firstName.text.toString(),
             lastName = binding.lastName.text.toString(),
             company = binding.company.text.toString(),
@@ -140,7 +176,7 @@ class AddressEditDialogFragment : DaggerFragment() {
                     ?: originalBillingEmail
     )
 
-    private fun generateShippingAddressModel() = Shipping(
+    private fun generateShippingAddressModel(binding: FragmentAddressEditDialogBinding) = Shipping(
             firstName = binding.firstName.text.toString(),
             lastName = binding.lastName.text.toString(),
             company = binding.company.text.toString(),
@@ -152,13 +188,4 @@ class AddressEditDialogFragment : DaggerFragment() {
             country = binding.country.text.toString(),
             phone = binding.phone.text.toString()
     )
-
-    companion object {
-        @JvmStatic
-        fun newInstance(order: WCOrderModel) = AddressEditDialogFragment().also { fragment ->
-            CoroutineScope(Dispatchers.IO).launch {
-                fragment.selectedOrder.value = order
-            }
-        }
-    }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
@@ -26,6 +26,8 @@ import javax.inject.Inject
 
 class AddressEditDialogFragment : DaggerFragment() {
     companion object {
+        // These instantiations won't work with screen rotation or process death scenarios.
+        // They are just for the sake of simplification of the example
         @JvmStatic
         fun newInstanceForEditing(order: WCOrderModel): AddressEditDialogFragment =
                 AddressEditDialogFragment().apply {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/AddressEditDialogFragment.kt
@@ -36,7 +36,8 @@ class AddressEditDialogFragment : DaggerFragment() {
                 }
 
         @JvmStatic
-        fun newInstanceForCreation(addressType: AddressType, listener: (OrderAddress) -> Unit): AddressEditDialogFragment =
+        fun newInstanceForCreation(addressType: AddressType, listener: (OrderAddress) -> Unit):
+                AddressEditDialogFragment =
                 AddressEditDialogFragment().apply {
                     this.selectedOrder = WCOrderModel()
                     this.mode = Add
@@ -93,7 +94,8 @@ class AddressEditDialogFragment : DaggerFragment() {
                 originalBillingEmail = selectedOrder.billingEmail
                 when (addressType) {
                     SHIPPING -> {
-                        binding.addressTypeSwitch.text = "Edit shipping address for order ${selectedOrder.remoteOrderId}"
+                        binding.addressTypeSwitch.text =
+                                "Edit shipping address for order ${selectedOrder.remoteOrderId}"
                         binding.firstName.setText(selectedOrder.shippingFirstName)
                         binding.lastName.setText(selectedOrder.shippingLastName)
                         binding.company.setText(selectedOrder.shippingCompany)
@@ -131,7 +133,7 @@ class AddressEditDialogFragment : DaggerFragment() {
                 BILLING -> generateBillingAddressModel(binding)
             }
 
-            when(mode) {
+            when (mode) {
                 Edit -> {
                     lifecycleScope.launch {
                         orderUpdateStore.updateOrderAddress(

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -5,11 +5,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import kotlinx.android.synthetic.main.fragment_woo_orders.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -21,13 +23,19 @@ import org.wordpress.android.fluxc.example.WCOrderListActivity
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.AddressType
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.AddressType.BILLING
+import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.AddressType.SHIPPING
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
+import org.wordpress.android.fluxc.model.order.CreateOrderRequest
+import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.store.OrderUpdateStore
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -45,6 +53,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
+import kotlin.coroutines.resume
 
 class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDialog.Listener {
     @Inject lateinit var dispatcher: Dispatcher
@@ -392,6 +401,45 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                 }
             }
         }
+
+        create_order.setOnClickListener {
+            selectedSite?.let { site ->
+                lifecycleScope.launch {
+                    val products = showSingleLineDialog(
+                            activity = requireActivity(),
+                            message = "Please type a comma separated list of product IDs",
+                            isNumeric = false
+                    )?.split(",")?.map { it.toLongOrNull() }
+
+                    if (products == null || products.any { it == null }) {
+                        prependToLog("Error while parsing the entered product IDs")
+                        return@launch
+                    }
+
+                    val shippingAddress = showAddressDialog(addressType = SHIPPING) as OrderAddress.Shipping
+                    val billingAddress = showAddressDialog(addressType = BILLING) as OrderAddress.Billing
+
+                    val result = wcOrderStore.createOrder(
+                            site,
+                            CreateOrderRequest(
+                                    lineItems = products.map {
+                                        LineItem().apply {
+                                            productId = it
+                                            quantity = 1f
+                                        }
+                                    },
+                                    shippingAddress = shippingAddress,
+                                    billingAddress = billingAddress
+                            )
+                    )
+                    if (result.isError) {
+                        prependToLog("Order creation failed, error ${result.error.type}")
+                    } else {
+                        prependToLog("Created order with id ${result.model!!.remoteOrderId}")
+                    }
+                }
+            }
+        }
     }
 
     private fun fetchOrderShipmentProviders(
@@ -559,6 +607,14 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
             } else {
                 prependToLog("Adding shipment tracking for remoteOrderId [${order.remoteOrderId}] FAILED!")
             }
+        }
+    }
+
+    private suspend fun showAddressDialog(addressType: AddressType): OrderAddress? {
+        return suspendCancellableCoroutine { continuation ->
+            replaceFragment(AddressEditDialogFragment.newInstanceForCreation(addressType) {
+                continuation.resume(it)
+            })
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -240,9 +240,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     showSingleLineDialog(activity, "Enter new order status") { editText ->
                         val status = editText.text.toString()
                         coroutineScope.launch {
-                            wcOrderStore.updateOrderStatus(LocalId(order.id), site, WCOrderStatusModel().apply {
-                                statusKey = status
-                            })
+                            wcOrderStore.updateOrderStatus(LocalId(order.id), site, WCOrderStatusModel(status))
                                     .collect {
                                         if (it.event.isError) {
                                             prependToLog("FAILED: Update order status for ${order.remoteOrderId} " +
@@ -423,9 +421,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     val shippingAddress = showAddressDialog(addressType = SHIPPING) as OrderAddress.Shipping
                     val billingAddress = showAddressDialog(addressType = BILLING) as OrderAddress.Billing
 
-                    val status = WCOrderStatusModel().apply {
-                        statusKey = CoreOrderStatus.PROCESSING.value
-                    }
+                    val status = WCOrderStatusModel(CoreOrderStatus.PROCESSING.value)
 
                     val result = wcOrderStore.createOrder(
                             site,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -240,7 +240,9 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     showSingleLineDialog(activity, "Enter new order status") { editText ->
                         val status = editText.text.toString()
                         coroutineScope.launch {
-                            wcOrderStore.updateOrderStatus(LocalId(order.id), site, status)
+                            wcOrderStore.updateOrderStatus(LocalId(order.id), site, WCOrderStatusModel().apply {
+                                statusKey = status
+                            })
                                     .collect {
                                         if (it.event.isError) {
                                             prependToLog("FAILED: Update order status for ${order.remoteOrderId} " +

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -31,7 +31,7 @@ import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
+import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.order.CreateOrderRequest

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -34,9 +34,11 @@ import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.CreateOrderRequest
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.OrderUpdateStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingPayload
@@ -419,9 +421,14 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     val shippingAddress = showAddressDialog(addressType = SHIPPING) as OrderAddress.Shipping
                     val billingAddress = showAddressDialog(addressType = BILLING) as OrderAddress.Billing
 
+                    val status = WCOrderStatusModel().apply {
+                        statusKey = CoreOrderStatus.PROCESSING.value
+                    }
+
                     val result = wcOrderStore.createOrder(
                             site,
                             CreateOrderRequest(
+                                    status = status,
                                     lineItems = products.map {
                                         LineItem(productId = it, quantity = 1f)
                                     },

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -365,7 +365,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
         update_latest_order_billing_address.setOnClickListener {
             selectedSite?.let { site ->
                 wcOrderStore.getOrdersForSite(site).firstOrNull()?.let { order ->
-                    replaceFragment(AddressEditDialogFragment.newInstance(order))
+                    replaceFragment(AddressEditDialogFragment.newInstanceForEditing(order))
                 } ?: showNoOrdersToast(site)
             }
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -423,10 +423,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                             site,
                             CreateOrderRequest(
                                     lineItems = products.map {
-                                        LineItem().apply {
-                                            productId = it
-                                            quantity = 1f
-                                        }
+                                        LineItem(productId = it, quantity = 1f)
                                     },
                                     shippingAddress = shippingAddress,
                                     billingAddress = billingAddress

--- a/example/src/main/res/layout/fragment_address_edit_dialog.xml
+++ b/example/src/main/res/layout/fragment_address_edit_dialog.xml
@@ -9,6 +9,14 @@
     android:stretchMode="columnWidth"
     tools:context=".ui.orders.AddressEditDialogFragment">
 
+    <TextView
+        android:id="@+id/addressTypeTitle"
+        android:layout_row="0"
+        android:layout_column="0"
+        android:layout_columnSpan="2"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:visibility="gone" />
+
     <Switch
         android:id="@+id/addressTypeSwitch"
         android:layout_width="match_parent"

--- a/example/src/main/res/layout/fragment_woo_orders.xml
+++ b/example/src/main/res/layout/fragment_woo_orders.xml
@@ -145,5 +145,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Create quick order" />
+
+        <Button
+            android:id="@+id/create_order"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Create Order" />
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderModelTest.kt
@@ -4,7 +4,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.junit.Test
 import org.wordpress.android.fluxc.UnitTestUtils
-import org.wordpress.android.fluxc.model.WCOrderModel.ShippingLine
+import org.wordpress.android.fluxc.model.order.ShippingLine
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -146,7 +146,7 @@ class WCOrderStoreTest {
         whenever(orderRestClient.updateOrderStatus(orderModel, site, CoreOrderStatus.REFUNDED.value))
             .thenReturn(result)
 
-        orderStore.updateOrderStatus(LocalId(orderModel.id), site, CoreOrderStatus.REFUNDED.value)
+        orderStore.updateOrderStatus(LocalId(orderModel.id), site, WCOrderStatusModel(CoreOrderStatus.REFUNDED.value))
             .toList()
 
         with(orderStore.getOrderByIdentifier(orderModel.getIdentifier())!!) {
@@ -288,7 +288,7 @@ class WCOrderStoreTest {
 
         assertThat(OrderSqlUtils.getOrderByLocalId(orderModel.id).status).isEqualTo(CoreOrderStatus.PROCESSING.value)
 
-        orderStore.updateOrderStatus(LocalId(orderModel.id), site, CoreOrderStatus.COMPLETED.value)
+        orderStore.updateOrderStatus(LocalId(orderModel.id), site, WCOrderStatusModel(CoreOrderStatus.COMPLETED.value))
                 .toList()
 
         assertThat(OrderSqlUtils.getOrderByLocalId(orderModel.id).status).isEqualTo(CoreOrderStatus.COMPLETED.value)
@@ -308,7 +308,7 @@ class WCOrderStoreTest {
             )
         )
 
-        orderStore.updateOrderStatus(LocalId(orderModel.id), site, CoreOrderStatus.COMPLETED.value)
+        orderStore.updateOrderStatus(LocalId(orderModel.id), site, WCOrderStatusModel(CoreOrderStatus.COMPLETED.value))
                 .toList()
 
         assertThat(OrderSqlUtils.getOrderByLocalId(orderModel.id).status).isEqualTo(CoreOrderStatus.PROCESSING.value)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -101,10 +101,10 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
         @SerializedName("parent_name")
         val parentName: String? = null
         @SerializedName("product_id")
-        val productId: Long? = null
+        var productId: Long? = null
         @SerializedName("variation_id")
         val variationId: Long? = null
-        val quantity: Float? = null
+        var quantity: Float? = null
         val subtotal: String? = null
         val total: String? = null // Price x quantity
         @SerializedName("total_tax")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -1,14 +1,16 @@
 package org.wordpress.android.fluxc.model
 
 import com.google.gson.Gson
-import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.order.FeeLine
+import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
+import org.wordpress.android.fluxc.model.order.ShippingLine
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
@@ -70,60 +72,6 @@ data class WCOrderModel(@PrimaryKey @Column private var id: Int = 0) : Identifia
 
     companion object {
         private val gson by lazy { Gson() }
-    }
-
-    class ShippingLine {
-        val id: Long? = null
-        val total: String? = null
-        @SerializedName("total_tax")
-        val totalTax: String? = null
-        @SerializedName("method_id")
-        val methodId: String? = null
-        @SerializedName("method_title")
-        val methodTitle: String? = null
-    }
-
-    /**
-     * Represents a fee line
-     * We are reading only the name and the total, as the tax is already included in the order totalTax
-     */
-    class FeeLine {
-        @SerializedName("name")
-        val name: String? = null
-
-        @SerializedName("total")
-        val total: String? = null
-    }
-
-    class LineItem {
-        val id: Long? = null
-        val name: String? = null
-        @SerializedName("parent_name")
-        val parentName: String? = null
-        @SerializedName("product_id")
-        var productId: Long? = null
-        @SerializedName("variation_id")
-        val variationId: Long? = null
-        var quantity: Float? = null
-        val subtotal: String? = null
-        val total: String? = null // Price x quantity
-        @SerializedName("total_tax")
-        val totalTax: String? = null
-        val sku: String? = null
-        val price: String? = null // The per-item price
-
-        @SerializedName("meta_data")
-        val metaData: List<WCMetaData>? = null
-
-        class Attribute(val key: String?, val value: String?)
-
-        fun getAttributeList(): List<Attribute> {
-            return metaData?.filter {
-                it.displayKey is String && it.displayValue is String
-            }?.map {
-                Attribute(it.displayKey, it.displayValue as String)
-            } ?: emptyList()
-        }
     }
 
     override fun getId() = id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatusModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderStatusModel.kt
@@ -8,6 +8,10 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCOrderStatusModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    constructor(statusKey: String) : this() {
+        this.statusKey = statusKey
+    }
+
     @Column var localSiteId = 0
     @Column var statusKey = ""
     @Column var label = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/CreateOrderRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/CreateOrderRequest.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.model.order
+
+import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
+
+data class CreateOrderRequest(
+    val lineItems: List<LineItem>,
+    val shippingAddress: OrderAddress.Shipping,
+    val billingAddress: OrderAddress.Billing
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/CreateOrderRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/CreateOrderRequest.kt
@@ -1,6 +1,9 @@
 package org.wordpress.android.fluxc.model.order
 
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+
 data class CreateOrderRequest(
+    val status: WCOrderStatusModel,
     val lineItems: List<LineItem>,
     val shippingAddress: OrderAddress.Shipping,
     val billingAddress: OrderAddress.Billing

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/CreateOrderRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/CreateOrderRequest.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.model.order
 
-import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
-
 data class CreateOrderRequest(
     val lineItems: List<LineItem>,
     val shippingAddress: OrderAddress.Shipping,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/FeeLine.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/FeeLine.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.fluxc.model.order
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a fee line
+ * We are reading only the name and the total, as the tax is already included in the order totalTax
+ */
+class FeeLine {
+    @SerializedName("name")
+    val name: String? = null
+
+    @SerializedName("total")
+    val total: String? = null
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -3,26 +3,26 @@ package org.wordpress.android.fluxc.model.order
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.model.WCMetaData
 
-class LineItem {
-    val id: Long? = null
-    val name: String? = null
+data class LineItem(
+    val id: Long? = null,
+    val name: String? = null,
     @SerializedName("parent_name")
-    val parentName: String? = null
+    val parentName: String? = null,
     @SerializedName("product_id")
-    var productId: Long? = null
+    var productId: Long? = null,
     @SerializedName("variation_id")
-    val variationId: Long? = null
-    var quantity: Float? = null
-    val subtotal: String? = null
-    val total: String? = null // Price x quantity
+    val variationId: Long? = null,
+    var quantity: Float? = null,
+    val subtotal: String? = null,
+    val total: String? = null, // Price x quantity
     @SerializedName("total_tax")
-    val totalTax: String? = null
-    val sku: String? = null
-    val price: String? = null // The per-item price
+    val totalTax: String? = null,
+    val sku: String? = null,
+    val price: String? = null, // The per-item price
 
     @SerializedName("meta_data")
     val metaData: List<WCMetaData>? = null
-
+) {
     class Attribute(val key: String?, val value: String?)
 
     fun getAttributeList(): List<Attribute> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.fluxc.model.order
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.model.WCMetaData
+
+class LineItem {
+    val id: Long? = null
+    val name: String? = null
+    @SerializedName("parent_name")
+    val parentName: String? = null
+    @SerializedName("product_id")
+    var productId: Long? = null
+    @SerializedName("variation_id")
+    val variationId: Long? = null
+    var quantity: Float? = null
+    val subtotal: String? = null
+    val total: String? = null // Price x quantity
+    @SerializedName("total_tax")
+    val totalTax: String? = null
+    val sku: String? = null
+    val price: String? = null // The per-item price
+
+    @SerializedName("meta_data")
+    val metaData: List<WCMetaData>? = null
+
+    class Attribute(val key: String?, val value: String?)
+
+    fun getAttributeList(): List<Attribute> {
+        return metaData?.filter {
+            it.displayKey is String && it.displayValue is String
+        }?.map {
+            Attribute(it.displayKey, it.displayValue as String)
+        } ?: emptyList()
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/ShippingLine.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/ShippingLine.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.model.order
+
+import com.google.gson.annotations.SerializedName
+
+class ShippingLine {
+    val id: Long? = null
+    val total: String? = null
+    @SerializedName("total_tax")
+    val totalTax: String? = null
+    @SerializedName("method_id")
+    val methodId: String? = null
+    @SerializedName("method_title")
+    val methodTitle: String? = null
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.network.Response
+import org.wordpress.android.fluxc.utils.DateUtils
 
 @Suppress("PropertyName")
 class OrderDto : Response {
@@ -69,4 +71,69 @@ class OrderDto : Response {
     val total: String? = null
     val total_tax: String? = null
     val meta_data: JsonElement? = null
+}
+
+fun OrderDto.toDomainModel(): WCOrderModel {
+    fun convertDateToUTCString(date: String?): String =
+            date?.let { DateUtils.formatGmtAsUtcDateString(it) } ?: "" // Store the date in UTC format
+
+    return WCOrderModel().apply {
+        remoteOrderId = this@toDomainModel.id ?: 0
+        number = this@toDomainModel.number ?: remoteOrderId.toString()
+        status = this@toDomainModel.status ?: ""
+        currency = this@toDomainModel.currency ?: ""
+        orderKey = this@toDomainModel.order_key ?: ""
+        dateCreated = convertDateToUTCString(this@toDomainModel.date_created_gmt)
+        dateModified = convertDateToUTCString(this@toDomainModel.date_modified_gmt)
+        total = this@toDomainModel.total ?: ""
+        totalTax = this@toDomainModel.total_tax ?: ""
+        shippingTotal = this@toDomainModel.shipping_total ?: ""
+        paymentMethod = this@toDomainModel.payment_method ?: ""
+        paymentMethodTitle = this@toDomainModel.payment_method_title ?: ""
+        datePaid = this@toDomainModel.date_paid_gmt?.let { "${it}Z" } ?: ""
+        pricesIncludeTax = this@toDomainModel.prices_include_tax
+
+        customerNote = this@toDomainModel.customer_note ?: ""
+
+        discountTotal = this@toDomainModel.discount_total ?: ""
+        this@toDomainModel.coupon_lines?.let { couponLines ->
+            // Extract the discount codes from the coupon_lines list and store them as a comma-delimited String
+            discountCodes = couponLines
+                    .filter { !it.code.isNullOrEmpty() }
+                    .joinToString { it.code!! }
+        }
+
+        this@toDomainModel.refunds?.let { refunds ->
+            // Extract the individual refund totals from the refunds list and store their sum as a Double
+            refundTotal = refunds.sumByDouble { it.total?.toDoubleOrNull() ?: 0.0 }
+        }
+
+        billingFirstName = this@toDomainModel.billing?.first_name ?: ""
+        billingLastName = this@toDomainModel.billing?.last_name ?: ""
+        billingCompany = this@toDomainModel.billing?.company ?: ""
+        billingAddress1 = this@toDomainModel.billing?.address_1 ?: ""
+        billingAddress2 = this@toDomainModel.billing?.address_2 ?: ""
+        billingCity = this@toDomainModel.billing?.city ?: ""
+        billingState = this@toDomainModel.billing?.state ?: ""
+        billingPostcode = this@toDomainModel.billing?.postcode ?: ""
+        billingCountry = this@toDomainModel.billing?.country ?: ""
+        billingEmail = this@toDomainModel.billing?.email ?: ""
+        billingPhone = this@toDomainModel.billing?.phone ?: ""
+
+        shippingFirstName = this@toDomainModel.shipping?.first_name ?: ""
+        shippingLastName = this@toDomainModel.shipping?.last_name ?: ""
+        shippingCompany = this@toDomainModel.shipping?.company ?: ""
+        shippingAddress1 = this@toDomainModel.shipping?.address_1 ?: ""
+        shippingAddress2 = this@toDomainModel.shipping?.address_2 ?: ""
+        shippingCity = this@toDomainModel.shipping?.city ?: ""
+        shippingState = this@toDomainModel.shipping?.state ?: ""
+        shippingPostcode = this@toDomainModel.shipping?.postcode ?: ""
+        shippingCountry = this@toDomainModel.shipping?.country ?: ""
+        shippingPhone = this@toDomainModel.shipping?.phone.orEmpty()
+
+        lineItems = this@toDomainModel.line_items.toString()
+        shippingLines = this@toDomainModel.shipping_lines.toString()
+        feeLines = this@toDomainModel.fee_lines.toString()
+        metaData = this@toDomainModel.meta_data.toString()
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
@@ -73,11 +73,12 @@ class OrderDto : Response {
     val meta_data: JsonElement? = null
 }
 
-fun OrderDto.toDomainModel(): WCOrderModel {
+fun OrderDto.toDomainModel(localSiteId: Int): WCOrderModel {
     fun convertDateToUTCString(date: String?): String =
             date?.let { DateUtils.formatGmtAsUtcDateString(it) } ?: "" // Store the date in UTC format
 
     return WCOrderModel().apply {
+        this.localSiteId = localSiteId
         remoteOrderId = this@toDomainModel.id ?: 0
         number = this@toDomainModel.number ?: remoteOrderId.toString()
         status = this@toDomainModel.status ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -818,6 +818,7 @@ class OrderRestClient @Inject constructor(
     ): WooPayload<OrderDto> {
         val url = WOOCOMMERCE.orders.pathV3
         val params = mapOf(
+                "status" to request.status.statusKey,
                 "line_items" to request.lineItems,
                 "shipping" to request.shippingAddress.toDto(),
                 "billing" to request.billingAddress.toDto()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import android.content.Context
 import com.android.volley.RequestQueue
-import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
+import org.wordpress.android.fluxc.model.order.CreateOrderRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -29,6 +30,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Shipping
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -806,6 +808,13 @@ class OrderRestClient @Inject constructor(
                 FetchOrderShipmentProvidersResponsePayload(trackingError, site, order)
             }
         }
+    }
+
+    suspend fun createOrder(
+        site: SiteModel,
+        request: CreateOrderRequest
+    ): WooPayload<OrderDto> {
+        TODO()
     }
 
     private fun orderResponseToOrderSummaryModel(response: OrderSummaryApiResponse): WCOrderSummaryModel {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -832,7 +832,7 @@ class OrderRestClient @Inject constructor(
                 OrderDto::class.java
         )
 
-        return when(response) {
+        return when (response) {
             is JetpackError -> WooPayload(response.error.toWooError())
             is JetpackSuccess -> WooPayload(response.data)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -846,6 +846,10 @@ class OrderRestClient @Inject constructor(
         }
     }
 
+    @Deprecated(
+            message = "Use OrderDto#toDomainModel() instead",
+            replaceWith = ReplaceWith("OrderDto.toDomainModel()")
+    )
     private fun orderResponseToOrderModel(response: OrderDto): WCOrderModel {
         return WCOrderModel().apply {
             remoteOrderId = response.id ?: 0

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.WCOrderModel.LineItem
+import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundShippingLine
 import org.wordpress.android.fluxc.network.UserAgent

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -18,10 +18,13 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
+import org.wordpress.android.fluxc.model.order.CreateOrderRequest
 import org.wordpress.android.fluxc.model.order.OrderIdentifier
 import org.wordpress.android.fluxc.model.order.toIdSet
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.toDomainModel
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 import org.wordpress.android.fluxc.store.ListStore.ListError
@@ -508,6 +511,20 @@ class WCOrderStore @Inject constructor(
             } else {
                 val rowsAffected = OrderSqlUtils.insertOrUpdateOrder(result.order)
                 OnOrderChanged(rowsAffected)
+            }
+        }
+    }
+
+    suspend fun createOrder(site: SiteModel, createOrderRequest: CreateOrderRequest): WooResult<WCOrderModel> {
+        return coroutineEngine.withDefaultContext(T.API, this, "createOrder") {
+            val result = wcOrderRestClient.createOrder(site, createOrderRequest)
+
+            return@withDefaultContext if (result.isError) {
+                WooResult(result.error)
+            } else {
+                val model = result.result!!.toDomainModel()
+                OrderSqlUtils.insertOrUpdateOrder(model)
+                WooResult(model)
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -542,19 +542,23 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    suspend fun updateOrderStatus(orderLocalId: LocalId, site: SiteModel, newStatus: String): Flow<UpdateOrderResult> {
+    suspend fun updateOrderStatus(
+        orderLocalId: LocalId,
+        site: SiteModel,
+        newStatus: WCOrderStatusModel
+    ): Flow<UpdateOrderResult> {
         return coroutineEngine.flowWithDefaultContext(T.API, this, "updateOrderStatus") {
             val orderModel = OrderSqlUtils.getOrderByLocalIdOrNull(orderLocalId)
 
             if (orderModel != null) {
-                val rowsAffected = updateOrderStatusLocally(LocalId(orderModel.id), newStatus)
+                val rowsAffected = updateOrderStatusLocally(LocalId(orderModel.id), newStatus.statusKey)
 
                 val optimisticUpdateResult = OnOrderChanged(rowsAffected)
                         .apply { causeOfChange = WCOrderAction.UPDATE_ORDER_STATUS }
 
                 emit(OptimisticUpdateResult(optimisticUpdateResult))
 
-                val remotePayload = wcOrderRestClient.updateOrderStatus(orderModel, site, newStatus)
+                val remotePayload = wcOrderRestClient.updateOrderStatus(orderModel, site, newStatus.statusKey)
                 val remoteUpdateResult: OnOrderChanged = if (remotePayload.isError) {
                     revertOrderStatus(remotePayload)
                 } else {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -522,7 +522,7 @@ class WCOrderStore @Inject constructor(
             return@withDefaultContext if (result.isError) {
                 WooResult(result.error)
             } else {
-                val model = result.result!!.toDomainModel()
+                val model = result.result!!.toDomainModel(site.id)
                 OrderSqlUtils.insertOrUpdateOrder(model)
                 WooResult(model)
             }


### PR DESCRIPTION
This PR adds the ability to create orders from the app, we support currently just: status, a list of products, and customer addresses (shipping and billing).

I created a separate class for the request [CreateOrderRequest](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/218d9523bd33cf04b5e0f151354cfe2e32aa8ab2/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/CreateOrderRequest.kt#L3) because:
1. WCOrderModel has a ton of stuff that we won't need for the creation, and we need to keep passing null arguments for it.
2. WCOrderModel doesn't play well with the OrderAddress type.
3. The new class would make it more flexible in organizing the classes of different sections later on (for example grouping the payment options in the same class).

The new class meant that I had to move the subclasses of WCOrderModel to their own files (for a better organization), sorry @wzieba for this, I know it will create conflicts with your Room changes.

### Testing
1. Open the example app.
2. Navigate to Woo then Orders.
3. Select a site.
4. Click on create order.
5. Enter the order's information.
6. Confirm that the created order's id is printed.
7. Check the order in wp-admin, and confirm that it's matching what you entered. 