### PR TITLE
Issue/2252 wcordermodel taxlines

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -92,6 +92,10 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals("\$10.00 fee", getFeeLineList()[0].name)
             assertEquals("2.00", getFeeLineList()[0].totalTax)
             assertEquals(28L, getFeeLineList()[0].id)
+            assertEquals(1, getTaxLineList().size)
+            assertEquals(318L, getTaxLineList()[0].id)
+            assertEquals(false, getTaxLineList()[0].compound)
+            assertEquals("1.35", getTaxLineList()[0].taxTotal)
         }
 
         // Customer note

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -96,6 +96,8 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals(318L, getTaxLineList()[0].id)
             assertEquals(false, getTaxLineList()[0].compound)
             assertEquals("1.35", getTaxLineList()[0].taxTotal)
+            assertEquals("State Tax", getTaxLineList()[0].label)
+            assertEquals("0.00", getTaxLineList()[0].shippingTaxTotal)
         }
 
         // Customer note

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -98,6 +98,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals("1.35", getTaxLineList()[0].taxTotal)
             assertEquals("State Tax", getTaxLineList()[0].label)
             assertEquals("0.00", getTaxLineList()[0].shippingTaxTotal)
+            assertEquals(5.25f, getTaxLineList()[0].ratePercent)
         }
 
         // Customer note

--- a/example/src/androidTest/resources/wc-orders-response-success.json
+++ b/example/src/androidTest/resources/wc-orders-response-success.json
@@ -244,6 +244,17 @@
           "price": 30
         }
       ],
+      "tax_lines": [
+        {
+          "id": 318,
+          "rate_code": "US-CA-STATE TAX",
+          "rate_id": 75,
+          "compound": false,
+          "tax_total": "1.35",
+          "shipping_tax_total": "0.00",
+          "meta_data": []
+        }
+      ],
       "refunds": [
         {
           "id": 940,

--- a/example/src/androidTest/resources/wc-orders-response-success.json
+++ b/example/src/androidTest/resources/wc-orders-response-success.json
@@ -74,6 +74,18 @@
           "price": 30
         }
       ],
+      "tax_lines": [
+        {
+          "id": 318,
+          "rate_code": "US-CA-STATE TAX",
+          "rate_id": 75,
+          "label": "State Tax",
+          "compound": false,
+          "tax_total": "1.35",
+          "shipping_tax_total": "0.00",
+          "meta_data": []
+        }
+      ],
       "fee_lines": [
         {
           "id": 28,
@@ -242,18 +254,6 @@
           "meta_data": [],
           "sku": "111-111-111",
           "price": 30
-        }
-      ],
-      "tax_lines": [
-        {
-          "id": 318,
-          "rate_code": "US-CA-STATE TAX",
-          "rate_id": 75,
-          "label": "State Tax",
-          "compound": false,
-          "tax_total": "1.35",
-          "shipping_tax_total": "0.00",
-          "meta_data": []
         }
       ],
       "refunds": [

--- a/example/src/androidTest/resources/wc-orders-response-success.json
+++ b/example/src/androidTest/resources/wc-orders-response-success.json
@@ -83,7 +83,8 @@
           "compound": false,
           "tax_total": "1.35",
           "shipping_tax_total": "0.00",
-          "meta_data": []
+          "meta_data": [],
+          "rate_percent": 5.25
         }
       ],
       "fee_lines": [

--- a/example/src/androidTest/resources/wc-orders-response-success.json
+++ b/example/src/androidTest/resources/wc-orders-response-success.json
@@ -249,6 +249,7 @@
           "id": 318,
           "rate_code": "US-CA-STATE TAX",
           "rate_id": 75,
+          "label": "State Tax",
           "compound": false,
           "tax_total": "1.35",
           "shipping_tax_total": "0.00",

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 169
+        return 168
     }
 
     override fun getDbName(): String {
@@ -1834,9 +1834,6 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 168 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD PURCHASABLE INTEGER")
-                }
-                169 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("ALTER TABLE WCOrderModel ADD TAX_LINES TEXT")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1836,7 +1836,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE WCProductModel ADD PURCHASABLE INTEGER")
                 }
                 169 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("ALTER TABLE WCOrderModel ADD TAX_LINES TEXT")
+                    db.execSQL("DROP TABLE IF EXISTS WCOrderModel")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 168
+        return 169
     }
 
     override fun getDbName(): String {
@@ -1833,8 +1833,11 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("DROP TABLE IF EXISTS WCOrderModel")
                 }
                 168 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                db.execSQL("ALTER TABLE WCProductModel ADD PURCHASABLE INTEGER")
-            }
+                    db.execSQL("ALTER TABLE WCProductModel ADD PURCHASABLE INTEGER")
+                }
+                169 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCOrderModel ADD TAX_LINES TEXT")
+                }
             }
         }
         db.setTransactionSuccessful()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1836,7 +1836,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE WCProductModel ADD PURCHASABLE INTEGER")
                 }
                 169 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("DROP TABLE IF EXISTS WCOrderModel")
