### PR TITLE
Dashboard Cards: Handle Authorization Required

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store.dashboard
 
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.single
@@ -117,7 +118,17 @@ class CardsStoreTest {
     }
 
     @Test
-    fun `given cards response, when fetch cards gets triggered, then null no error cards model is returned`() = test {
+    fun `given cards response, when fetch cards gets triggered, then cards model is inserted into db`() = test {
+        val payload = CardsPayload(CARDS_RESPONSE)
+        whenever(restClient.fetchCards(siteModel)).thenReturn(payload)
+
+        cardsStore.fetchCards(siteModel)
+
+        verify(dao).insertWithDate(siteModel.id, CARDS_MODEL)
+    }
+
+    @Test
+    fun `given cards response, when fetch cards gets triggered, then empty cards model is returned`() = test {
         val payload = CardsPayload(CARDS_RESPONSE)
         whenever(restClient.fetchCards(siteModel)).thenReturn(payload)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
@@ -165,6 +165,29 @@ class CardsStoreTest {
     }
 
     @Test
+    fun `given authorization required, when fetch cards gets triggered, then db is cleared of cards model`() = test {
+        val errorType = CardsErrorType.AUTHORIZATION_REQUIRED
+        val payload = CardsPayload<CardsResponse>(CardsError(errorType))
+        whenever(restClient.fetchCards(siteModel)).thenReturn(payload)
+
+        cardsStore.fetchCards(siteModel)
+
+        verify(dao).clear()
+    }
+
+    @Test
+    fun `given authorization required, when fetch cards gets triggered, then empty cards model is returned`() = test {
+        val errorType = CardsErrorType.AUTHORIZATION_REQUIRED
+        val payload = CardsPayload<CardsResponse>(CardsError(errorType))
+        whenever(restClient.fetchCards(siteModel)).thenReturn(payload)
+
+        val result = cardsStore.fetchCards(siteModel)
+
+        assertThat(result.model).isNull()
+        assertThat(result.error).isNull()
+    }
+
+    @Test
     fun `given empty cards payload, when fetch cards gets triggered, then cards error is returned`() = test {
         val payload = CardsPayload<CardsResponse>()
         whenever(restClient.fetchCards(siteModel)).thenReturn(payload)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/dashboard/CardsDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/dashboard/CardsDao.kt
@@ -22,6 +22,9 @@ abstract class CardsDao {
         insert(cards.map { CardEntity.from(siteLocalId, it, insertDate) })
     }
 
+    @Query("DELETE FROM DashboardCards")
+    abstract fun clear()
+
     @Entity(
             tableName = "DashboardCards",
             primaryKeys = ["siteLocalId", "type"]

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
@@ -38,8 +38,12 @@ class CardsStore @Inject constructor(
 
     private fun handlePayloadError(
         error: CardsError
-    ): CardsResult<List<CardModel>> {
-        return CardsResult(error)
+    ): CardsResult<List<CardModel>> = when (error.type) {
+        CardsErrorType.AUTHORIZATION_REQUIRED -> {
+            cardsDao.clear()
+            CardsResult()
+        }
+        else -> CardsResult(error)
     }
 
     private suspend fun handlePayloadResponse(


### PR DESCRIPTION
Related: [WordPress-Android#15736](https://github.com/wordpress-mobile/WordPress-Android/issues/15736)

This PR:
- Adds the `clear()` function to `CardsDao`, which deletes all rows from the `DashboardCards` table.
- Implements the `authorization required` case on `CardsStore`, which makes sure that when a user gets downgraded from an 'administrator', 'editor', 'author' or 'contributor' to a 'follower' or 'subscriber', on an authorization required error:
  1) The database is being cleaned of any cards model from previous requests, and
  2) Instead of having the user seeing an error message, no error message is shown. Instead, the dashboard cards feed just disappears from the 'My Site' tab.

-----

To test:
- Start with a site with `draft` and `scheduled` posts.
- Make sure you are an `administrator` of that site.
- Add another `editor` user to your side.
- Make sure that this `editor` user is able to see all the `draft` and `scheduled` posts.
- Downgrade this user to a `follower` (or `subscriber`).
  - Make sure that this `follower` user is no longer able to see any of the `draft` or `scheduled` posts, or the dashboard feed in general.
  - Make sure that this `follower` user is not seeing any dashboard feed related error card, snackbar or stale message.

-----

Note:
1) Before trying all the above, maybe try it once without applying this solution and see how it works atm.
2) You will need to have two instances of the app running side-by-side on your device, or two devices, each with an instance of the app. Then, when the user is downgraded on one instance, or a device, you should pull-to-refresh on this other instance/device to see the result. Otherwise, if you close the app and swipe it off from running in the background, the next time you open the app that site will not be visible altogether. Thus, this PR only solves this edge case where the user gets downgraded while their app is currently open or running on the background.