### PR TITLE
Add timezone option parameter to site creation request

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -167,13 +167,13 @@ public class SitesFragment extends Fragment {
     }
 
     private void newSiteAction(String name) {
-        // Default language "en" (english)
-        // Default time zone "Europe/London" (GMT)
+        String defaultLanguage = "en";
+        String defaultTimeZoneId = "Europe/London";
 
         NewSitePayload newSitePayload = new NewSitePayload(
                 name,
-                "en",
-                "Europe/London",
+                defaultLanguage,
+                defaultTimeZoneId,
                 SiteVisibility.PUBLIC,
                 true);
         mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload));

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -168,7 +168,14 @@ public class SitesFragment extends Fragment {
 
     private void newSiteAction(String name) {
         // Default language "en" (english)
-        NewSitePayload newSitePayload = new NewSitePayload(name, "en", SiteVisibility.PUBLIC, true);
+        // Default time zone "Europe/London" (GMT)
+
+        NewSitePayload newSitePayload = new NewSitePayload(
+                name,
+                "en",
+                "Europe/London",
+                SiteVisibility.PUBLIC,
+                true);
         mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload));
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -177,8 +177,9 @@ class SiteRestClientTest {
         val visibility = PUBLIC
         val segmentId = 123L
         val siteDesign = "design"
+        val timeZoneId = "Europe/London"
 
-        val result = restClient.newSite(siteName, language, visibility, segmentId, siteDesign, dryRun)
+        val result = restClient.newSite(siteName, language, timeZoneId, visibility, segmentId, siteDesign, dryRun)
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
         assertThat(result.dryRun).isEqualTo(dryRun)
@@ -193,7 +194,11 @@ class SiteRestClientTest {
                         "validate" to "0",
                         "client_id" to appId,
                         "client_secret" to appSecret,
-                        "options" to mapOf<String, Any>("site_segment" to segmentId, "template" to siteDesign)
+                        "options" to mapOf<String, Any>(
+                                "site_segment" to segmentId,
+                                "template" to siteDesign,
+                                "timezone_string" to timeZoneId
+                        )
                 )
         )
     }
