### PR TITLE
Fix: Missing file extension on media upload response causes NPE

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -232,7 +232,7 @@ class MimeTypes {
         return expected.any { mimeType -> mimeType.subtypes.any { print(mimeType.type, it) == type } }
     }
 
-    fun getMimeTypeForExtension(extension: String): String? {
+    fun getMimeTypeForExtension(extension: String?): String? {
         return (imageTypes + videoTypes + audioTypes + documentTypes).find { it.extensions.contains(extension) }
                 ?.toString()
     }


### PR DESCRIPTION
Fixes #1910 

This PR sets the  "extension" parameter of fun `getMimeTypeForExtension` to accept null values. This will prevent a Kotlin NPE when the file extension is null upon return from a media upload response.

There is no WordPress-Android companion, as this can go with the next release of FluxC. 

@renanferrari - I was unable to reproduce the error, so there are no testing instructions. What are you thoughts?



