### PR TITLE
Issue/5335 locations endpoint active plugin fluxc

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
@@ -137,7 +137,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenGetStoreLocationForSiteErrorWithUrl() = runBlocking {
         interceptor.respondWithError("wc-pay-store-location-for-site-address-missing-with-url-error.json", 500)
 
-        val result = restClient.getStoreLocationForSite(SiteModel().apply { siteId = 123L })
+        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
         assertTrue(result.isError)
         assertTrue(result.error?.type is MissingAddress)
@@ -150,7 +150,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenGetStoreLocationForSiteErrorWithEmptyUrl() = runBlocking {
         interceptor.respondWithError("wc-pay-store-location-for-site-address-missing-with-empty-url-error.json", 500)
 
-        val result = restClient.getStoreLocationForSite(SiteModel().apply { siteId = 123L })
+        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
         assertTrue(result.isError)
         assertTrue(result.error?.type is GenericError)
@@ -160,7 +160,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenGetStoreLocationForSiteErrorWithoutUrl() = runBlocking {
         interceptor.respondWithError("wc-pay-store-location-for-site-address-missing-without-url-error.json", 500)
 
-        val result = restClient.getStoreLocationForSite(SiteModel().apply { siteId = 123L })
+        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
         assertTrue(result.isError)
         assertTrue(result.error?.type is GenericError)
@@ -170,7 +170,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenGetStoreLocationForSiteWithInvalidPostalCodeError() = runBlocking {
         interceptor.respondWithError("wc-pay-store-location-for-site-invalid-postal-code-error.json", 500)
 
-        val result = restClient.getStoreLocationForSite(SiteModel().apply { siteId = 123L })
+        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
         assertTrue(result.isError)
         assertTrue(result.error?.type is InvalidPostalCode)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.STRIPE
 import javax.inject.Inject
+import org.junit.Assert.assertFalse
 
 class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
     @Inject internal lateinit var store: WCInPersonPaymentsStore
@@ -76,17 +77,16 @@ class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
 
     @Test
     fun givenSiteHasStripeExtensionAndStripeAddressThenLocationDataReturned() = runBlocking {
-        // TODO cardreader Update when we add support for Stripe Extension endpoint
-//        val result = store.getStoreLocationForSite(sSite)
-//
-//        assertFalse(result.isError)
-//        assertEquals("tml_EUZ4bQQTxLWMq2", result.locationId)
-//        assertEquals("Woo WCPay", result.displayName)
-//        assertEquals("San Francisco", result.address?.city)
-//        assertEquals("US", result.address?.country)
-//        assertEquals("1230 Lawton St", result.address?.line1)
-//        assertEquals("71", result.address?.line2)
-//        assertEquals("94122", result.address?.postalCode)
-//        assertEquals("CA", result.address?.state)
+        val result = store.getStoreLocationForSite(STRIPE, sSite)
+
+        assertFalse(result.isError)
+        assertEquals("tml_EbIYQbo6EsyAee", result.locationId)
+        assertEquals("Woo Jetpack Stripe Extension", result.displayName)
+        assertEquals("San Francisco", result.address?.city)
+        assertEquals("US", result.address?.country)
+        assertEquals("1230 Lawton St", result.address?.line1)
+        assertEquals("", result.address?.line2)
+        assertEquals("94122", result.address?.postalCode)
+        assertEquals("CA", result.address?.state)
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsWCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsWCPayTest.kt
@@ -73,7 +73,7 @@ class ReleaseStack_InPersonPaymentsWCPayTest : ReleaseStack_WCBase() {
 
     @Test
     fun givenSiteHasWCPayAndStripeAddressThenLocationDataReturned() = runBlocking {
-        val result = store.getStoreLocationForSite(sSite)
+        val result = store.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, sSite)
 
         assertFalse(result.isError)
         assertEquals("tml_EUZ4bQQTxLWMq2", result.locationId)

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -52,6 +52,7 @@
 /payments/terminal/locations/store
 
 /wc_stripe/account/summary
+/wc_stripe/terminal/locations/store
 
 /taxes
 /taxes/classes/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -148,8 +148,14 @@ class InPersonPaymentsRestClient @Inject constructor(
         }
     }
 
-    suspend fun getStoreLocationForSite(site: SiteModel): WCTerminalStoreLocationResult {
-        val url = WOOCOMMERCE.payments.terminal.locations.store.pathV3
+    suspend fun getStoreLocationForSite(
+        activePlugin: InPersonPaymentsPluginType,
+        site: SiteModel
+    ): WCTerminalStoreLocationResult {
+        val url = when (activePlugin) {
+            WOOCOMMERCE_PAYMENTS -> WOOCOMMERCE.payments.terminal.locations.store.pathV3
+            STRIPE -> WOOCOMMERCE.wc_stripe.terminal.locations.store.pathV3
+        }
 
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
                 this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
@@ -60,9 +60,12 @@ class WCInPersonPaymentsStore @Inject constructor(
         }
     }
 
-    suspend fun getStoreLocationForSite(site: SiteModel): WCTerminalStoreLocationResult {
+    suspend fun getStoreLocationForSite(
+        activePlugin: InPersonPaymentsPluginType,
+        site: SiteModel
+    ): WCTerminalStoreLocationResult {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "getStoreLocationForSite") {
-            restClient.getStoreLocationForSite(site)
+            restClient.getStoreLocationForSite(activePlugin, site)
         }
     }
 


### PR DESCRIPTION
Merge instructions:

1. Review this PR
2. Make sure https://github.com/woocommerce/woocommerce-android/pull/5500 is reviewed and ready to be merged
3. Remove the "Not ready for merge" label
4. Merge this PR

This PR adds support for `/wc_stripe/terminal/locations/store` Stripe Extension endpoint which is identical to `/payments/locations/store` WCPayments endpoint.

To test:
Green CI should be enough