@@ -215,8 +220,9 @@ class SiteRestClientTest {
         val siteName = "Site name"
         val language = "CZ"
         val visibility = SiteVisibility.PRIVATE
+        val timeZoneId = "Europe/London"
 
-        val result = restClient.newSite(siteName, language, visibility, null, null, dryRun)
+        val result = restClient.newSite(siteName, language, timeZoneId, visibility, null, null, dryRun)
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
         assertThat(result.dryRun).isEqualTo(dryRun)
@@ -230,7 +236,8 @@ class SiteRestClientTest {
                         "public" to "-1",
                         "validate" to "1",
                         "client_id" to appId,
-                        "client_secret" to appSecret
+                        "client_secret" to appSecret,
+                        "options" to mapOf<String, Any>("timezone_string" to timeZoneId)
                 )
         )
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -168,13 +168,14 @@ class SiteStoreTest {
     @Test
     fun `creates a new site`() = test {
         val dryRun = false
-        val payload = NewSitePayload("New site", "CZ", PUBLIC, dryRun)
+        val payload = NewSitePayload("New site", "CZ", "Europe/London", PUBLIC, dryRun)
         val newSiteRemoteId: Long = 123
         val response = NewSiteResponsePayload(newSiteRemoteId, dryRun)
         whenever(
                 siteRestClient.newSite(
                         payload.siteName,
                         payload.language,
+                        payload.timeZoneId,
                         payload.visibility,
                         null,
                         null,
@@ -191,7 +192,7 @@ class SiteStoreTest {
     @Test
     fun `fails to create a new site`() = test {
         val dryRun = false
-        val payload = NewSitePayload("New site", "CZ", PUBLIC, dryRun)
+        val payload = NewSitePayload("New site", "CZ", "Europe/London", PUBLIC, dryRun)
         val response = NewSiteResponsePayload()
         val newSiteError = NewSiteError(SITE_NAME_INVALID, "Site name invalid")
         response.error = newSiteError
@@ -199,6 +200,7 @@ class SiteStoreTest {
                 siteRestClient.newSite(
                         payload.siteName,
                         payload.language,
+                        payload.timeZoneId,
                         payload.visibility,
                         null,
                         null,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -179,6 +179,7 @@ class SiteRestClient @Inject constructor(
     suspend fun newSite(
         siteName: String,
         language: String,
+        timeZoneId: String?,
         visibility: SiteVisibility,
         segmentId: Long?,
         siteDesign: String?,
@@ -201,6 +202,10 @@ class SiteRestClient @Inject constructor(
         if (siteDesign != null) {
             options["template"] = siteDesign
         }
+        if (timeZoneId != null) {
+            options["timezone_string"] = timeZoneId
+        }
+
         if (options.isNotEmpty()) {
             body["options"] = options
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -156,6 +156,21 @@ open class SiteStore
         constructor(
             siteName: String,
             language: String,
+            visibility: SiteVisibility,
+            dryRun: Boolean
+        ) : this(siteName, language, null, visibility, null, null, dryRun)
+
+        constructor(
+            siteName: String,
+            language: String,
+            visibility: SiteVisibility,
+            segmentId: Long?,
+            dryRun: Boolean
+        ) : this(siteName, language, null, visibility, segmentId, null, dryRun)
+
+        constructor(
+            siteName: String,
+            language: String,
             timeZoneId: String,
             visibility: SiteVisibility,
             dryRun: Boolean

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -156,21 +156,6 @@ open class SiteStore
         constructor(
             siteName: String,
             language: String,
-            visibility: SiteVisibility,
-            dryRun: Boolean
-        ) : this(siteName, language, null, visibility, null, null, dryRun)
-
-        constructor(
-            siteName: String,
-            language: String,
-            visibility: SiteVisibility,
-            segmentId: Long?,
-            dryRun: Boolean
-        ) : this(siteName, language, null, visibility, segmentId, null, dryRun)
-
-        constructor(
-            siteName: String,
-            language: String,
             timeZoneId: String,
             visibility: SiteVisibility,
             dryRun: Boolean

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.store
 
 import android.text.TextUtils
+import androidx.annotation.VisibleForTesting
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.ASYNC
 import org.wordpress.android.fluxc.Dispatcher
@@ -1450,6 +1451,7 @@ open class SiteStore
         return rowsAffected
     }
 
+    @VisibleForTesting
     suspend fun createNewSite(payload: NewSitePayload): OnNewSiteCreated {
         val result = siteRestClient.newSite(
                 payload.siteName,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -146,6 +146,7 @@ open class SiteStore
     data class NewSitePayload(
         @JvmField val siteName: String,
         @JvmField val language: String,
+        @JvmField val timeZoneId: String?,
         @JvmField val visibility: SiteVisibility,
         @JvmField val segmentId: Long? = null,
         @JvmField val siteDesign: String? = null,
@@ -154,6 +155,7 @@ open class SiteStore
         constructor(siteName: String, language: String, visibility: SiteVisibility, dryRun: Boolean) : this(
                 siteName,
                 language,
+                null,
                 visibility,
                 null,
                 null,
@@ -166,7 +168,15 @@ open class SiteStore
             visibility: SiteVisibility,
             segmentId: Long?,
             dryRun: Boolean
-        ) : this(siteName, language, visibility, segmentId, null, dryRun)
+        ) : this(siteName, language, null, visibility, segmentId, null, dryRun)
+
+        constructor(
+            siteName: String,
+            language: String,
+            timeZoneId: String,
+            visibility: SiteVisibility,
+            dryRun: Boolean
+        ) : this(siteName, language, timeZoneId, visibility, null, null, dryRun)
     }
 
     data class FetchedPostFormatsPayload(
@@ -1442,8 +1452,13 @@ open class SiteStore
 
     suspend fun createNewSite(payload: NewSitePayload): OnNewSiteCreated {
         val result = siteRestClient.newSite(
-                payload.siteName, payload.language, payload.visibility,
-                payload.segmentId, payload.siteDesign, payload.dryRun
+                payload.siteName,
+                payload.language,
+                payload.timeZoneId,
+                payload.visibility,
+                payload.segmentId,
+                payload.siteDesign,
+                payload.dryRun
         )
         return handleCreateNewSiteCompleted(
                 payload = result

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -153,15 +153,12 @@ open class SiteStore
         @JvmField val siteDesign: String? = null,
         @JvmField val dryRun: Boolean
     ) : Payload<BaseNetworkError>() {
-        constructor(siteName: String, language: String, visibility: SiteVisibility, dryRun: Boolean) : this(
-                siteName,
-                language,
-                null,
-                visibility,
-                null,
-                null,
-                dryRun
-        )
+        constructor(
+            siteName: String,
+            language: String,
+            visibility: SiteVisibility,
+            dryRun: Boolean
+        ) : this(siteName, language, null, visibility, null, null, dryRun)
 
         constructor(
             siteName: String,


### PR DESCRIPTION
# Add timezone option parameter to site creation request
Fixes [#14400 Site timezone defaults to UTC instead of user timezone](https://github.com/wordpress-mobile/WordPress-Android/issues/14400)

## Description

Adds the possibility to specify the time zone programatically for sites created via the WP.com REST API.
The changes enable projects that depend on `WordPress-Flux-Android` to create WP.com sites in the time zone of the device.

Before this change, the default time zone of a new site was always UTC, which caused issues with posts that are scheduled to publish in the future.

**Related:**
- Integrated in [WordPress-Android PR # 15904](https://github.com/wordpress-mobile/WordPress-Android/pull/15904)

## To Test

I've updated existing unit tests to assert on the value of the `options.timezone_string` property inside the payload for site creation requests to the WP.com REST API.

**See changes in the following tests:**
- `SiteRestClientTest`
	- `creates new site without params with dry run`
	- `creates new site with all params`

**Integration**
- Integration can be tested with the [WordPress-Android PR # 15904](https://github.com/wordpress-mobile/WordPress-Android/pull/15904).
