### PR TITLE
Fallback to destructive migration for 1 and 2 db versions

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -44,6 +44,7 @@ abstract class WCAndroidDatabase : RoomDatabase() {
                 "wc-android-database"
         ).allowMainThreadQueries()
                 .fallbackToDestructiveMigrationOnDowngrade()
+                .fallbackToDestructiveMigrationFrom(1, 2)
                 .addMigrations(MIGRATION_3_4)
                 .addMigrations(MIGRATION_4_5)
                 .build()


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce-android/issues/5754

### Context

p1643197580193900-slack-C6H8C3G23

TLDR; we're missing database schemas and migrations, so migrating from e.g. version `1` to `5` of database causes crash.

### Relations between WooCommerce vs FluxC vs Room Database versions

In order to fully understand issue and prepare the robust solution, I've decided to backtrace how those version relate to each other. The result is: 

| WooCommerce | FluxC used in WooCommerce                | Room database | Room integrity hash |
|-------------|------------------------------------------|---------------|---------------------|
| 8.3         | 1.33.0                                   | 5             |           -          |
| 8.2         | 1.32.0                                   | 3             |             -        |
| 8.1.1       | 1.31.0                                   | 3             |               -      |
| 8.1         | 1.31.0                                   | 3             |                 -    |
| 8.0         | 4823726ffc80ce39039ea58ca6b5c0de679eb468 | 3             |                   -  |
| 7.9         | 1.29.0                                   | 3             |                   -  |
| 7.8         | 1.28.0                                   | 3             |                   -  |
| 7.7         | 1.27.0                                   | 3             |                   -  |
| 7.6.1       | 1.26.0                                   | 3             |                  -   |
| 7.6         | 1.26.0                                   | 3             |                   -  |
| 7.5         | 1.25.0                                   | 1             |  **1c7da575bae4649a823927048ff38aff**                   |
| 7.4         | 1.24.0                                   | 1             | **eceebb52d47d1f2b24d50aa08a6a2f5c**         |
| 7.3.1       | 1.23.0                                   | no room       | n/a                 |

### Solutions

#### Solution A - Add `1.json` schema and provide `MIGRATION_1_3`

The challenge in this solution is to determine which `1.json` we should add. As you can see, unfortunately we released Woo with two different db schemes marked with the same version: `1`. The difference in between Add-on entities so I'm pretty sure it's me who messed this. It didn't backfire us on release as we had `fallbackToDestructiveMigration` option enabled so the database just recreated itself. 

POC for Solution A: https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/woo/5754_provide_all_migrations

#### Solution B - use [`fallbackToDestructiveMigrationFrom`](https://developer.android.com/reference/android/arch/persistence/room/RoomDatabase.Builder#fallbacktodestructivemigrationfrom)

Thankfully, `Room` provides a solution that should satisfy all scenarios. We can use `fallbackToDestructiveMigrationFrom` and determine to which starting point we're providing destructive migration. 

In other words, the destructive migration will only run for specific version of database which should resolve (very valid) concern @malinajirka you had about:

> The risk of forgetting to remove that line when we use the db for non-cache data could be fatal.

I think Solution B will fit as better as it's 1) simpler 2) doesn't force us to specify `1.json`

### Testing

#### Reproduction

Please start with reproduction so we're on the same page.

1. Apply `PATCH`
1. Remove `example` app
2. Checkout a471f62 (version `1.24.0`)
3. Install app
4. Run app. Check if `wc-android-database` is visible in App Inspector
4. Checkout `develop`
5. Install app
6. Run app. **Assert that app crashed with `A migration from 1 to 5 was required but not found.`**

#### Test fix
1. Apply `PATCH`
1. Remove `example` app
2. Checkout a471f62 (version `1.24.0`)
3. Install app
4. Run app. Check if `wc-android-database` is visible in App Inspector
4. Checkout `woo/5754_fallback_from_1_and_2`
5. Install app
6. Run app. **Assert there's no crash**


### Appendix


<details>
  <summary>`PATCH` for testing</summary>
  
 ```
Index: example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt	(revision a471f6245ea15181c3463a1892a3a586ac546c83)
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainExampleActivity.kt	(date 1643731047683)
@@ -10,10 +10,15 @@
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import kotlinx.android.synthetic.main.activity_example.*
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.persistence.dao.AddonsDao
 import javax.inject.Inject
 
 class MainExampleActivity : AppCompatActivity(), OnBackStackChangedListener, HasAndroidInjector {
     @Inject lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Any>
+    @Inject lateinit var addonsDao: AddonsDao
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
@@ -32,6 +37,9 @@
         prependToLog("I'll log stuff here.")
 
         updateBackArrow()
+        GlobalScope.launch {
+            addonsDao.observeGlobalAddonsForSite(0).first { true }
+        }
     }
 
     fun prependToLog(s: String) {
```
</details>

