### PR TITLE
Fix for ReleaseStack_WCOrderTest

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.release;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
-
 import android.content.Context;
+
+import static androidx.test.InstrumentationRegistry.getInstrumentation;
 
 import com.android.volley.RequestQueue;
 import com.yarolegovich.wellsql.WellSql;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import static androidx.test.InstrumentationRegistry.getInstrumentation;
+
 import android.content.Context;
 
 import com.android.volley.RequestQueue;
@@ -10,14 +12,13 @@ import org.junit.Before;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.module.AppContextModule;
+import org.wordpress.android.fluxc.persistence.WCAndroidDatabase;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 
 import java.util.concurrent.CountDownLatch;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
 
 /**
  * NOTE:
@@ -34,6 +35,7 @@ public class ReleaseStack_Base {
     @Inject Dispatcher mDispatcher;
     @Inject @Named("regular") RequestQueue mRequestQueueRegular;
     @Inject @Named("custom-ssl") RequestQueue mRequestQueueCustomSsl;
+    @Inject WCAndroidDatabase mRoomDatabase;
 
     Context mAppContext;
     ReleaseStack_AppComponent mReleaseStackAppComponent;
@@ -69,6 +71,8 @@ public class ReleaseStack_Base {
         if (mRequestQueueCustomSsl != null) {
             mRequestQueueCustomSsl.stop();
         }
+
+        mRoomDatabase.clearAllTables();
     }
 
     protected void init() throws Exception {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -1,9 +1,9 @@
 @file:Suppress("DEPRECATION_ERROR")
+
 package org.wordpress.android.fluxc.release
 
 import kotlinx.coroutines.runBlocking
 import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
 
@@ -39,7 +38,6 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         NONE,
         FETCHED_ORDERS,
         FETCHED_ORDERS_COUNT,
-        FETCHED_HAS_ORDERS,
         SEARCHED_ORDERS,
         ERROR_ORDER_STATUS_NOT_FOUND,
         FETCHED_ORDER_STATUS_OPTIONS
@@ -50,11 +48,11 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
     private var nextEvent: TestEvent = TestEvent.NONE
     private val orderModel by lazy {
         WCOrderModel(
-                id = 8,
-                localSiteId = sSite.localId(),
-                remoteOrderId = RemoteId(1125),
-                number = "1125",
-                dateCreated = "2018-04-20T15:45:14Z"
+            id = 8,
+            localSiteId = sSite.localId(),
+            remoteOrderId = RemoteId(1125),
+            number = "1125",
+            dateCreated = "2018-04-20T15:45:14Z"
         )
     }
     private var lastEvent: OnOrderChanged? = null
@@ -78,7 +76,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
 
         mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, loadMore = false)))
 
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         val firstFetchOrders = orderStore.getOrdersForSite(sSite).size
 
@@ -93,13 +91,13 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         val statusFilter = "completed"
 
         mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, statusFilter, false)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         val firstFetchOrders = orderStore.getOrdersForSite(sSite)
         val isValid = firstFetchOrders.stream().allMatch { it.status == statusFilter }
         assertTrue(
-                firstFetchOrders.isNotEmpty() &&
-                        firstFetchOrders.size <= WCOrderStore.NUM_ORDERS_PER_FETCH && isValid
+            firstFetchOrders.isNotEmpty() &&
+                firstFetchOrders.size <= WCOrderStore.NUM_ORDERS_PER_FETCH && isValid
         )
     }
 
@@ -108,16 +106,16 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         val idsToRequest = listOf(RemoteId(1128), RemoteId(1129))
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
-                WCOrderActionBuilder.newFetchOrdersByIdsAction(
-                        FetchOrdersByIdsPayload(
-                                sSite,
-                                idsToRequest
-                        )
+            WCOrderActionBuilder.newFetchOrdersByIdsAction(
+                FetchOrdersByIdsPayload(
+                    sSite,
+                    idsToRequest
                 )
+            )
         )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
-        assertTrue(orderStore.getOrdersForSite(sSite).count() == idsToRequest.size)
+        assertEquals(idsToRequest.size, orderStore.getOrdersForSite(sSite).count())
     }
 
     @Throws(InterruptedException::class)
@@ -127,15 +125,15 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         mCountDownLatch = CountDownLatch(1)
 
         mDispatcher.dispatch(
-                WCOrderActionBuilder.newSearchOrdersAction(
-                        SearchOrdersPayload(
-                                sSite,
-                                orderSearchQuery,
-                                0
-                        )
+            WCOrderActionBuilder.newSearchOrdersAction(
+                SearchOrdersPayload(
+                    sSite,
+                    orderSearchQuery,
+                    0
                 )
+            )
         )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
     }
 
     @Throws(InterruptedException::class)
@@ -146,7 +144,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         val statusFilter = CoreOrderStatus.COMPLETED.value
 
         mDispatcher.dispatch(
-                WCOrderActionBuilder.newFetchOrdersCountAction(FetchOrdersCountPayload(sSite, statusFilter))
+            WCOrderActionBuilder.newFetchOrdersCountAction(FetchOrdersCountPayload(sSite, statusFilter))
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -163,7 +161,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         val statusFilter = ""
 
         mDispatcher.dispatch(
-                WCOrderActionBuilder.newFetchOrdersCountAction(FetchOrdersCountPayload(sSite, statusFilter))
+            WCOrderActionBuilder.newFetchOrdersCountAction(FetchOrdersCountPayload(sSite, statusFilter))
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
     }
@@ -184,7 +182,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.FETCHED_ORDERS
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersAction(FetchOrdersPayload(sSite, loadMore = false)))
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         // Fetch notes for the first order returned
         val firstOrder = orderStore.getOrdersForSite(sSite)[0]
@@ -205,7 +203,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
             isCustomerNote = true
         }
         orderStore.postOrderNote(
-                PostOrderNotePayload(orderModel.id, orderModel.remoteOrderId.value, sSite, originalNote)
+            PostOrderNotePayload(orderModel.id, orderModel.remoteOrderId.value, sSite, originalNote)
         )
 
         // Verify results
@@ -227,10 +225,10 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         mCountDownLatch = CountDownLatch(1)
 
         mDispatcher.dispatch(
-                WCOrderActionBuilder
-                        .newFetchOrderStatusOptionsAction(FetchOrderStatusOptionsPayload(sSite))
+            WCOrderActionBuilder
+                .newFetchOrderStatusOptionsAction(FetchOrderStatusOptionsPayload(sSite))
         )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         val orderStatusOptions = orderStore.getOrderStatusOptionsForSite(sSite)
         assertTrue(orderStatusOptions.isNotEmpty())
@@ -251,7 +249,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
     }
 
     @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
+    @Subscribe(threadMode = MAIN)
     fun onOrderChanged(event: OnOrderChanged) {
         event.error?.let {
             when (event.causeOfChange) {
@@ -280,7 +278,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
     }
 
     @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
+    @Subscribe(threadMode = MAIN)
     fun onOrdersSearched(event: OnOrdersSearched) {
         event.error?.let {
             throw AssertionError("OnOrdersSearched has error: " + it.type)
@@ -292,7 +290,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
     }
 
     @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
+    @Subscribe(threadMode = MAIN)
     fun onOrderStatusOptionsChanged(event: OnOrderStatusOptionsChanged) {
         event.error?.let {
             throw AssertionError("OnOrderStatusOptionsChanged has error: " + it.type)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -48,13 +48,15 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
     @Inject internal lateinit var orderStore: WCOrderStore
 
     private var nextEvent: TestEvent = TestEvent.NONE
-    private val orderModel = WCOrderModel(
-            id = 8,
-            localSiteId = sSite.localId(),
-            remoteOrderId = RemoteId(1125),
-            number = "1125",
-            dateCreated = "2018-04-20T15:45:14Z"
-    )
+    private val orderModel by lazy {
+        WCOrderModel(
+                id = 8,
+                localSiteId = sSite.localId(),
+                remoteOrderId = RemoteId(1125),
+                number = "1125",
+                dateCreated = "2018-04-20T15:45:14Z"
+        )
+    }
     private var lastEvent: OnOrderChanged? = null
     private val orderSearchQuery = "bogus query"
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.wc
 
 import android.app.Application
-import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
@@ -33,7 +32,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestCli
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.ActivePluginsResponse.SystemPluginModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.SSRResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.WPSiteSettingsResponse
-import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.WCPluginSqlUtils.WCPluginModel
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.site.SiteUtils

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -55,13 +55,6 @@ class WooCommerceStoreTest {
     private val restClient = mock<WooSystemRestClient>()
     private val siteStore = mock<SiteStore>()
 
-    private val roomDB = Room.inMemoryDatabaseBuilder(
-            appContext,
-            WCAndroidDatabase::class.java
-    )
-            .allowMainThreadQueries()
-            .build()
-
     private val wooCommerceStore = WooCommerceStore(
             appContext = appContext,
             dispatcher = Dispatcher(),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -846,9 +846,9 @@ class WCOrderStore @Inject constructor(
             OnOrderChanged(orderError = payload.error)
         } else {
             with(payload) {
-                OnOrderChanged(statusFilter = statusFilter, causeOfChange = WCOrderAction.FETCH_ORDERS_COUNT)
+                OnOrderChanged(statusFilter = statusFilter)
             }
-        }
+        }.copy(causeOfChange = WCOrderAction.FETCH_ORDERS_COUNT)
         emitChange(onOrderChanged)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCHED_ORDERS
+import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.ListActionBuilder
@@ -744,7 +745,7 @@ class WCOrderStore @Inject constructor(
             payload.orders.forEach { ordersDao.insertOrUpdateOrder(it) }
 
             OnOrderChanged(payload.statusFilter, canLoadMore = payload.canLoadMore)
-        }.copy(causeOfChange = FETCHED_ORDERS)
+        }.copy(causeOfChange = FETCH_ORDERS)
 
         emitChange(onOrderChanged)
     }


### PR DESCRIPTION
`sSite` variable was accessed before it was initialized. This fixes the main issue, but one test still failing due to unknown reason (may be that the test is wrong or the code behavior has changed)