### PR TITLE
[Woo] ability to serialize null values for shipping and fee lines to support deletion

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/FeeLine.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/FeeLine.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.model.order
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.utils.NullStringJsonAdapter
 
 /**
  * Represents a fee line.
@@ -10,6 +12,7 @@ class FeeLine {
     var id: Long? = null
 
     @SerializedName("name")
+    @JsonAdapter(NullStringJsonAdapter::class, nullSafe = false)
     var name: String? = null
 
     @SerializedName("total")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/ShippingLine.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/ShippingLine.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.model.order
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.utils.NullStringJsonAdapter
 
 data class ShippingLine(
     val id: Long? = null,
@@ -8,6 +10,7 @@ data class ShippingLine(
     @SerializedName("total_tax")
     val totalTax: String? = null,
     @SerializedName("method_id")
+    @JsonAdapter(NullStringJsonAdapter::class, nullSafe = false)
     val methodId: String? = null,
     @SerializedName("method_title")
     val methodTitle: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/NullStringJsonAdapter.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/NullStringJsonAdapter.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken.NULL
+import com.google.gson.stream.JsonToken.STRING
+import com.google.gson.stream.JsonWriter
+import com.google.gson.stream.MalformedJsonException
+
+class NullStringJsonAdapter : TypeAdapter<String>() {
+    override fun write(out: JsonWriter, value: String?) {
+        val defaultSerializeNullValue = out.serializeNulls
+        out.serializeNulls = true
+        if (value == null) {
+            out.nullValue()
+        } else {
+            out.value(value)
+        }
+        out.serializeNulls = defaultSerializeNullValue
+    }
+
+    override fun read(input: JsonReader): String? {
+        return when (val token = input.peek()) {
+            STRING -> input.nextString()
+            NULL -> {
+                input.nextNull()
+                null
+            }
+            else -> throw MalformedJsonException("Unexpected token: $token")
+        }
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/NullStringJsonAdapterTests.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/NullStringJsonAdapterTests.kt
@@ -1,0 +1,57 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.Gson
+import com.google.gson.annotations.JsonAdapter
+import com.google.gson.annotations.SerializedName
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class NullStringJsonAdapterTests {
+    data class Example(
+        @JsonAdapter(NullStringJsonAdapter::class, nullSafe = false)
+        @SerializedName("an_id")
+        val id: String?
+    )
+
+    private val gson = Gson()
+
+    @Test
+    fun `when passing null in json, then it should be deserialized to null value`() {
+        val json = """{
+            "an_id": null
+            }"""
+
+        val example = gson.fromJson(json, Example::class.java)
+
+        assertThat(example.id).isNull()
+    }
+
+    @Test
+    fun `when serializing a null value, then it should be exposed to the json`() {
+        val example = Example(null)
+
+        val json = gson.toJson(example)
+
+        assertThat(json).contains(""""an_id":null""")
+    }
+
+    @Test
+    fun `when passing non-null value in json, then it should be deserialized to the correct value`() {
+        val json = """{
+            "an_id": "some_id"
+            }"""
+
+        val example = gson.fromJson(json, Example::class.java)
+
+        assertThat(example.id).isEqualTo("some_id")
+    }
+
+    @Test
+    fun `when serializing a non-null value, then it should be correctly serialized`() {
+        val example = Example("some_id")
+
+        val json = gson.toJson(example)
+
+        assertThat(json).contains(""""an_id":"some_id"""")
+    }
+}


### PR DESCRIPTION
To delete a shipping line or a fee line from an Order, the API expects the following:
1. Passing `null` in the `method_id` field for the shipping line.
2. Passing `null` in the `name` field of the fee line.

So we need to be able to keep the `null` values when serializing those fields, this PR achieves this.

@ThomazFB please check the code, and if you have a better solution, please don't hesitate on suggesting it, I wanted to avoid dealing with Json manually, so I tried to make use of the `TypeAdapter` API.