### PR TITLE
[Woo] Order Creation: handle customer note

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -460,6 +460,12 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                         return@launch
                     }
 
+                    val customerNote = showSingleLineDialog(
+                        activity = requireActivity(),
+                        message = "Please enter a customer note?",
+                        isNumeric = false
+                    )
+
                     val shippingAddress = showAddressDialog(addressType = SHIPPING) as OrderAddress.Shipping
                     val billingAddress = showAddressDialog(addressType = BILLING) as OrderAddress.Billing
 
@@ -473,7 +479,8 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                                         LineItem(productId = it, quantity = 1f)
                                     },
                                     shippingAddress = shippingAddress,
-                                    billingAddress = billingAddress
+                                    billingAddress = billingAddress,
+                                    customerNote = customerNote
                             )
                     )
                     if (result.isError) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/CreateOrderRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/CreateOrderRequest.kt
@@ -6,5 +6,6 @@ data class CreateOrderRequest(
     val status: WCOrderStatusModel,
     val lineItems: List<LineItem>,
     val shippingAddress: OrderAddress.Shipping,
-    val billingAddress: OrderAddress.Billing
+    val billingAddress: OrderAddress.Billing,
+    val customerNote: String?
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -828,7 +828,8 @@ class OrderRestClient @Inject constructor(
                 "status" to request.status.statusKey,
                 "line_items" to request.lineItems,
                 "shipping" to request.shippingAddress.toDto(),
-                "billing" to request.billingAddress.toDto()
+                "billing" to request.billingAddress.toDto(),
+                "customer_note" to request.customerNote.orEmpty()
         )
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(


### PR DESCRIPTION
This PR just updates the `OrderCreationRequest` model to include a customer note.

WCAndroid's PR: https://github.com/woocommerce/woocommerce-android/pull/5494

#### Testing
Test order creation in the sample, and confirm the customer note is working as expected.