### PR TITLE
Make statementDescriptor on PaymentAccount nullable

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.mocked
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.model.SiteModel
@@ -44,7 +45,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
     @Test
     fun whenValidDataProvidedForCapturePaymentThenSuccessReturned() = runBlocking {
-        interceptor.respondWithError("wc-pay-capture-terminal-payment-response-success.json", 200)
+        interceptor.respondWith("wc-pay-capture-terminal-payment-response-success.json")
 
         val result = restClient.capturePayment(
             WOOCOMMERCE_PAYMENTS,
@@ -115,7 +116,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
     @Test
     fun whenLoadAccountInvalidStatusThenFallbacksToUnknown() = runBlocking {
-        interceptor.respondWithError("wc-pay-load-account-response-new-status.json", 200)
+        interceptor.respondWith("wc-pay-load-account-response-new-status.json")
 
         val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
@@ -124,7 +125,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
     @Test
     fun whenLoadAccountEmptyStatusThenFallbackToNoAccount() = runBlocking {
-        interceptor.respondWithError("wc-pay-load-account-response-empty-status.json", 200)
+        interceptor.respondWith("wc-pay-load-account-response-empty-status.json")
 
         val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
@@ -133,7 +134,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
     @Test
     fun whenOverdueRequirementsThenCurrentDeadlineCorrectlyParsed() = runBlocking {
-        interceptor.respondWithError("wc-pay-load-account-response-current-deadline.json", 200)
+        interceptor.respondWith("wc-pay-load-account-response-current-deadline.json")
 
         val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
@@ -142,7 +143,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
     @Test
     fun whenLoadAccountRestrictedSoonStatusThenRestrictedSoonStatusReturned() = runBlocking {
-        interceptor.respondWithError("wc-pay-load-account-response-restricted-soon-status.json", 200)
+        interceptor.respondWith("wc-pay-load-account-response-restricted-soon-status.json")
 
         val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
@@ -151,11 +152,20 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
     @Test
     fun whenLoadAccountIsLiveThenIsLiveFlagIsTrue() = runBlocking {
-        interceptor.respondWithError("wc-pay-load-account-response-is-live-account.json", 200)
+        interceptor.respondWith("wc-pay-load-account-response-is-live-account.json")
 
         val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
 
         assertTrue(result.result!!.isLive)
+    }
+
+    @Test
+    fun whenStatementeDescriptorNullThenFieldSetToNull() = runBlocking {
+        interceptor.respondWith("stripe-extension-statement-descriptor-null.json")
+
+        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+
+        assertNull(result.result!!.statementDescriptor)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
@@ -46,7 +46,7 @@ class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
         assertEquals("US", result.model?.country)
         assertEquals(false, result.model?.hasPendingRequirements)
         assertEquals(false, result.model?.hasOverdueRequirements)
-        assertEquals("", result.model?.statementDescriptor)
+        assertTrue(result.model?.statementDescriptor.isNullOrEmpty())
         assertEquals("US", result.model?.country)
         assertEquals("usd", result.model?.storeCurrencies?.default)
         assertEquals(listOf("usd"), result.model?.storeCurrencies?.supportedCurrencies)

--- a/example/src/androidTest/resources/stripe-extension-statement-descriptor-null.json
+++ b/example/src/androidTest/resources/stripe-extension-statement-descriptor-null.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "has_pending_requirements": false,
+    "has_overdue_requirements": false,
+    "current_deadline": null,
+    "is_live": true,
+    "status": "restricted_soon",
+    "statement_descriptor": null,
+    "store_currencies": {
+      "default": "usd",
+      "supported": ["usd"]
+    },
+    "country": "US"
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCPaymentAccountResult.kt
@@ -23,7 +23,7 @@ data class WCPaymentAccountResult(
      * See https://stripe.com/docs/statement-descriptors
      */
     @SerializedName("statement_descriptor")
-    val statementDescriptor: String,
+    val statementDescriptor: String?,
     @SerializedName("store_currencies")
     val storeCurrencies: StoreCurrencies,
 


### PR DESCRIPTION
Stripe Extension version 6.2.0+ returns null instead of an empty string when the statement descriptor is not set.

[WPAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/5836)