### PR TITLE
Dashboard Cards: Convert Date to GMT Timezone

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsUtils.kt
@@ -2,18 +2,31 @@ package org.wordpress.android.fluxc.network.rest.wpcom.dashboard
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import java.lang.reflect.Type
+import java.text.DateFormat
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 
 object CardsUtils {
     private const val INSERT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ"
+
     private const val DATE_FORMAT = "yyyy-MM-dd HH:mm:ss"
+    private const val TIMEZONE = "GMT"
 
     val GSON: Gson by lazy {
         val builder = GsonBuilder()
-        builder.setDateFormat(DATE_FORMAT)
+        builder.registerTypeAdapter(Date::class.java, GsonDateAdapter())
         builder.create()
     }
 
@@ -25,6 +38,40 @@ object CardsUtils {
 
     fun fromDate(date: String): Date {
         val dateFormat = SimpleDateFormat(DATE_FORMAT, Locale.ROOT)
+        dateFormat.timeZone = TimeZone.getTimeZone(TIMEZONE)
         return dateFormat.parse(date) ?: Date()
+    }
+
+    /* GSON ADAPTER */
+
+    private class GsonDateAdapter : JsonSerializer<Date>, JsonDeserializer<Date> {
+        private val dateFormat: DateFormat
+
+        @Synchronized
+        override fun serialize(
+            date: Date,
+            type: Type?,
+            jsonSerializationContext: JsonSerializationContext?
+        ): JsonElement {
+            return JsonPrimitive(dateFormat.format(date))
+        }
+
+        @Synchronized
+        override fun deserialize(
+            jsonElement: JsonElement,
+            type: Type?,
+            jsonDeserializationContext: JsonDeserializationContext?
+        ): Date {
+            return try {
+                dateFormat.parse(jsonElement.asString) ?: Date()
+            } catch (e: ParseException) {
+                throw JsonParseException(e)
+            }
+        }
+
+        init {
+            dateFormat = SimpleDateFormat(DATE_FORMAT, Locale.ROOT)
+            dateFormat.timeZone = TimeZone.getTimeZone(TIMEZONE)
+        }
     }
 }


### PR DESCRIPTION
Parent: [WordPress-Android#15200](https://github.com/wordpress-mobile/WordPress-Android/issues/15200)

The API endpoint date for the post cards are in GMT format and as such this PR makes sure that this is being respected.

As such:
- First, when converting the `date` post response string using the `fromDate(...)` function, the date format timezone is set to `GMT`.
- Then, when converting the card entity from and to a JSON using GSON in order to save and retrieve the card model from the database, a newly created, private to cards `GsonDateAdapter` is used which also sets the date format timezone to `GMT`.

Both additions, makes sure that the date ends up being the expected one when it is being utilized later on and converted to the user's timezone.

-----

To test:
- First, install the `WordPress-Android` app without with branch and verify that any scheduled post time is incorrectly displayed (use latest `develop`).
- Then, install the `WordPress-Android` app with with branch and verify that any scheduled post time is now correctly displayed (use latest `develop`, but point to `issue/dashboard-cards-date-gmt-timezone` branch through `local-build.gradle`).