### PR TITLE
Issue/5382 Use of site id in order to uniquely identify WCOrderNoteModel

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -201,7 +201,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         orderStore.fetchOrderNotes(firstOrder.orderId, sSite)
 
         // Verify results
-        val fetchedNotes = orderStore.getOrderNotesForOrder(firstOrder.orderId)
+        val fetchedNotes = orderStore.getOrderNotesForOrder(sSite, firstOrder.orderId)
         assertTrue(fetchedNotes.isNotEmpty())
     }
 
@@ -219,7 +219,7 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
         )
 
         // Verify results
-        val fetchedNotes = orderStore.getOrderNotesForOrder(orderModel.orderId)
+        val fetchedNotes = orderStore.getOrderNotesForOrder(sSite, orderModel.orderId)
         assertTrue(fetchedNotes.isNotEmpty())
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -209,13 +209,14 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                 coroutineScope.launch {
                     getFirstWCOrder()?.let { order ->
                         @Suppress("DEPRECATION_ERROR")
-                        val notesCountBeforeRequest = wcOrderStore.getOrderNotesForOrder(order.orderId).size
+                        val notesCountBeforeRequest = wcOrderStore.getOrderNotesForOrder(site, order.orderId).size
                         coroutineScope.launch {
                             @Suppress("DEPRECATION_ERROR")
                             wcOrderStore.fetchOrderNotes(order.orderId, site)
                                 .takeUnless { it.isError }
                                 ?.let {
                                     val notesCountAfterRequest = wcOrderStore.getOrderNotesForOrder(
+                                            site,
                                             order.orderId
                                     ).size
                                     prependToLog(

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
@@ -50,16 +50,17 @@ class OrderSqlUtilsTest {
         val order = OrderTestUtils.generateSampleOrder(orderId)
         val note1 = OrderTestUtils.generateSampleNote(1, order.localSiteId, orderId)
         val note2 = OrderTestUtils.generateSampleNote(2, order.localSiteId, orderId)
+        val site = SiteModel().apply { id = order.localSiteId.value }
 
         // Test inserting notes
         OrderSqlUtils.insertOrIgnoreOrderNotes(listOf(note1, note2))
-        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(orderId)
+        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(site, orderId)
         assertEquals(2, storedNotes.size)
 
         // Test ignoring notes already saved to db
         val inserted = OrderSqlUtils.insertOrIgnoreOrderNotes(listOf(note1))
         assertEquals(0, inserted)
-        val storedNotes2 = OrderSqlUtils.getOrderNotesForOrder(orderId)
+        val storedNotes2 = OrderSqlUtils.getOrderNotesForOrder(site, orderId)
         assertEquals(2, storedNotes2.size)
     }
 
@@ -69,17 +70,18 @@ class OrderSqlUtilsTest {
         val order = OrderTestUtils.generateSampleOrder(orderId)
         val note1 = OrderTestUtils.generateSampleNote(1, order.localSiteId, orderId)
         val note2 = OrderTestUtils.generateSampleNote(2, order.localSiteId, orderId)
+        val site = SiteModel().apply { id = order.localSiteId.value }
 
         // Test inserting notes
         OrderSqlUtils.insertOrIgnoreOrderNote(note1)
         OrderSqlUtils.insertOrIgnoreOrderNote(note2)
-        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(orderId)
+        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(site, orderId)
         assertEquals(2, storedNotes.size)
 
         // Test ignoring notes already saved to db
         val inserted = OrderSqlUtils.insertOrIgnoreOrderNote(note1)
         assertEquals(0, inserted)
-        val storedNotes2 = OrderSqlUtils.getOrderNotesForOrder(orderId)
+        val storedNotes2 = OrderSqlUtils.getOrderNotesForOrder(site, orderId)
         assertEquals(2, storedNotes2.size)
     }
 
@@ -90,8 +92,9 @@ class OrderSqlUtilsTest {
         val note1 = OrderTestUtils.generateSampleNote(1, order.localSiteId, orderId)
         val note2 = OrderTestUtils.generateSampleNote(2, order.localSiteId, orderId)
         OrderSqlUtils.insertOrIgnoreOrderNotes(listOf(note1, note2))
+        val site = SiteModel().apply { id = order.localSiteId.value }
 
-        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(orderId)
+        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(site, orderId)
         assertEquals(2, storedNotes.size)
     }
 
@@ -104,12 +107,12 @@ class OrderSqlUtilsTest {
         OrderSqlUtils.insertOrIgnoreOrderNotes(listOf(note1, note2))
         val site = SiteModel().apply { id = order.localSiteId.value }
 
-        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(orderId)
+        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(site, orderId)
         assertEquals(2, storedNotes.size)
 
         val deletedCount = OrderSqlUtils.deleteOrderNotesForSite(site)
         assertEquals(2, deletedCount)
-        val verify = OrderSqlUtils.getOrderNotesForOrder(orderId)
+        val verify = OrderSqlUtils.getOrderNotesForOrder(site, orderId)
         assertEquals(0, verify.size)
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -220,10 +220,11 @@ class WCOrderStoreTest {
         val orderId = 949L
         val noteModels = OrderTestUtils.getOrderNotesFromJsonString(notesJson, 6, orderId)
         val orderModel = OrderTestUtils.generateSampleOrder(1).copy(orderId = orderId)
+        val site = SiteModel().apply { id = orderModel.localSiteId.value }
         assertEquals(6, noteModels.size)
         OrderSqlUtils.insertOrIgnoreOrderNote(noteModels[0])
 
-        val retrievedNotes = orderStore.getOrderNotesForOrder(orderModel.orderId)
+        val retrievedNotes = orderStore.getOrderNotesForOrder(site, orderModel.orderId)
         assertEquals(1, retrievedNotes.size)
         assertEquals(noteModels[0], retrievedNotes[0])
     }

--- a/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
+++ b/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
@@ -54,7 +54,7 @@ class MigrationTests {
                 execSQL(
                         // language=RoomSql
                         """
-                            INSERT INTO OrderEntity VALUES(1, 2, 3, '123', 'processing', '$', 'key', 'date of creation', 'date of modification', '123', '456', '789', 'card', 'by card', 'date paid', TRUE, 'sample customer note', '213', 'CODE', 123, 'billing first name', 'billing last name', 'billing company', 'billing address1', 'billing address2', 'billing city', 'billing state', 'billing postcode', 'billing country', 'billing email', 'billing phone', 'shipping first name', 'shipping last name', 'shipping company', 'shipping address1', 'shipping address2', 'shipping city', 'shipping state', 'shipping postcode', 'shipping country', 'shipping phone', 'line items', 'shipping lines', 'fee lines', 'meta data')
+                            INSERT INTO OrderEntity VALUES(1, 2, 3, '123', 'processing', '$', 'key', 'date of creation', 'date of modification', '123', '456', '789', 'card', 'by card', 'date paid', 1, 'sample customer note', '213', 'CODE', 123, 'billing first name', 'billing last name', 'billing company', 'billing address1', 'billing address2', 'billing city', 'billing state', 'billing postcode', 'billing country', 'billing email', 'billing phone', 'shipping first name', 'shipping last name', 'shipping company', 'shipping address1', 'shipping address2', 'shipping city', 'shipping state', 'shipping postcode', 'shipping country', 'shipping phone', 'line items', 'shipping lines', 'fee lines', 'meta data')
                         """.trimIndent()
                 )
             }.close()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -83,10 +83,11 @@ object OrderSqlUtils {
         }
     }
 
-    fun getOrderNotesForOrder(orderId: Long): List<WCOrderNoteModel> =
+    fun getOrderNotesForOrder(site: SiteModel, orderId: Long): List<WCOrderNoteModel> =
             WellSql.select(WCOrderNoteModel::class.java)
                     .where()
                     .equals(WCOrderNoteModelTable.LOCAL_ORDER_ID, orderId)
+                    .equals(WCOrderNoteModelTable.LOCAL_SITE_ID, site.id)
                     .endWhere()
                     .orderBy(WCOrderNoteModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
                     .asModel

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -405,8 +405,8 @@ class WCOrderStore @Inject constructor(
     /**
      * Returns the notes belonging to supplied [OrderEntity] as a list of [WCOrderNoteModel].
      */
-    fun getOrderNotesForOrder(orderId: Long): List<WCOrderNoteModel> =
-        OrderSqlUtils.getOrderNotesForOrder(orderId)
+    fun getOrderNotesForOrder(site: SiteModel, orderId: Long): List<WCOrderNoteModel> =
+        OrderSqlUtils.getOrderNotesForOrder(site, orderId)
 
     /**
      * Returns the order status options available for the provided site [SiteModel] as a list of [WCOrderStatusModel].


### PR DESCRIPTION
I found only 1 place where we didn't use site id in order to query either `WCOrderNoteModel` or `WCOrderShipmentTrackingModel`. This PR adds site id to the query