### PR TITLE
Change ShippingLine to a data class with all properties part of the constructor

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/ShippingLine.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/ShippingLine.kt
@@ -2,13 +2,13 @@ package org.wordpress.android.fluxc.model.order
 
 import com.google.gson.annotations.SerializedName
 
-class ShippingLine {
-    val id: Long? = null
-    val total: String? = null
+data class ShippingLine(
+    val id: Long? = null,
+    val total: String? = null,
     @SerializedName("total_tax")
-    val totalTax: String? = null
+    val totalTax: String? = null,
     @SerializedName("method_id")
-    val methodId: String? = null
+    val methodId: String? = null,
     @SerializedName("method_title")
     val methodTitle: String? = null
-}
+)


### PR DESCRIPTION
This simple PR just updates the `ShippingLine` class to move all the properties to the primary constructor, which would make it possible to instantiate with valid values in WCAndroid.
I made it as a data class, it's not really needed not, but I think having a proper equality check is already useful to avoid hidden bugs.

This is not a breaking change for WCAndroid, so it can be merged right away.