### PR TITLE
Hide customize insights card

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -163,7 +164,7 @@ class StatsStoreTest {
         )
     }
 
-    @Test
+    @Test @Ignore
     fun `insight types starts with news type and ends with control type when news card was not shown`() = test {
         whenever(insightTypesSqlUtils.selectAddedItemsOrderedByStatus(site)).thenReturn(listOf(COMMENTS))
         whenever(sharedPreferences.getBoolean(INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN, false)).thenReturn(false)
@@ -176,7 +177,7 @@ class StatsStoreTest {
         assertThat(insightTypes[2]).isEqualTo(ManagementType.CONTROL)
     }
 
-    @Test
+    @Test @Ignore
     fun `insight types does not start with news type when news card was shown`() = test {
         whenever(insightTypesSqlUtils.selectAddedItemsOrderedByStatus(site)).thenReturn(listOf(COMMENTS))
         whenever(sharedPreferences.getBoolean(INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN, false)).thenReturn(true)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -59,7 +59,8 @@ class StatsStore
                 val types = mutableListOf<StatsType>()
 /**
  * Customize Insights Management card is being hidden for now.
- * It will be updated to new design in the next iteration
+ * It will be updated to new design in the next iteration.
+ * Also, make sure to remove @Ignore annotation on tests in StatsStoreTest when this is undone.
  **/
 //                if (!preferenceUtils.getFluxCPreferences().getBoolean(INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN, false)) {
 //                    types.add(ManagementType.NEWS_CARD)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -57,9 +57,13 @@ class StatsStore
     suspend fun getInsightTypes(site: SiteModel): List<StatsType> =
             coroutineEngine.withDefaultContext(AppLog.T.STATS, this, "getInsightTypes") {
                 val types = mutableListOf<StatsType>()
-                if (!preferenceUtils.getFluxCPreferences().getBoolean(INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN, false)) {
-                    types.add(ManagementType.NEWS_CARD)
-                }
+/**
+ * Customize Insights Management card is being hidden for now.
+ * It will be updated to new design in the next iteration
+ **/
+//                if (!preferenceUtils.getFluxCPreferences().getBoolean(INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN, false)) {
+//                    types.add(ManagementType.NEWS_CARD)
+//                }
                 types.addAll(getAddedInsights(site))
                 types.add(ManagementType.CONTROL)
                 return@withDefaultContext types


### PR DESCRIPTION
Temporarily hiding customize insights card due to changed priorities.  It will be updated to a new design in the next iteration.

So it is commented for now instead of changing or deleting.

Fixes: [#16020](https://github.com/wordpress-mobile/WordPress-Android/issues/16020)