### PR TITLE
Add two more parameters to WCRevenueStatsModel.kt 

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     kapt fluxcProcessorProjectDependency
 
     // External libs
-    api 'org.greenrobot:eventbus:3.2.0'
+    api 'org.greenrobot:eventbus:3.3.0'
     api 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.0'
     api 'com.android.volley:volley:1.1.1'

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     kapt fluxcProcessorProjectDependency
 
     // External libs
-    api 'org.greenrobot:eventbus:3.2.0'
+    api 'org.greenrobot:eventbus:3.3.1'
     api 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.0'
     api 'com.android.volley:volley:1.1.1'

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     kapt fluxcProcessorProjectDependency
 
     // External libs
-    api 'org.greenrobot:eventbus:3.3.0'
+    api 'org.greenrobot:eventbus:3.3.1'
     api 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.9.0'
     api 'com.android.volley:volley:1.1.1'

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsUtils.kt
@@ -2,18 +2,31 @@ package org.wordpress.android.fluxc.network.rest.wpcom.dashboard
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import java.lang.reflect.Type
+import java.text.DateFormat
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 
 object CardsUtils {
     private const val INSERT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ"
+
     private const val DATE_FORMAT = "yyyy-MM-dd HH:mm:ss"
+    private const val TIMEZONE = "GMT"
 
     val GSON: Gson by lazy {
         val builder = GsonBuilder()
-        builder.setDateFormat(DATE_FORMAT)
+        builder.registerTypeAdapter(Date::class.java, GsonDateAdapter())
         builder.create()
     }
 
@@ -25,6 +38,40 @@ object CardsUtils {
 
     fun fromDate(date: String): Date {
         val dateFormat = SimpleDateFormat(DATE_FORMAT, Locale.ROOT)
+        dateFormat.timeZone = TimeZone.getTimeZone(TIMEZONE)
         return dateFormat.parse(date) ?: Date()
+    }
+
+    /* GSON ADAPTER */
+
+    private class GsonDateAdapter : JsonSerializer<Date>, JsonDeserializer<Date> {
+        private val dateFormat: DateFormat
+
+        @Synchronized
+        override fun serialize(
+            date: Date,
+            type: Type?,
+            jsonSerializationContext: JsonSerializationContext?
+        ): JsonElement {
+            return JsonPrimitive(dateFormat.format(date))
+        }
+
+        @Synchronized
+        override fun deserialize(
+            jsonElement: JsonElement,
+            type: Type?,
+            jsonDeserializationContext: JsonDeserializationContext?
+        ): Date {
+            return try {
+                dateFormat.parse(jsonElement.asString) ?: Date()
+            } catch (e: ParseException) {
+                throw JsonParseException(e)
+            }
+        }
+
+        init {
+            dateFormat = SimpleDateFormat(DATE_FORMAT, Locale.ROOT)
+            dateFormat.timeZone = TimeZone.getTimeZone(TIMEZONE)
+        }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -59,7 +59,7 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
         @SerializedName("avg_order_value")
         val avgOrderValue: Double? = null
         @SerializedName("num_items_sold")
-        val itemsSold: Double? = null
+        val itemsSold: Int? = null
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -58,6 +58,8 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
         val netRevenue: Double? = null
         @SerializedName("avg_order_value")
         val avgOrderValue: Double? = null
+        @SerializedName("num_items_sold")
+        val itemsSold: Double? = null
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -56,6 +56,8 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
         val totalSales: Double? = null
         @SerializedName("net_revenue")
         val netRevenue: Double? = null
+        @SerializedName("avg_order_value")
+        val avgOrderValue: Double? = null
     }
 
     /**


### PR DESCRIPTION
As part of the [analytics hub issue ](https://github.com/woocommerce/woocommerce-android/issues/5237) we need to parse avg value of order and the number of items sold in WCRevenueStatsModel total field response.

This pull request adds those 2 new params to the model.