### PR TITLE
POC for exposing a Flow to observe the NotificationModel table

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -10,7 +10,6 @@ import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOn

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -141,7 +141,7 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
                 withContext(Dispatchers.IO) {
                     getNotificationsForSite(site, order, filterByType, filterBySubtype)
                 }
-        }
+            }
     }
 
     fun hasUnreadNotificationsForSite(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/NotificationSqlUtils.kt
@@ -10,11 +10,12 @@ import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.notification.NoteIdSet
 import org.wordpress.android.fluxc.model.notification.NotificationModel
@@ -136,12 +137,11 @@ class NotificationSqlUtils @Inject constructor(private val formattableContentMap
         filterBySubtype: List<String>? = null
     ): Flow<List<NotificationModel>> {
         return dataUpdatesTrigger
-            .onStart { emit(Unit) }
-            .mapLatest {
-                withContext(Dispatchers.IO) {
+                .onStart { emit(Unit) }
+                .mapLatest {
                     getNotificationsForSite(site, order, filterByType, filterBySubtype)
                 }
-            }
+                .flowOn(Dispatchers.IO)
     }
 
     fun hasUnreadNotificationsForSite(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.store
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.util.Log
 import com.yarolegovich.wellsql.SelectQuery.ORDER_DESCENDING
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -509,10 +508,6 @@ class NotificationStore @Inject constructor(
     }
 
     private fun onUnreadNotificationUpdate(onNotificationChanged: OnNotificationChanged) {
-        Log.i(
-            "TEST_UNSEEN",
-            "NotificationStore onUnreadNotificationUpdate: ${onNotificationChanged.causeOfChange.toString()}"
-        )
         coroutineEngine.launch(T.API, this, "Unread notification state updated") {
             unreadNotificationUpdates.emit(onNotificationChanged)
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -42,9 +42,9 @@ class NotificationStore @Inject constructor(
 
     private val preferences by lazy { PreferenceUtils.getFluxCPreferences(context) }
 
-    private val unreadNotificationUpdates: MutableSharedFlow<OnNotificationChanged> = MutableSharedFlow(replay = 0)
+    private val unreadNotificationUpdates: MutableSharedFlow<Unit> = MutableSharedFlow(replay = 0)
 
-    fun observeNotificationChanges(): Flow<OnNotificationChanged> = unreadNotificationUpdates
+    fun observeNotificationChanges(): Flow<Unit> = unreadNotificationUpdates
 
     class RegisterDevicePayload(
         val gcmToken: String,
@@ -438,7 +438,7 @@ class NotificationStore @Inject constructor(
             causeOfChange = NotificationAction.FETCH_NOTIFICATION
         }
         emitChange(onNotificationChanged)
-        onUnreadNotificationUpdate(onNotificationChanged)
+        onUnreadNotificationUpdate()
     }
 
     private fun markNotificationSeen(payload: MarkNotificationsSeenPayload) {
@@ -490,9 +490,8 @@ class NotificationStore @Inject constructor(
                 result.notifications?.forEach {
                     changedNotificationLocalIds.add(it.noteId)
                 }
-                causeOfChange = NotificationAction.MARK_NOTIFICATIONS_SEEN
             }
-            onUnreadNotificationUpdate(onNotificationChanged)
+            onUnreadNotificationUpdate()
             onNotificationChanged
         }
     }
@@ -507,9 +506,9 @@ class NotificationStore @Inject constructor(
         emitChange(onNotificationChanged)
     }
 
-    private fun onUnreadNotificationUpdate(onNotificationChanged: OnNotificationChanged) {
+    private fun onUnreadNotificationUpdate() {
         coroutineEngine.launch(T.API, this, "Unread notification state updated") {
-            unreadNotificationUpdates.emit(onNotificationChanged)
+            unreadNotificationUpdates.emit(Unit)
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/NotificationStore.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.store
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
 import com.yarolegovich.wellsql.SelectQuery.ORDER_DESCENDING
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -438,6 +439,7 @@ class NotificationStore @Inject constructor(
             causeOfChange = NotificationAction.FETCH_NOTIFICATION
         }
         emitChange(onNotificationChanged)
+        onUnreadNotificationUpdate(onNotificationChanged)
     }
 
     private fun markNotificationSeen(payload: MarkNotificationsSeenPayload) {
@@ -460,7 +462,6 @@ class NotificationStore @Inject constructor(
             causeOfChange = NotificationAction.MARK_NOTIFICATIONS_SEEN
         }
         emitChange(onNotificationChanged)
-        onUnreadNotificationUpdate(onNotificationChanged)
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
@@ -505,10 +506,13 @@ class NotificationStore @Inject constructor(
             causeOfChange = NotificationAction.UPDATE_NOTIFICATION
         }
         emitChange(onNotificationChanged)
-        onUnreadNotificationUpdate(onNotificationChanged)
     }
 
     private fun onUnreadNotificationUpdate(onNotificationChanged: OnNotificationChanged) {
+        Log.i(
+            "TEST_UNSEEN",
+            "NotificationStore onUnreadNotificationUpdate: ${onNotificationChanged.causeOfChange.toString()}"
+        )
         coroutineEngine.launch(T.API, this, "Unread notification state updated") {
             unreadNotificationUpdates.emit(onNotificationChanged)
         }


### PR DESCRIPTION
@JorgeMucientes as discussed, this is a POC for exposing a Flow to observe the NotificationModel table changes.

My first plan when I spoke with you, was to try to use the native [update hook](https://www.sqlite.org/c3ref/update_hook.html) from SQLite, but it turns out it's not exposed on Android, and even Room uses its own logic for keeping track of the changes through the [`InvalidationTracker`](https://developer.android.com/reference/androidx/room/InvalidationTracker) which keeps a separate table for logging all changes, then they [use](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:room/room-ktx/src/main/java/androidx/room/CoroutinesRoom.kt;l=104-139) those events to compose the Flow.

So I followed a similar approach, but just for the `NotificationModel`, I added a `SharedFlow` that emits a value after each DB update, it's then used as a base for any function that wants to observe the DB, I added an implementation for `observeNotificationsForSite` which we currently need, but this can be extended to all other functions.

I think the advantage of this over the previous solution is the following:
1. It's similar to what Room does, and the logic is kept inside the storage layer, so migrating to Room later won't cause any unwanted changes.
2. It's extensible, and can be used for all other functions.
3. It observes the DB changes, which is always the best approach for "DB first" patterns.
4. It simplifies `UnseenReviewsCountHandler` further, since `observeNotificationsForSite` returns the list of notifications directly.

This PR goes with the following WCAndroid [changes](https://github.com/woocommerce/woocommerce-android/compare/issue/5752-refactor-unseen-reviews-count...review-notifications-observe-db?expand=1).

As always, this is just a suggestion, if you feel this doesn't bring any added value, let's close this PR, it was a fun exercise after all 😄.