### PR TITLE
Woo/simple payments cleanup

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -450,11 +450,11 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                     coroutineScope.launch {
                         try {
                             val amount = editText.text.toString()
-                            val result = wcOrderStore.postSimplePayment(site, amount, true)
+                            val result = orderUpdateStore.createSimplePayment(site, amount, true)
                             if (result.isError) {
                                 prependToLog("Creating simple payment failed.")
                             } else {
-                                prependToLog("Created simple payment with remote ID ${result.order?.remoteOrderId}.")
+                                prependToLog("Created simple payment with remote ID ${result.model?.remoteOrderId}.")
                             }
                         } catch (e: NumberFormatException) {
                             prependToLog("Invalid amount.")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -485,8 +485,7 @@ class OrderRestClient @Inject constructor(
 
     /**
      * @Deprecated("Use OrderUpdateStore.createSimplePayment instead")
-     * Creates a "simple payment," which is an empty order assigned the passed amount. The backend will
-     * return a new order with the tax already calculated.
+     * This function can be dropped once WCAndroid switches to OrderUpdateStore.createSimplePayment
      */
     suspend fun postSimplePayment(site: SiteModel, amount: String, isTaxable: Boolean): RemoteOrderPayload {
         val params = mapOf(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -484,6 +484,7 @@ class OrderRestClient @Inject constructor(
     )
 
     /**
+     * @Deprecated("Use OrderUpdateStore.createSimplePayment instead")
      * Creates a "simple payment," which is an empty order assigned the passed amount. The backend will
      * return a new order with the tax already calculated.
      */

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -118,6 +118,17 @@ class OrderUpdateStore @Inject internal constructor(
         }
     }
 
+    /**
+     * Creates a "simple payment," which is an empty order assigned the passed amount. The backend will
+     * return a new order with the tax already calculated.
+     */
+    suspend fun createSimplePayment(site: SiteModel, amount: String, isTaxable: Boolean): WooResult<WCOrderModel> {
+        val createOrderRequest = UpdateOrderRequest(
+                feeLines = generateSimplePaymentFeeLineList(amount, isTaxable)
+        )
+        return createOrder(site, createOrderRequest)
+    }
+
     suspend fun updateSimplePayment(
         site: SiteModel,
         orderId: Long,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -200,7 +200,7 @@ class OrderUpdateStore @Inject internal constructor(
      * the passed information. Pass null for the feeId if this is a new fee line item, otherwise
      * pass the id of an existing fee line item to replace it.
      */
-    private fun generateSimplePaymentFeeLineList(
+    fun generateSimplePaymentFeeLineList(
         amount: String,
         isTaxable: Boolean,
         feeId: Long? = null

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -410,7 +410,7 @@ class OrderUpdateStoreTest {
 
     @Test
     fun `should create simple payment with correct amount and tax status`(): Unit = runBlocking {
-        //given
+        // given
         val newOrder = initialOrder.copy(
                 feeLines = OrderRestClient.generateSimplePaymentFeeLineJson(
                         SIMPLE_PAYMENT_AMOUNT,
@@ -420,7 +420,7 @@ class OrderUpdateStoreTest {
         )
 
         setUp {
-            orderRestClient = mock{
+            orderRestClient = mock {
                 onBlocking {
                     createOrder(any(), any())
                 }.doReturn(

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -409,11 +409,30 @@ class OrderUpdateStoreTest {
 //      Simple payments
 
     @Test
-    fun `should create simple payment`(): Unit = runBlocking {
+    fun `should create simple payment with correct amount and tax status`(): Unit = runBlocking {
+        //given
+        val newOrder = initialOrder.copy(
+                feeLines = OrderRestClient.generateSimplePaymentFeeLineJson(
+                        SIMPLE_PAYMENT_AMOUNT,
+                        SIMPLE_PAYMENT_IS_TAXABLE,
+                        SIMPLE_PAYMENT_FEE_ID
+                ).toString()
+        )
+
         setUp {
-            orderRestClient = mock()
+            orderRestClient = mock{
+                onBlocking {
+                    createOrder(any(), any())
+                }.doReturn(
+                    WooPayload(newOrder)
+                )
+            }
         }
+
+        // when
         val result = sut.createSimplePayment(site, SIMPLE_PAYMENT_AMOUNT, SIMPLE_PAYMENT_IS_TAXABLE)
+
+        // then
         assertThat(result.isError).isFalse()
         assertThat(result.model).isNotNull
         assertThat(result.model!!.getFeeLineList()).hasSize(1)

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.order.FeeLineTaxStatus
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
@@ -405,6 +406,21 @@ class OrderUpdateStoreTest {
         assertThat(results[1].event.error.type).isEqualTo(GENERIC_ERROR)
     }
 
+//      Simple payments
+
+    @Test
+    fun `should create simple payment`(): Unit = runBlocking {
+        setUp {
+            orderRestClient = mock()
+        }
+        val result = sut.createSimplePayment(site, SIMPLE_PAYMENT_AMOUNT, SIMPLE_PAYMENT_IS_TAXABLE)
+        assertThat(result.isError).isFalse()
+        assertThat(result.model).isNotNull
+        assertThat(result.model!!.getFeeLineList()).hasSize(1)
+        assertThat(result.model!!.getFeeLineList()[0].total).isEqualTo(SIMPLE_PAYMENT_AMOUNT)
+        assertThat(result.model!!.getFeeLineList()[0].taxStatus!!.value).isEqualTo(SIMPLE_PAYMENT_TAX_STATUS)
+    }
+
     @Test
     fun `should optimistically update simple payment`(): Unit = runBlocking {
         // given
@@ -468,6 +484,7 @@ class OrderUpdateStoreTest {
         const val SIMPLE_PAYMENT_CUSTOMER_NOTE = "Simple payment customer note"
         const val SIMPLE_PAYMENT_BILLING_EMAIL = "example@example.com"
         const val SIMPLE_PAYMENT_IS_TAXABLE = true
+        val SIMPLE_PAYMENT_TAX_STATUS = FeeLineTaxStatus.Taxable.value
 
         val initialOrder = WCOrderModel(
                 remoteOrderId = TEST_REMOTE_ORDER_ID,


### PR DESCRIPTION
This is the first of two FluxC PRs to clean up handling of simple payments. In this PR, creating simple payments is added to `OrderUpdateStore` and simple payment creation is marked as deprecated in `OrderRestClient`. Once WCAndroid switches to the `OrderUpdateStore` function, we can drop the one in `OrderRestClient` and complete the cleanup.