### PR TITLE
[Woo] ability to delete order

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/AlertDialogUtils.kt
@@ -49,3 +49,25 @@ suspend fun showSingleLineDialog(
     }
     alert.show()
 }
+
+suspend fun showTwoButtonsDialog(
+    activity: FragmentActivity,
+    message: String,
+    positiveButtonText: String = "Yes",
+    negativeButtonText: String = "No"
+): Boolean = suspendCancellableCoroutine { continuation ->
+    val dialog = AlertDialog.Builder(activity)
+            .setMessage(message)
+            .setPositiveButton(positiveButtonText) { _, _ ->
+                continuation.resume(true)
+            }
+            .setNegativeButton(negativeButtonText) { _, _ ->
+                continuation.resume(false)
+            }
+            .setCancelable(false)
+            .show()
+
+    continuation.invokeOnCancellation {
+        dialog.dismiss()
+    }
+}

--- a/example/src/main/res/layout/fragment_woo_orders.xml
+++ b/example/src/main/res/layout/fragment_woo_orders.xml
@@ -159,5 +159,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Create Order" />
+
+        <Button
+            android:id="@+id/delete_order"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Delete an order" />
     </LinearLayout>
 </ScrollView>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
@@ -162,9 +162,10 @@ class JetpackTunnelGsonRequestBuilder @Inject constructor() {
         restClient: BaseWPComRestClient,
         site: SiteModel,
         url: String,
-        clazz: Class<T>
+        clazz: Class<T>,
+        params: Map<String, String> = emptyMap()
     ) = suspendCancellableCoroutine<JetpackResponse<T>> { cont ->
-        val request = JetpackTunnelGsonRequest.buildDeleteRequest<T>(url, site.siteId, mapOf(), clazz, {
+        val request = JetpackTunnelGsonRequest.buildDeleteRequest<T>(url, site.siteId, params, clazz, {
             cont.resume(JetpackSuccess(it))
         }, {
             cont.resume(JetpackError(it))

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -879,7 +879,7 @@ class OrderRestClient @Inject constructor(
     suspend fun deleteOrder(
         site: SiteModel,
         orderId: Long,
-        force: Boolean
+        trash: Boolean
     ): WooPayload<Unit> {
         val url = WOOCOMMERCE.orders.id(orderId).pathV3
 
@@ -888,7 +888,7 @@ class OrderRestClient @Inject constructor(
                 site = site,
                 url = url,
                 clazz = Unit::class.java,
-                params = mapOf("force" to force.toString())
+                params = mapOf("force" to trash.not().toString())
         )
 
         return when (response) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -876,6 +876,27 @@ class OrderRestClient @Inject constructor(
         }
     }
 
+    suspend fun deleteOrder(
+        site: SiteModel,
+        orderId: Long,
+        force: Boolean
+    ): WooPayload<Unit> {
+        val url = WOOCOMMERCE.orders.id(orderId).pathV3
+
+        val response = jetpackTunnelGsonRequestBuilder.syncDeleteRequest(
+                restClient = this,
+                site = site,
+                url = url,
+                clazz = Unit::class.java,
+                params = mapOf("force" to force.toString())
+        )
+
+        return when (response) {
+            is JetpackError -> WooPayload(response.error.toWooError())
+            is JetpackSuccess -> WooPayload(Unit)
+        }
+    }
+
     private fun UpdateOrderRequest.toNetworkRequest(): Map<String, Any> {
         return mutableMapOf<String, Any>().apply {
             status?.let { put("status", it.statusKey) }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
@@ -60,4 +60,7 @@ abstract class OrdersDao {
 
     @Query("SELECT COUNT(*) FROM OrderEntity WHERE localSiteId = :localSiteId")
     abstract fun getOrderCountForSite(localSiteId: LocalId): Int
+
+    @Query("DELETE FROM OrderEntity WHERE localSiteId = :localSiteId AND remoteOrderId = :orderId")
+    abstract suspend fun deleteOrder(localSiteId: LocalId, orderId: Long)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -237,6 +237,23 @@ class OrderUpdateStore @Inject internal constructor(
         }
     }
 
+    suspend fun deleteOrder(
+        site: SiteModel,
+        orderId: Long,
+        force: Boolean = false
+    ): WooResult<Unit> {
+        return coroutineEngine.withDefaultContext(T.API, this, "deleteOrder") {
+            val result = wcOrderRestClient.deleteOrder(site, orderId, force)
+
+            return@withDefaultContext if (result.isError) {
+                WooResult(result.error)
+            } else {
+                ordersDao.deleteOrder(site.localId(), orderId)
+                WooResult(Unit)
+            }
+        }
+    }
+
     private suspend fun FlowCollector<UpdateOrderResult>.takeWhenOrderDataAcquired(
         remoteOrderId: RemoteId,
         localSiteId: LocalId,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -240,10 +240,10 @@ class OrderUpdateStore @Inject internal constructor(
     suspend fun deleteOrder(
         site: SiteModel,
         orderId: Long,
-        force: Boolean = false
+        trash: Boolean = true
     ): WooResult<Unit> {
         return coroutineEngine.withDefaultContext(T.API, this, "deleteOrder") {
-            val result = wcOrderRestClient.deleteOrder(site, orderId, force)
+            val result = wcOrderRestClient.deleteOrder(site, orderId, trash)
 
             return@withDefaultContext if (result.isError) {
                 WooResult(result.error)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -224,7 +224,7 @@ class OrderUpdateStore @Inject internal constructor(
         orderId: Long,
         updateRequest: UpdateOrderRequest
     ): WooResult<WCOrderModel> {
-        return coroutineEngine.withDefaultContext(T.API, this, "createOrder") {
+        return coroutineEngine.withDefaultContext(T.API, this, "updateOrder") {
             val result = wcOrderRestClient.updateOrder(site, orderId, updateRequest)
 
             return@withDefaultContext if (result.isError) {

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -454,6 +454,26 @@ class OrderUpdateStoreTest {
         }
     }
 
+    @Test
+    fun `should delete local copy of order when delete request succeeds`(): Unit = runBlocking {
+        setUp {
+            orderRestClient = mock {
+                onBlocking {
+                    deleteOrder(any(), any(), any())
+                }.doReturn(
+                    WooPayload(Unit)
+                )
+            }
+        }
+
+        sut.deleteOrder(
+            site = site,
+            orderId = TEST_REMOTE_ORDER_ID.value
+        )
+
+        verify(ordersDao).deleteOrder(site.localId(), TEST_REMOTE_ORDER_ID.value)
+    }
+
     private companion object {
         val TEST_REMOTE_ORDER_ID = RemoteId(321L)
         val TEST_LOCAL_SITE_ID = LocalId(654)


### PR DESCRIPTION
This PR just adds support for deleting an order, this is needed for the task https://github.com/woocommerce/woocommerce-android/issues/5823 to cleanup the draft order created to calculate taxes.

#### Test
1. Open the example app.
2. Click on Woo, then Orders.
3. Click on "Delete an order"
4. Type an order id, and choose whether to move the order to trash or to delete it permanently.
5. Confirm that the order is deleted.