### PR TITLE
Drop jcenter repository and use jcenter-mirror when necessary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,16 @@ allprojects {
             }
         }
         google()
-        jcenter()
         mavenCentral()
+        maven {
+            url "https://a8c-libs.s3.amazonaws.com/android/jcenter-mirror"
+            content {
+                includeVersion "com.android.volley", "volley", "1.1.1"
+                includeVersion "org.wordpress", "wellsql", "1.6.0"
+                includeVersion "org.wordpress", "wellsql-core", "1.6.0"
+                includeVersion "org.wordpress", "wellsql-processor", "1.6.0"
+            }
+        }
     }
 
     task checkstyle(type: Checkstyle) {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ allprojects {
                 includeVersion "org.wordpress", "wellsql", "1.6.0"
                 includeVersion "org.wordpress", "wellsql-core", "1.6.0"
                 includeVersion "org.wordpress", "wellsql-processor", "1.6.0"
+                includeVersion "com.facebook.flipper", "flipper", "0.51.0"
+                includeVersion "com.facebook.flipper", "flipper-network-plugin", "0.51.0"
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,6 @@ pluginManagement {
         }
         gradlePluginPortal()
         google()
-        jcenter()
     }
     resolutionStrategy {
         eachPlugin {

--- a/tests/api/build.gradle
+++ b/tests/api/build.gradle
@@ -13,5 +13,4 @@ test {
 
 repositories {
     google()
-    jcenter()
 }


### PR DESCRIPTION
In the last week, we have had a lot of dependency resolution issues from `jcenter`, especially in [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android/), so we are dropping it from our projects. In order to have a smooth transition and not try to update all our dependencies at once, we created a `jcenter-mirror` s3 maven repository to serve the artifacts we need from `jcenter`. This PR removes `jcenter` as a repository and adds `jcenter-mirror` as a limited repository.

We use the [includeVersion](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.html#includeVersion-java.lang.String-java.lang.String-java.lang.String-) syntax to declare which versions & dependencies we use from `jcenter-mirror`, so that it is clear to us which dependencies we need to update to drop it. Our preference moving forward will be to upgrade these dependencies to versions which are hosted in other maven repositories, such as `mavenCentral`. However, there is no rush to do these upgrades right now as hosting the `jcenter-mirror` repository has no considerable maintenance cost to us.

**To test:**
No testing should be necessary since the changes only impact the dependency resolution.