### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ allprojects {
         configFile file("${project.rootDir}/config/checkstyle.xml")
     }
 
+    // See https://issuetracker.google.com/issues/174695268?pli=1,
+    // remove this when Room version is upgraded to 2.4.0 or later
     configurations.all {
         resolutionStrategy {
             force 'org.xerial:sqlite-jdbc:3.34.0'

--- a/build.gradle
+++ b/build.gradle
@@ -45,14 +45,6 @@ allprojects {
         toolVersion = '8.3'
         configFile file("${project.rootDir}/config/checkstyle.xml")
     }
-
-    // See https://issuetracker.google.com/issues/174695268?pli=1,
-    // remove this when Room version is upgraded to 2.4.0 or later
-    configurations.all {
-        resolutionStrategy {
-            force 'org.xerial:sqlite-jdbc:3.34.0'
-        }
-    }
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,12 @@ allprojects {
         toolVersion = '8.3'
         configFile file("${project.rootDir}/config/checkstyle.xml")
     }
+
+    configurations.all {
+        resolutionStrategy {
+            force 'org.xerial:sqlite-jdbc:3.34.0'
+        }
+    }
 }
 
 subprojects {

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -87,6 +87,11 @@ dependencies {
     implementation 'org.apache.commons:commons-text:1.1'
     api "androidx.paging:paging-runtime:2.1.2"
     implementation "androidx.room:room-runtime:$roomVersion"
+
+    // See https://issuetracker.google.com/issues/174695268?pli=1,
+    // remove this when Room version is upgraded to 2.4.0 or later
+    kapt("org.xerial:sqlite-jdbc:3.36.0")
+
     kapt "androidx.room:room-compiler:$roomVersion"
     implementation "androidx.room:room-ktx:$roomVersion"
 

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -75,6 +75,11 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
 
     implementation "androidx.room:room-runtime:$roomVersion"
+
+    // See https://issuetracker.google.com/issues/174695268?pli=1,
+    // remove this when Room version is upgraded to 2.4.0 or later
+    kapt("org.xerial:sqlite-jdbc:3.36.0")
+
     kapt "androidx.room:room-compiler:$roomVersion"
     api "androidx.room:room-ktx:$roomVersion"
 


### PR DESCRIPTION
This PR applies a work around to avoid the following error that crops up when doing a Composite build with local FluxC repo due to [sqlite-jdbc library used in Room](https://issuetracker.google.com/issues/174695268?pli=1)
```
 error: cannot find symbol
    private final XMLRPC mMethod;
```

It is fixed in Room ~ v2.4.0.  Until FluxC is upgraded to it,  this would prevent the issue for anyone going to use a M1 Mac (as more people are moving to M1 now) and hopefully saves a lot of time and frustration.

Thanks to @AjeshRPai and @JorgeMucientes who first investigated this issue (p1634023130210300-slack-C02QANACA, p1634815713005700-slack-C02QANACA).  Surprisingly I didn't face this issue till now, even though I have been on a M1 since the beginning!

To test:

Test 1
- Using an M1 Mac, checkout WordPress-FluxC-Android repo
- Build and Run example app on trunk
- Notice the above error

Test 2
- Using an M1 Mac
- Checkout this branch
- Build and Run example app 
- Notice it will build and run without the error

Test 3
- For completeness, Please test this fix on an Intel Mac to ensure there are no regression issues and works fine

NOTE:  I couldn't perform Test 3 as I don't have an Intel Mac.  Greatly appreciate it if you could please try it out.  Thanks