### PR TITLE
Stats update default insights list

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/StatsStoreTest.kt
@@ -18,7 +18,7 @@ import org.wordpress.android.fluxc.persistence.InsightTypeSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.COMMENTS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.FOLLOWERS
-import org.wordpress.android.fluxc.store.StatsStore.InsightType.LATEST_POST_SUMMARY
+import org.wordpress.android.fluxc.store.StatsStore.InsightType.MOST_POPULAR_DAY_AND_HOUR
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.POSTING_ACTIVITY
 import org.wordpress.android.fluxc.store.StatsStore.ManagementType
 import org.wordpress.android.fluxc.store.StatsStore.TimeStatsType.FILE_DOWNLOADS
@@ -59,17 +59,19 @@ class StatsStoreTest {
 
     @Test
     fun `returns updated stats types from DB`() = test {
-        whenever(insightTypesSqlUtils.selectAddedItemsOrderedByStatus(site)).thenReturn(listOf(COMMENTS))
+        whenever(insightTypesSqlUtils
+                .selectAddedItemsOrderedByStatus(site))
+                .thenReturn(listOf(MOST_POPULAR_DAY_AND_HOUR))
 
         val result = store.getAddedInsights(site)
 
-        assertThat(result).containsExactly(COMMENTS)
+        assertThat(result).containsExactly(MOST_POPULAR_DAY_AND_HOUR)
     }
 
     @Test
     fun `updates types with added and removed`() = test {
         val addedTypes = listOf(
-                COMMENTS
+                MOST_POPULAR_DAY_AND_HOUR
         )
         val removedTypes = store.getRemovedInsights(addedTypes)
         store.updateTypes(site, addedTypes)
@@ -81,7 +83,7 @@ class StatsStoreTest {
     @Test
     fun `moves type up in the list when it is last`() = test {
         val insightType = listOf(
-                LATEST_POST_SUMMARY,
+                MOST_POPULAR_DAY_AND_HOUR,
                 FOLLOWERS,
                 COMMENTS
         )
@@ -89,14 +91,17 @@ class StatsStoreTest {
 
         store.moveTypeUp(site, COMMENTS)
 
-        verify(insightTypesSqlUtils).insertOrReplaceAddedItems(site, listOf(LATEST_POST_SUMMARY, COMMENTS, FOLLOWERS))
+        verify(insightTypesSqlUtils).insertOrReplaceAddedItems(
+                site,
+                listOf(MOST_POPULAR_DAY_AND_HOUR, COMMENTS, FOLLOWERS
+        ))
     }
 
     @Test
     fun `does not move type up in the list when it is first`() = test {
         val insightType = listOf(
                 COMMENTS,
-                LATEST_POST_SUMMARY,
+                MOST_POPULAR_DAY_AND_HOUR,
                 FOLLOWERS
         )
         whenever(insightTypesSqlUtils.selectAddedItemsOrderedByStatus(site)).thenReturn(insightType)
@@ -109,15 +114,17 @@ class StatsStoreTest {
     @Test
     fun `moves type down in the list when it is first`() = test {
         val insightType = listOf(
-                LATEST_POST_SUMMARY,
+                MOST_POPULAR_DAY_AND_HOUR,
                 FOLLOWERS,
                 COMMENTS
         )
         whenever(insightTypesSqlUtils.selectAddedItemsOrderedByStatus(site)).thenReturn(insightType)
 
-        store.moveTypeDown(site, LATEST_POST_SUMMARY)
+        store.moveTypeDown(site, MOST_POPULAR_DAY_AND_HOUR)
 
-        verify(insightTypesSqlUtils).insertOrReplaceAddedItems(site, listOf(FOLLOWERS, LATEST_POST_SUMMARY, COMMENTS))
+        verify(insightTypesSqlUtils).insertOrReplaceAddedItems(
+                site, listOf(FOLLOWERS, MOST_POPULAR_DAY_AND_HOUR, COMMENTS
+        ))
     }
 
     @Test
@@ -125,20 +132,20 @@ class StatsStoreTest {
         val insightType = listOf(
                 COMMENTS,
                 FOLLOWERS,
-                LATEST_POST_SUMMARY
+                MOST_POPULAR_DAY_AND_HOUR
         )
         whenever(insightTypesSqlUtils.selectAddedItemsOrderedByStatus(site)).thenReturn(insightType)
 
-        store.moveTypeDown(site, LATEST_POST_SUMMARY)
+        store.moveTypeDown(site, MOST_POPULAR_DAY_AND_HOUR)
 
         verify(insightTypesSqlUtils, never()).insertOrReplaceAddedItems(eq(site), any())
     }
 
     @Test
     fun `removes type from list`() = test {
-        store.removeType(site, LATEST_POST_SUMMARY)
+        store.removeType(site, MOST_POPULAR_DAY_AND_HOUR)
 
-        val addedTypes = DEFAULT_INSIGHTS - LATEST_POST_SUMMARY
+        val addedTypes = DEFAULT_INSIGHTS - MOST_POPULAR_DAY_AND_HOUR
 
         // executed twice, because the first time the default list is inserted first
         verify(insightTypesSqlUtils).insertOrReplaceAddedItems(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -19,8 +19,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.persistence.InsightTypeSqlUtils
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.ALL_TIME_STATS
-import org.wordpress.android.fluxc.store.StatsStore.InsightType.FOLLOWER_TOTALS
-import org.wordpress.android.fluxc.store.StatsStore.InsightType.LATEST_POST_SUMMARY
+import org.wordpress.android.fluxc.store.StatsStore.InsightType.COMMENTS
+import org.wordpress.android.fluxc.store.StatsStore.InsightType.FOLLOWERS
+import org.wordpress.android.fluxc.store.StatsStore.InsightType.MOST_POPULAR_DAY_AND_HOUR
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TODAY_STATS
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType
@@ -34,7 +35,7 @@ import java.util.Collections
 import javax.inject.Inject
 import javax.inject.Singleton
 
-val DEFAULT_INSIGHTS = listOf(LATEST_POST_SUMMARY, TODAY_STATS, ALL_TIME_STATS, FOLLOWER_TOTALS)
+val DEFAULT_INSIGHTS = listOf(MOST_POPULAR_DAY_AND_HOUR, ALL_TIME_STATS, TODAY_STATS, FOLLOWERS, COMMENTS)
 val STATS_UNAVAILABLE_WITH_JETPACK = listOf(FILE_DOWNLOADS)
 const val INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN = "INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN"
 


### PR DESCRIPTION
Update the default insights from previous defaults to new defaults as below:

Fixes: [#16029](https://github.com/wordpress-mobile/WordPress-Android/issues/16029)

Previous defaults

1. LATEST_POST_SUMMARY
2. TODAY_STATS
3. ALL_TIME_STATS
4. FOLLOWER_TOTALS

New defaults

1. MOST_POPULAR_DAY_AND_HOUR
2. ALL_TIME_STATS
3. TODAY_STATS
4. FOLLOWERS
5. COMMENTS