### PR TITLE
create customer endpoint for active plugin

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.STRIPE
 import javax.inject.Inject
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 
 class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
     @Inject internal lateinit var store: WCInPersonPaymentsStore
@@ -55,24 +56,24 @@ class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
 
     @Test
     fun givenSiteHasStripeExtensionAndOrderWhenCreateCustomerByOrderIdCustomerIdReturned() = runBlocking {
-        // TODO cardreader Update when we add support for Stripe Extension endpoint
-//        val result = store.createCustomerByOrderId(
-//                sSite,
-//                17L
-//        )
-//
-//        assertEquals("cus_JyzaCUE61Qmy8y", result.model?.customerId)
+        val result = store.createCustomerByOrderId(
+            STRIPE,
+                sSite,
+                17L
+        )
+
+        assertEquals("cus_KpWfupr71lMX0W", result.model?.customerId)
     }
 
     @Test
     fun givenSiteHasStripeExtensionAndWrongOrderIdWhenCreateCustomerByOrderIdCustomerIdReturned() = runBlocking {
-        // TODO cardreader Update when we add support for Stripe Extension endpoint
-//        val result = store.createCustomerByOrderId(
-//                sSite,
-//                1L
-//        )
-//
-//        assertTrue(result.isError)
+        val result = store.createCustomerByOrderId(
+            STRIPE,
+                sSite,
+                1L
+        )
+
+        assertTrue(result.isError)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsWCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsWCPayTest.kt
@@ -54,6 +54,7 @@ class ReleaseStack_InPersonPaymentsWCPayTest : ReleaseStack_WCBase() {
     @Test
     fun givenSiteHasWCPayAndOrderWhenCreateCustomerByOrderIdCustomerIdReturned() = runBlocking {
         val result = store.createCustomerByOrderId(
+            WOOCOMMERCE_PAYMENTS,
                 sSite,
                 17L
         )
@@ -64,6 +65,7 @@ class ReleaseStack_InPersonPaymentsWCPayTest : ReleaseStack_WCBase() {
     @Test
     fun givenSiteHasWCPayAndWrongOrderIdWhenCreateCustomerByOrderIdCustomerIdReturned() = runBlocking {
         val result = store.createCustomerByOrderId(
+            WOOCOMMERCE_PAYMENTS,
                 sSite,
                 1L
         )

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -53,6 +53,7 @@
 
 /wc_stripe/account/summary
 /wc_stripe/terminal/locations/store
+/wc_stripe/orders/<order_id>/create_customer
 
 /taxes
 /taxes/classes/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -129,10 +129,14 @@ class InPersonPaymentsRestClient @Inject constructor(
     }
 
     suspend fun createCustomerByOrderId(
+        activePlugin: InPersonPaymentsPluginType,
         site: SiteModel,
         orderId: Long
     ): WooPayload<WCCreateCustomerByOrderIdResult> {
-        val url = WOOCOMMERCE.payments.orders.order(orderId).create_customer.pathV3
+        val url = when (activePlugin) {
+            WOOCOMMERCE_PAYMENTS -> WOOCOMMERCE.payments.orders.order(orderId).create_customer.pathV3
+            STRIPE -> WOOCOMMERCE.wc_stripe.orders.order(orderId).create_customer.pathV3
+        }
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 restClient = this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
@@ -52,11 +52,12 @@ class WCInPersonPaymentsStore @Inject constructor(
     }
 
     suspend fun createCustomerByOrderId(
+        activePlugin: InPersonPaymentsPluginType,
         site: SiteModel,
         orderId: Long
     ): WooResult<WCCreateCustomerByOrderIdResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "createCustomerByOrderId") {
-            restClient.createCustomerByOrderId(site, orderId).asWooResult()
+            restClient.createCustomerByOrderId(activePlugin, site, orderId).asWooResult()
         }
     }
 


### PR DESCRIPTION
Merge instructions:

1. Review this PR
2. Make sure "Create customer" endpoint for active plugin https://github.com/woocommerce/woocommerce-android/pull/5520 is reviewed and ready to be merged
3. Remove the "Not ready for merge" label
4. Merge this PR

This PR adds support for `wc/v3/wc_stripe/orders/<order_id>/create_customer` Stripe Extension endpoint which is identical to `/payments/orders/<order_id>/create_customer` WCPayments endpoint.

To test:
Green CI should be enough