### PR TITLE
woo/update-order-public

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -214,7 +214,7 @@ class OrderUpdateStore @Inject internal constructor(
         }
     }
 
-    private suspend fun updateOrder(
+    suspend fun updateOrder(
         site: SiteModel,
         orderId: Long,
         updateRequest: UpdateOrderRequest


### PR DESCRIPTION
This PR corrects a mistake made in #2267 which changed `updateOrder` to private.