### PR TITLE
Fix WellSql's DB version number

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 168
+        return 169
     }
 
     override fun getDbName(): String {


### PR DESCRIPTION
The last two migrations of WellSql had a wrong version number, where it's lower than its expected value by 1, this is causing an issue for future migrations, where the migration code might be executed twice.
Today while I tried adding a migration, I ran into this exception:
```     
Caused by: android.database.sqlite.SQLiteException: duplicate column name: PURCHASABLE (code 1 SQLITE_ERROR): , while compiling: ALTER TABLE WCProductModel ADD PURCHASABLE INTEGER
```

So I'm writing this small PR to avoid shipping the broken version into the next code freeze.