### PR TITLE
woo/simple-payment-billing-fix

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -148,19 +148,24 @@ class OrderUpdateStore @Inject internal constructor(
                 }
                 emit(UpdateOrderResult.OptimisticUpdateResult(OnOrderChanged()))
 
-                val billing = Billing(
-                    email = billingEmail,
-                    firstName = "",
-                    lastName = "",
-                    company = "",
-                    address1 = "",
-                    address2 = "",
-                    city = "",
-                    state = "",
-                    postcode = "",
-                    country = "",
-                    phone = ""
-                )
+                val billing = if (billingEmail.isNotEmpty()) {
+                    Billing(
+
+                            email = billingEmail,
+                            firstName = "",
+                            lastName = "",
+                            company = "",
+                            address1 = "",
+                            address2 = "",
+                            city = "",
+                            state = "",
+                            postcode = "",
+                            country = "",
+                            phone = ""
+                    )
+                } else {
+                    null
+                }
 
                 val updateRequest = UpdateOrderRequest(
                     customerNote = customerNote,


### PR DESCRIPTION
This small PR corrects a bug that sends an empty billing model when creating a simple payment without an email address. This causes the `POST` to fail with "Invalid parameter(s): billing." The fix is to skip sending a billing model if the email address is empty.