### PR TITLE
[Order Update] ability to update more fields

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -500,7 +500,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                             )
                     )
                     if (result.isError) {
-                        prependToLog("Order creation failed, error ${result.error.type}")
+                        prependToLog("Order creation failed, error ${result.error.type} ${result.error.message}")
                     } else {
                         prependToLog("Created order with id ${result.model!!.remoteOrderId}")
                     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -487,7 +487,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
 
                     val status = WCOrderStatusModel(CoreOrderStatus.PROCESSING.value)
 
-                    val result = wcOrderStore.createOrder(
+                    val result = orderUpdateStore.createOrder(
                             site,
                             UpdateOrderRequest(
                                     status = status,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -33,7 +33,7 @@ import org.wordpress.android.fluxc.model.WCOrderModel
 import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
-import org.wordpress.android.fluxc.model.order.CreateOrderRequest
+import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
@@ -489,7 +489,7 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
 
                     val result = wcOrderStore.createOrder(
                             site,
-                            CreateOrderRequest(
+                            UpdateOrderRequest(
                                     status = status,
                                     lineItems = products.map {
                                         LineItem(productId = it, quantity = 1f)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/FeeLine.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/FeeLine.kt
@@ -17,4 +17,14 @@ class FeeLine {
 
     @SerializedName("total_tax")
     val totalTax: String? = null
+
+    @SerializedName("tax_status")
+    val taxStatus: FeeLineTaxStatus? = null
+}
+
+enum class FeeLineTaxStatus {
+    @SerializedName("taxable")
+    Taxable,
+    @SerializedName("none")
+    None
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
@@ -7,5 +7,6 @@ data class UpdateOrderRequest(
     val lineItems: List<LineItem>? = null,
     val shippingAddress: OrderAddress.Shipping? = null,
     val billingAddress: OrderAddress.Billing? = null,
+    val feeLines: List<FeeLine>? = null,
     val customerNote: String? = null
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.model.order
 
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 
-data class CreateOrderRequest(
+data class UpdateOrderRequest(
     val status: WCOrderStatusModel,
     val lineItems: List<LineItem>,
     val shippingAddress: OrderAddress.Shipping,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
@@ -3,9 +3,9 @@ package org.wordpress.android.fluxc.model.order
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 
 data class UpdateOrderRequest(
-    val status: WCOrderStatusModel,
-    val lineItems: List<LineItem>,
-    val shippingAddress: OrderAddress.Shipping,
-    val billingAddress: OrderAddress.Billing,
-    val customerNote: String?
+    val status: WCOrderStatusModel? = null,
+    val lineItems: List<LineItem>? = null,
+    val shippingAddress: OrderAddress.Shipping? = null,
+    val billingAddress: OrderAddress.Billing? = null,
+    val customerNote: String? = null
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
@@ -8,5 +8,6 @@ data class UpdateOrderRequest(
     val shippingAddress: OrderAddress.Shipping? = null,
     val billingAddress: OrderAddress.Billing? = null,
     val feeLines: List<FeeLine>? = null,
+    val shippingLines: List<ShippingLine>? = null,
     val customerNote: String? = null
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
-import org.wordpress.android.fluxc.model.order.CreateOrderRequest
+import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -822,7 +822,7 @@ class OrderRestClient @Inject constructor(
 
     suspend fun createOrder(
         site: SiteModel,
-        request: CreateOrderRequest
+        request: UpdateOrderRequest
     ): WooPayload<OrderDto> {
         val url = WOOCOMMERCE.orders.pathV3
         val params = mapOf(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
 import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -847,7 +848,13 @@ class OrderRestClient @Inject constructor(
             is JetpackError -> WooPayload(response.error.toWooError())
             is JetpackSuccess -> response.data?.let { orderDto ->
                 WooPayload(orderDto.toDomainModel(site.localId()))
-            } ?: WooPayload(error = WooError(WooErrorType.GENERIC_ERROR, message = "Success response with empty data"))
+            } ?: WooPayload(
+                    error = WooError(
+                            type = WooErrorType.GENERIC_ERROR,
+                            original = GenericErrorType.UNKNOWN,
+                            message = "Success response with empty data"
+                    )
+            )
         }
     }
 
@@ -877,7 +884,13 @@ class OrderRestClient @Inject constructor(
             is JetpackError -> WooPayload(response.error.toWooError())
             is JetpackSuccess -> response.data?.let { orderDto ->
                 WooPayload(orderDto.toDomainModel(site.localId()))
-            } ?: WooPayload(error = WooError(WooErrorType.GENERIC_ERROR, message = "Success response with empty data"))
+            } ?: WooPayload(
+                    error = WooError(
+                            type = WooErrorType.GENERIC_ERROR,
+                            original = GenericErrorType.UNKNOWN,
+                            message = "Success response with empty data"
+                    )
+            )
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -829,14 +829,14 @@ class OrderRestClient @Inject constructor(
     ): WooPayload<WCOrderModel> {
         val url = WOOCOMMERCE.orders.pathV3
         val params = mutableMapOf<String, Any>().apply {
-            request.status?.let { put("status", it) }
+            request.status?.let { put("status", it.statusKey) }
             request.lineItems?.let { put("line_items", it) }
             request.shippingAddress?.toDto()?.let { put("shipping", it) }
             request.billingAddress?.toDto()?.let { put("billing", it) }
             request.customerNote?.let { put("customer_note", it) }
         }
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPutRequest(
+        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this,
                 site,
                 url,
@@ -865,14 +865,14 @@ class OrderRestClient @Inject constructor(
     ): WooPayload<WCOrderModel> {
         val url = WOOCOMMERCE.orders.id(orderId).pathV3
         val params = mutableMapOf<String, Any>().apply {
-            request.status?.let { put("status", it) }
+            request.status?.let { put("status", it.statusKey) }
             request.lineItems?.let { put("line_items", it) }
             request.shippingAddress?.toDto()?.let { put("shipping", it) }
             request.billingAddress?.toDto()?.let { put("billing", it) }
             request.customerNote?.let { put("customer_note", it) }
         }
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
+        val response = jetpackTunnelGsonRequestBuilder.syncPutRequest(
                 this,
                 site,
                 url,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -828,13 +828,7 @@ class OrderRestClient @Inject constructor(
         request: UpdateOrderRequest
     ): WooPayload<WCOrderModel> {
         val url = WOOCOMMERCE.orders.pathV3
-        val params = mutableMapOf<String, Any>().apply {
-            request.status?.let { put("status", it.statusKey) }
-            request.lineItems?.let { put("line_items", it) }
-            request.shippingAddress?.toDto()?.let { put("shipping", it) }
-            request.billingAddress?.toDto()?.let { put("billing", it) }
-            request.customerNote?.let { put("customer_note", it) }
-        }
+        val params = request.toNetworkRequest()
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this,
@@ -864,13 +858,7 @@ class OrderRestClient @Inject constructor(
         request: UpdateOrderRequest
     ): WooPayload<WCOrderModel> {
         val url = WOOCOMMERCE.orders.id(orderId).pathV3
-        val params = mutableMapOf<String, Any>().apply {
-            request.status?.let { put("status", it.statusKey) }
-            request.lineItems?.let { put("line_items", it) }
-            request.shippingAddress?.toDto()?.let { put("shipping", it) }
-            request.billingAddress?.toDto()?.let { put("billing", it) }
-            request.customerNote?.let { put("customer_note", it) }
-        }
+        val params = request.toNetworkRequest()
 
         val response = jetpackTunnelGsonRequestBuilder.syncPutRequest(
                 this,
@@ -891,6 +879,18 @@ class OrderRestClient @Inject constructor(
                             message = "Success response with empty data"
                     )
             )
+        }
+    }
+
+    private fun UpdateOrderRequest.toNetworkRequest(): Map<String, Any> {
+        return mutableMapOf<String, Any>().apply {
+            status?.let { put("status", it.statusKey) }
+            lineItems?.let { put("line_items", it) }
+            shippingAddress?.toDto()?.let { put("shipping", it) }
+            billingAddress?.toDto()?.let { put("billing", it) }
+            feeLines?.let { put("fee_lines", it) }
+            shippingLines?.let { put("shipping_lines", it) }
+            customerNote?.let { put("customer_note", it) }
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDtoMapper.toDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.toDomainModel
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
@@ -124,7 +123,7 @@ class OrderUpdateStore @Inject internal constructor(
             return@withDefaultContext if (result.isError) {
                 WooResult(result.error)
             } else {
-                val model = result.result!!.toDomainModel(site.localId())
+                val model = result.result!!
                 ordersDao.insertOrUpdateOrder(model)
                 WooResult(model)
             }
@@ -138,7 +137,7 @@ class OrderUpdateStore @Inject internal constructor(
             return@withDefaultContext if (result.isError) {
                 WooResult(result.error)
             } else {
-                val model = result.result!!.toDomainModel(site.localId())
+                val model = result.result!!
                 ordersDao.insertOrUpdateOrder(model)
                 WooResult(model)
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -130,7 +130,11 @@ class OrderUpdateStore @Inject internal constructor(
         }
     }
 
-    suspend fun updateOrder(site: SiteModel, orderId: Long, updateRequest: UpdateOrderRequest): WooResult<WCOrderModel> {
+    suspend fun updateOrder(
+        site: SiteModel,
+        orderId: Long,
+        updateRequest: UpdateOrderRequest
+    ): WooResult<WCOrderModel> {
         return coroutineEngine.withDefaultContext(T.API, this, "createOrder") {
             val result = wcOrderRestClient.updateOrder(site, orderId, updateRequest)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -19,11 +19,8 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
-import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.toDomainModel
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -557,20 +557,6 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    suspend fun createOrder(site: SiteModel, createOrderRequest: UpdateOrderRequest): WooResult<WCOrderModel> {
-        return coroutineEngine.withDefaultContext(T.API, this, "createOrder") {
-            val result = wcOrderRestClient.createOrder(site, createOrderRequest)
-
-            return@withDefaultContext if (result.isError) {
-                WooResult(result.error)
-            } else {
-                val model = result.result!!.toDomainModel(site.localId())
-                ordersDao.insertOrUpdateOrder(model)
-                WooResult(model)
-            }
-        }
-    }
-
     suspend fun updateOrderStatus(
         remoteOrderId: RemoteId,
         site: SiteModel,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -19,7 +19,7 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
-import org.wordpress.android.fluxc.model.order.CreateOrderRequest
+import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
@@ -557,7 +557,7 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    suspend fun createOrder(site: SiteModel, createOrderRequest: CreateOrderRequest): WooResult<WCOrderModel> {
+    suspend fun createOrder(site: SiteModel, createOrderRequest: UpdateOrderRequest): WooResult<WCOrderModel> {
         return coroutineEngine.withDefaultContext(T.API, this, "createOrder") {
             val result = wcOrderRestClient.createOrder(site, createOrderRequest)
 


### PR DESCRIPTION
⚠️ Please don't merge until the WCAndroid's [PR](https://github.com/woocommerce/woocommerce-android/pull/5671) is reviewed

This PR adds support for updating orders using a single entry point to the OrderUpdateStore, this is actually needed to support Order Creation and Simple Payments.

We can probably refactor the Store to remove the repeated functionality between the new function and the other functions in an upcoming PR.

#### Testing
Just confirm that there is no regression in order creation in the example app.