### PR TITLE
Expose Flow from NotificationStore.kt to observe changes on "unseen" …

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.store
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.util.Log
 import com.yarolegovich.wellsql.SelectQuery.ORDER_DESCENDING
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -509,10 +508,6 @@ class NotificationStore @Inject constructor(
     }
 
     private fun onUnreadNotificationUpdate(onNotificationChanged: OnNotificationChanged) {
-        Log.i(
-            "TEST_UNSEEN",
-            "NotificationStore onUnreadNotificationUpdate: ${onNotificationChanged.causeOfChange.toString()}"
-        )
         coroutineEngine.launch(T.API, this, "Unread notification state updated") {
             unreadNotificationUpdates.emit(onNotificationChanged)
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -42,9 +42,9 @@ class NotificationStore @Inject constructor(
 
     private val preferences by lazy { PreferenceUtils.getFluxCPreferences(context) }
 
-    private val unreadNotificationUpdates: MutableSharedFlow<OnNotificationChanged> = MutableSharedFlow(replay = 0)
+    private val unreadNotificationUpdates: MutableSharedFlow<Unit> = MutableSharedFlow(replay = 0)
 
-    fun observeNotificationChanges(): Flow<OnNotificationChanged> = unreadNotificationUpdates
+    fun observeNotificationChanges(): Flow<Unit> = unreadNotificationUpdates
 
     class RegisterDevicePayload(
         val gcmToken: String,
@@ -438,7 +438,7 @@ class NotificationStore @Inject constructor(
             causeOfChange = NotificationAction.FETCH_NOTIFICATION
         }
         emitChange(onNotificationChanged)
-        onUnreadNotificationUpdate(onNotificationChanged)
+        onUnreadNotificationUpdate()
     }
 
     private fun markNotificationSeen(payload: MarkNotificationsSeenPayload) {
@@ -490,9 +490,8 @@ class NotificationStore @Inject constructor(
                 result.notifications?.forEach {
                     changedNotificationLocalIds.add(it.noteId)
                 }
-                causeOfChange = NotificationAction.MARK_NOTIFICATIONS_SEEN
             }
-            onUnreadNotificationUpdate(onNotificationChanged)
+            onUnreadNotificationUpdate()
             onNotificationChanged
         }
     }
@@ -507,9 +506,9 @@ class NotificationStore @Inject constructor(
         emitChange(onNotificationChanged)
     }
 
-    private fun onUnreadNotificationUpdate(onNotificationChanged: OnNotificationChanged) {
+    private fun onUnreadNotificationUpdate() {
         coroutineEngine.launch(T.API, this, "Unread notification state updated") {
-            unreadNotificationUpdates.emit(onNotificationChanged)
+            unreadNotificationUpdates.emit(Unit)
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.store
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
 import com.yarolegovich.wellsql.SelectQuery.ORDER_DESCENDING
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -438,6 +439,7 @@ class NotificationStore @Inject constructor(
             causeOfChange = NotificationAction.FETCH_NOTIFICATION
         }
         emitChange(onNotificationChanged)
+        onUnreadNotificationUpdate(onNotificationChanged)
     }
 
     private fun markNotificationSeen(payload: MarkNotificationsSeenPayload) {
@@ -460,7 +462,6 @@ class NotificationStore @Inject constructor(
             causeOfChange = NotificationAction.MARK_NOTIFICATIONS_SEEN
         }
         emitChange(onNotificationChanged)
-        onUnreadNotificationUpdate(onNotificationChanged)
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
@@ -505,10 +506,13 @@ class NotificationStore @Inject constructor(
             causeOfChange = NotificationAction.UPDATE_NOTIFICATION
         }
         emitChange(onNotificationChanged)
-        onUnreadNotificationUpdate(onNotificationChanged)
     }
 
     private fun onUnreadNotificationUpdate(onNotificationChanged: OnNotificationChanged) {
+        Log.i(
+            "TEST_UNSEEN",
+            "NotificationStore onUnreadNotificationUpdate: ${onNotificationChanged.causeOfChange.toString()}"
+        )
         coroutineEngine.launch(T.API, this, "Unread notification state updated") {
             unreadNotificationUpdates.emit(onNotificationChanged)
         }


### PR DESCRIPTION
Closes: #5752 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
⚠️  WIP 

As part of a [refactor](https://github.com/woocommerce/woocommerce-android/pull/5844) done in WooCommerce app to simplify how we are handling the unread state from notifications this PR exposes a new `unreadNotificationUpdates: MutableSharedFlow<Unit>` from `NotificationStore` that will notify its subscribers whener an event that changes the `read` state of a notification, happens.

### Testing instructions
This has to be teste together with this [changes](https://github.com/woocommerce/woocommerce-android/pull/5844)

