### PR TITLE
Update event bus to v3.3.1

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     kapt fluxcProcessorProjectDependency
 
     // External libs
-    api 'org.greenrobot:eventbus:3.2.0'
+    api 'org.greenrobot:eventbus:3.3.0'
     api 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.0'
     api 'com.android.volley:volley:1.1.1'

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     kapt fluxcProcessorProjectDependency
 
     // External libs
-    api 'org.greenrobot:eventbus:3.3.0'
+    api 'org.greenrobot:eventbus:3.3.1'
     api 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.0'
     api 'com.android.volley:volley:1.1.1'


### PR DESCRIPTION
This PR updates event bus to v3.3.0. The main change is that the new version doesn't depend on the support library.
https://github.com/greenrobot/EventBus/releases/tag/V3.3.0

WPAndroid - https://github.com/wordpress-mobile/WordPress-Android/pull/15664
WCAndroid - https://github.com/woocommerce/woocommerce-android/pull/5413

The client libraries were updated to v 3.3.0 in the above PRs => if both the PRs are merged, it is safe to merge this PR (it is not necessary to update the commit hash in the clients).
