### PR TITLE
Npe site.username must not be null

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -122,7 +122,7 @@ class SiteRestClientTest {
 
         initSitesResponse(data = sitesResponse)
 
-        val responseModel = restClient.fetchSites(listOf(WPCOM))
+        val responseModel = restClient.fetchSites(listOf(WPCOM), false)
         assertThat(responseModel.sites).hasSize(1)
         assertThat(responseModel.sites[0].name).isEqualTo(name)
         assertThat(responseModel.sites[0].siteId).isEqualTo(siteId)
@@ -140,6 +140,26 @@ class SiteRestClientTest {
     }
 
     @Test
+    fun `fetched sites can filter JP connected package sites`() = test {
+        val response = SiteWPComRestResponse()
+        response.ID = siteId
+        val name = "Updated name"
+        response.name = name
+        response.URL = "site.com"
+        response.jetpack = false
+        response.jetpack_connection = true
+
+        val sitesResponse = SitesResponse()
+        sitesResponse.sites = listOf(response)
+
+        initSitesResponse(data = sitesResponse)
+
+        val responseModel = restClient.fetchSites(listOf(WPCOM), true)
+
+        assertThat(responseModel.sites).hasSize(0)
+    }
+
+    @Test
     fun `fetchSites returns error when API call fails`() = test {
         val errorMessage = "message"
         initSitesResponse(
@@ -151,7 +171,7 @@ class SiteRestClientTest {
                         )
                 )
         )
-        val errorResponse = restClient.fetchSites(listOf())
+        val errorResponse = restClient.fetchSites(listOf(), false)
 
         assertThat(errorResponse.error).isNotNull()
         assertThat(errorResponse.error.type).isEqualTo(GenericErrorType.NETWORK_ERROR)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -137,7 +137,7 @@ class SiteStoreTest {
         val siteA = SiteModel()
         val siteB = SiteModel()
         sitesModel.sites = listOf(siteA, siteB)
-        whenever(siteRestClient.fetchSites(payload.filters)).thenReturn(sitesModel)
+        whenever(siteRestClient.fetchSites(payload.filters, false)).thenReturn(sitesModel)
         whenever(siteSqlUtils.insertOrUpdateSite(siteA)).thenReturn(1)
         whenever(siteSqlUtils.insertOrUpdateSite(siteB)).thenReturn(1)
 
@@ -156,7 +156,7 @@ class SiteStoreTest {
         val payload = FetchSitesPayload(listOf(WPCOM))
         val sitesModel = SitesModel()
         sitesModel.error = BaseNetworkError(PARSE_ERROR)
-        whenever(siteRestClient.fetchSites(payload.filters)).thenReturn(sitesModel)
+        whenever(siteRestClient.fetchSites(payload.filters, false)).thenReturn(sitesModel)
 
         val onSiteChanged = siteStore.fetchSites(payload)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -126,7 +126,7 @@ class SiteRestClient @Inject constructor(
         val site: SiteModel? = null
     ) : Payload<SiteError>()
 
-    suspend fun fetchSites(filters: List<SiteFilter?>): SitesModel {
+    suspend fun fetchSites(filters: List<SiteFilter?>, filterJetpackConnectedPackageSite: Boolean): SitesModel {
         val params = getFetchSitesParams(filters)
         val url = WPCOMREST.me.sites.urlV1_2
         val response = wpComGsonRequestBuilder.syncGetRequest(this, url, params, SitesResponse::class.java)
@@ -134,7 +134,10 @@ class SiteRestClient @Inject constructor(
             is Success -> {
                 val siteArray = mutableListOf<SiteModel>()
                 for (siteResponse in response.data.sites) {
-                    siteArray.add(siteResponseToSiteModel(siteResponse))
+                    val siteModel = siteResponseToSiteModel(siteResponse)
+                    // see https://github.com/wordpress-mobile/WordPress-Android/issues/15540#issuecomment-993752880
+                    if (filterJetpackConnectedPackageSite && siteModel.isJetpackCPConnected) continue
+                    siteArray.add(siteModel)
                 }
                 SitesModel(siteArray)
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -141,7 +141,10 @@ open class SiteStore
         @JvmField var url: String = ""
     ) : Payload<BaseNetworkError>()
 
-    data class FetchSitesPayload(@JvmField val filters: List<SiteFilter> = ArrayList()) : Payload<BaseNetworkError>()
+    data class FetchSitesPayload @JvmOverloads constructor(
+        @JvmField val filters: List<SiteFilter> = ArrayList(),
+        @JvmField val filterJetpackConnectedPackageSite: Boolean = false
+    ) : Payload<BaseNetworkError>()
 
     data class NewSitePayload(
         @JvmField val siteName: String,
@@ -1274,7 +1277,7 @@ open class SiteStore
 
     suspend fun fetchSites(payload: FetchSitesPayload): OnSiteChanged {
         return coroutineEngine.withDefaultContext(T.API, this, "Fetch sites") {
-            val result = siteRestClient.fetchSites(payload.filters)
+            val result = siteRestClient.fetchSites(payload.filters, payload.filterJetpackConnectedPackageSite)
             handleFetchedSitesWPComRest(result)
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/15540 and adds the possibility for the fetchSites of the rest client to filter out jetpack package connected sites (filtering disabled by default).

Woo mobile should not be affected AFAIU since they have their own `fetchWooCommerceSites` in `WooCommerceStore` that will continue to use the default false value for the `filterJetpackConnectedPackageSite` (cc @hichamboushaba for a doucle check, thanks! 🙇 )

This has a companion PR in https://github.com/wordpress-mobile/WordPress-Android/pull/15895 , you can use that PR to test here.

