### PR TITLE
Woo: Add possibility to specify locale when formatting prices

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
@@ -15,22 +15,38 @@ object WCCurrencyUtils {
      * Currency symbol and placement are not handled.
      */
     fun formatCurrencyForDisplay(rawValue: Double, siteSettings: WCSettingsModel, locale: Locale? = null): String {
-        val pattern = if (siteSettings.currencyDecimalNumber > 0) {
-            "#,##0.${"0".repeat(siteSettings.currencyDecimalNumber)}"
+        return formatCurrencyForDisplay(
+            rawValue = rawValue,
+            currencyDecimalNumber = siteSettings.currencyDecimalNumber,
+            currencyDecimalSeparator = siteSettings.currencyDecimalSeparator,
+            currencyThousandSeparator = siteSettings.currencyThousandSeparator,
+            locale = locale
+        )
+    }
+
+    fun formatCurrencyForDisplay(
+        rawValue: Double,
+        currencyDecimalNumber: Int,
+        currencyDecimalSeparator: String,
+        currencyThousandSeparator: String,
+        locale: Locale? = null
+    ): String {
+        val pattern = if (currencyDecimalNumber > 0) {
+            "#,##0.${"0".repeat(currencyDecimalNumber)}"
         } else {
             "#,##0"
         }
 
         val decimalFormat = locale?.let { DecimalFormat(pattern, DecimalFormatSymbols(locale)) }
-                ?: DecimalFormat(pattern)
+            ?: DecimalFormat(pattern)
 
         decimalFormat.decimalFormatSymbols = decimalFormat.decimalFormatSymbols.apply {
             // If no decimal separator is set, keep whatever the system default is
-            siteSettings.currencyDecimalSeparator.takeIf { it.isNotEmpty() }?.let {
+            currencyDecimalSeparator.takeIf { it.isNotEmpty() }?.let {
                 decimalSeparator = it[0]
             }
             // If no thousands separator is set, assume it's intentional and clear it in the formatter
-            siteSettings.currencyThousandSeparator.takeIf { it.isNotEmpty() }?.let {
+            currencyThousandSeparator.takeIf { it.isNotEmpty() }?.let {
                 groupingSeparator = it[0]
             } ?: run { decimalFormat.isGroupingUsed = false }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.model.WCSettingsModel
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
 import java.util.Currency
 import java.util.Locale
 
@@ -13,12 +14,15 @@ object WCCurrencyUtils {
      *
      * Currency symbol and placement are not handled.
      */
-    fun formatCurrencyForDisplay(rawValue: Double, siteSettings: WCSettingsModel): String {
-        val decimalFormat = if (siteSettings.currencyDecimalNumber > 0) {
-            DecimalFormat("#,##0.${"0".repeat(siteSettings.currencyDecimalNumber)}")
+    fun formatCurrencyForDisplay(rawValue: Double, siteSettings: WCSettingsModel, locale: Locale? = null): String {
+        val pattern = if (siteSettings.currencyDecimalNumber > 0) {
+            "#,##0.${"0".repeat(siteSettings.currencyDecimalNumber)}"
         } else {
-            DecimalFormat("#,##0")
+            "#,##0"
         }
+
+        val decimalFormat = locale?.let { DecimalFormat(pattern, DecimalFormatSymbols(locale)) }
+                ?: DecimalFormat(pattern)
 
         decimalFormat.decimalFormatSymbols = decimalFormat.decimalFormatSymbols.apply {
             // If no decimal separator is set, keep whatever the system default is


### PR DESCRIPTION
This is a simple change that does the following:
1. Allows passing a custom `Locale` for formatting.
2. Adds an overloaded version that's not coupled to the FluxC model `WCSettingsModel`

This is needed for the WCAndroid PR: https://github.com/woocommerce/woocommerce-android/pull/5929