### PR TITLE
Capture terminal endpoint for active plugin

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
@@ -46,7 +46,12 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenValidDataProvidedForCapturePaymentThenSuccessReturned() = runBlocking {
         interceptor.respondWithError("wc-pay-capture-terminal-payment-response-success.json", 200)
 
-        val result = restClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+        val result = restClient.capturePayment(
+            WOOCOMMERCE_PAYMENTS,
+            SiteModel().apply { siteId = 123L },
+            DUMMY_PAYMENT_ID,
+            -10L
+        )
 
         Assert.assertFalse(result.isError)
         assertTrue(result.status != null)
@@ -56,7 +61,12 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenInvalidOrderIdProvidedForCapturePaymentThenInvalidIdIsReturned() = runBlocking {
         interceptor.respondWithError("wc-pay-capture-terminal-payment-response-missing-order.json", 404)
 
-        val result = restClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+        val result = restClient.capturePayment(
+            WOOCOMMERCE_PAYMENTS,
+            SiteModel().apply { siteId = 123L },
+            DUMMY_PAYMENT_ID,
+            -10L
+        )
 
         assertTrue(result.error?.type == MISSING_ORDER)
     }
@@ -65,7 +75,12 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenPaymentAlreadyCapturedThenUncapturableErrorReturned() = runBlocking {
         interceptor.respondWithError("wc-pay-capture-terminal-payment-response-uncapturable.json", 409)
 
-        val result = restClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+        val result = restClient.capturePayment(
+            WOOCOMMERCE_PAYMENTS,
+            SiteModel().apply { siteId = 123L },
+            DUMMY_PAYMENT_ID,
+            -10L
+        )
 
         assertTrue(result.error?.type == PAYMENT_ALREADY_CAPTURED)
     }
@@ -74,7 +89,12 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenPaymentCaptureFailsThenCaptureFailedErrorReturned() = runBlocking {
         interceptor.respondWithError("wc-pay-capture-terminal-payment-response-capture-error.json", 502)
 
-        val result = restClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+        val result = restClient.capturePayment(
+            WOOCOMMERCE_PAYMENTS,
+            SiteModel().apply { siteId = 123L },
+            DUMMY_PAYMENT_ID,
+            -10L
+        )
 
         assertTrue(result.error?.type == CAPTURE_ERROR)
     }
@@ -83,7 +103,12 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenUnexpectedErrorOccursDuringCaptureThenWCPayServerErrorReturned() = runBlocking {
         interceptor.respondWithError("wc-pay-capture-terminal-payment-response-unexpected-error.json", 500)
 
-        val result = restClient.capturePayment(SiteModel().apply { siteId = 123L }, DUMMY_PAYMENT_ID, -10L)
+        val result = restClient.capturePayment(
+            WOOCOMMERCE_PAYMENTS,
+            SiteModel().apply { siteId = 123L },
+            DUMMY_PAYMENT_ID,
+            -10L
+        )
 
         assertTrue(result.error?.type == SERVER_ERROR)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/pay/WCInPersonPaymentsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/pay/WCInPersonPaymentsStoreTest.kt
@@ -29,11 +29,11 @@ class WCInPersonPaymentsStoreTest {
     @Test
     fun `given server returns valid token, when fetchConnectionToken, then result contains the token`() = test {
         val token = "valid token"
-        whenever(restClient.fetchConnectionToken(any())).thenReturn(
+        whenever(restClient.fetchConnectionToken(any(), any())).thenReturn(
                 WooPayload(ConnectionTokenApiResponse(token, false))
         )
 
-        val result = store.fetchConnectionToken(mock())
+        val result = store.fetchConnectionToken(mock(), mock())
 
         assertThat(result.model?.token).isEqualTo(token)
     }
@@ -41,22 +41,22 @@ class WCInPersonPaymentsStoreTest {
     @Test
     fun `given server response is testMode=true, when fetchConnectionToken, then testMode=true returned`() = test {
         val isTestMode = true
-        whenever(restClient.fetchConnectionToken(any())).thenReturn(
+        whenever(restClient.fetchConnectionToken(any(), any())).thenReturn(
                 WooPayload(ConnectionTokenApiResponse("", isTestMode))
         )
 
-        val result = store.fetchConnectionToken(mock())
+        val result = store.fetchConnectionToken(mock(), mock())
 
         assertThat(result.model?.isTestMode).isEqualTo(isTestMode)
     }
 
     @Test
     fun `given server response is error, when fetchConnectionToken, then WooError returned`() = test {
-        whenever(restClient.fetchConnectionToken(any())).thenReturn(
+        whenever(restClient.fetchConnectionToken(any(), any())).thenReturn(
                 WooPayload(mock())
         )
 
-        val result = store.fetchConnectionToken(mock())
+        val result = store.fetchConnectionToken(mock(), mock())
 
         assertThat(result.error).isNotNull
     }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -55,6 +55,7 @@
 /wc_stripe/terminal/locations/store
 /wc_stripe/orders/<order_id>/create_customer
 /wc_stripe/connection_tokens
+/wc_stripe/orders/<order_id>/capture_terminal_payment
 
 /taxes
 /taxes/classes/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -72,11 +72,15 @@ class InPersonPaymentsRestClient @Inject constructor(
     }
 
     suspend fun capturePayment(
+        activePlugin: InPersonPaymentsPluginType,
         site: SiteModel,
         paymentId: String,
         orderId: Long
     ): WCCapturePaymentResponsePayload {
-        val url = WOOCOMMERCE.payments.orders.id(orderId).capture_terminal_payment.pathV3
+        val url = when (activePlugin) {
+            WOOCOMMERCE_PAYMENTS -> WOOCOMMERCE.payments.orders.id(orderId).capture_terminal_payment.pathV3
+            STRIPE -> WOOCOMMERCE.wc_stripe.orders.order(orderId).capture_terminal_payment.pathV3
+        }
         val params = mapOf(
                 "payment_intent_id" to paymentId
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
@@ -39,9 +39,13 @@ class WCInPersonPaymentsStore @Inject constructor(
         }
     }
 
-    suspend fun capturePayment(site: SiteModel, paymentId: String, orderId: Long): WCCapturePaymentResponsePayload {
+    suspend fun capturePayment(
+        activePlugin: InPersonPaymentsPluginType,
+        site: SiteModel,
+        paymentId: String,
+        orderId: Long): WCCapturePaymentResponsePayload {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "capturePayment") {
-            restClient.capturePayment(site, paymentId, orderId)
+            restClient.capturePayment(activePlugin, site, paymentId, orderId)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
@@ -43,7 +43,8 @@ class WCInPersonPaymentsStore @Inject constructor(
         activePlugin: InPersonPaymentsPluginType,
         site: SiteModel,
         paymentId: String,
-        orderId: Long): WCCapturePaymentResponsePayload {
+        orderId: Long
+    ): WCCapturePaymentResponsePayload {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "capturePayment") {
             restClient.capturePayment(activePlugin, site, paymentId, orderId)
         }


### PR DESCRIPTION
Merge instructions:

1. Review this PR
2. Make sure the "Capture terminal" endpoint for the active plugin is reviewed and ready to be merged
Remove the "Not ready for merge" label
3. Merge this PR
4. This PR adds support for `/wc_stripe/orders/<order_id>/capture_terminal_payment` Stripe Extension endpoint which is identical to `/payments/orders/<id>/capture_terminal_payment` WCPayments endpoint.

To test:
Green CI should be enough