### PR TITLE
Migrate newUpdateProductReviewStatusAction to a suspend function 

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResp
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteDeleteProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductSkuAvailabilityPayload
@@ -492,20 +491,15 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testUpdateProductReviewStatusSuccess() {
+    fun testUpdateProductReviewStatusSuccess() = runBlocking{
         interceptor.respondWith("wc-update-product-review-response-success.json")
-        productRestClient.updateProductReviewStatus(siteModel, 0, "spam")
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        val result = productRestClient.updateProductReviewStatus(siteModel, 0, "spam")
 
-        assertEquals(WCProductAction.UPDATED_PRODUCT_REVIEW_STATUS, lastAction!!.type)
 
-        // Verify payload and product review properties
-        val payload = lastAction!!.payload as RemoteProductReviewPayload
-        assertFalse(payload.isError)
-        assertEquals(siteModel.id, payload.site.id)
-        payload.productReview?.let {
+        assertFalse(result.isError)
+        assertEquals(siteModel.id, result.site.id)
+        result.productReview?.let {
             with(it) {
                 assertEquals(5499, remoteProductReviewId)
                 assertEquals("2019-07-09T15:48:07Z", dateCreated)
@@ -522,17 +516,13 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testUpdateProductReviewStatusFailed() {
+    fun testUpdateProductReviewStatusFailed() = runBlocking {
         interceptor.respondWithError("wc-response-failure-invalid-param.json")
-        productRestClient.updateProductReviewStatus(siteModel, 0, "spam")
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        val result = productRestClient.updateProductReviewStatus(siteModel, 0, "spam")
 
-        assertEquals(WCProductAction.UPDATED_PRODUCT_REVIEW_STATUS, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteProductReviewPayload
-        assertTrue(payload.isError)
-        assertEquals(ProductErrorType.INVALID_PARAM, payload.error.type)
+        assertTrue(result.isError)
+        assertEquals(ProductErrorType.INVALID_PARAM, result.error.type)
     }
 
     private fun generateTestImageList(): List<WCProductImageModel> {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -491,11 +491,10 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testUpdateProductReviewStatusSuccess() = runBlocking{
+    fun testUpdateProductReviewStatusSuccess() = runBlocking {
         interceptor.respondWith("wc-update-product-review-response-success.json")
 
         val result = productRestClient.updateProductReviewStatus(siteModel, 0, "spam")
-
 
         assertFalse(result.isError)
         assertEquals(siteModel.id, result.site.id)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -512,6 +512,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
                 assertEquals(3, reviewerAvatarUrlBySize.size)
             }
         }
+        Unit
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -426,15 +426,13 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
         // Update review status to spam - should get deleted from db
         review?.let {
-            val newStatus = "spam"
-            nextEvent = TestEvent.UPDATED_PRODUCT_REVIEW_STATUS
-            mCountDownLatch = CountDownLatch(1)
-            mDispatcher.dispatch(
-                    WCProductActionBuilder.newUpdateProductReviewStatusAction(
-                            UpdateProductReviewStatusPayload(sSite, review.remoteProductReviewId, newStatus)
-                    )
+            val payload = WCProductStore.UpdateProductReviewStatusPayload(
+                    sSite,
+                    remoteProductReviewId,
+                    newStatus = "spam"
             )
-            assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+            productStore.updateProductReviewStatus(payload)
 
             // Verify results - review should be deleted from db
             val savedReview = productStore
@@ -442,17 +440,20 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
             assertNull(savedReview)
         }
 
+
+
+
+
         // Update review status to approved - should get added to db
         review?.let {
             val newStatus = "approved"
-            nextEvent = TestEvent.UPDATED_PRODUCT_REVIEW_STATUS
-            mCountDownLatch = CountDownLatch(1)
-            mDispatcher.dispatch(
-                    WCProductActionBuilder.newUpdateProductReviewStatusAction(
-                            UpdateProductReviewStatusPayload(sSite, review.remoteProductReviewId, newStatus)
-                    )
+            val payload = WCProductStore.UpdateProductReviewStatusPayload(
+                    sSite,
+                    remoteProductReviewId,
+                    newStatus = newStatus
             )
-            assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+            productStore.updateProductReviewStatus(payload)
 
             // Verify results
             val savedReview = productStore
@@ -464,14 +465,13 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         // Update review status to trash - should get deleted from db
         review?.let {
             val newStatus = "trash"
-            nextEvent = TestEvent.UPDATED_PRODUCT_REVIEW_STATUS
-            mCountDownLatch = CountDownLatch(1)
-            mDispatcher.dispatch(
-                    WCProductActionBuilder.newUpdateProductReviewStatusAction(
-                            UpdateProductReviewStatusPayload(sSite, review.remoteProductReviewId, newStatus)
-                    )
+            val payload = WCProductStore.UpdateProductReviewStatusPayload(
+                    sSite,
+                    remoteProductReviewId,
+                    newStatus = newStatus
             )
-            assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+
+            productStore.updateProductReviewStatus(payload)
 
             // Verify results - review should be deleted from db
             val savedReview = productStore

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -440,10 +440,6 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
             assertNull(savedReview)
         }
 
-
-
-
-
         // Update review status to approved - should get added to db
         review?.let {
             val newStatus = "approved"

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_TAGS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_VARIATIONS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_SHIPPING_CLASS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_VARIATION
-import org.wordpress.android.fluxc.action.WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
@@ -485,9 +484,6 @@ class WooProductsFragment : StoreSelectingFragment() {
                         pendingFetchSingleProductVariationOffset = 0
                         load_more_product_variations.isEnabled = false
                     }
-                }
-                UPDATE_PRODUCT_REVIEW_STATUS -> {
-                    prependToLog("${event.rowsAffected} product reviews updated")
                 }
                 DELETED_PRODUCT -> {
                     prependToLog("${event.rowsAffected} product deleted")

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -39,7 +39,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductReviewStatusPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateVariationPayload;
 
 @ActionEnum
@@ -57,8 +56,6 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = FetchSingleProductShippingClassPayload.class)
     FETCH_SINGLE_PRODUCT_SHIPPING_CLASS,
-    @Action(payloadType = UpdateProductReviewStatusPayload.class)
-    UPDATE_PRODUCT_REVIEW_STATUS,
     @Action(payloadType = UpdateProductImagesPayload.class)
     UPDATE_PRODUCT_IMAGES,
     @Action(payloadType = UpdateProductPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient.TaxClassApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
@@ -1075,7 +1074,11 @@ class ProductRestClient @Inject constructor(
      * @param [remoteReviewId] The remote ID of the product review to be updated
      * @param [newStatus] The new status to update the product review to
      */
-    suspend fun updateProductReviewStatus(site: SiteModel, remoteReviewId: Long, newStatus: String):RemoteProductReviewPayload{
+    suspend fun updateProductReviewStatus(
+        site: SiteModel,
+        remoteReviewId: Long,
+        newStatus: String
+    ): RemoteProductReviewPayload {
         val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
         val responseType = object : TypeToken<ProductReviewApiResponse>() {}.type
         val params = mapOf("status" to newStatus)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1069,44 +1069,13 @@ class ProductRestClient @Inject constructor(
      * Makes a PUT call to `/wc/v3/products/reviews/<id>` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * updating the status for the given product review to [newStatus].
      *
-     * Dispatches a [WCProductAction.UPDATED_PRODUCT_REVIEW_STATUS]
+     * returns  a [RemoteProductReviewPayload]
      *
      * @param [site] The site to fetch product reviews for
      * @param [remoteReviewId] The remote ID of the product review to be updated
      * @param [newStatus] The new status to update the product review to
      */
-    fun updateProductReviewStatus(site: SiteModel, remoteReviewId: Long, newStatus: String) {
-        val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
-        val responseType = object : TypeToken<ProductReviewApiResponse>() {}.type
-        val params = mapOf("status" to newStatus)
-        val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, params, responseType,
-                { response: ProductReviewApiResponse? ->
-                    response?.let {
-                        val review = productReviewResponseToProductReviewModel(response).apply {
-                            localSiteId = site.id
-                        }
-                        val payload = RemoteProductReviewPayload(site, review)
-                        dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductReviewStatusAction(payload))
-                    }
-                },
-                { networkError ->
-                    val productReviewError = networkErrorToProductError(networkError)
-                    val payload = RemoteProductReviewPayload(productReviewError, site)
-                    dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductReviewStatusAction(payload))
-                })
-        add(request)
-    }
-    /**
-     * Makes a PUT call to `/wc/v3/products/reviews/<id>` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * updating the status for the given product review to [newStatus].
-     *
-     * returns  a [WCProductAction.UPDATED_PRODUCT_REVIEW_STATUS]
-     *
-     * @param [site] The site to fetch product reviews for
-     * @param [remoteReviewId] The remote ID of the product review to be updated
-     * @param [newStatus] The new status to update the product review to
-     */
-    suspend fun updateProductReviewStatusSuspend(site: SiteModel, remoteReviewId: Long, newStatus: String):RemoteProductReviewPayload{
+    suspend fun updateProductReviewStatus(site: SiteModel, remoteReviewId: Long, newStatus: String):RemoteProductReviewPayload{
         val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
         val responseType = object : TypeToken<ProductReviewApiResponse>() {}.type
         val params = mapOf("status" to newStatus)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1119,16 +1119,19 @@ class ProductRestClient @Inject constructor(
         )
         return when (response) {
             is JetpackSuccess -> {
-                val review = response.data?.let{
-                    productReviewResponseToProductReviewModel(it).apply {
+                response.data?.let {
+                    val review = productReviewResponseToProductReviewModel(it).apply {
                         localSiteId = site.id
                     }
-                }
-                RemoteProductReviewPayload(site,review)
+                    RemoteProductReviewPayload(site, review)
+                } ?: RemoteProductReviewPayload(
+                        error = ProductError(GENERIC_ERROR, "Success response with empty data"),
+                        site = site
+                )
             }
             is JetpackError -> {
-                val productError = networkErrorToProductError(response.error)
-                RemoteProductReviewPayload(productError, site)
+                val productReviewError = networkErrorToProductError(response.error)
+                RemoteProductReviewPayload(error = productReviewError, site = site)
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1236,9 +1236,7 @@ class WCProductStore @Inject constructor(
                 wcProductRestClient.updateProductReviewStatus(site, remoteReviewId, newStatus)
             }
             return@withDefaultContext if (result.isError) {
-                OnProductReviewChanged(0).also { it.error = result.error
-                    it.causeOfChange = WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS
-                }
+                OnProductReviewChanged(0)
             } else {
                 val rowsAffected = result.productReview?.let { review ->
                     if (review.status == "spam" || review.status == "trash") {
@@ -1249,9 +1247,7 @@ class WCProductStore @Inject constructor(
                         ProductSqlUtils.insertOrUpdateProductReview(review)
                     }
                 } ?: 0
-                OnProductReviewChanged(rowsAffected).also {
-                    it.causeOfChange = WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS
-                }
+                OnProductReviewChanged(rowsAffected)
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1236,7 +1236,7 @@ class WCProductStore @Inject constructor(
                 wcProductRestClient.updateProductReviewStatus(site, remoteReviewId, newStatus)
             }
             return@withDefaultContext if (result.isError) {
-                OnProductReviewChanged(0)
+                OnProductReviewChanged(0).also{it.error = result.error}
             } else {
                 val rowsAffected = result.productReview?.let { review ->
                     if (review.status == "spam" || review.status == "trash") {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1230,25 +1230,25 @@ class WCProductStore @Inject constructor(
         emitChange(onProductChanged)
     }
 
-    suspend fun updateProductReviewStatus(payload: UpdateProductReviewStatusPayload) : OnProductReviewChanged{
-        return coroutineEngine.withDefaultContext(API,this,"updateProductReviewStatus"){
-            val result = with(payload){
-                wcProductRestClient.updateProductReviewStatus(site,remoteReviewId,newStatus)
+    suspend fun updateProductReviewStatus(payload: UpdateProductReviewStatusPayload): OnProductReviewChanged {
+        return coroutineEngine.withDefaultContext(API, this, "updateProductReviewStatus") {
+            val result = with(payload) {
+                wcProductRestClient.updateProductReviewStatus(site, remoteReviewId, newStatus)
             }
             return@withDefaultContext if (result.isError) {
                 OnProductReviewChanged(0).also { it.error = result.error
                     it.causeOfChange = WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS
                 }
-            }else {
-                val rowsAffected = result.productReview?.let{review->
-                    if(review.status == "spam" || review.status == "trash"){
+            } else {
+                val rowsAffected = result.productReview?.let { review ->
+                    if (review.status == "spam" || review.status == "trash") {
                         // Delete this review from the database
                         ProductSqlUtils.deleteProductReview(review)
-                    }else {
+                    } else {
                         // Insert or update in the database
                         ProductSqlUtils.insertOrUpdateProductReview(review)
                     }
-                }?:0
+                } ?: 0
                 OnProductReviewChanged(rowsAffected).also {
                     it.causeOfChange = WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS
                 }


### PR DESCRIPTION
Closes: #[5647](https://github.com/woocommerce/woocommerce-android/issues/5647) . This is a dependency in FluxC for the main fix 

**Description**

The main change for  5647 is to decouple the   tight coupling between ReviewDetailFragment and ReviewListFragment. As one of the item for the same newUpdateProductReviewStatusAction was also required to be migrated to suspend function. This will allow removal of EventBus from the class implementing the logic of moderation.

**Changes** 
Migrate the function to suspend
Update the tests