+                    db.execSQL("ALTER TABLE WCOrderModel ADD TAX_LINES TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderModel.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.order.FeeLine
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.ShippingLine
+import org.wordpress.android.fluxc.model.order.TaxLine
 import java.math.BigDecimal
 import kotlin.DeprecationLevel.ERROR
 
@@ -74,6 +75,7 @@ data class WCOrderModel(
     val lineItems: String = "",
     val shippingLines: String = "",
     val feeLines: String = "",
+    val taxLines: String = "",
     val metaData: String = ""
 ) {
     companion object {
@@ -128,6 +130,14 @@ data class WCOrderModel(
     fun getFeeLineList(): List<FeeLine> {
         val responseType = object : TypeToken<List<FeeLine>>() {}.type
         return gson.fromJson(feeLines, responseType) as? List<FeeLine> ?: emptyList()
+    }
+
+    /**
+     * Deserializes the JSON contained in [taxLines] into a list of [TaxLine] objects.
+     */
+    fun getTaxLineList(): List<TaxLine> {
+        val responseType = object : TypeToken<List<TaxLine>>() {}.type
+        return gson.fromJson(taxLines, responseType) as? List<TaxLine> ?: emptyList()
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/TaxLine.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/TaxLine.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.model.order
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a tax line
+ */
+class TaxLine {
+    @SerializedName("id")
+    val id: Long? = null
+
+    @SerializedName("rate_code")
+    val rateCode: String? = null
+
+    @SerializedName("rate_id")
+    val rateId: Long? = null
+
+    @SerializedName("compound")
+    val compound: Boolean? = null
+
+    @SerializedName("tax_total")
+    val taxTotal: String? = null
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/TaxLine.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/TaxLine.kt
@@ -12,6 +12,9 @@ class TaxLine {
     @SerializedName("rate_code")
     val rateCode: String? = null
 
+    @SerializedName("label")
+    val label: String? = null
+
     @SerializedName("rate_id")
     val rateId: Long? = null
 
@@ -20,4 +23,7 @@ class TaxLine {
 
     @SerializedName("tax_total")
     val taxTotal: String? = null
+
+    @SerializedName("shipping_tax_total")
+    val shippingTaxTotal: String? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/TaxLine.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/TaxLine.kt
@@ -9,14 +9,17 @@ class TaxLine {
     @SerializedName("id")
     val id: Long? = null
 
+    @SerializedName("rate_id")
+    val rateId: Long? = null
+
     @SerializedName("rate_code")
     val rateCode: String? = null
 
+    @SerializedName("rate_percent")
+    val ratePercent: Float? = null
+
     @SerializedName("label")
     val label: String? = null
-
-    @SerializedName("rate_id")
-    val rateId: Long? = null
 
     @SerializedName("compound")
     val compound: Boolean? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
@@ -74,6 +74,7 @@ class OrderDto : Response {
     val total: String? = null
     val total_tax: String? = null
     val meta_data: JsonElement? = null
+    val tax_lines: JsonElement? = null
 }
 
 fun OrderDto.toDomainModel(localSiteId: LocalId): WCOrderModel {
@@ -131,6 +132,7 @@ fun OrderDto.toDomainModel(localSiteId: LocalId): WCOrderModel {
             lineItems = this.line_items.toString(),
             shippingLines = this.shipping_lines.toString(),
             feeLines = this.fee_lines.toString(),
+            taxLines = this.tax_lines.toString(),
             metaData = this.meta_data.toString()
     )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -985,6 +985,7 @@ class OrderRestClient @Inject constructor(
                 "date_paid_gmt",
                 "discount_total",
                 "fee_lines",
+                "tax_lines",
                 "id",
                 "line_items",
                 "number",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -18,9 +18,10 @@ import org.wordpress.android.fluxc.persistence.entity.GlobalAddonGroupEntity
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_6_7
 
 @Database(
-        version = 6,
+        version = 7,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,
@@ -50,6 +51,7 @@ abstract class WCAndroidDatabase : RoomDatabase() {
                 .addMigrations(MIGRATION_3_4)
                 .addMigrations(MIGRATION_4_5)
                 .addMigrations(MIGRATION_5_6)
+                .addMigrations(MIGRATION_6_7)
                 .build()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.persistence.entity.GlobalAddonGroupEntity
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
-import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_6_7
 
 @Database(
         version = 7,
@@ -51,7 +50,6 @@ abstract class WCAndroidDatabase : RoomDatabase() {
                 .addMigrations(MIGRATION_3_4)
                 .addMigrations(MIGRATION_4_5)
                 .addMigrations(MIGRATION_5_6)
-                .addMigrations(MIGRATION_6_7)
                 .build()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
 
 @Database(
-        version = 7,
+        version = 6,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
 
 @Database(
-        version = 6,
+        version = 7,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -142,6 +142,6 @@ internal val MIGRATION_5_6 = object : Migration(5, 6) {
 
 internal val MIGRATION_6_7 = object : Migration(6, 7) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE WCOrderModel ADD TAX_LINES TEXT")
+        database.execSQL("ALTER TABLE OrderEntity ADD TAX_LINES TEXT")
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -139,3 +139,9 @@ internal val MIGRATION_5_6 = object : Migration(5, 6) {
         }
     }
 }
+
+internal val MIGRATION_6_7 = object : Migration(6, 7) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE WCOrderModel ADD TAX_LINES TEXT")
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -139,9 +139,3 @@ internal val MIGRATION_5_6 = object : Migration(5, 6) {
         }
     }
 }
-
-internal val MIGRATION_6_7 = object : Migration(6, 7) {
-    override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE OrderEntity ADD TAX_LINES TEXT")
-    }
-}


### PR DESCRIPTION
Closes #2252 - This PR adds support for fetching and parsing `tax_lines` in the order model. For a description of why this is necessary, please refer to [this WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/5731).