### PR TITLE
Usage of start and end date for ProductLeaderBoard request in ISO format

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
@@ -48,14 +48,14 @@ class LeaderboardsRestClientTest {
         val expectedResult = generateSampleLeaderboardsApiResponse()
         configureSuccessRequest(expectedResult!!)
 
-        val response = restClientUnderTest.fetchLeaderboards(stubSite, DAYS, 1L..22L, 5)
+        val response = restClientUnderTest.fetchLeaderboards(stubSite, DAYS, "10-10-2022", "22-10-2022", 5)
         verify(requestBuilder, times(1)).syncGetRequest(
                 restClientUnderTest,
                 stubSite,
                 WOOCOMMERCE.leaderboards.pathV4Analytics,
                 mapOf(
-                        "before" to "22",
-                        "after" to "1",
+                        "before" to "22-10-2022",
+                        "after" to "10-10-2022",
                         "per_page" to "5",
                         "interval" to "day"
                 ),
@@ -73,7 +73,8 @@ class LeaderboardsRestClientTest {
         val response = restClientUnderTest.fetchLeaderboards(
                 stubSite,
                 DAYS,
-                1L..22L,
+                "10-10-2022",
+                "22-10-2022",
                 5
         )
 
@@ -91,8 +92,8 @@ class LeaderboardsRestClientTest {
                         stubSite,
                         WOOCOMMERCE.leaderboards.pathV4Analytics,
                         mapOf(
-                                "after" to "1",
-                                "before" to "22",
+                                "after" to "10-1-2022",
+                                "before" to "22-10-2022",
                                 "per_page" to "5",
                                 "interval" to "day"
                         ),
@@ -109,8 +110,8 @@ class LeaderboardsRestClientTest {
                         stubSite,
                         WOOCOMMERCE.leaderboards.pathV4Analytics,
                         mapOf(
-                                "after" to "1",
-                                "before" to "22",
+                                "after" to "10-1-2022",
+                                "before" to "22-10-2022",
                                 "per_page" to "5",
                                 "interval" to "day"
                         ),

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
@@ -34,12 +34,12 @@ class LeaderboardsRestClientTest {
         jetpackSuccessResponse = mock()
         jetpackErrorResponse = mock()
         restClientUnderTest = LeaderboardsRestClient(
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                requestBuilder
+            mock(),
+            mock(),
+            mock(),
+            mock(),
+            mock(),
+            requestBuilder
         )
     }
 
@@ -50,16 +50,16 @@ class LeaderboardsRestClientTest {
 
         val response = restClientUnderTest.fetchLeaderboards(stubSite, DAYS, "10-10-2022", "22-10-2022", 5)
         verify(requestBuilder, times(1)).syncGetRequest(
-                restClientUnderTest,
-                stubSite,
-                WOOCOMMERCE.leaderboards.pathV4Analytics,
-                mapOf(
-                        "before" to "22-10-2022",
-                        "after" to "10-10-2022",
-                        "per_page" to "5",
-                        "interval" to "day"
-                ),
-                Array<LeaderboardsApiResponse>::class.java
+            restClientUnderTest,
+            stubSite,
+            WOOCOMMERCE.leaderboards.pathV4Analytics,
+            mapOf(
+                "before" to "22-10-2022",
+                "after" to "10-10-2022",
+                "per_page" to "5",
+                "interval" to "day"
+            ),
+            Array<LeaderboardsApiResponse>::class.java
         )
         assertThat(response).isNotNull
         assertThat(response.result).isNotNull
@@ -71,11 +71,11 @@ class LeaderboardsRestClientTest {
     fun `fetch leaderboards should correctly return failure as WooError`() = test {
         configureErrorRequest()
         val response = restClientUnderTest.fetchLeaderboards(
-                stubSite,
-                DAYS,
-                "10-10-2022",
-                "22-10-2022",
-                5
+            stubSite,
+            DAYS,
+            "10-10-2022",
+            "22-10-2022",
+            5
         )
 
         assertThat(response).isNotNull
@@ -87,36 +87,36 @@ class LeaderboardsRestClientTest {
     private suspend fun configureSuccessRequest(expectedResult: Array<LeaderboardsApiResponse>) {
         whenever(jetpackSuccessResponse.data).thenReturn(expectedResult)
         whenever(
-                requestBuilder.syncGetRequest(
-                        restClientUnderTest,
-                        stubSite,
-                        WOOCOMMERCE.leaderboards.pathV4Analytics,
-                        mapOf(
-                                "after" to "10-1-2022",
-                                "before" to "22-10-2022",
-                                "per_page" to "5",
-                                "interval" to "day"
-                        ),
-                        Array<LeaderboardsApiResponse>::class.java
-                )
+            requestBuilder.syncGetRequest(
+                restClientUnderTest,
+                stubSite,
+                WOOCOMMERCE.leaderboards.pathV4Analytics,
+                mapOf(
+                    "after" to "10-10-2022",
+                    "before" to "22-10-2022",
+                    "per_page" to "5",
+                    "interval" to "day"
+                ),
+                Array<LeaderboardsApiResponse>::class.java
+            )
         ).thenReturn(jetpackSuccessResponse)
     }
 
     private suspend fun configureErrorRequest() {
         whenever(jetpackErrorResponse.error).thenReturn(WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
         whenever(
-                requestBuilder.syncGetRequest(
-                        restClientUnderTest,
-                        stubSite,
-                        WOOCOMMERCE.leaderboards.pathV4Analytics,
-                        mapOf(
-                                "after" to "10-10-2022",
-                                "before" to "22-10-2022",
-                                "per_page" to "5",
-                                "interval" to "day"
-                        ),
-                        Array<LeaderboardsApiResponse>::class.java
-                )
+            requestBuilder.syncGetRequest(
+                restClientUnderTest,
+                stubSite,
+                WOOCOMMERCE.leaderboards.pathV4Analytics,
+                mapOf(
+                    "after" to "10-10-2022",
+                    "before" to "22-10-2022",
+                    "per_page" to "5",
+                    "interval" to "day"
+                ),
+                Array<LeaderboardsApiResponse>::class.java
+            )
         ).thenReturn(jetpackErrorResponse)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
@@ -110,7 +110,7 @@ class LeaderboardsRestClientTest {
                         stubSite,
                         WOOCOMMERCE.leaderboards.pathV4Analytics,
                         mapOf(
-                                "after" to "10-1-2022",
+                                "after" to "10-10-2022",
                                 "before" to "22-10-2022",
                                 "per_page" to "5",
                                 "interval" to "day"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
@@ -45,9 +45,9 @@ class WCLeaderboardsStoreTest {
     fun setUp() {
         val appContext = RuntimeEnvironment.application.applicationContext
         val config = SingleStoreWellSqlConfigForTests(
-                appContext,
-                listOf(SiteModel::class.java, WCTopPerformerProductModel::class.java, WCProductModel::class.java),
-                WellSqlConfig.ADDON_WOOCOMMERCE
+            appContext,
+            listOf(SiteModel::class.java, WCTopPerformerProductModel::class.java, WCProductModel::class.java),
+            WellSqlConfig.ADDON_WOOCOMMERCE
         )
         WellSql.init(config)
         config.reset()
@@ -58,7 +58,7 @@ class WCLeaderboardsStoreTest {
     @Test
     fun `fetch product leaderboards with empty result should return WooError`() = test {
         whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
-                .thenReturn(WooPayload(emptyArray()))
+            .thenReturn(WooPayload(emptyArray()))
 
         val result = storeUnderTest.fetchProductLeaderboards(stubSite)
         assertThat(result.model).isNull()
@@ -73,7 +73,7 @@ class WCLeaderboardsStoreTest {
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
         whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
-                .thenReturn(WooPayload(response))
+            .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
         verify(mapper).map(filteredResponse!!, stubSite, productStore, DAYS)
@@ -86,7 +86,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
 
         whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
-                .thenReturn(WooPayload(response))
+            .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
         verify(mapper, times(1)).map(any(), any(), any(), any())
@@ -98,7 +98,7 @@ class WCLeaderboardsStoreTest {
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
         whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
-                .thenReturn(WooPayload(response))
+            .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(stubbedTopPerformersList)
 
@@ -114,14 +114,17 @@ class WCLeaderboardsStoreTest {
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
         whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
-                .thenReturn(WooPayload(response))
+            .thenReturn(WooPayload(response))
 
-        whenever(mapper.map(
+        whenever(
+            mapper.map(
                 filteredResponse!!,
                 SiteModel().apply { id = 100 },
                 productStore,
-                DAYS))
-                .thenReturn(stubbedTopPerformersList)
+                DAYS
+            )
+        )
+            .thenReturn(stubbedTopPerformersList)
 
         val result = storeUnderTest.fetchProductLeaderboards(stubSite)
         assertThat(result.model).isNull()
@@ -134,7 +137,7 @@ class WCLeaderboardsStoreTest {
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
         whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
-                .thenReturn(WooPayload(response))
+            .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(duplicatedTopPerformersList)
 
@@ -152,10 +155,10 @@ class WCLeaderboardsStoreTest {
     }
 
     private fun createStoreUnderTest() =
-            WCLeaderboardsStore(
-                    restClient,
-                    productStore,
-                    mapper,
-                    initCoroutineEngine()
-            ).apply { storeUnderTest = this }
+        WCLeaderboardsStore(
+            restClient,
+            productStore,
+            mapper,
+            initCoroutineEngine()
+        ).apply { storeUnderTest = this }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
@@ -67,7 +67,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), eq(null)))
             .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -80,7 +80,7 @@ class WCLeaderboardsStoreTest {
         createStoreUnderTest()
         val response = generateSampleLeaderboardsApiResponse()
 
-        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), eq(null)))
             .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -92,7 +92,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), eq(null)))
             .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(stubbedTopPerformersList)
@@ -108,7 +108,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), eq(null)))
             .thenReturn(WooPayload(response))
 
         whenever(
@@ -131,7 +131,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), eq(null)))
             .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(duplicatedTopPerformersList)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
@@ -57,7 +57,7 @@ class WCLeaderboardsStoreTest {
 
     @Test
     fun `fetch product leaderboards with empty result should return WooError`() = test {
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
             .thenReturn(WooPayload(emptyArray()))
 
         val result = storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -72,7 +72,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -85,7 +85,7 @@ class WCLeaderboardsStoreTest {
         createStoreUnderTest()
         val response = generateSampleLeaderboardsApiResponse()
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -97,7 +97,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(stubbedTopPerformersList)
@@ -113,7 +113,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         whenever(
@@ -136,7 +136,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(duplicatedTopPerformersList)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
@@ -52,7 +52,7 @@ class WCLeaderboardsStoreTest {
 
     @Test
     fun `fetch product leaderboards with empty result should return WooError`() = test {
-        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), null))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), eq(null)))
             .thenReturn(WooPayload(emptyArray()))
 
         val result = storeUnderTest.fetchProductLeaderboards(stubSite)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
@@ -1,11 +1,6 @@
 package org.wordpress.android.fluxc.wc.leaderboards
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
 import com.yarolegovich.wellsql.WellSql
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -57,7 +52,7 @@ class WCLeaderboardsStoreTest {
 
     @Test
     fun `fetch product leaderboards with empty result should return WooError`() = test {
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), null))
             .thenReturn(WooPayload(emptyArray()))
 
         val result = storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -72,7 +67,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -85,7 +80,7 @@ class WCLeaderboardsStoreTest {
         createStoreUnderTest()
         val response = generateSampleLeaderboardsApiResponse()
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -97,7 +92,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(stubbedTopPerformersList)
@@ -113,7 +108,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         whenever(
@@ -136,7 +131,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, any(), any(), any()))
+        whenever(restClient.fetchLeaderboards(eq(stubSite), eq(DAYS), any(), any(), any()))
             .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(duplicatedTopPerformersList)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
@@ -57,7 +57,7 @@ class WCLeaderboardsStoreTest {
 
     @Test
     fun `fetch product leaderboards with empty result should return WooError`() = test {
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
                 .thenReturn(WooPayload(emptyArray()))
 
         val result = storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -72,7 +72,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
                 .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -85,7 +85,7 @@ class WCLeaderboardsStoreTest {
         createStoreUnderTest()
         val response = generateSampleLeaderboardsApiResponse()
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
                 .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -97,7 +97,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
                 .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(stubbedTopPerformersList)
@@ -113,7 +113,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
                 .thenReturn(WooPayload(response))
 
         whenever(mapper.map(
@@ -133,7 +133,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, null))
                 .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(duplicatedTopPerformersList)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsRestClient.kt
@@ -29,41 +29,37 @@ class LeaderboardsRestClient @Inject constructor(
     suspend fun fetchLeaderboards(
         site: SiteModel,
         unit: StatsGranularity?,
-        queryTimeRange: LongRange?,
+        startDate: String?,
+        endDate: String?,
         quantity: Int?
     ) = WOOCOMMERCE.leaderboards.pathV4Analytics
-            .requestTo(site, unit, queryTimeRange, quantity)
-            .handleResult()
+        .requestTo(site, unit, startDate, endDate, quantity)
+        .handleResult()
 
     private suspend fun String.requestTo(
         site: SiteModel,
         unit: StatsGranularity?,
-        queryTimeRange: LongRange?,
+        startDate: String?,
+        endDate: String?,
         quantity: Int?
     ) = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this@LeaderboardsRestClient,
-            site,
-            this,
-            createParameters(site, unit, queryTimeRange, quantity),
-            Array<LeaderboardsApiResponse>::class.java
+        this@LeaderboardsRestClient,
+        site,
+        this,
+        createParameters(site, unit, startDate, endDate, quantity),
+        Array<LeaderboardsApiResponse>::class.java
     )
 
     private fun createParameters(
         site: SiteModel,
         unit: StatsGranularity?,
-        queryTimeRange: LongRange?,
+        startDate: String?,
+        endDate: String?,
         quantity: Int?
     ) = mapOf(
-            "before" to (
-                    queryTimeRange?.endInclusive
-                            ?: DateUtils.getEndDateForSite(site))
-                    .toString(),
-            "after" to (
-                    queryTimeRange?.start
-                            ?: unit?.startDateTime(site)
-                            ?: "")
-                    .toString(),
-            "per_page" to quantity?.toString().orEmpty(),
-            "interval" to (unit?.let { OrderStatsApiUnit.fromStatsGranularity(it).toString() } ?: "")
+        "before" to (endDate ?: DateUtils.getEndDateForSite(site)).toString(),
+        "after" to (startDate ?: (unit?.startDateTime(site) ?: "")).toString(),
+        "per_page" to quantity?.toString().orEmpty(),
+        "interval" to (unit?.let { OrderStatsApiUnit.fromStatsGranularity(it).toString() } ?: "")
     ).filter { it.value.isNotEmpty() }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -72,7 +72,7 @@ class WCLeaderboardsStore @Inject constructor(
     ): WooResult<List<LeaderboardsApiResponse>> =
         with(restClient.fetchLeaderboards(site, unit, startDate, endDate, quantity)) {
             return when {
-                isError && error != null -> WooResult(error)
+                isError -> WooResult(error)
                 result != null -> WooResult(result.toList())
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -72,7 +72,7 @@ class WCLeaderboardsStore @Inject constructor(
     ): WooResult<List<LeaderboardsApiResponse>> =
         with(restClient.fetchLeaderboards(site, unit, startDate, endDate, quantity)) {
             return when {
-                isError -> WooResult(error)
+                isError && error != null -> WooResult(error)
                 result != null -> WooResult(result.toList())
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }


### PR DESCRIPTION
This request changes the current implementation of WCLeaderboardsStore and WCLeaderboardsRestClient to get products with a start date and end date period using dates in ISO format instead of time in milliseconds as the API defines.

This is a curl example of the failure (Some private data has been deleted for security reasons):
```

curl -v -X GET 'https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/1XXXXXX/rest-api/?path=%2Fwc-analytics%2Fleaderboards%2F%26_method%3Dget&json=true&query=%7B%22before%22%3A%221608073200000%22%2C%22after%22%3A%221608073200000%22%2C%22per_page%22%3A%225%22%2C%22interval%22%3A%22day%22%7D&locale=en_US' -H 'Accept-Encoding: gzip' -H $'Authorization: Bearer DELETED' -H 'Connection: Keep-Alive' -H 'Cookie: _wpndash=DELETED; recognized_logins=DELETED' -H 'Host: public-api.wordpress.com' -H 'User-Agent: Mozilla/5.0 (Linux; Android 11; Android SDK built for x86 Build/RSR1.210210.001.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36 wc-android/8.1'

* Connection #0 to host public-api.wordpress.com left intact
{"error":"rest_invalid_param","message":"Invalid parameter(s): after, before"}*
```

This is a curl example after the change:

```
 curl -X GET 'https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/1XXXXX/rest-api/?path=%2Fwc-analytics%2Fleaderboards%2F%26_method%3Dget&json=true&query=%7B%22before%22%3A%222021-12-16T23%3A59%3A59%22%2C%22after%22%3A%222021-01-01T00%3A00%3A00%22%2C%22per_page%22%3A%225%22%2C%22interval%22%3A%22year%22%7D&locale=en_US' -H 'Accept-Encoding: gzip' -H $'Authorization: Bearer DELETED' -H 'Connection: Keep-Alive' -H 'Cookie: DELETED, recognized_logins=DELETED' -H 'Host: public-api.wordpress.com' -H 'User-Agent: Mozilla/5.0 (Linux; Android 11; Android SDK built for x86 Build/RSR1.210210.001.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36 wc-android/8.1'
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```

The problems are the dates, API is expecting dates in ISO format.

Also, I've applied format to these classes.

