### PR TITLE
Stats remove lates post summary card

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.store.StatsStore.InsightType.COMMENTS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.FOLLOWERS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.LATEST_POST_SUMMARY
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.POSTING_ACTIVITY
+import org.wordpress.android.fluxc.store.StatsStore.InsightType.TODAY_STATS
 import org.wordpress.android.fluxc.store.StatsStore.ManagementType
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsType.FILE_DOWNLOADS
 import org.wordpress.android.fluxc.test
@@ -136,9 +137,9 @@ class StatsStoreTest {
 
     @Test
     fun `removes type from list`() = test {
-        store.removeType(site, LATEST_POST_SUMMARY)
+        store.removeType(site, TODAY_STATS)
 
-        val addedTypes = DEFAULT_INSIGHTS - LATEST_POST_SUMMARY
+        val addedTypes = DEFAULT_INSIGHTS - TODAY_STATS
 
         // executed twice, because the first time the default list is inserted first
         verify(insightTypesSqlUtils).insertOrReplaceAddedItems(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.persistence.InsightTypeSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.ALL_TIME_STATS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.FOLLOWER_TOTALS
-import org.wordpress.android.fluxc.store.StatsStore.InsightType.LATEST_POST_SUMMARY
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TODAY_STATS
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType
@@ -34,7 +33,7 @@ import java.util.Collections
 import javax.inject.Inject
 import javax.inject.Singleton
 
-val DEFAULT_INSIGHTS = listOf(LATEST_POST_SUMMARY, TODAY_STATS, ALL_TIME_STATS, FOLLOWER_TOTALS)
+val DEFAULT_INSIGHTS = listOf(TODAY_STATS, ALL_TIME_STATS, FOLLOWER_TOTALS)
 val STATS_UNAVAILABLE_WITH_JETPACK = listOf(FILE_DOWNLOADS)
 const val INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN = "INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN"
 


### PR DESCRIPTION
This PR removes **Latest Post Summary** card from the defaults on Insights tab on Stats screen.  This also pulls the **Today** card to the top of the list. Please use the [corresponding PR here](https://github.com/wordpress-mobile/WordPress-Android/pull/16011) to test the before and after scenario.

Fixes: [#16010](https://github.com/wordpress-mobile/WordPress-Android/issues/16010)