### PR TITLE
Convert fetchSingleProduct action into suspendable function

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResp
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteDeleteProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassPayload
@@ -81,7 +80,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchSingleProductSuccess()  = runBlocking {
+    fun testFetchSingleProductSuccess() = runBlocking {
         interceptor.respondWith("wc-fetch-product-response-success.json")
         val payload = productRestClient.fetchSingleProduct(siteModel, remoteProductId)
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -81,15 +81,10 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testFetchSingleProductSuccess() {
+    fun testFetchSingleProductSuccess()  = runBlocking {
         interceptor.respondWith("wc-fetch-product-response-success.json")
-        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
+        val payload = productRestClient.fetchSingleProduct(siteModel, remoteProductId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCProductAction.FETCHED_SINGLE_PRODUCT, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteProductPayload
         with(payload) {
             assertNull(error)
             assertEquals(remoteProductId, product.remoteProductId)
@@ -126,61 +121,43 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(product.downloadExpiry, 10)
             assertEquals(product.downloadLimit, 123123124124)
         }
+        Unit
     }
 
     @Test
-    fun testFetchSingleProductError() {
+    fun testFetchSingleProductError() = runBlocking {
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
-        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
+        val payload = productRestClient.fetchSingleProduct(siteModel, remoteProductId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCProductAction.FETCHED_SINGLE_PRODUCT, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteProductPayload
         assertNotNull(payload.error)
     }
 
     @Test
-    fun testFetchInvalidProductIdError() {
+    fun testFetchInvalidProductIdError() = runBlocking {
         interceptor.respondWithError("wc-fetch-invalid-product-id.json")
-        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
+        val payload = productRestClient.fetchSingleProduct(siteModel, remoteProductId)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCProductAction.FETCHED_SINGLE_PRODUCT, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteProductPayload
         assertNotNull(payload.error)
         assertEquals(payload.error.type, ProductErrorType.INVALID_PRODUCT_ID)
     }
 
     @Test
-    fun testFetchSingleProductManageStock() {
+    fun testFetchSingleProductManageStock() = runBlocking {
         // check that a product's manage stock field is correctly set to true
         interceptor.respondWith("wc-fetch-product-response-manage-stock-true.json")
-        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-        val payloadTrue = lastAction!!.payload as RemoteProductPayload
+        val payloadTrue = productRestClient.fetchSingleProduct(siteModel, remoteProductId)
         assertTrue(payloadTrue.product.manageStock)
 
         // check that a product's manage stock field is correctly set to false
         interceptor.respondWith("wc-fetch-product-response-manage-stock-false.json")
-        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-        val payloadFalse = lastAction!!.payload as RemoteProductPayload
+        val payloadFalse = productRestClient.fetchSingleProduct(siteModel, remoteProductId)
         assertFalse(payloadFalse.product.manageStock)
 
         // check that a product's manage stock field is correctly set to true when response contains
         // "parent" rather than true/false (this is for product variations who inherit the parent's
         // manage stock)
         interceptor.respondWith("wc-fetch-product-response-manage-stock-parent.json")
-        productRestClient.fetchSingleProduct(siteModel, remoteProductId)
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-        val payloadParent = lastAction!!.payload as RemoteProductPayload
+        val payloadParent = productRestClient.fetchSingleProduct(siteModel, remoteProductId)
         assertTrue(payloadParent.product.manageStock)
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooAddonsTestFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooAddonsTestFragment.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.R.layout
-import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WCAddonsStore

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooAddonsTestFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooAddonsTestFragment.kt
@@ -74,14 +74,14 @@ class WooAddonsTestFragment : DialogFragment() {
         }
 
         addons_fetch_product.setOnClickListener {
-            dispatcher.dispatch(
-                    WCProductActionBuilder.newFetchSingleProductAction(
-                            FetchSingleProductPayload(
-                                    selectedSite,
-                                    selectedProduct.remoteProductId
-                            )
-                    )
-            )
+            coroutineScope.launch {
+                wcProductStore.fetchSingleProduct(
+                        FetchSingleProductPayload(
+                                selectedSite,
+                                selectedProduct.remoteProductId
+                        )
+                )
+            }
         }
 
         addons_fetch_global.setOnClickListener {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_CATEGORIES
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_TAGS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_VARIATIONS
-import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_SHIPPING_CLASS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_VARIATION
 import org.wordpress.android.fluxc.action.WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS
@@ -67,7 +66,6 @@ class WooProductsFragment : StoreSelectingFragment() {
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
     @Inject internal lateinit var mediaStore: MediaStore
 
-    private var pendingFetchSingleProductRemoteId: Long? = null
     private var pendingFetchSingleVariationRemoteId: Long? = null
     private var pendingFetchSingleProductShippingClassRemoteId: Long? = null
 
@@ -92,11 +90,26 @@ class WooProductsFragment : StoreSelectingFragment() {
         fetch_single_product.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter the remoteProductId of product to fetch:") { editText ->
-                    pendingFetchSingleProductRemoteId = editText.text.toString().toLongOrNull()
-                    pendingFetchSingleProductRemoteId?.let { id ->
-                        prependToLog("Submitting request to fetch product by remoteProductID $id")
-                        val payload = FetchSingleProductPayload(site, id)
-                        dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductAction(payload))
+                    editText.text.toString().toLongOrNull()?.let { remoteProductId ->
+                        prependToLog("Submitting request to fetch product by remoteProductID $remoteProductId")
+                        coroutineScope.launch {
+                            val result = wcProductStore.fetchSingleProduct(
+                                    FetchSingleProductPayload(
+                                            site,
+                                            remoteProductId
+                                    )
+                            )
+
+                            val product = wcProductStore.getProductByRemoteId(site, result.remoteProductId)
+                            product?.let {
+                                val numVariations = it.getNumVariations()
+                                if (numVariations > 0) {
+                                    prependToLog("Single product with $numVariations variations fetched! ${it.name}")
+                                } else {
+                                    prependToLog("Single product fetched! ${it.name}")
+                                }
+                            } ?: prependToLog("WARNING: Fetched product not found in the local database!")
+                        }
                     } ?: prependToLog("No valid remoteOrderId defined...doing nothing")
                 }
             }
@@ -108,8 +121,8 @@ class WooProductsFragment : StoreSelectingFragment() {
                         activity,
                         "Enter the remoteProductId of variation to fetch:"
                 ) { productIdText ->
-                    pendingFetchSingleProductRemoteId = productIdText.text.toString().toLongOrNull()
-                    pendingFetchSingleProductRemoteId?.let { productId ->
+                    val productRemoteId = productIdText.text.toString().toLongOrNull()
+                    productRemoteId?.let { productId ->
                         showSingleLineDialog(
                                 activity,
                                 "Enter the remoteVariationId of variation to fetch:"
@@ -117,7 +130,7 @@ class WooProductsFragment : StoreSelectingFragment() {
                             pendingFetchSingleVariationRemoteId = variationIdText.text.toString().toLongOrNull()
                             pendingFetchSingleVariationRemoteId?.let { variationId ->
                                 prependToLog("Submitting request to fetch product by " +
-                                        "remoteProductId $pendingFetchSingleProductRemoteId, " +
+                                        "remoteProductId $productRemoteId, " +
                                         "remoteVariationProductID $variationId")
                                 val payload = FetchSingleVariationPayload(site, productId, variationId)
                                 dispatcher.dispatch(WCProductActionBuilder.newFetchSingleVariationAction(payload))
@@ -458,20 +471,6 @@ class WooProductsFragment : StoreSelectingFragment() {
 
         selectedSite?.let { site ->
             when (event.causeOfChange) {
-                FETCH_SINGLE_PRODUCT -> {
-                    pendingFetchSingleProductRemoteId?.let { remoteId ->
-                        pendingFetchSingleProductRemoteId = null
-                        val product = wcProductStore.getProductByRemoteId(site, remoteId)
-                        product?.let {
-                            val numVariations = it.getNumVariations()
-                            if (numVariations > 0) {
-                                prependToLog("Single product with $numVariations variations fetched! ${it.name}")
-                            } else {
-                                prependToLog("Single product fetched! ${it.name}")
-                            }
-                        } ?: prependToLog("WARNING: Fetched product not found in the local database!")
-                    }
-                }
                 FETCH_PRODUCTS -> {
                     prependToLog("Fetched ${event.rowsAffected} products")
                 }
@@ -510,7 +509,6 @@ class WooProductsFragment : StoreSelectingFragment() {
             when (event.causeOfChange) {
                 FETCH_SINGLE_VARIATION -> {
                     pendingFetchSingleVariationRemoteId = null
-                    pendingFetchSingleProductRemoteId = null
                     val variation = wcProductStore.getVariationByRemoteId(
                             site,
                             event.remoteProductId,

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabil
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductTagsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleVariationPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
@@ -24,7 +23,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteDeleteProductPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassPayload;

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -47,8 +47,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.UpdateVariationPayload;
 @ActionEnum
 public enum WCProductAction implements IAction {
     // Remote actions
-    @Action(payloadType = FetchSingleProductPayload.class)
-    FETCH_SINGLE_PRODUCT,
     @Action(payloadType = FetchSingleVariationPayload.class)
     FETCH_SINGLE_VARIATION,
     @Action(payloadType = FetchProductsPayload.class)
@@ -89,8 +87,6 @@ public enum WCProductAction implements IAction {
     DELETE_PRODUCT,
 
     // Remote responses
-    @Action(payloadType = RemoteProductPayload.class)
-    FETCHED_SINGLE_PRODUCT,
     @Action(payloadType = RemoteVariationPayload.class)
     FETCHED_SINGLE_VARIATION,
     @Action(payloadType = RemoteProductListPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -269,9 +269,9 @@ class ProductRestClient @Inject constructor(
                     }
                     RemoteProductPayload(newModel, site)
                 } ?: RemoteProductPayload(
-                        error = ProductError(GENERIC_ERROR, "Success response with empty data"),
+                        ProductError(GENERIC_ERROR, "Success response with empty data"),
                         WCProductModel().apply { this.remoteProductId = remoteProductId },
-                        site = site
+                        site
                 )
             }
             is JetpackError -> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
@@ -41,7 +40,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUC
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_TAGS_PAGE_SIZE
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_VARIATIONS_PAGE_SIZE
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductReviewsResponsePayload
-import org.wordpress.android.fluxc.store.WCProductStore.OnProductChanged
 import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting
 import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting.NAME_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductError

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -921,7 +921,7 @@ class WCProductStore @Inject constructor(
                 val rowsAffected = ProductSqlUtils.insertOrUpdateProduct(result.product)
 
                 // TODO: 18/08/2021 @wzieba add tests
-                coroutineEngine?.launch(T.DB, this, "cacheProductAddons") {
+                coroutineEngine.launch(T.DB, this, "cacheProductAddons") {
                     val domainAddons = mapProductAddonsToDomain(result.product.addons)
                     addonsDao.cacheProductAddons(
                             productRemoteId = result.product.remoteProductId,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -909,7 +909,7 @@ class WCProductStore @Inject constructor(
     override fun onRegister() = AppLog.d(API, "WCProductStore onRegister")
 
     suspend fun fetchSingleProduct(payload: FetchSingleProductPayload): OnProductChanged {
-        return coroutineEngine?.withDefaultContext(API, this, "fetchSingleProduct") {
+        return coroutineEngine.withDefaultContext(API, this, "fetchSingleProduct") {
             val result = with(payload) { wcProductRestClient.fetchSingleProduct(site, remoteProductId) }
 
             return@withDefaultContext if (result.isError) {


### PR DESCRIPTION
Implements  https://github.com/woocommerce/woocommerce-android/issues/5193 partially

This PR refactors fetchSingleProduct into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.


## How to test
1. Test fetchSingleProduct action in the example app ( or test in WCAndroid PR tbd)