### PR TITLE
Woo/add product purchasable field

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 167
+        return 168
     }
 
     override fun getDbName(): String {
@@ -1832,6 +1832,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 167 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("DROP TABLE IF EXISTS WCOrderModel")
                 }
+                168 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                db.execSQL("ALTER TABLE WCProductModel ADD PURCHASABLE INTEGER")
+            }
             }
         }
         db.setTransactionSuccessful()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -51,6 +51,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var salePrice = ""
     @Column var onSale = false
     @Column var totalSales = 0L
+    @Column var purchasable = false
 
     @Column var dateOnSaleFrom = ""
     @Column var dateOnSaleTo = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -31,6 +31,7 @@ class ProductApiResponse : Response {
     var sale_price: String? = null
     var on_sale = false
     var total_sales = 0L
+    var purchasable = false
 
     var virtual = false
     var downloadable = false
@@ -115,6 +116,7 @@ class ProductApiResponse : Response {
             salePrice = response.sale_price ?: ""
             onSale = response.on_sale
             totalSales = response.total_sales
+            purchasable = response.purchasable
 
             virtual = response.virtual
             downloadable = response.downloadable


### PR DESCRIPTION
This PR simply adds the `purchasable` field at the `WCProductModel` in order to support better product configuration and filters inside the Woo app, testing this just requires us to verify if the field is correctly added to the database and reflects the API response as expected.