### PR TITLE
Issue/wc simple payments taxable

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -545,9 +545,8 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     @Test
     fun testPostSimplePayment() = runBlocking {
         interceptor.respondWith("wc-fetch-order-response-success.json")
-        val response1 = orderRestClient.postSimplePayment(siteModel, "10.00", isTaxable = false)
+        val response1 = orderRestClient.postSimplePayment(siteModel, "10.00", isTaxable = true)
 
-        // TODO nbradbury - verify tax status, test with isTaxable = true
         with(response1) {
             assertNull(error)
             assertNotNull(order)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -545,9 +545,9 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     @Test
     fun testPostSimplePayment() = runBlocking {
         interceptor.respondWith("wc-fetch-order-response-success.json")
-        val response1 = orderRestClient.postSimplePayment(siteModel, "10.00", isTaxable = true)
+        val response = orderRestClient.postSimplePayment(siteModel, "10.00", isTaxable = true)
 
-        with(response1) {
+        with(response) {
             assertNull(error)
             assertNotNull(order)
         }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -543,11 +543,12 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testPostQuickOrder() = runBlocking {
+    fun testPostSimplePayment() = runBlocking {
         interceptor.respondWith("wc-fetch-order-response-success.json")
-        val response = orderRestClient.postQuickOrder(siteModel, "10.00")
+        val response1 = orderRestClient.postSimplePayment(siteModel, "10.00", isTaxable = false)
 
-        with(response) {
+        // TODO nbradbury - verify tax status, test with isTaxable = true
+        with(response1) {
             assertNull(error)
             assertNotNull(order)
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -423,7 +423,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
             }
         }
 
-        create_quick_order.setOnClickListener {
+        create_simple_payment.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
                         activity,
@@ -432,11 +432,11 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     coroutineScope.launch {
                         try {
                             val amount = editText.text.toString()
-                            val result = wcOrderStore.postQuickOrder(site, amount)
+                            val result = wcOrderStore.postSimplePayment(site, amount, false)
                             if (result.isError) {
-                                prependToLog("Creating quick order failed.")
+                                prependToLog("Creating simple payment failed.")
                             } else {
-                                prependToLog("Created quick order with remote ID ${result.order?.remoteOrderId}.")
+                                prependToLog("Created simple payment with remote ID ${result.order?.remoteOrderId}.")
                             }
                         } catch (e: NumberFormatException) {
                             prependToLog("Invalid amount.")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -432,7 +432,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     coroutineScope.launch {
                         try {
                             val amount = editText.text.toString()
-                            val result = wcOrderStore.postSimplePayment(site, amount, false)
+                            val result = wcOrderStore.postSimplePayment(site, amount, true)
                             if (result.isError) {
                                 prependToLog("Creating simple payment failed.")
                             } else {

--- a/example/src/main/res/layout/fragment_woo_orders.xml
+++ b/example/src/main/res/layout/fragment_woo_orders.xml
@@ -140,11 +140,11 @@
             android:text="Update latest order billing address" />
 
         <Button
-            android:id="@+id/create_quick_order"
+            android:id="@+id/create_simple_payment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Create quick order" />
+            android:text="Create simple payment" />
 
         <Button
             android:id="@+id/create_order"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -485,7 +485,7 @@ class OrderRestClient @Inject constructor(
     suspend fun postSimplePayment(site: SiteModel, amount: String, isTaxable: Boolean): RemoteOrderPayload {
         val taxStatus = if (isTaxable) "taxable" else "none"
         val jsonFee = JsonObject().also {
-            it.addProperty("name", "Quick Order")
+            it.addProperty("name", "Simple Payment")
             it.addProperty("total", amount)
             it.addProperty("tax_status", taxStatus)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -480,14 +480,6 @@ class OrderRestClient @Inject constructor(
     )
 
     /**
-     * @deprecated This function can be dropped once the client is updated to use postSimplePayment
-     */
-    @Deprecated("Use postSimplePayment instead")
-    suspend fun postQuickOrder(site: SiteModel, amount: String): RemoteOrderPayload {
-        return postSimplePayment(site, amount, false)
-    }
-
-    /**
      * Creates a "simple payment," which is an empty order assigned the passed amount
      */
     suspend fun postSimplePayment(site: SiteModel, amount: String, isTaxable: Boolean): RemoteOrderPayload {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -480,15 +480,24 @@ class OrderRestClient @Inject constructor(
     )
 
     /**
-     * Creates a "quick order," which is an empty order assigned the passed amount
+     * @deprecated This function can be dropped once the client is updated to use postSimplePayment
      */
+    @Deprecated("Use postSimplePayment instead")
     suspend fun postQuickOrder(site: SiteModel, amount: String): RemoteOrderPayload {
+        return postSimplePayment(site, amount, false)
+    }
+
+    /**
+     * Creates a "simple payment," which is an empty order assigned the passed amount
+     */
+    suspend fun postSimplePayment(site: SiteModel, amount: String, isTaxable: Boolean): RemoteOrderPayload {
+        val taxStatus = if (isTaxable) "taxable" else "none"
         val jsonFee = JsonObject().also {
             it.addProperty("name", "Quick Order")
             it.addProperty("total", amount)
-            it.addProperty("tax_status", "none")
-            it.addProperty("tax_class", "")
+            it.addProperty("tax_status", taxStatus)
         }
+
         val jsonFeeItems = JsonArray().also { it.add(jsonFee) }
         val params = mapOf(
                 "fee_lines" to jsonFeeItems,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -508,7 +508,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 response.data?.let {
-                    val newModel = orderResponseToOrderModel(it, localSiteId = site.localId())
+                    val newModel = it.toDomainModel(localSiteId = site.localId())
                     RemoteOrderPayload(newModel, site)
                 } ?: RemoteOrderPayload(
                         OrderError(type = GENERIC_ERROR, message = "Success response with empty data"),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -540,7 +540,7 @@ class WCOrderStore @Inject constructor(
     }
 
     suspend fun postSimplePayment(site: SiteModel, amount: String, isTaxable: Boolean): OnQuickOrderResult {
-        return coroutineEngine.withDefaultContext(T.API, this, "postQuickOrder") {
+        return coroutineEngine.withDefaultContext(T.API, this, "postSimplePayment") {
             val result = wcOrderRestClient.postSimplePayment(site, amount, isTaxable)
 
             return@withDefaultContext if (result.isError) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -531,9 +531,17 @@ class WCOrderStore @Inject constructor(
         }
     }
 
+    /**
+     * @deprecated This function can be removed once the client is updated to use postSimplePayment
+     */
+    @Deprecated("Use postSimplePayment instead")
     suspend fun postQuickOrder(site: SiteModel, amount: String): OnQuickOrderResult {
+        return postSimplePayment(site, amount, false)
+    }
+
+    suspend fun postSimplePayment(site: SiteModel, amount: String, isTaxable: Boolean): OnQuickOrderResult {
         return coroutineEngine.withDefaultContext(T.API, this, "postQuickOrder") {
-            val result = wcOrderRestClient.postQuickOrder(site, amount)
+            val result = wcOrderRestClient.postSimplePayment(site, amount, isTaxable)
 
             return@withDefaultContext if (result.isError) {
                 OnQuickOrderResult().also { it.error = result.error }


### PR DESCRIPTION
This simple PR renames FluxC's "Quick Order" to "Simple Payment" and adds the `tax_status` field when posting a simple payment.  This is for use with [this WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/5498).

The reason `tax_status` is added is so when the order is created, core will automatically assign taxes to the order. Otherwise we wouldn't know how to calculate taxes.