### PR TITLE
Issue/5387 Steps to remove order identifier from the Woo app

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -409,6 +409,14 @@ class WCOrderStore @Inject constructor(
     }
 
     /**
+     * Given an [RemoteId] and [SiteModel],
+     * returns the corresponding order from the database as a [WCOrderModel].
+     */
+    fun getOrderByRemoteIdAndSite(orderRemoteId: RemoteId, site: SiteModel): WCOrderModel? {
+        return ordersDao.getOrder(orderRemoteId, site.localId())
+    }
+
+    /**
      * Returns the notes belonging to supplied [WCOrderModel] as a list of [WCOrderNoteModel].
      */
     fun getOrderNotesForOrder(orderId: Int): List<WCOrderNoteModel> =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -409,11 +409,11 @@ class WCOrderStore @Inject constructor(
     }
 
     /**
-     * Given an [RemoteId] and [SiteModel],
+     * Given an order id and [SiteModel],
      * returns the corresponding order from the database as a [WCOrderModel].
      */
-    fun getOrderByRemoteIdAndSite(orderRemoteId: RemoteId, site: SiteModel): WCOrderModel? {
-        return ordersDao.getOrder(orderRemoteId, site.localId())
+    fun getOrderByIdAndSite(orderId: Long, site: SiteModel): WCOrderModel? {
+        return ordersDao.getOrder(RemoteId(orderId), site.localId())
     }
 
     /**


### PR DESCRIPTION
Part of  https://github.com/woocommerce/woocommerce-android/issues/5387

The PR adds `getOrderByRemoteIdAndSite` method that used in the Woo app as a replacement for `getOrderByIdentifier` which will be removed soon