### PR TITLE
Fix stripe extension test

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_InPersonPaymentsStripeExtensionTest.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPayment
 import javax.inject.Inject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import java.util.Locale
 
 class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
     @Inject internal lateinit var store: WCInPersonPaymentsStore
@@ -46,7 +47,7 @@ class ReleaseStack_InPersonPaymentsStripeExtensionTest : ReleaseStack_WCBase() {
         assertEquals("US", result.model?.country)
         assertEquals(false, result.model?.hasPendingRequirements)
         assertEquals(false, result.model?.hasOverdueRequirements)
-        assertTrue(result.model?.statementDescriptor.isNullOrEmpty())
+        assertEquals(result.model?.statementDescriptor?.toLowerCase(Locale.ROOT), "custom descriptor")
         assertEquals("US", result.model?.country)
         assertEquals("usd", result.model?.storeCurrencies?.default)
         assertEquals(listOf("usd"), result.model?.storeCurrencies?.supportedCurrencies)


### PR DESCRIPTION
This PR fixes a failing test. I've updated "Statement descriptor" in Stripe's dashboard yesterday for testing purposes. However, I didn't realize it's not possible to clear the statement descriptor once it's added. This PR simply updates the expected value in tests.