### PR TITLE
Migrate Order Notes to Room

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersCountResponsePa
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload
+import org.wordpress.android.util.DateTimeUtils
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.inject.Inject
@@ -281,7 +282,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         // Verify basic order fields and private, system note
         with(payload.result!![0]) {
             assertEquals(RemoteId(1942), noteId)
-            assertEquals("2018-04-27T20:48:10Z", dateCreated)
+            assertEquals(DateTimeUtils.dateUTCFromIso8601("2018-04-27T20:48:10Z"), dateCreated)
             assertEquals(siteModel.remoteId(), siteId)
             assertEquals(RemoteId(88), orderId)
             assertEquals(

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -340,7 +340,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals(true, result!!.isCustomerNote)
             assertFalse(result!!.isSystemNote) // Any note created from the app should be flagged as user-created
             assertEquals(orderModel.remoteOrderId, result!!.orderId)
-            assertEquals(siteModel.localId(), result!!.siteId)
+            assertEquals(siteModel.remoteId(), result!!.siteId)
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.annotations.action.Action
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
@@ -283,7 +282,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         with(payload.result!![0]) {
             assertEquals(RemoteId(1942), noteId)
             assertEquals("2018-04-27T20:48:10Z", dateCreated)
-            assertEquals(LocalId(5), localSiteId)
+            assertEquals(RemoteId(5), siteId)
             assertEquals(RemoteId(88), orderId)
             assertEquals(
                     "Email queued: Poster Purchase Follow-Up scheduled " +
@@ -341,7 +340,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals(true, result!!.isCustomerNote)
             assertFalse(result!!.isSystemNote) // Any note created from the app should be flagged as user-created
             assertEquals(orderModel.remoteOrderId, result!!.orderId)
-            assertEquals(siteModel.localId(), result!!.localSiteId)
+            assertEquals(siteModel.localId(), result!!.siteId)
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
@@ -280,10 +281,10 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
 
         // Verify basic order fields and private, system note
         with(payload.result!![0]) {
-            assertEquals(1942, noteId)
+            assertEquals(RemoteId(1942), noteId)
             assertEquals("2018-04-27T20:48:10Z", dateCreated)
-            assertEquals(5, localSiteId)
-            assertEquals(88, orderId)
+            assertEquals(LocalId(5), localSiteId)
+            assertEquals(RemoteId(88), orderId)
             assertEquals(
                     "Email queued: Poster Purchase Follow-Up scheduled " +
                             "on Poster Purchase Follow-Up<br/>Trigger: Poster Purchase Follow-Up", note
@@ -318,7 +319,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         with(payload) {
             // Expecting a 'invalid id' error from the server
             assertNotNull(error)
-            assertEquals(OrderErrorType.INVALID_ID, error.type)
+            assertEquals(WooErrorType.INVALID_ID, error.type)
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -282,7 +282,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         with(payload.result!![0]) {
             assertEquals(RemoteId(1942), noteId)
             assertEquals("2018-04-27T20:48:10Z", dateCreated)
-            assertEquals(RemoteId(5), siteId)
+            assertEquals(siteModel.remoteId(), siteId)
             assertEquals(RemoteId(88), orderId)
             assertEquals(
                     "Email queued: Poster Purchase Follow-Up scheduled " +

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCOrderTest.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
@@ -27,7 +26,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderStatusOptionsChange
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrdersFetchedByIds
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrdersSearched
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
-import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -200,28 +198,25 @@ class ReleaseStack_WCOrderTest : ReleaseStack_WCBase() {
 
         // Fetch notes for the first order returned
         val firstOrder = orderStore.getOrdersForSite(sSite)[0]
-        orderStore.fetchOrderNotes(firstOrder.id, firstOrder.remoteOrderId.value, sSite)
+        orderStore.fetchOrderNotes(sSite, firstOrder.remoteOrderId)
 
         // Verify results
-        val fetchedNotes = orderStore.getOrderNotesForOrder(firstOrder.id)
+        val fetchedNotes = orderStore.getOrderNotesForOrder(sSite, firstOrder.remoteOrderId)
         assertTrue(fetchedNotes.isNotEmpty())
     }
 
     @Throws(InterruptedException::class)
     @Test
     fun testPostOrderNote() = runBlocking {
-        val originalNote = WCOrderNoteModel().apply {
-            localOrderId = orderModel.id
-            localSiteId = sSite.id
-            note = "Test rest note"
-            isCustomerNote = true
-        }
         orderStore.postOrderNote(
-            PostOrderNotePayload(orderModel.id, orderModel.remoteOrderId.value, sSite, originalNote)
+                site = sSite,
+                orderId = orderModel.remoteOrderId,
+                note = "Test rest note",
+                isCustomerNote = true
         )
 
         // Verify results
-        val fetchedNotes = orderStore.getOrderNotesForOrder(orderModel.id)
+        val fetchedNotes = orderStore.getOrderNotesForOrder(sSite, orderModel.remoteOrderId)
         assertTrue(fetchedNotes.isNotEmpty())
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -31,7 +31,6 @@ import org.wordpress.android.fluxc.example.utils.showTwoButtonsDialog
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.LineItem
@@ -52,7 +51,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.HasOrdersResult.Success
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderStatusOptionsChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrdersSearched
-import org.wordpress.android.fluxc.store.WCOrderStore.PostOrderNotePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
@@ -209,13 +207,16 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                 coroutineScope.launch {
                     getFirstWCOrder()?.let { order ->
                         @Suppress("DEPRECATION_ERROR")
-                        val notesCountBeforeRequest = wcOrderStore.getOrderNotesForOrder(order.id).size
+                        val notesCountBeforeRequest = wcOrderStore.getOrderNotesForOrder(site, order.remoteOrderId).size
                         coroutineScope.launch {
                             @Suppress("DEPRECATION_ERROR")
-                            wcOrderStore.fetchOrderNotes(order.id, order.remoteOrderId.value, site)
+                            wcOrderStore.fetchOrderNotes(site, order.remoteOrderId)
                                 .takeUnless { it.isError }
                                 ?.let {
-                                    val notesCountAfterRequest = wcOrderStore.getOrderNotesForOrder(order.id).size
+                                    val notesCountAfterRequest = wcOrderStore.getOrderNotesForOrder(
+                                            site = site,
+                                            orderId = order.remoteOrderId
+                                    ).size
                                     prependToLog(
                                         "Fetched order(${order.remoteOrderId}) notes. " +
                                                 "${notesCountAfterRequest - notesCountBeforeRequest} " +
@@ -233,13 +234,15 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                 coroutineScope.launch {
                     getFirstWCOrder()?.let { order ->
                         showSingleLineDialog(activity, "Enter note") { editText ->
-                            val newNote = WCOrderNoteModel().apply {
-                                note = editText.text.toString()
-                            }
+                            val newNote = editText.text.toString()
                             coroutineScope.launch {
                                 @Suppress("DEPRECATION_ERROR")
-                                val payload = PostOrderNotePayload(order.id, order.remoteOrderId.value, site, newNote)
-                                val onOrderChanged = wcOrderStore.postOrderNote(payload)
+                                val onOrderChanged = wcOrderStore.postOrderNote(
+                                        site = site,
+                                        orderId = order.remoteOrderId,
+                                        note = newNote,
+                                        isCustomerNote = false
+                                )
                                 if (!onOrderChanged.isError) {
                                     prependToLog(
                                         "Posted note to the api for order ${order.remoteOrderId}"

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderSqlUtilsTest.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.fluxc.TestSiteSqlUtils
 import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -34,7 +33,6 @@ class OrderSqlUtilsTest {
         val config = SingleStoreWellSqlConfigForTests(
                 appContext,
                 listOf(
-                        WCOrderNoteModel::class.java,
                         WCOrderStatusModel::class.java,
                         WCOrderShipmentTrackingModel::class.java,
                         WCOrderShipmentProviderModel::class.java,
@@ -43,71 +41,6 @@ class OrderSqlUtilsTest {
                 WellSqlConfig.ADDON_WOOCOMMERCE)
         WellSql.init(config)
         config.reset()
-    }
-
-    @Test
-    fun testInsertOrIgnoreOrderNotes() {
-        val order = OrderTestUtils.generateSampleOrder(42)
-        val note1 = OrderTestUtils.generateSampleNote(1, order.localSiteId, order.id)
-        val note2 = OrderTestUtils.generateSampleNote(2, order.localSiteId, order.id)
-
-        // Test inserting notes
-        OrderSqlUtils.insertOrIgnoreOrderNotes(listOf(note1, note2))
-        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(order.id)
-        assertEquals(2, storedNotes.size)
-
-        // Test ignoring notes already saved to db
-        val inserted = OrderSqlUtils.insertOrIgnoreOrderNotes(listOf(note1))
-        assertEquals(0, inserted)
-        val storedNotes2 = OrderSqlUtils.getOrderNotesForOrder(order.id)
-        assertEquals(2, storedNotes2.size)
-    }
-
-    @Test
-    fun testInsertOrIgnoreOrderNote() {
-        val order = OrderTestUtils.generateSampleOrder(42)
-        val note1 = OrderTestUtils.generateSampleNote(1, order.localSiteId, order.id)
-        val note2 = OrderTestUtils.generateSampleNote(2, order.localSiteId, order.id)
-
-        // Test inserting notes
-        OrderSqlUtils.insertOrIgnoreOrderNote(note1)
-        OrderSqlUtils.insertOrIgnoreOrderNote(note2)
-        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(order.id)
-        assertEquals(2, storedNotes.size)
-
-        // Test ignoring notes already saved to db
-        val inserted = OrderSqlUtils.insertOrIgnoreOrderNote(note1)
-        assertEquals(0, inserted)
-        val storedNotes2 = OrderSqlUtils.getOrderNotesForOrder(order.id)
-        assertEquals(2, storedNotes2.size)
-    }
-
-    @Test
-    fun testGetOrderNotesForOrder() {
-        val order = OrderTestUtils.generateSampleOrder(42)
-        val note1 = OrderTestUtils.generateSampleNote(1, order.localSiteId, order.id)
-        val note2 = OrderTestUtils.generateSampleNote(2, order.localSiteId, order.id)
-        OrderSqlUtils.insertOrIgnoreOrderNotes(listOf(note1, note2))
-
-        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(order.id)
-        assertEquals(2, storedNotes.size)
-    }
-
-    @Test
-    fun testDeleteOrderNotesForSite() {
-        val order = OrderTestUtils.generateSampleOrder(42)
-        val note1 = OrderTestUtils.generateSampleNote(1, order.localSiteId, order.id)
-        val note2 = OrderTestUtils.generateSampleNote(2, order.localSiteId, order.id)
-        OrderSqlUtils.insertOrIgnoreOrderNotes(listOf(note1, note2))
-        val site = SiteModel().apply { id = order.localSiteId.value }
-
-        val storedNotes = OrderSqlUtils.getOrderNotesForOrder(order.id)
-        assertEquals(2, storedNotes.size)
-
-        val deletedCount = OrderSqlUtils.deleteOrderNotesForSite(site)
-        assertEquals(2, deletedCount)
-        val verify = OrderSqlUtils.getOrderNotesForOrder(order.id)
-        assertEquals(0, verify.size)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.OrderNoteEntity
+import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.OrderNoteEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -57,7 +57,7 @@ object OrderTestUtils {
         }
     }
 
-    fun getOrderNotesFromJsonString(json: String, siteId: Int, orderId: Long): List<WCOrderNoteModel> {
+    fun getOrderNotesFromJsonString(json: String, siteId: Int, orderId: Long): List<OrderNoteEntity> {
         val responseType = object : TypeToken<List<OrderNoteApiResponse>>() {}.type
         val converted = Gson().fromJson(json, responseType) as? List<OrderNoteApiResponse> ?: emptyList()
         return converted.map {
@@ -65,7 +65,7 @@ object OrderTestUtils {
         }
     }
 
-    fun generateSampleNote(remoteId: Long, siteId: LocalId, orderId: Int) = WCOrderNoteModel(
+    fun generateSampleNote(remoteId: Long, siteId: LocalId, orderId: Int) = OrderNoteEntity(
         localSiteId = siteId,
         noteId = RemoteId(0L),
         orderId = RemoteId(remoteId),

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -66,15 +66,6 @@ object OrderTestUtils {
         }
     }
 
-    fun generateSampleNote(remoteId: Long, siteId: RemoteId, orderId: Int) = OrderNoteEntity(
-        siteId = siteId,
-        noteId = RemoteId(0L),
-        orderId = RemoteId(remoteId),
-        dateCreated = DateTimeUtils.dateUTCFromIso8601("1955-11-05T14:15:00Z"),
-        note = "This is a test note",
-        isCustomerNote = true
-    )
-
     fun getOrderStatusOptionsFromJson(json: String, siteId: Int): List<WCOrderStatusModel> {
         val responseType = object : TypeToken<List<OrderStatusApiResponse>>() {}.type
         val converted = Gson().fromJson(json, responseType) as? List<OrderStatusApiResponse> ?: emptyList()

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderSummaryApiRe
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.toDataModel
 import org.wordpress.android.fluxc.site.SiteUtils
 import org.wordpress.android.fluxc.utils.DateUtils
+import org.wordpress.android.util.DateTimeUtils
 import kotlin.collections.MutableMap.MutableEntry
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -69,7 +70,7 @@ object OrderTestUtils {
         siteId = siteId,
         noteId = RemoteId(0L),
         orderId = RemoteId(remoteId),
-        dateCreated = "1955-11-05T14:15:00Z",
+        dateCreated = DateTimeUtils.dateUTCFromIso8601("1955-11-05T14:15:00Z"),
         note = "This is a test note",
         isCustomerNote = true
     )

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderSummaryApiRe
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.toDataModel
 import org.wordpress.android.fluxc.site.SiteUtils
 import org.wordpress.android.fluxc.utils.DateUtils
-import org.wordpress.android.util.DateTimeUtils
 import kotlin.collections.MutableMap.MutableEntry
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -57,16 +57,16 @@ object OrderTestUtils {
         }
     }
 
-    fun getOrderNotesFromJsonString(json: String, siteId: Int, orderId: Long): List<OrderNoteEntity> {
+    fun getOrderNotesFromJsonString(json: String, siteId: Long, orderId: Long): List<OrderNoteEntity> {
         val responseType = object : TypeToken<List<OrderNoteApiResponse>>() {}.type
         val converted = Gson().fromJson(json, responseType) as? List<OrderNoteApiResponse> ?: emptyList()
         return converted.map {
-            it.toDataModel(localSiteId = LocalId(siteId), orderId = RemoteId(orderId))
+            it.toDataModel(siteId = RemoteId(siteId), orderId = RemoteId(orderId))
         }
     }
 
-    fun generateSampleNote(remoteId: Long, siteId: LocalId, orderId: Int) = OrderNoteEntity(
-        localSiteId = siteId,
+    fun generateSampleNote(remoteId: Long, siteId: RemoteId, orderId: Int) = OrderNoteEntity(
+        siteId = siteId,
         noteId = RemoteId(0L),
         orderId = RemoteId(remoteId),
         dateCreated = "1955-11-05T14:15:00Z",

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderNoteApiRespo
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderShipmentTrackingApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderStatusApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderSummaryApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.toDataModel
 import org.wordpress.android.fluxc.site.SiteUtils
 import org.wordpress.android.fluxc.utils.DateUtils
 import kotlin.collections.MutableMap.MutableEntry
@@ -56,31 +57,22 @@ object OrderTestUtils {
         }
     }
 
-    fun getOrderNotesFromJsonString(json: String, siteId: Int, orderId: Int): List<WCOrderNoteModel> {
+    fun getOrderNotesFromJsonString(json: String, siteId: Int, orderId: Long): List<WCOrderNoteModel> {
         val responseType = object : TypeToken<List<OrderNoteApiResponse>>() {}.type
         val converted = Gson().fromJson(json, responseType) as? List<OrderNoteApiResponse> ?: emptyList()
         return converted.map {
-            WCOrderNoteModel().apply {
-                remoteNoteId = it.id ?: 0
-                dateCreated = "${it.date_created_gmt}Z"
-                note = it.note ?: ""
-                isCustomerNote = it.customer_note
-                localSiteId = siteId
-                localOrderId = orderId
-            }
+            it.toDataModel(localSiteId = LocalId(siteId), orderId = RemoteId(orderId))
         }
     }
 
-    fun generateSampleNote(remoteId: Long, siteId: LocalId, orderId: Int): WCOrderNoteModel {
-        return WCOrderNoteModel().apply {
-            localSiteId = siteId.value
-            localOrderId = orderId
-            remoteNoteId = remoteId
-            dateCreated = "1955-11-05T14:15:00Z"
-            note = "This is a test note"
-            isCustomerNote = true
-        }
-    }
+    fun generateSampleNote(remoteId: Long, siteId: LocalId, orderId: Int) = WCOrderNoteModel(
+        localSiteId = siteId,
+        noteId = RemoteId(0L),
+        orderId = RemoteId(remoteId),
+        dateCreated = "1955-11-05T14:15:00Z",
+        note = "This is a test note",
+        isCustomerNote = true
+    )
 
     fun getOrderStatusOptionsFromJson(json: String, siteId: Int): List<WCOrderStatusModel> {
         val responseType = object : TypeToken<List<OrderStatusApiResponse>>() {}.type

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -241,7 +241,7 @@ class WCOrderStoreTest {
         assertEquals(6, noteModels.size)
         orderNotesDao.insertNotes(noteModels[0])
 
-        val retrievedNotes = orderStore.getOrderNotesForOrder(SiteModel().apply { id = 6 }, orderModel.remoteOrderId)
+        val retrievedNotes = orderStore.getOrderNotesForOrder(SiteModel().apply { siteId = 6 }, orderModel.remoteOrderId)
         assertEquals(1, retrievedNotes.size)
         assertEquals(noteModels[0], retrievedNotes[0])
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
@@ -38,6 +37,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.fluxc.persistence.dao.OrderNotesDao
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import org.wordpress.android.fluxc.store.WCOrderFetcher
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -59,6 +59,7 @@ class WCOrderStoreTest {
     private val orderFetcher: WCOrderFetcher = mock()
     private val orderRestClient: OrderRestClient = mock()
     lateinit var ordersDao: OrdersDao
+    lateinit var orderNotesDao: OrderNotesDao
     lateinit var orderStore: WCOrderStore
 
     @Before
@@ -70,12 +71,20 @@ class WCOrderStoreTest {
                 .build()
 
         ordersDao = database.ordersDao()
+        orderNotesDao = database.orderNotesDao()
 
-        orderStore = WCOrderStore(Dispatcher(), orderRestClient, orderFetcher, initCoroutineEngine(), ordersDao)
+        orderStore = WCOrderStore(
+                dispatcher = Dispatcher(),
+                wcOrderRestClient = orderRestClient,
+                wcOrderFetcher = orderFetcher,
+                coroutineEngine = initCoroutineEngine(),
+                ordersDao = ordersDao,
+                orderNotesDao = orderNotesDao
+        )
 
         val config = SingleStoreWellSqlConfigForTests(
                 appContext,
-                listOf(WCOrderNoteModel::class.java, WCOrderStatusModel::class.java),
+                listOf(WCOrderStatusModel::class.java),
                 WellSqlConfig.ADDON_WOOCOMMERCE
         )
         WellSql.init(config)
@@ -225,14 +234,14 @@ class WCOrderStoreTest {
     }
 
     @Test
-    fun testGetOrderNotesForOrder() {
+    fun testGetOrderNotesForOrder() = runBlocking {
         val notesJson = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/order_notes.json")
         val noteModels = OrderTestUtils.getOrderNotesFromJsonString(notesJson, 6, 949)
-        val orderModel = OrderTestUtils.generateSampleOrder(1).copy(id = 949)
+        val orderModel = OrderTestUtils.generateSampleOrder(1).copy(remoteOrderId = RemoteId(949))
         assertEquals(6, noteModels.size)
-        OrderSqlUtils.insertOrIgnoreOrderNote(noteModels[0])
+        orderNotesDao.insertNotes(noteModels[0])
 
-        val retrievedNotes = orderStore.getOrderNotesForOrder(orderModel.id)
+        val retrievedNotes = orderStore.getOrderNotesForOrder(SiteModel().apply { id = 6 }, orderModel.remoteOrderId)
         assertEquals(1, retrievedNotes.size)
         assertEquals(noteModels[0], retrievedNotes[0])
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -241,7 +241,10 @@ class WCOrderStoreTest {
         assertEquals(6, noteModels.size)
         orderNotesDao.insertNotes(noteModels[0])
 
-        val retrievedNotes = orderStore.getOrderNotesForOrder(SiteModel().apply { siteId = 6 }, orderModel.remoteOrderId)
+        val retrievedNotes = orderStore.getOrderNotesForOrder(
+                site = SiteModel().apply { siteId = 6 },
+                orderId = orderModel.remoteOrderId
+        )
         assertEquals(1, retrievedNotes.size)
         assertEquals(noteModels[0], retrievedNotes[0])
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.model;
 
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 
@@ -11,6 +13,7 @@ import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -20,8 +23,6 @@ import java.lang.annotation.Retention;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-
-import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})
@@ -152,6 +153,14 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public LocalId localId() {
         return new LocalOrRemoteId.LocalId(mId);
+    }
+
+    public RemoteId remoteId() {
+        if (mSiteId != 0L) {
+            return new RemoteId(mSiteId);
+        } else {
+            return new RemoteId(mSelfHostedSiteId);
+        }
     }
 
     public SiteModel() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.model;
 
-import static java.lang.annotation.RetentionPolicy.SOURCE;
-
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 
@@ -23,6 +21,8 @@ import java.lang.annotation.Retention;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 170
+        return 171
     }
 
     override fun getDbName(): String {
@@ -1837,6 +1837,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 169 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("DROP TABLE IF EXISTS WCPlugins")
+                }
+                170 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCOrderNoteModel")
                 }
             }
         }

--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/8.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/8.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 8,
-    "identityHash": "7b16e46b71fe7c665fba76f535862ed2",
+    "identityHash": "483895ec92768edddcad4043881acd49",
     "entities": [
       {
         "tableName": "AddonEntity",
@@ -528,7 +528,7 @@
       },
       {
         "tableName": "OrderNotes",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `noteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `dateCreated` TEXT NOT NULL DEFAULT '', `note` TEXT NOT NULL DEFAULT '', `author` TEXT NOT NULL DEFAULT '', `isSystemNote` INTEGER NOT NULL DEFAULT 0, `isCustomerNote` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`siteId`, `noteId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `noteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `dateCreated` TEXT, `note` TEXT, `author` TEXT, `isSystemNote` INTEGER NOT NULL DEFAULT 0, `isCustomerNote` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`siteId`, `noteId`))",
         "fields": [
           {
             "fieldPath": "siteId",
@@ -552,22 +552,19 @@
             "fieldPath": "dateCreated",
             "columnName": "dateCreated",
             "affinity": "TEXT",
-            "notNull": true,
-            "defaultValue": "''"
+            "notNull": false
           },
           {
             "fieldPath": "note",
             "columnName": "note",
             "affinity": "TEXT",
-            "notNull": true,
-            "defaultValue": "''"
+            "notNull": false
           },
           {
             "fieldPath": "author",
             "columnName": "author",
             "affinity": "TEXT",
-            "notNull": true,
-            "defaultValue": "''"
+            "notNull": false
           },
           {
             "fieldPath": "isSystemNote",
@@ -598,7 +595,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7b16e46b71fe7c665fba76f535862ed2')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '483895ec92768edddcad4043881acd49')"
     ]
   }
 }

--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/8.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/8.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 8,
-    "identityHash": "233fcefc836e2cf7b023d58a59ed9211",
+    "identityHash": "5d9d5b8abbef48c07f2baf6a7c535f3f",
     "entities": [
       {
         "tableName": "AddonEntity",
@@ -527,7 +527,7 @@
         "foreignKeys": []
       },
       {
-        "tableName": "OrderNoteEntity",
+        "tableName": "OrderNotes",
         "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `noteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `dateCreated` TEXT NOT NULL DEFAULT '', `note` TEXT NOT NULL DEFAULT '', `author` TEXT NOT NULL DEFAULT '', `isSystemNote` INTEGER NOT NULL DEFAULT 0, `isCustomerNote` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`localSiteId`, `noteId`))",
         "fields": [
           {
@@ -598,7 +598,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '233fcefc836e2cf7b023d58a59ed9211')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5d9d5b8abbef48c07f2baf6a7c535f3f')"
     ]
   }
 }

--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/8.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/8.json
@@ -1,0 +1,604 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "233fcefc836e2cf7b023d58a59ed9211",
+    "entities": [
+      {
+        "tableName": "AddonEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`addonLocalId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `globalGroupLocalId` INTEGER, `productRemoteId` INTEGER, `siteRemoteId` INTEGER, `type` TEXT NOT NULL, `display` TEXT, `name` TEXT NOT NULL, `titleFormat` TEXT NOT NULL, `description` TEXT, `required` INTEGER NOT NULL, `position` INTEGER NOT NULL, `restrictions` TEXT, `priceType` TEXT, `price` TEXT, `min` INTEGER, `max` INTEGER, FOREIGN KEY(`globalGroupLocalId`) REFERENCES `GlobalAddonGroupEntity`(`globalGroupLocalId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "addonLocalId",
+            "columnName": "addonLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "globalGroupLocalId",
+            "columnName": "globalGroupLocalId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "productRemoteId",
+            "columnName": "productRemoteId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "siteRemoteId",
+            "columnName": "siteRemoteId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "display",
+            "columnName": "display",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleFormat",
+            "columnName": "titleFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "required",
+            "columnName": "required",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restrictions",
+            "columnName": "restrictions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priceType",
+            "columnName": "priceType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "min",
+            "columnName": "min",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "max",
+            "columnName": "max",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "addonLocalId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "GlobalAddonGroupEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "globalGroupLocalId"
+            ],
+            "referencedColumns": [
+              "globalGroupLocalId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "AddonOptionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`addonOptionLocalId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `addonLocalId` INTEGER NOT NULL, `priceType` TEXT NOT NULL, `label` TEXT, `price` TEXT, `image` TEXT, FOREIGN KEY(`addonLocalId`) REFERENCES `AddonEntity`(`addonLocalId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "addonOptionLocalId",
+            "columnName": "addonOptionLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addonLocalId",
+            "columnName": "addonLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priceType",
+            "columnName": "priceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "addonOptionLocalId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AddonEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "addonLocalId"
+            ],
+            "referencedColumns": [
+              "addonLocalId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAddonGroupEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`globalGroupLocalId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `restrictedCategoriesIds` TEXT NOT NULL, `siteRemoteId` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "globalGroupLocalId",
+            "columnName": "globalGroupLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restrictedCategoriesIds",
+            "columnName": "restrictedCategoriesIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteRemoteId",
+            "columnName": "siteRemoteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "globalGroupLocalId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "OrderEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `localSiteId` INTEGER NOT NULL, `remoteOrderId` INTEGER NOT NULL, `number` TEXT NOT NULL, `status` TEXT NOT NULL, `currency` TEXT NOT NULL, `orderKey` TEXT NOT NULL, `dateCreated` TEXT NOT NULL, `dateModified` TEXT NOT NULL, `total` TEXT NOT NULL, `totalTax` TEXT NOT NULL, `shippingTotal` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `paymentMethodTitle` TEXT NOT NULL, `datePaid` TEXT NOT NULL, `pricesIncludeTax` INTEGER NOT NULL, `customerNote` TEXT NOT NULL, `discountTotal` TEXT NOT NULL, `discountCodes` TEXT NOT NULL, `refundTotal` TEXT NOT NULL, `billingFirstName` TEXT NOT NULL, `billingLastName` TEXT NOT NULL, `billingCompany` TEXT NOT NULL, `billingAddress1` TEXT NOT NULL, `billingAddress2` TEXT NOT NULL, `billingCity` TEXT NOT NULL, `billingState` TEXT NOT NULL, `billingPostcode` TEXT NOT NULL, `billingCountry` TEXT NOT NULL, `billingEmail` TEXT NOT NULL, `billingPhone` TEXT NOT NULL, `shippingFirstName` TEXT NOT NULL, `shippingLastName` TEXT NOT NULL, `shippingCompany` TEXT NOT NULL, `shippingAddress1` TEXT NOT NULL, `shippingAddress2` TEXT NOT NULL, `shippingCity` TEXT NOT NULL, `shippingState` TEXT NOT NULL, `shippingPostcode` TEXT NOT NULL, `shippingCountry` TEXT NOT NULL, `shippingPhone` TEXT NOT NULL, `lineItems` TEXT NOT NULL, `shippingLines` TEXT NOT NULL, `feeLines` TEXT NOT NULL, `taxLines` TEXT NOT NULL, `metaData` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteOrderId",
+            "columnName": "remoteOrderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderKey",
+            "columnName": "orderKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCreated",
+            "columnName": "dateCreated",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalTax",
+            "columnName": "totalTax",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingTotal",
+            "columnName": "shippingTotal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentMethod",
+            "columnName": "paymentMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentMethodTitle",
+            "columnName": "paymentMethodTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datePaid",
+            "columnName": "datePaid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pricesIncludeTax",
+            "columnName": "pricesIncludeTax",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customerNote",
+            "columnName": "customerNote",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discountTotal",
+            "columnName": "discountTotal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discountCodes",
+            "columnName": "discountCodes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refundTotal",
+            "columnName": "refundTotal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingFirstName",
+            "columnName": "billingFirstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingLastName",
+            "columnName": "billingLastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingCompany",
+            "columnName": "billingCompany",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingAddress1",
+            "columnName": "billingAddress1",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingAddress2",
+            "columnName": "billingAddress2",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingCity",
+            "columnName": "billingCity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingState",
+            "columnName": "billingState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingPostcode",
+            "columnName": "billingPostcode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingCountry",
+            "columnName": "billingCountry",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingEmail",
+            "columnName": "billingEmail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingPhone",
+            "columnName": "billingPhone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingFirstName",
+            "columnName": "shippingFirstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingLastName",
+            "columnName": "shippingLastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingCompany",
+            "columnName": "shippingCompany",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingAddress1",
+            "columnName": "shippingAddress1",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingAddress2",
+            "columnName": "shippingAddress2",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingCity",
+            "columnName": "shippingCity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingState",
+            "columnName": "shippingState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingPostcode",
+            "columnName": "shippingPostcode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingCountry",
+            "columnName": "shippingCountry",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingPhone",
+            "columnName": "shippingPhone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineItems",
+            "columnName": "lineItems",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingLines",
+            "columnName": "shippingLines",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feeLines",
+            "columnName": "feeLines",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taxLines",
+            "columnName": "taxLines",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metaData",
+            "columnName": "metaData",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_OrderEntity_localSiteId_remoteOrderId",
+            "unique": true,
+            "columnNames": [
+              "localSiteId",
+              "remoteOrderId"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_OrderEntity_localSiteId_remoteOrderId` ON `${TABLE_NAME}` (`localSiteId`, `remoteOrderId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "OrderNoteEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `noteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `dateCreated` TEXT NOT NULL DEFAULT '', `note` TEXT NOT NULL DEFAULT '', `author` TEXT NOT NULL DEFAULT '', `isSystemNote` INTEGER NOT NULL DEFAULT 0, `isCustomerNote` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`localSiteId`, `noteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderId",
+            "columnName": "orderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCreated",
+            "columnName": "dateCreated",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isSystemNote",
+            "columnName": "isSystemNote",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isCustomerNote",
+            "columnName": "isCustomerNote",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId",
+            "noteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '233fcefc836e2cf7b023d58a59ed9211')"
+    ]
+  }
+}

--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/8.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/8.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 8,
-    "identityHash": "5d9d5b8abbef48c07f2baf6a7c535f3f",
+    "identityHash": "7b16e46b71fe7c665fba76f535862ed2",
     "entities": [
       {
         "tableName": "AddonEntity",
@@ -528,11 +528,11 @@
       },
       {
         "tableName": "OrderNotes",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `noteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `dateCreated` TEXT NOT NULL DEFAULT '', `note` TEXT NOT NULL DEFAULT '', `author` TEXT NOT NULL DEFAULT '', `isSystemNote` INTEGER NOT NULL DEFAULT 0, `isCustomerNote` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`localSiteId`, `noteId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `noteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `dateCreated` TEXT NOT NULL DEFAULT '', `note` TEXT NOT NULL DEFAULT '', `author` TEXT NOT NULL DEFAULT '', `isSystemNote` INTEGER NOT NULL DEFAULT 0, `isCustomerNote` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`siteId`, `noteId`))",
         "fields": [
           {
-            "fieldPath": "localSiteId",
-            "columnName": "localSiteId",
+            "fieldPath": "siteId",
+            "columnName": "siteId",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -586,7 +586,7 @@
         ],
         "primaryKey": {
           "columnNames": [
-            "localSiteId",
+            "siteId",
             "noteId"
           ],
           "autoGenerate": false
@@ -598,7 +598,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5d9d5b8abbef48c07f2baf6a7c535f3f')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7b16e46b71fe7c665fba76f535862ed2')"
     ]
   }
 }

--- a/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
+++ b/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_6_7
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_7_8
 
 @RunWith(AndroidJUnit4::class)
 class MigrationTests {
@@ -66,6 +67,14 @@ class MigrationTests {
                         SELECT * FROM OrderEntity
                     """.trimIndent()
             )
+        }
+    }
+
+    @Test
+    fun testMigration7to8() {
+        helper.apply {
+            createDatabase(TEST_DB, 7).close()
+            runMigrationsAndValidate(TEST_DB, 8, true, MIGRATION_7_8)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
@@ -21,4 +21,6 @@ class WCDatabaseModule {
     @Provides fun provideOrdersDao(database: WCAndroidDatabase): OrdersDao {
         return database.ordersDao()
     }
+
+    @Provides fun provideOrderNotesDao(database: WCAndroidDatabase) = database.orderNotesDao()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderNoteEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderNoteEntity.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 
 @Entity(tableName = "OrderNoteEntity", primaryKeys = ["localSiteId", "noteId"])
-data class WCOrderNoteModel(
+data class OrderNoteEntity(
     var localSiteId: LocalId,
     var noteId: RemoteId,
     var orderId: RemoteId,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderNoteModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderNoteModel.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 data class WCOrderNoteModel(
     var localSiteId: LocalId,
     var noteId: RemoteId,
-    var orderid: RemoteId,
+    var orderId: RemoteId,
     @ColumnInfo(defaultValue = "") var dateCreated: String = "", // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @ColumnInfo(defaultValue = "") var note: String = "",
     @ColumnInfo(defaultValue = "") var author: String = "",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderNoteModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderNoteModel.kt
@@ -1,29 +1,18 @@
 package org.wordpress.android.fluxc.model
 
-import com.yarolegovich.wellsql.core.Identifiable
-import com.yarolegovich.wellsql.core.annotation.Column
-import com.yarolegovich.wellsql.core.annotation.PrimaryKey
-import com.yarolegovich.wellsql.core.annotation.Table
-import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 
-@Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
-data class WCOrderNoteModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
-    @Column var localSiteId = 0
-    @Column var localOrderId = 0 // The local db unique identifier for the parent order object
-    @Column var remoteNoteId = 0L // The unique identifier for this note on the server
-    @Column var dateCreated = "" // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
-    @Column var note = ""
-    @Column var author = ""
-    @Column var isSystemNote = false // True if the note is 'system-created', else created by a site user
-        @JvmName("setIsSystemNote")
-        set
-    @Column var isCustomerNote = false // False if private, else customer-facing. Default is false
-        @JvmName("setIsCustomerNote")
-        set
-
-    override fun getId() = id
-
-    override fun setId(id: Int) {
-        this.id = id
-    }
-}
+@Entity(tableName = "OrderNoteEntity", primaryKeys = ["localSiteId", "noteId"])
+data class WCOrderNoteModel(
+    var localSiteId: LocalId,
+    var noteId: RemoteId,
+    var orderid: RemoteId,
+    @ColumnInfo(defaultValue = "") var dateCreated: String = "", // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    @ColumnInfo(defaultValue = "") var note: String = "",
+    @ColumnInfo(defaultValue = "") var author: String = "",
+    @ColumnInfo(defaultValue = "0") var isSystemNote: Boolean = false, // True if the note is 'system-created', else created by a site user
+    @ColumnInfo(defaultValue = "0") var isCustomerNote: Boolean = false// False if private, else customer-facing. Default is false
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderNoteModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderNoteModel.kt
@@ -10,9 +10,14 @@ data class WCOrderNoteModel(
     var localSiteId: LocalId,
     var noteId: RemoteId,
     var orderId: RemoteId,
-    @ColumnInfo(defaultValue = "") var dateCreated: String = "", // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
-    @ColumnInfo(defaultValue = "") var note: String = "",
-    @ColumnInfo(defaultValue = "") var author: String = "",
-    @ColumnInfo(defaultValue = "0") var isSystemNote: Boolean = false, // True if the note is 'system-created', else created by a site user
-    @ColumnInfo(defaultValue = "0") var isCustomerNote: Boolean = false// False if private, else customer-facing. Default is false
+    @ColumnInfo(defaultValue = "")
+    var dateCreated: String = "", // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    @ColumnInfo(defaultValue = "")
+    var note: String = "",
+    @ColumnInfo(defaultValue = "")
+    var author: String = "",
+    @ColumnInfo(defaultValue = "0")
+    var isSystemNote: Boolean = false, // True if the note is 'system-created', else created by a site user
+    @ColumnInfo(defaultValue = "0")
+    var isCustomerNote: Boolean = false // False if private, else customer-facing. Default is false
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -29,7 +29,9 @@ enum class WooErrorType {
     INVALID_ID,
     GENERIC_ERROR,
     INVALID_RESPONSE,
-    AUTHORIZATION_REQUIRED
+    AUTHORIZATION_REQUIRED,
+    INVALID_PARAM,
+    PLUGIN_NOT_ACTIVE
 }
 
 fun WPComGsonNetworkError.toWooError(): WooError {
@@ -46,8 +48,13 @@ fun WPComGsonNetworkError.toWooError(): WooError {
         AUTHORIZATION_REQUIRED,
         NOT_AUTHENTICATED -> WooErrorType.AUTHORIZATION_REQUIRED
         NOT_FOUND -> WooErrorType.INVALID_ID
-        UNKNOWN,
-        null -> WooErrorType.GENERIC_ERROR
+        UNKNOWN, null -> {
+            when (apiError) {
+                "rest_invalid_param" -> WooErrorType.INVALID_PARAM
+                "rest_no_route" -> WooErrorType.PLUGIN_NOT_ACTIVE
+                else -> WooErrorType.GENERIC_ERROR
+            }
+        }
     }
     return WooError(type, this.type, message)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.network.Response
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
+import org.wordpress.android.util.DateTimeUtils
 
 @Suppress("PropertyName")
 class OrderNoteApiResponse : Response {
@@ -19,7 +20,7 @@ fun OrderNoteApiResponse.toDataModel(siteId: RemoteId, orderId: RemoteId) = Orde
     siteId = siteId,
     noteId = RemoteId(id ?: 0),
     orderId = orderId,
-    dateCreated = date_created_gmt?.let { "${it}Z" },
+    dateCreated = date_created_gmt?.let { DateTimeUtils.dateUTCFromIso8601("${it}Z") },
     note = note,
     isSystemNote = author == "system" || author == "WooCommerce",
     author = author ?: "",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.network.Response
@@ -16,9 +15,9 @@ class OrderNoteApiResponse : Response {
     val customer_note: Boolean = false
 }
 
-fun OrderNoteApiResponse.toDataModel(localSiteId: LocalId, orderId: RemoteId): OrderNoteEntity =
+fun OrderNoteApiResponse.toDataModel(siteId: RemoteId, orderId: RemoteId): OrderNoteEntity =
         OrderNoteEntity(
-                localSiteId = localSiteId,
+                siteId = siteId,
                 noteId = RemoteId(id ?: 0),
                 orderId = orderId,
                 dateCreated = date_created_gmt?.let { "${it}Z" } ?: "",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.network.Response
+import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 
 @Suppress("PropertyName")
 class OrderNoteApiResponse : Response {
@@ -15,14 +15,13 @@ class OrderNoteApiResponse : Response {
     val customer_note: Boolean = false
 }
 
-fun OrderNoteApiResponse.toDataModel(siteId: RemoteId, orderId: RemoteId): OrderNoteEntity =
-        OrderNoteEntity(
-                siteId = siteId,
-                noteId = RemoteId(id ?: 0),
-                orderId = orderId,
-                dateCreated = date_created_gmt?.let { "${it}Z" } ?: "",
-                note = note ?: "",
-                isSystemNote = author == "system" || author == "WooCommerce",
-                author = author ?: "",
-                isCustomerNote = customer_note
-        )
+fun OrderNoteApiResponse.toDataModel(siteId: RemoteId, orderId: RemoteId) = OrderNoteEntity(
+    siteId = siteId,
+    noteId = RemoteId(id ?: 0),
+    orderId = orderId,
+    dateCreated = date_created_gmt?.let { "${it}Z" },
+    note = note,
+    isSystemNote = author == "system" || author == "WooCommerce",
+    author = author ?: "",
+    isCustomerNote = customer_note
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.OrderNoteEntity
 import org.wordpress.android.fluxc.network.Response
 
 @Suppress("PropertyName")
@@ -16,8 +16,8 @@ class OrderNoteApiResponse : Response {
     val customer_note: Boolean = false
 }
 
-fun OrderNoteApiResponse.toDataModel(localSiteId: LocalId, orderId: RemoteId): WCOrderNoteModel =
-        WCOrderNoteModel(
+fun OrderNoteApiResponse.toDataModel(localSiteId: LocalId, orderId: RemoteId): OrderNoteEntity =
+        OrderNoteEntity(
                 localSiteId = localSiteId,
                 noteId = RemoteId(id ?: 0),
                 orderId = orderId,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.network.Response
 
 @Suppress("PropertyName")
@@ -12,3 +15,15 @@ class OrderNoteApiResponse : Response {
     // reference only. Default is false.
     val customer_note: Boolean = false
 }
+
+fun OrderNoteApiResponse.toDataModel(localSiteId: LocalId, orderId: RemoteId): WCOrderNoteModel =
+        WCOrderNoteModel(
+                localSiteId = localSiteId,
+                noteId = RemoteId(id ?: 0),
+                orderId = orderId,
+                dateCreated = date_created_gmt?.let { "${it}Z" } ?: "",
+                note = note ?: "",
+                isSystemNote = author == "system" || author == "WooCommerce",
+                author = author ?: "",
+                isCustomerNote = customer_note
+        )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderNoteApiResponse.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.model.OrderNoteEntity
+import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.network.Response
 
 @Suppress("PropertyName")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -496,7 +496,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 val noteModels = response.data?.map {
-                    it.toDataModel(site.localId(), orderId)
+                    it.toDataModel(site.remoteId(), orderId)
                 }.orEmpty()
                 WooPayload(noteModels)
             }
@@ -532,7 +532,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 response.data?.let {
-                    val newNote = it.toDataModel(site.localId(), remoteOrderId)
+                    val newNote = it.toDataModel(site.remoteId(), remoteOrderId)
                     return WooPayload(newNote)
                 } ?: WooPayload(
                         WooError(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -499,10 +499,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 val noteModels = response.data?.map {
-                    orderNoteResponseToOrderNoteModel(it).apply {
-                        localSiteId = site.id
-                        this.localOrderId = localOrderId
-                    }
+                    it.toDataModel(site.localId(), RemoteId(remoteOrderId))
                 }.orEmpty()
                 FetchOrderNotesResponsePayload(localOrderId, remoteOrderId, site, noteModels)
             }
@@ -541,10 +538,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 response.data?.let {
-                    val newNote = orderNoteResponseToOrderNoteModel(it).apply {
-                        localSiteId = site.id
-                        this.localOrderId = localOrderId
-                    }
+                    val newNote = it.toDataModel(site.localId(), RemoteId(remoteOrderId))
                     return RemoteOrderNotePayload(localOrderId, remoteOrderId, site, newNote)
                 } ?: RemoteOrderNotePayload(
                         OrderError(type = GENERIC_ERROR, message = "Success response with empty data"),
@@ -865,17 +859,6 @@ class OrderRestClient @Inject constructor(
             remoteOrderId = response.id ?: 0
             dateCreated = convertDateToUTCString(response.dateCreatedGmt)
             dateModified = convertDateToUTCString(response.dateModifiedGmt)
-        }
-    }
-
-    private fun orderNoteResponseToOrderNoteModel(response: OrderNoteApiResponse): WCOrderNoteModel {
-        return WCOrderNoteModel().apply {
-            remoteNoteId = response.id ?: 0
-            dateCreated = response.date_created_gmt?.let { "${it}Z" } ?: ""
-            note = response.note ?: ""
-            isSystemNote = response.author == "system" || response.author == "WooCommerce"
-            author = response.author ?: ""
-            isCustomerNote = response.customer_note
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.OrderNoteEntity
+import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.OrderNoteEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -484,7 +484,7 @@ class OrderRestClient @Inject constructor(
     suspend fun fetchOrderNotes(
         orderId: RemoteId,
         site: SiteModel
-    ): WooPayload<List<WCOrderNoteModel>> {
+    ): WooPayload<List<OrderNoteEntity>> {
         val url = WOOCOMMERCE.orders.id(orderId.value).notes.pathV3
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
             this,
@@ -513,7 +513,7 @@ class OrderRestClient @Inject constructor(
         site: SiteModel,
         note: String,
         isCustomerNote: Boolean
-    ): WooPayload<WCOrderNoteModel> {
+    ): WooPayload<OrderNoteEntity> {
         val url = WOOCOMMERCE.orders.id(remoteOrderId.value).notes.pathV3
 
         val params = mutableMapOf(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.persistence
 
-import com.wellsql.generated.WCOrderNoteModelTable
 import com.wellsql.generated.WCOrderShipmentProviderModelTable
 import com.wellsql.generated.WCOrderShipmentTrackingModelTable
 import com.wellsql.generated.WCOrderStatusModelTable
@@ -9,7 +8,6 @@ import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -51,51 +49,6 @@ object OrderSqlUtils {
         WellSql.delete(WCOrderSummaryModel::class.java)
                 .where()
                 .equals(WCOrderSummaryModelTable.LOCAL_SITE_ID, site.id)
-                .endWhere()
-                .execute()
-    }
-
-    fun insertOrIgnoreOrderNotes(notes: List<WCOrderNoteModel>): Int {
-        var totalChanged = 0
-        notes.forEach { totalChanged += insertOrIgnoreOrderNote(it) }
-        return totalChanged
-    }
-
-    fun insertOrIgnoreOrderNote(note: WCOrderNoteModel): Int {
-        val noteResult = WellSql.select(WCOrderNoteModel::class.java)
-                .where().beginGroup()
-                .equals(WCOrderNoteModelTable.ID, note.id)
-                .or()
-                .beginGroup()
-                .equals(WCOrderNoteModelTable.REMOTE_NOTE_ID, note.remoteNoteId)
-                .equals(WCOrderNoteModelTable.LOCAL_SITE_ID, note.localSiteId)
-                .equals(WCOrderNoteModelTable.LOCAL_ORDER_ID, note.localOrderId)
-                .endGroup()
-                .endGroup().endWhere()
-                .asModel
-
-        return if (noteResult.isEmpty()) {
-            // Insert
-            WellSql.insert(note).asSingleTransaction(true).execute()
-            1
-        } else {
-            // Ignore
-            0
-        }
-    }
-
-    fun getOrderNotesForOrder(localId: Int): List<WCOrderNoteModel> =
-            WellSql.select(WCOrderNoteModel::class.java)
-                    .where()
-                    .equals(WCOrderNoteModelTable.LOCAL_ORDER_ID, localId)
-                    .endWhere()
-                    .orderBy(WCOrderNoteModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
-                    .asModel
-
-    fun deleteOrderNotesForSite(site: SiteModel): Int {
-        return WellSql.delete(WCOrderNoteModel::class.java)
-                .where()
-                .equals(WCOrderNoteModelTable.LOCAL_SITE_ID, site.id)
                 .endWhere()
                 .execute()
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_6_7
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_7_8
 
 @Database(
         version = 8,
@@ -55,6 +56,7 @@ abstract class WCAndroidDatabase : RoomDatabase() {
                 .addMigrations(MIGRATION_4_5)
                 .addMigrations(MIGRATION_5_6)
                 .addMigrations(MIGRATION_6_7)
+                .addMigrations(MIGRATION_7_8)
                 .build()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import org.wordpress.android.fluxc.model.WCOrderModel
+import org.wordpress.android.fluxc.model.WCOrderNoteModel
 import org.wordpress.android.fluxc.persistence.converters.BigDecimalConverter
 import org.wordpress.android.fluxc.persistence.converters.LocalIdConverter
 import org.wordpress.android.fluxc.persistence.converters.LongListConverter
@@ -21,12 +22,13 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_6_7
 
 @Database(
-        version = 7,
+        version = 8,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,
             GlobalAddonGroupEntity::class,
-            WCOrderModel::class
+            WCOrderModel::class,
+            WCOrderNoteModel::class
         ]
 )
 @TypeConverters(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.OrderNoteEntity
+import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.persistence.converters.BigDecimalConverter
 import org.wordpress.android.fluxc.persistence.converters.LocalIdConverter
 import org.wordpress.android.fluxc.persistence.converters.LongListConverter

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.OrderNoteEntity
 import org.wordpress.android.fluxc.persistence.converters.BigDecimalConverter
 import org.wordpress.android.fluxc.persistence.converters.LocalIdConverter
 import org.wordpress.android.fluxc.persistence.converters.LongListConverter
@@ -30,7 +30,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_7_8
             AddonOptionEntity::class,
             GlobalAddonGroupEntity::class,
             WCOrderModel::class,
-            WCOrderNoteModel::class
+            OrderNoteEntity::class
         ]
 )
 @TypeConverters(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.persistence.converters.LocalIdConverter
 import org.wordpress.android.fluxc.persistence.converters.LongListConverter
 import org.wordpress.android.fluxc.persistence.converters.RemoteIdConverter
 import org.wordpress.android.fluxc.persistence.dao.AddonsDao
+import org.wordpress.android.fluxc.persistence.dao.OrderNotesDao
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import org.wordpress.android.fluxc.persistence.entity.AddonEntity
 import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
@@ -43,6 +44,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_7_8
 abstract class WCAndroidDatabase : RoomDatabase() {
     internal abstract fun addonsDao(): AddonsDao
     abstract fun ordersDao(): OrdersDao
+    abstract fun orderNotesDao(): OrderNotesDao
 
     companion object {
         fun buildDb(applicationContext: Context) = Room.databaseBuilder(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -6,7 +6,6 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.persistence.converters.BigDecimalConverter
 import org.wordpress.android.fluxc.persistence.converters.LocalIdConverter
 import org.wordpress.android.fluxc.persistence.converters.LongListConverter
@@ -17,6 +16,7 @@ import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import org.wordpress.android.fluxc.persistence.entity.AddonEntity
 import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
 import org.wordpress.android.fluxc.persistence.entity.GlobalAddonGroupEntity
+import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/converters/ISO8601DateConverter.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/converters/ISO8601DateConverter.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.persistence.converters
+
+import androidx.room.TypeConverter
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+
+/**
+ * A Room type converter for ISO 8601-formatted dates
+ */
+class ISO8601DateConverter {
+    @TypeConverter
+    fun stringToDate(value: String?) = value?.let { DateTimeUtils.dateUTCFromIso8601(it) }
+
+    @TypeConverter
+    fun dateToString(date: Date?) = date?.let { DateTimeUtils.iso8601FromDate(it) }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
@@ -6,15 +6,15 @@ import androidx.room.OnConflictStrategy.REPLACE
 import androidx.room.Query
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.OrderNoteEntity
 
 @Dao
 interface OrderNotesDao {
     @Insert(onConflict = REPLACE)
-    suspend fun insertNotes(vararg notes: WCOrderNoteModel)
+    suspend fun insertNotes(vararg notes: OrderNoteEntity)
 
     @Query("SELECT * FROM OrderNoteEntity WHERE localSiteId = :localSiteId AND orderId = :orderId")
-    suspend fun queryNotesOfOrder(localSiteId: LocalId, orderId: RemoteId): List<WCOrderNoteModel>
+    suspend fun queryNotesOfOrder(localSiteId: LocalId, orderId: RemoteId): List<OrderNoteEntity>
 
     @Query("DELETE FROM OrderNoteEntity WHERE localSiteId = :localSiteId")
     fun deleteOrderNotesForSite(localSiteId: LocalId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy.REPLACE
+import androidx.room.Query
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.WCOrderNoteModel
+
+@Dao
+interface OrderNotesDao {
+    @Insert(onConflict = REPLACE)
+    suspend fun insertNotes(vararg notes: WCOrderNoteModel)
+
+    @Query("SELECT * FROM OrderNoteEntity WHERE localSiteId = :localSiteId AND orderId = :orderId")
+    suspend fun queryNotesOfOrder(localSiteId: LocalId, orderId: RemoteId): List<WCOrderNoteModel>
+
+    @Query("DELETE FROM OrderNoteEntity WHERE localSiteId = :localSiteId")
+    fun deleteOrderNotesForSite(localSiteId: LocalId)
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
@@ -6,7 +6,7 @@ import androidx.room.OnConflictStrategy.REPLACE
 import androidx.room.Query
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.model.OrderNoteEntity
+import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 
 @Dao
 interface OrderNotesDao {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
@@ -4,7 +4,6 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy.REPLACE
 import androidx.room.Query
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 
@@ -13,9 +12,9 @@ interface OrderNotesDao {
     @Insert(onConflict = REPLACE)
     suspend fun insertNotes(vararg notes: OrderNoteEntity)
 
-    @Query("SELECT * FROM OrderNotes WHERE localSiteId = :localSiteId AND orderId = :orderId")
-    suspend fun queryNotesOfOrder(localSiteId: LocalId, orderId: RemoteId): List<OrderNoteEntity>
+    @Query("SELECT * FROM OrderNotes WHERE siteId = :siteId AND orderId = :orderId")
+    suspend fun queryNotesOfOrder(siteId: RemoteId, orderId: RemoteId): List<OrderNoteEntity>
 
-    @Query("DELETE FROM OrderNotes WHERE localSiteId = :localSiteId")
-    fun deleteOrderNotesForSite(localSiteId: LocalId)
+    @Query("DELETE FROM OrderNotes WHERE siteId = :siteId")
+    fun deleteOrderNotesForSite(siteId: RemoteId)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
@@ -13,9 +13,9 @@ interface OrderNotesDao {
     @Insert(onConflict = REPLACE)
     suspend fun insertNotes(vararg notes: OrderNoteEntity)
 
-    @Query("SELECT * FROM OrderNoteEntity WHERE localSiteId = :localSiteId AND orderId = :orderId")
+    @Query("SELECT * FROM OrderNotes WHERE localSiteId = :localSiteId AND orderId = :orderId")
     suspend fun queryNotesOfOrder(localSiteId: LocalId, orderId: RemoteId): List<OrderNoteEntity>
 
-    @Query("DELETE FROM OrderNoteEntity WHERE localSiteId = :localSiteId")
+    @Query("DELETE FROM OrderNotes WHERE localSiteId = :localSiteId")
     fun deleteOrderNotesForSite(localSiteId: LocalId)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
@@ -2,12 +2,11 @@ package org.wordpress.android.fluxc.persistence.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 
-@Entity(tableName = "OrderNotes", primaryKeys = ["localSiteId", "noteId"])
+@Entity(tableName = "OrderNotes", primaryKeys = ["siteId", "noteId"])
 data class OrderNoteEntity(
-    val localSiteId: LocalId,
+    val siteId: RemoteId,
     val noteId: RemoteId,
     val orderId: RemoteId,
     @ColumnInfo(defaultValue = "")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.fluxc.model
+package org.wordpress.android.fluxc.persistence.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
@@ -5,7 +5,7 @@ import androidx.room.Entity
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 
-@Entity(tableName = "OrderNoteEntity", primaryKeys = ["localSiteId", "noteId"])
+@Entity(tableName = "OrderNotes", primaryKeys = ["localSiteId", "noteId"])
 data class OrderNoteEntity(
     val localSiteId: LocalId,
     val noteId: RemoteId,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
@@ -9,12 +9,9 @@ data class OrderNoteEntity(
     val siteId: RemoteId,
     val noteId: RemoteId,
     val orderId: RemoteId,
-    @ColumnInfo(defaultValue = "")
-    val dateCreated: String = "", // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
-    @ColumnInfo(defaultValue = "")
-    val note: String = "",
-    @ColumnInfo(defaultValue = "")
-    val author: String = "",
+    val dateCreated: String? = null, // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    val note: String? = null,
+    val author: String? = null,
     @ColumnInfo(defaultValue = "0")
     val isSystemNote: Boolean = false, // True if the note is 'system-created', else created by a site user
     @ColumnInfo(defaultValue = "0")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.persistence.entity
 
-import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.TypeConverters
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
@@ -15,8 +14,6 @@ data class OrderNoteEntity(
     @field:TypeConverters(ISO8601DateConverter::class) val dateCreated: Date? = null,
     val note: String? = null,
     val author: String? = null,
-    @ColumnInfo(defaultValue = "0")
-    val isSystemNote: Boolean = false, // True if the note is 'system-created', else created by a site user
-    @ColumnInfo(defaultValue = "0")
-    val isCustomerNote: Boolean = false // False if private, else customer-facing. Default is false
+    val isSystemNote: Boolean, // True if the note is 'system-created', else created by a site user
+    val isCustomerNote: Boolean // False if private, else customer-facing.
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
@@ -2,14 +2,17 @@ package org.wordpress.android.fluxc.persistence.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.TypeConverters
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.persistence.converters.ISO8601DateConverter
+import java.util.Date
 
 @Entity(tableName = "OrderNotes", primaryKeys = ["siteId", "noteId"])
 data class OrderNoteEntity(
     val siteId: RemoteId,
     val noteId: RemoteId,
     val orderId: RemoteId,
-    val dateCreated: String? = null, // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    @field:TypeConverters(ISO8601DateConverter::class) val dateCreated: Date? = null,
     val note: String? = null,
     val author: String? = null,
     @ColumnInfo(defaultValue = "0")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderNoteEntity.kt
@@ -7,17 +7,17 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 
 @Entity(tableName = "OrderNoteEntity", primaryKeys = ["localSiteId", "noteId"])
 data class OrderNoteEntity(
-    var localSiteId: LocalId,
-    var noteId: RemoteId,
-    var orderId: RemoteId,
+    val localSiteId: LocalId,
+    val noteId: RemoteId,
+    val orderId: RemoteId,
     @ColumnInfo(defaultValue = "")
-    var dateCreated: String = "", // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    val dateCreated: String = "", // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
     @ColumnInfo(defaultValue = "")
-    var note: String = "",
+    val note: String = "",
     @ColumnInfo(defaultValue = "")
-    var author: String = "",
+    val author: String = "",
     @ColumnInfo(defaultValue = "0")
-    var isSystemNote: Boolean = false, // True if the note is 'system-created', else created by a site user
+    val isSystemNote: Boolean = false, // True if the note is 'system-created', else created by a site user
     @ColumnInfo(defaultValue = "0")
-    var isCustomerNote: Boolean = false // False if private, else customer-facing. Default is false
+    val isCustomerNote: Boolean = false // False if private, else customer-facing. Default is false
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -150,16 +150,15 @@ internal val MIGRATION_7_8 = object : Migration(7, 8) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL("""
             CREATE TABLE IF NOT EXISTS OrderNotes (
-                siteId INTEGER NOT NULL, 
-                noteId INTEGER NOT NULL, 
-                orderId INTEGER NOT NULL, 
-                dateCreated TEXT NOT NULL DEFAULT '', 
-                note TEXT NOT NULL DEFAULT '', 
-                author TEXT NOT NULL DEFAULT '', 
-                isSystemNote INTEGER NOT NULL DEFAULT 0, 
-                isCustomerNote INTEGER NOT NULL DEFAULT 0, 
-                PRIMARY KEY(siteId, noteId)
-            )
+                siteId INTEGER NOT NULL,
+                noteId INTEGER NOT NULL,
+                orderId INTEGER NOT NULL,
+                dateCreated TEXT,
+                note TEXT,
+                author TEXT,
+                isSystemNote INTEGER NOT NULL DEFAULT 0,
+                isCustomerNote INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(`siteId`, `noteId`))
         """.trimIndent())
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -149,7 +149,7 @@ internal val MIGRATION_6_7 = object : Migration(6, 7) {
 internal val MIGRATION_7_8 = object : Migration(7, 8) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL("""
-            CREATE TABLE IF NOT EXISTS OrderNoteEntity (
+            CREATE TABLE IF NOT EXISTS OrderNotes (
                 localSiteId INTEGER NOT NULL, 
                 noteId INTEGER NOT NULL, 
                 orderId INTEGER NOT NULL, 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -145,3 +145,21 @@ internal val MIGRATION_6_7 = object : Migration(6, 7) {
         database.execSQL("ALTER TABLE OrderEntity ADD taxLines TEXT NOT NULL DEFAULT ''")
     }
 }
+
+internal val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("""
+            CREATE TABLE IF NOT EXISTS OrderNoteEntity (
+                localSiteId INTEGER NOT NULL, 
+                noteId INTEGER NOT NULL, 
+                orderId INTEGER NOT NULL, 
+                dateCreated TEXT NOT NULL DEFAULT '', 
+                note TEXT NOT NULL DEFAULT '', 
+                author TEXT NOT NULL DEFAULT '', 
+                isSystemNote INTEGER NOT NULL DEFAULT 0, 
+                isCustomerNote INTEGER NOT NULL DEFAULT 0, 
+                PRIMARY KEY(localSiteId, noteId)
+            )
+        """.trimIndent())
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -150,7 +150,7 @@ internal val MIGRATION_7_8 = object : Migration(7, 8) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL("""
             CREATE TABLE IF NOT EXISTS OrderNotes (
-                localSiteId INTEGER NOT NULL, 
+                siteId INTEGER NOT NULL, 
                 noteId INTEGER NOT NULL, 
                 orderId INTEGER NOT NULL, 
                 dateCreated TEXT NOT NULL DEFAULT '', 
@@ -158,7 +158,7 @@ internal val MIGRATION_7_8 = object : Migration(7, 8) {
                 author TEXT NOT NULL DEFAULT '', 
                 isSystemNote INTEGER NOT NULL DEFAULT 0, 
                 isCustomerNote INTEGER NOT NULL DEFAULT 0, 
-                PRIMARY KEY(localSiteId, noteId)
+                PRIMARY KEY(siteId, noteId)
             )
         """.trimIndent())
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -383,9 +383,6 @@ class WCOrderStore @Inject constructor(
     /**
      * Returns the notes belonging to supplied [WCOrderModel] as a list of [OrderNoteEntity].
      */
-    fun getOrderNotesForOrder(orderId: Int): List<OrderNoteEntity> =
-            error("")
-
     suspend fun getOrderNotesForOrder(site: SiteModel, orderId: RemoteId): List<OrderNoteEntity> =
             orderNotesDao.queryNotesOfOrder(site.localId(), orderId)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -181,13 +181,6 @@ class WCOrderStore @Inject constructor(
         data class RemoteUpdateResult(override val event: OnOrderChanged) : UpdateOrderResult()
     }
 
-    class PostOrderNotePayload(
-        var remoteOrderId: Long,
-        val site: SiteModel,
-        val note: String,
-        val isCustomerNote: Boolean
-    ) : Payload<BaseNetworkError>()
-
     class FetchOrderStatusOptionsPayload(val site: SiteModel) : Payload<BaseNetworkError>()
 
     class FetchOrderStatusOptionsResponsePayload(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.WCOrderNoteModel
+import org.wordpress.android.fluxc.model.OrderNoteEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -381,12 +381,12 @@ class WCOrderStore @Inject constructor(
     }
 
     /**
-     * Returns the notes belonging to supplied [WCOrderModel] as a list of [WCOrderNoteModel].
+     * Returns the notes belonging to supplied [WCOrderModel] as a list of [OrderNoteEntity].
      */
-    fun getOrderNotesForOrder(orderId: Int): List<WCOrderNoteModel> =
+    fun getOrderNotesForOrder(orderId: Int): List<OrderNoteEntity> =
             error("")
 
-    suspend fun getOrderNotesForOrder(site: SiteModel, orderId: RemoteId): List<WCOrderNoteModel> =
+    suspend fun getOrderNotesForOrder(site: SiteModel, orderId: RemoteId): List<OrderNoteEntity> =
             orderNotesDao.queryNotesOfOrder(site.localId(), orderId)
 
     /**
@@ -552,7 +552,7 @@ class WCOrderStore @Inject constructor(
     suspend fun fetchOrderNotes(
         site: SiteModel,
         orderId: RemoteId
-    ): WooResult<List<WCOrderNoteModel>> {
+    ): WooResult<List<OrderNoteEntity>> {
         return coroutineEngine.withDefaultContext(T.API, this, "fetchOrderNotes") {
             val result = wcOrderRestClient.fetchOrderNotes(orderId, site)
 
@@ -570,7 +570,7 @@ class WCOrderStore @Inject constructor(
         orderId: RemoteId,
         note: String,
         isCustomerNote: Boolean
-    ): WooResult<WCOrderNoteModel> {
+    ): WooResult<OrderNoteEntity> {
         return coroutineEngine.withDefaultContext(T.API, this, "postOrderNote") {
             val result = wcOrderRestClient.postOrderNote(orderId, site, note, isCustomerNote)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -384,7 +384,7 @@ class WCOrderStore @Inject constructor(
      * Returns the notes belonging to supplied [WCOrderModel] as a list of [OrderNoteEntity].
      */
     suspend fun getOrderNotesForOrder(site: SiteModel, orderId: RemoteId): List<OrderNoteEntity> =
-            orderNotesDao.queryNotesOfOrder(site.localId(), orderId)
+            orderNotesDao.queryNotesOfOrder(site.remoteId(), orderId)
 
     /**
      * Returns the order status options available for the provided site [SiteModel] as a list of [WCOrderStatusModel].
@@ -678,7 +678,7 @@ class WCOrderStore @Inject constructor(
             // or if the user manual changed some order IDs)
             if (!payload.loadedMore) {
                 ordersDao.deleteOrdersForSite(payload.site.localId())
-                orderNotesDao.deleteOrderNotesForSite(payload.site.localId())
+                orderNotesDao.deleteOrderNotesForSite(payload.site.remoteId())
                 OrderSqlUtils.deleteOrderShipmentTrackingsForSite(payload.site)
             }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderModel
-import org.wordpress.android.fluxc.model.OrderNoteEntity
+import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel


### PR DESCRIPTION
⚠️ Please don't merge until the corresponding WCAndroid [PR](https://github.com/woocommerce/woocommerce-android/pull/5971) is approved.

This PR started as a fix for the [issue](https://github.com/woocommerce/woocommerce-android/issues/5970), but then I decided to take it as an opportunity to migrate the table to Room too.

Even though the number of changed lines is big, the big part of the change is just the autogenerated Room schema file, which you can ignore.

#### Testing
Please test the Order Note feature in the example app (you need to make sure orders are fetched before you run the tests)
Or preferably refer to the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/5971 for test steps.