### PR TITLE
Update wellsql to 1.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ allprojects {
             content {
                 includeGroup "org.wordpress"
                 includeGroup "org.wordpress.fluxc"
+                includeGroup "org.wordpress.wellsql"
             }
         }
         google()
@@ -28,9 +29,6 @@ allprojects {
             url "https://a8c-libs.s3.amazonaws.com/android/jcenter-mirror"
             content {
                 includeVersion "com.android.volley", "volley", "1.1.1"
-                includeVersion "org.wordpress", "wellsql", "1.6.0"
-                includeVersion "org.wordpress", "wellsql-core", "1.6.0"
-                includeVersion "org.wordpress", "wellsql-processor", "1.6.0"
                 includeVersion "com.facebook.flipper", "flipper", "0.51.0"
                 includeVersion "com.facebook.flipper", "flipper-network-plugin", "0.51.0"
             }
@@ -73,7 +71,7 @@ subprojects {
 
 ext {
     daggerVersion = '2.29.1'
-    wellSqlVersion = '1.6.0'
+    wellSqlVersion = '20-79efb712efc4e02d5ee887935a94b87692616d85'
     supportLibraryVersion = '27.1.1'
     arch_paging_version = '1.0.1'
     arch_lifecycle_version = '1.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
 
 ext {
     daggerVersion = '2.29.1'
-    wellSqlVersion = '20-79efb712efc4e02d5ee887935a94b87692616d85'
+    wellSqlVersion = '1.7.0'
     supportLibraryVersion = '27.1.1'
     arch_paging_version = '1.0.1'
     arch_lifecycle_version = '1.1.1'

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 
     // Custom WellSql version
     api "org.wordpress:wellsql:$wellSqlVersion"
-    kapt "org.wordpress:wellsql-processor:$wellSqlVersion"
+    kapt "org.wordpress.wellsql:wellsql-processor:$wellSqlVersion"
 
     // FluxC annotations
     api fluxcAnnotationsProjectDependency

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     }
 
     api "org.wordpress:wellsql:$wellSqlVersion"
-    kapt "org.wordpress:wellsql-processor:$wellSqlVersion"
+    kapt "org.wordpress.wellsql:wellsql-processor:$wellSqlVersion"
 
     // FluxC annotations
     api fluxcAnnotationsProjectDependency


### PR DESCRIPTION
This PR will update `wellsql` to `1.7.0` which will be published to our S3 Maven repository once https://github.com/wordpress-mobile/wellsql/pull/20 lands (update: it landed). At the time of PR creation, `wellsql` is updated to `20-79efb712efc4e02d5ee887935a94b87692616d85` so it can be used to test https://github.com/wordpress-mobile/wellsql/pull/20. Since we no longer need to fetch `1.6.0` from our `jcenter-mirror`, it removes the relevant `includeVersion` lines.

One slight modification https://github.com/wordpress-mobile/wellsql/pull/20 makes is that the `wellsql-processor` will no longer be fetched from `org.wordpress:wellsql-processor` but instead will be fetched from `org.wordpress.wellsql:wellsql-processor`. This is so that the library follows our typical maven structure.