### PR TITLE
Connection tokens endpoint for active plugin

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
@@ -36,7 +36,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun givenSiteHasWCPayWhenFetchConnectionTokenInvokedThenTokenReturned() = runBlocking {
         interceptor.respondWith("wc-pay-fetch-connection-token-response-success.json")
 
-        val result = restClient.fetchConnectionToken(SiteModel().apply { siteId = 123L })
+        val result = restClient.fetchConnectionToken(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
         assertTrue(result.result?.token?.isNotEmpty() == true)
         assertTrue(result.result?.isTestMode == true)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.STRIPE
 import javax.inject.Inject
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 
 class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
     @Inject internal lateinit var store: WCInPersonPaymentsStore
@@ -55,24 +56,24 @@ class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
 
     @Test
     fun givenSiteHasStripeExtensionAndOrderWhenCreateCustomerByOrderIdCustomerIdReturned() = runBlocking {
-        // TODO cardreader Update when we add support for Stripe Extension endpoint
-//        val result = store.createCustomerByOrderId(
-//                sSite,
-//                17L
-//        )
-//
-//        assertEquals("cus_JyzaCUE61Qmy8y", result.model?.customerId)
+        val result = store.createCustomerByOrderId(
+            STRIPE,
+                sSite,
+                17L
+        )
+
+        assertEquals("cus_KpWfupr71lMX0W", result.model?.customerId)
     }
 
     @Test
     fun givenSiteHasStripeExtensionAndWrongOrderIdWhenCreateCustomerByOrderIdCustomerIdReturned() = runBlocking {
-        // TODO cardreader Update when we add support for Stripe Extension endpoint
-//        val result = store.createCustomerByOrderId(
-//                sSite,
-//                1L
-//        )
-//
-//        assertTrue(result.isError)
+        val result = store.createCustomerByOrderId(
+            STRIPE,
+                sSite,
+                1L
+        )
+
+        assertTrue(result.isError)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
@@ -34,10 +34,9 @@ class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
 
     @Test
     fun givenSiteHasStripeExtensionWhenFetchConnectionTokenInvokedThenTokenReturned() = runBlocking {
-        // TODO cardreader Update when we add support for Stripe Extension endpoint
-//        val result = store.fetchConnectionToken(sSite)
-//
-//        assertTrue(result.model?.token?.isNotEmpty() == true)
+        val result = store.fetchConnectionToken(STRIPE, sSite)
+
+        assertTrue(result.model?.token?.isNotEmpty() == true)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsWCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsWCPayTest.kt
@@ -54,6 +54,7 @@ class ReleaseStack_InPersonPaymentsWCPayTest : ReleaseStack_WCBase() {
     @Test
     fun givenSiteHasWCPayAndOrderWhenCreateCustomerByOrderIdCustomerIdReturned() = runBlocking {
         val result = store.createCustomerByOrderId(
+            WOOCOMMERCE_PAYMENTS,
                 sSite,
                 17L
         )
@@ -64,6 +65,7 @@ class ReleaseStack_InPersonPaymentsWCPayTest : ReleaseStack_WCBase() {
     @Test
     fun givenSiteHasWCPayAndWrongOrderIdWhenCreateCustomerByOrderIdCustomerIdReturned() = runBlocking {
         val result = store.createCustomerByOrderId(
+            WOOCOMMERCE_PAYMENTS,
                 sSite,
                 1L
         )

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsWCPayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsWCPayTest.kt
@@ -32,7 +32,7 @@ class ReleaseStack_InPersonPaymentsWCPayTest : ReleaseStack_WCBase() {
 
     @Test
     fun givenSiteHasWCPayWhenFetchConnectionTokenInvokedThenTokenReturned() = runBlocking {
-        val result = store.fetchConnectionToken(sSite)
+        val result = store.fetchConnectionToken(WOOCOMMERCE_PAYMENTS, sSite)
 
         assertTrue(result.model?.token?.isNotEmpty() == true)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/pay/WCInPersonPaymentsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/pay/WCInPersonPaymentsStoreTest.kt
@@ -29,11 +29,11 @@ class WCInPersonPaymentsStoreTest {
     @Test
     fun `given server returns valid token, when fetchConnectionToken, then result contains the token`() = test {
         val token = "valid token"
-        whenever(restClient.fetchConnectionToken(any())).thenReturn(
+        whenever(restClient.fetchConnectionToken(any(), any())).thenReturn(
                 WooPayload(ConnectionTokenApiResponse(token, false))
         )
 
-        val result = store.fetchConnectionToken(mock())
+        val result = store.fetchConnectionToken(mock(), mock())
 
         assertThat(result.model?.token).isEqualTo(token)
     }
@@ -41,22 +41,22 @@ class WCInPersonPaymentsStoreTest {
     @Test
     fun `given server response is testMode=true, when fetchConnectionToken, then testMode=true returned`() = test {
         val isTestMode = true
-        whenever(restClient.fetchConnectionToken(any())).thenReturn(
+        whenever(restClient.fetchConnectionToken(any(), any())).thenReturn(
                 WooPayload(ConnectionTokenApiResponse("", isTestMode))
         )
 
-        val result = store.fetchConnectionToken(mock())
+        val result = store.fetchConnectionToken(mock(), mock())
 
         assertThat(result.model?.isTestMode).isEqualTo(isTestMode)
     }
 
     @Test
     fun `given server response is error, when fetchConnectionToken, then WooError returned`() = test {
-        whenever(restClient.fetchConnectionToken(any())).thenReturn(
+        whenever(restClient.fetchConnectionToken(any(), any())).thenReturn(
                 WooPayload(mock())
         )
 
-        val result = store.fetchConnectionToken(mock())
+        val result = store.fetchConnectionToken(mock(), mock())
 
         assertThat(result.error).isNotNull
     }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -54,6 +54,7 @@
 /wc_stripe/account/summary
 /wc_stripe/terminal/locations/store
 /wc_stripe/orders/<order_id>/create_customer
+/wc_stripe/connection_tokens
 
 /taxes
 /taxes/classes/

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -53,6 +53,7 @@
 
 /wc_stripe/account/summary
 /wc_stripe/terminal/locations/store
+/wc_stripe/orders/<order_id>/create_customer
 
 /taxes
 /taxes/classes/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -129,10 +129,14 @@ class InPersonPaymentsRestClient @Inject constructor(
     }
 
     suspend fun createCustomerByOrderId(
+        activePlugin: InPersonPaymentsPluginType,
         site: SiteModel,
         orderId: Long
     ): WooPayload<WCCreateCustomerByOrderIdResult> {
-        val url = WOOCOMMERCE.payments.orders.order(orderId).create_customer.pathV3
+        val url = when (activePlugin) {
+            WOOCOMMERCE_PAYMENTS -> WOOCOMMERCE.payments.orders.order(orderId).create_customer.pathV3
+            STRIPE -> WOOCOMMERCE.wc_stripe.orders.order(orderId).create_customer.pathV3
+        }
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 restClient = this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -45,8 +45,14 @@ class InPersonPaymentsRestClient @Inject constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    suspend fun fetchConnectionToken(site: SiteModel): WooPayload<ConnectionTokenApiResponse> {
-        val url = WOOCOMMERCE.payments.connection_tokens.pathV3
+    suspend fun fetchConnectionToken(
+        activePlugin: InPersonPaymentsPluginType,
+        site: SiteModel
+    ): WooPayload<ConnectionTokenApiResponse> {
+        val url = when (activePlugin) {
+            WOOCOMMERCE_PAYMENTS -> WOOCOMMERCE.payments.connection_tokens.pathV3
+            STRIPE -> WOOCOMMERCE.wc_stripe.connection_tokens.pathV3
+        }
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this,
                 site,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
@@ -21,9 +21,12 @@ class WCInPersonPaymentsStore @Inject constructor(
     private val coroutineEngine: CoroutineEngine,
     private val restClient: InPersonPaymentsRestClient
 ) {
-    suspend fun fetchConnectionToken(site: SiteModel): WooResult<WCConnectionTokenResult> {
+    suspend fun fetchConnectionToken(
+        activePlugin: InPersonPaymentsPluginType,
+        site: SiteModel
+    ): WooResult<WCConnectionTokenResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchConnectionToken") {
-            val response = restClient.fetchConnectionToken(site)
+            val response = restClient.fetchConnectionToken(activePlugin, site)
             return@withDefaultContext when {
                 response.isError -> {
                     WooResult(response.error)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
@@ -52,11 +52,12 @@ class WCInPersonPaymentsStore @Inject constructor(
     }
 
     suspend fun createCustomerByOrderId(
+        activePlugin: InPersonPaymentsPluginType,
         site: SiteModel,
         orderId: Long
     ): WooResult<WCCreateCustomerByOrderIdResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "createCustomerByOrderId") {
-            restClient.createCustomerByOrderId(site, orderId).asWooResult()
+            restClient.createCustomerByOrderId(activePlugin, site, orderId).asWooResult()
         }
     }
 


### PR DESCRIPTION
Merge instructions:

1. Review this PR
2. Make sure the "Connection tokens" endpoint for the active plugin https://github.com/woocommerce/woocommerce-android/pull/5538 is reviewed and ready to be merged
3. Remove the "Not ready for merge" label
4. Merge this PR

This PR adds support for `/wc_stripe/connection_tokens` Stripe Extension endpoint which is identical to `/payments/connection_tokens` WCPayments endpoint.

To test:
Green CI should be enough