### PR TITLE
Woo: Pass blank billing email as null to avoid order creation failure

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -13,7 +13,9 @@ object OrderDtoMapper {
             state = this.state,
             postcode = this.postcode,
             country = this.country,
-            email = this.email,
+            // the backend will fail to create the order if the billing email is an empty string,
+            // so we use null to avoid this situation
+            email = this.email.ifEmpty { null },
             phone = this.phone
     )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -10,9 +10,9 @@ import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -825,25 +825,15 @@ class OrderRestClient @Inject constructor(
     }
 
     private fun UpdateOrderRequest.toNetworkRequest(): Map<String, Any> {
-        // the backend will fail to create the order if the billing email is an empty string,
-        // so we pass it as null to avoid this situation
-        val billingDto = if (billingAddress?.email?.isEmpty() == true) {
-            billingAddress.toDto().copy(email = null)
-        } else {
-            billingAddress?.toDto()
-        }
-
-        val params = mutableMapOf<String, Any>().apply {
+        return mutableMapOf<String, Any>().apply {
             status?.let { put("status", it.statusKey) }
             lineItems?.let { put("line_items", it) }
             shippingAddress?.toDto()?.let { put("shipping", it) }
-            billingDto?.let { put("billing", it) }
+            billingAddress?.toDto()?.let { put("billing", it) }
             feeLines?.let { put("fee_lines", it) }
             shippingLines?.let { put("shipping_lines", it) }
             customerNote?.let { put("customer_note", it) }
         }
-
-        return params
     }
 
     private fun orderResponseToOrderSummaryModel(response: OrderSummaryApiResponse): WCOrderSummaryModel {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -10,9 +10,9 @@ import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
-import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -825,15 +825,25 @@ class OrderRestClient @Inject constructor(
     }
 
     private fun UpdateOrderRequest.toNetworkRequest(): Map<String, Any> {
-        return mutableMapOf<String, Any>().apply {
+        // the backend will fail to create the order if the billing email is an empty string,
+        // so we pass it as null to avoid this situation
+        val billingDto = if (billingAddress?.email?.isEmpty() == true) {
+            billingAddress.toDto().copy(email = null)
+        } else {
+            billingAddress?.toDto()
+        }
+
+        val params = mutableMapOf<String, Any>().apply {
             status?.let { put("status", it.statusKey) }
             lineItems?.let { put("line_items", it) }
             shippingAddress?.toDto()?.let { put("shipping", it) }
-            billingAddress?.toDto()?.let { put("billing", it) }
+            billingDto?.let { put("billing", it) }
             feeLines?.let { put("fee_lines", it) }
             shippingLines?.let { put("shipping_lines", it) }
             customerNote?.let { put("customer_note", it) }
         }
+
+        return params
     }
 
     private fun orderResponseToOrderSummaryModel(response: OrderSummaryApiResponse): WCOrderSummaryModel {

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -538,6 +538,6 @@ class OrderUpdateStoreTest {
         val emptyShipping = OrderAddress.Shipping("", "", "", "", "", "", "", "", "", "")
         val emptyBilling = OrderAddress.Billing("", "", "", "", "", "", "", "", "", "", "")
         val emptyShippingDto = Shipping("", "", "", "", "", "", "", "", "", "")
-        val emptyBillingDto = Billing("", "", "", "", "", "", "", "", "", "", "")
+        val emptyBillingDto = Billing("", "", "", "", "", "", "", "", "", null, "")
     }
 }


### PR DESCRIPTION
Closes #2306 - If we pass a blank billing email address when creating an order, the server responds with "Invalid parameter(s): billing" and the order fails to be created. This PR works around this by passing a blank email as null.

Only one review is required, but I tagged two reviewers because something about this fix seems hacky and I wanted feedback. It does, however, have the benefit of working :)