### PR TITLE
Add default value for `taxLines` migration

### DIFF
--- a/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
+++ b/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
@@ -49,8 +49,23 @@ class MigrationTests {
     @Test
     fun testMigrate6to7() {
         helper.apply {
-            createDatabase(TEST_DB, 6).close()
-            runMigrationsAndValidate(TEST_DB, 7, true, MIGRATION_6_7)
+            val existingDb = createDatabase(TEST_DB, 6).apply {
+                execSQL(
+                        // language=RoomSql
+                        """
+                            INSERT INTO OrderEntity VALUES(1, 2, 3, '123', 'processing', '$', 'key', 'date of creation', 'date of modification', '123', '456', '789', 'card', 'by card', 'date paid', TRUE, 'sample customer note', '213', 'CODE', 123, 'billing first name', 'billing last name', 'billing company', 'billing address1', 'billing address2', 'billing city', 'billing state', 'billing postcode', 'billing country', 'billing email', 'billing phone', 'shipping first name', 'shipping last name', 'shipping company', 'shipping address1', 'shipping address2', 'shipping city', 'shipping state', 'shipping postcode', 'shipping country', 'shipping phone', 'line items', 'shipping lines', 'fee lines', 'meta data')
+                        """.trimIndent()
+                )
+            }.close()
+
+            val migratedDb = runMigrationsAndValidate(TEST_DB, 7, true, MIGRATION_6_7)
+
+            migratedDb.query(
+                    // language=RoomSql
+                    """
+                        SELECT * FROM OrderEntity
+                    """.trimIndent()
+            )
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -142,6 +142,6 @@ internal val MIGRATION_5_6 = object : Migration(5, 6) {
 
 internal val MIGRATION_6_7 = object : Migration(6, 7) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE OrderEntity ADD taxLines TEXT NOT NULL")
+        database.execSQL("ALTER TABLE OrderEntity ADD taxLines TEXT NOT NULL DEFAULT ''")
     }
 }


### PR DESCRIPTION
Fixes: #2273 

### Description

We’re altering database with a new non-null column in `MIGRATION_6_7` but we don’t provide a default value for that. We do have a default value but it's declared in `WCOrderModel` Kotlin class but during SQL migration, if there are existing values, SQL wouldn’t know how to behave (at the moment of migration).

### Testing

1. Checkout this branch
2. Remove any changes in `MIGRATION_6_7` (remove ` DEFAULT ''` part)
3. Run `testMigrate6to7()` test (on any device)
4. **Assert that test is crashing**
5. Revet change made in 2
6. Run `testMigrate6to7()` again
7. **Assert that test is not crashing**