### PR TITLE
[Woo] Add ability to observe order changes for a given site

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
@@ -43,6 +43,9 @@ abstract class OrdersDao {
     @Query("SELECT * FROM OrderEntity WHERE localSiteId = :localSiteId")
     abstract suspend fun getOrdersForSite(localSiteId: LocalId): List<WCOrderModel>
 
+    @Query("SELECT * FROM OrderEntity WHERE localSiteId = :localSiteId")
+    abstract fun observeOrdersForSite(localSiteId: LocalId): Flow<List<WCOrderModel>>
+
     @Query("SELECT * FROM OrderEntity WHERE localSiteId = :localSiteId AND status IN (:status)")
     abstract fun observeOrdersForSite(localSiteId: LocalId, status: List<String>): Flow<List<WCOrderModel>>
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -6,9 +6,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.action.WCOrderAction
-import org.wordpress.android.fluxc.action.WCOrderAction.FETCHED_ORDERS
 import org.wordpress.android.fluxc.action.WCOrderAction.FETCH_ORDERS
-import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.ListActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
@@ -381,8 +379,20 @@ class WCOrderStore @Inject constructor(
         ordersDao.getOrdersForSite(site.localId(), status = status.asList())
     }
 
-    fun observeOrdersForSite(siteLocalId: LocalId, statuses: List<String>) =
-            ordersDao.observeOrdersForSite(siteLocalId, statuses)
+    /**
+     * Observe the changes to orders for a given [SiteModel]
+     *
+     * @param site the current site
+     * @param statuses an optional list of statuses to filter the list of orders, pass an empty list to include all
+     *                 orders
+     */
+    fun observeOrdersForSite(site: SiteModel, statuses: List<String> = emptyList()): Flow<List<WCOrderModel>> {
+        return if (statuses.isEmpty()) {
+            ordersDao.observeOrdersForSite(site.localId())
+        } else {
+            ordersDao.observeOrdersForSite(site.localId(), statuses)
+        }
+    }
 
     fun getOrdersForDescriptor(
         orderListDescriptor: WCOrderListDescriptor,


### PR DESCRIPTION
This just updates the WCOrderStore#observeOrdersForSite to make the list of statuses optional, and return updates of Orders for all changes.
This is currently needed for https://github.com/woocommerce/woocommerce-android/pull/5641 to allow refreshing the order list after saving a new order.

**Just for the sake of discussion:**
We can actually solve this a different way, by making a call similar to this https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/e7eb88bcd9e9462328b158069a77bc2a85f5ab79/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt#L828-L830 when we save the order, but IMO observing the database should be the preferred way going forward, and we may even go back to the implementation above and adjust it, since this call is made after fetching orders, but normally the database should be the source of truth, and we should only react to its changes.