### PR TITLE
Reduce `OrderEntity` payload before saving it

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -4,9 +4,15 @@ import android.content.Context;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.Volley;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.wordpress.android.fluxc.module.MockedNetworkModule.MockedNetworkModuleBindings;
 import org.wordpress.android.fluxc.network.OkHttpStack;
+import org.wordpress.android.fluxc.network.rest.JsonObjectOrEmptyArray;
+import org.wordpress.android.fluxc.network.rest.JsonObjectOrEmptyArrayDeserializer;
+import org.wordpress.android.fluxc.network.rest.JsonObjectOrFalse;
+import org.wordpress.android.fluxc.network.rest.JsonObjectOrFalseDeserializer;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -73,5 +79,15 @@ public class MockedNetworkModule {
     @Provides
     public CoroutineContext provideCoroutineContext() {
         return Dispatchers.getDefault();
+    }
+
+    @Provides
+    public Gson provideGson() {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.setLenient();
+        gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrFalse.class, new JsonObjectOrFalseDeserializer());
+        gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrEmptyArray.class,
+                new JsonObjectOrEmptyArrayDeserializer());
+        return gsonBuilder.create();
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.util.AppLog.T
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     companion object {
-        internal const val ADDONS_METADATA_KEY = "_product_addons"
+        private const val ADDONS_METADATA_KEY = "_product_addons"
     }
 
     @Column var localSiteId = 0

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.util.AppLog.T
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
     companion object {
-        const val ADDONS_METADATA_KEY = "_product_addons"
+        internal const val ADDONS_METADATA_KEY = "_product_addons"
     }
 
     @Column var localSiteId = 0

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -20,12 +20,15 @@ data class LineItem(
     val sku: String? = null,
     val price: String? = null, // The per-item price
     @SerializedName("meta_data")
-    val metaData: List<WCMetaData>? = null,
-    val attributeList: List<AttributeDto> = metaData?.filter {
-        it.displayKey is String && it.displayValue is String
-    }?.map {
-        AttributeDto(it.displayKey, it.displayValue as String)
-    } ?: emptyList()
+    val metaData: List<WCMetaData>? = null
 ) {
-    class AttributeDto(val key: String?, val value: String?)
+    class Attribute(val key: String?, val value: String?)
+
+    fun getAttributeList(): List<Attribute> {
+        return metaData?.filter {
+            it.displayKey is String && it.displayValue is String
+        }?.map {
+            Attribute(it.displayKey, it.displayValue as String)
+        } ?: emptyList()
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -19,17 +19,13 @@ data class LineItem(
     val totalTax: String? = null,
     val sku: String? = null,
     val price: String? = null, // The per-item price
-
     @SerializedName("meta_data")
-    val metaData: List<WCMetaData>? = null
+    val metaData: List<WCMetaData>? = null,
+    val attributeList: List<AttributeDto> = metaData?.filter {
+        it.displayKey is String && it.displayValue is String
+    }?.map {
+        AttributeDto(it.displayKey, it.displayValue as String)
+    } ?: emptyList()
 ) {
-    class Attribute(val key: String?, val value: String?)
-
-    fun getAttributeList(): List<Attribute> {
-        return metaData?.filter {
-            it.displayKey is String && it.displayValue is String
-        }?.map {
-            Attribute(it.displayKey, it.displayValue as String)
-        } ?: emptyList()
-    }
+    class AttributeDto(val key: String?, val value: String?)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
@@ -1,11 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import com.google.gson.JsonElement
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
-import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.network.Response
-import org.wordpress.android.fluxc.utils.DateUtils
-import java.math.BigDecimal
 
 @Suppress("PropertyName")
 class OrderDto : Response {
@@ -74,64 +70,4 @@ class OrderDto : Response {
     val total_tax: String? = null
     val meta_data: JsonElement? = null
     val tax_lines: JsonElement? = null
-}
-
-fun OrderDto.toDomainModel(localSiteId: LocalId): OrderEntity {
-    fun convertDateToUTCString(date: String?): String =
-            date?.let { DateUtils.formatGmtAsUtcDateString(it) } ?: "" // Store the date in UTC format
-
-    return OrderEntity(
-            orderId = this.id ?: 0,
-            localSiteId = localSiteId,
-            number = this.number ?: (this.id ?: 0).toString(),
-            status = this.status ?: "",
-            currency = this.currency ?: "",
-            orderKey = this.order_key ?: "",
-            dateCreated = convertDateToUTCString(this.date_created_gmt),
-            dateModified = convertDateToUTCString(this.date_modified_gmt),
-            total = this.total ?: "",
-            totalTax = this.total_tax ?: "",
-            shippingTotal = this.shipping_total ?: "",
-            paymentMethod = this.payment_method ?: "",
-            paymentMethodTitle = this.payment_method_title ?: "",
-            datePaid = this.date_paid_gmt?.let { "${it}Z" } ?: "",
-            pricesIncludeTax = this.prices_include_tax,
-            customerNote = this.customer_note ?: "",
-            discountTotal = this.discount_total ?: "",
-            discountCodes = this.coupon_lines?.let { couponLines ->
-                // Extract the discount codes from the coupon_lines list and store them as a comma-delimited String
-                couponLines
-                        .filter { !it.code.isNullOrEmpty() }
-                        .joinToString { it.code!! }
-            }.orEmpty(),
-            refundTotal = this.refunds?.let { refunds ->
-                // Extract the individual refund totals from the refunds list and store their sum as a Double,
-                refunds.sumOf { it.total?.toBigDecimalOrNull() ?: BigDecimal.ZERO }
-            } ?: BigDecimal.ZERO,
-            billingFirstName = this.billing?.first_name ?: "",
-            billingLastName = this.billing?.last_name ?: "",
-            billingCompany = this.billing?.company ?: "",
-            billingAddress1 = this.billing?.address_1 ?: "",
-            billingAddress2 = this.billing?.address_2 ?: "",
-            billingCity = this.billing?.city ?: "",
-            billingState = this.billing?.state ?: "",
-            billingPostcode = this.billing?.postcode ?: "",
-            billingCountry = this.billing?.country ?: "",
-            billingEmail = this.billing?.email ?: "",
-            billingPhone = this.billing?.phone ?: "",
-            shippingFirstName = this.shipping?.first_name ?: "",
-            shippingLastName = this.shipping?.last_name ?: "",
-            shippingCompany = this.shipping?.company ?: "",
-            shippingAddress1 = this.shipping?.address_1 ?: "",
-            shippingAddress2 = this.shipping?.address_2 ?: "",
-            shippingCity = this.shipping?.city ?: "",
-            shippingState = this.shipping?.state ?: "",
-            shippingPostcode = this.shipping?.postcode ?: "",
-            shippingCountry = this.shipping?.country ?: "",
-            lineItems = this.line_items.toString(),
-            shippingLines = this.shipping_lines.toString(),
-            feeLines = this.fee_lines.toString(),
-            taxLines = this.tax_lines.toString(),
-            metaData = this.meta_data.toString()
-    )
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -1,32 +1,105 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.order.OrderAddress
+import org.wordpress.android.fluxc.utils.DateUtils
+import java.math.BigDecimal
+import javax.inject.Inject
 
-object OrderDtoMapper {
-    fun OrderAddress.Billing.toDto() = OrderDto.Billing(
-            first_name = this.firstName,
-            last_name = this.lastName,
-            company = this.company,
-            address_1 = this.address1,
-            address_2 = this.address2,
-            city = this.city,
-            state = this.state,
-            postcode = this.postcode,
-            country = this.country,
-            email = this.email,
-            phone = this.phone
-    )
+internal class OrderDtoMapper @Inject constructor(
+    private val stripOrder: StripOrder
+) {
+    fun toDatabaseEntity(orderDto: OrderDto, localSiteId: LocalId): OrderEntity {
+        fun convertDateToUTCString(date: String?): String =
+                date?.let { DateUtils.formatGmtAsUtcDateString(it) } ?: "" // Store the date in UTC format
 
-    fun OrderAddress.Shipping.toDto() = OrderDto.Shipping(
-            first_name = this.firstName,
-            last_name = this.lastName,
-            company = this.company,
-            address_1 = this.address1,
-            address_2 = this.address2,
-            city = this.city,
-            state = this.state,
-            postcode = this.postcode,
-            country = this.country,
-            phone = this.phone
-    )
+        val rawRemoteDataEntity = with(orderDto) {
+            OrderEntity(
+                    orderId = this.id ?: 0,
+                    localSiteId = localSiteId,
+                    number = this.number ?: (this.id ?: 0).toString(),
+                    status = this.status ?: "",
+                    currency = this.currency ?: "",
+                    orderKey = this.order_key ?: "",
+                    dateCreated = convertDateToUTCString(this.date_created_gmt),
+                    dateModified = convertDateToUTCString(this.date_modified_gmt),
+                    total = this.total ?: "",
+                    totalTax = this.total_tax ?: "",
+                    shippingTotal = this.shipping_total ?: "",
+                    paymentMethod = this.payment_method ?: "",
+                    paymentMethodTitle = this.payment_method_title ?: "",
+                    datePaid = this.date_paid_gmt?.let { "${it}Z" } ?: "",
+                    pricesIncludeTax = this.prices_include_tax,
+                    customerNote = this.customer_note ?: "",
+                    discountTotal = this.discount_total ?: "",
+                    discountCodes = this.coupon_lines?.let { couponLines ->
+                        // Extract the discount codes from the coupon_lines list and store them as a comma-delimited String
+                        couponLines
+                                .filter { !it.code.isNullOrEmpty() }
+                                .joinToString { it.code!! }
+                    }.orEmpty(),
+                    refundTotal = this.refunds?.let { refunds ->
+                        // Extract the individual refund totals from the refunds list and store their sum as a Double,
+                        refunds.sumOf { it.total?.toBigDecimalOrNull() ?: BigDecimal.ZERO }
+                    } ?: BigDecimal.ZERO,
+                    billingFirstName = this.billing?.first_name ?: "",
+                    billingLastName = this.billing?.last_name ?: "",
+                    billingCompany = this.billing?.company ?: "",
+                    billingAddress1 = this.billing?.address_1 ?: "",
+                    billingAddress2 = this.billing?.address_2 ?: "",
+                    billingCity = this.billing?.city ?: "",
+                    billingState = this.billing?.state ?: "",
+                    billingPostcode = this.billing?.postcode ?: "",
+                    billingCountry = this.billing?.country ?: "",
+                    billingEmail = this.billing?.email ?: "",
+                    billingPhone = this.billing?.phone ?: "",
+                    shippingFirstName = this.shipping?.first_name ?: "",
+                    shippingLastName = this.shipping?.last_name ?: "",
+                    shippingCompany = this.shipping?.company ?: "",
+                    shippingAddress1 = this.shipping?.address_1 ?: "",
+                    shippingAddress2 = this.shipping?.address_2 ?: "",
+                    shippingCity = this.shipping?.city ?: "",
+                    shippingState = this.shipping?.state ?: "",
+                    shippingPostcode = this.shipping?.postcode ?: "",
+                    shippingCountry = this.shipping?.country ?: "",
+                    lineItems = this.line_items.toString(),
+                    shippingLines = this.shipping_lines.toString(),
+                    feeLines = this.fee_lines.toString(),
+                    taxLines = this.tax_lines.toString(),
+                    metaData = this.meta_data.toString()
+            )
+        }
+
+        return stripOrder(rawRemoteDataEntity)
+    }
+
+    companion object {
+        fun OrderAddress.Billing.toDto() = OrderDto.Billing(
+                first_name = this.firstName,
+                last_name = this.lastName,
+                company = this.company,
+                address_1 = this.address1,
+                address_2 = this.address2,
+                city = this.city,
+                state = this.state,
+                postcode = this.postcode,
+                country = this.country,
+                email = this.email,
+                phone = this.phone
+        )
+
+        fun OrderAddress.Shipping.toDto() = OrderDto.Shipping(
+                first_name = this.firstName,
+                last_name = this.lastName,
+                company = this.company,
+                address_1 = this.address1,
+                address_2 = this.address2,
+                city = this.city,
+                state = this.state,
+                postcode = this.postcode,
+                country = this.country,
+                phone = this.phone
+        )
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -7,7 +7,7 @@ import org.wordpress.android.fluxc.utils.DateUtils
 import java.math.BigDecimal
 import javax.inject.Inject
 
-internal class OrderDtoMapper @Inject constructor(
+class OrderDtoMapper @Inject internal constructor(
     private val stripOrder: StripOrder
 ) {
     fun toDatabaseEntity(orderDto: OrderDto, localSiteId: LocalId): OrderEntity {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
+
+import org.wordpress.android.fluxc.model.WCMetaData
+
+object OrderMappingConst {
+    const val CHARGE_ID_KEY = "_charge_id"
+    const val SHIPPING_PHONE_KEY = "_shipping_phone"
+    internal val WCMetaData.isNotInternalAttributeData
+        get() = key.first() != '_'
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -65,7 +65,7 @@ import javax.inject.Singleton
 import kotlin.collections.MutableMap.MutableEntry
 
 @Singleton
-internal class OrderRestClient @Inject constructor(
+class OrderRestClient @Inject constructor(
     appContext: Context,
     private val dispatcher: Dispatcher,
     @Named("regular") requestQueue: RequestQueue,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -10,9 +10,9 @@ import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
-import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -34,7 +34,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Shipping
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDtoMapper.toDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDtoMapper.Companion.toDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -65,11 +65,12 @@ import javax.inject.Singleton
 import kotlin.collections.MutableMap.MutableEntry
 
 @Singleton
-class OrderRestClient @Inject constructor(
+internal class OrderRestClient @Inject constructor(
     appContext: Context,
     private val dispatcher: Dispatcher,
     @Named("regular") requestQueue: RequestQueue,
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
+    private val orderDtoMapper: OrderDtoMapper,
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
@@ -98,7 +99,7 @@ class OrderRestClient @Inject constructor(
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderDto>? ->
                     val orderModels = response?.map { orderDto ->
-                        orderDto.toDomainModel(site.localId())
+                        orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
 
                     val canLoadMore = orderModels.size == WCOrderStore.NUM_ORDERS_PER_FETCH
@@ -198,7 +199,7 @@ class OrderRestClient @Inject constructor(
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderDto>? ->
                     val orderModels = response?.map { orderDto ->
-                        orderDto.toDomainModel(site.localId())
+                        orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
 
                     val payload = FetchOrdersByIdsResponsePayload(
@@ -268,7 +269,7 @@ class OrderRestClient @Inject constructor(
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderDto>? ->
                     val orderModels = response?.map { orderDto ->
-                        orderDto.toDomainModel(site.localId())
+                        orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
 
                     val canLoadMore = orderModels.size == WCOrderStore.NUM_ORDERS_PER_FETCH
@@ -305,7 +306,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 response.data?.let { orderDto ->
-                    val newModel = orderDto.toDomainModel(site.localId())
+                    val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     RemoteOrderPayload(newModel, site)
                 } ?: RemoteOrderPayload(
                         OrderError(type = GENERIC_ERROR, message = "Success response with empty data"),
@@ -434,7 +435,9 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 response.data?.let { orderDto ->
-                    val newModel = orderDto.toDomainModel(orderToUpdate.localSiteId)
+                    val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId()).copy(
+                            orderId = orderToUpdate.orderId
+                    )
                     RemoteOrderPayload(newModel, site)
                 } ?: RemoteOrderPayload(
                     OrderError(type = GENERIC_ERROR, message = "Success response with empty data"),
@@ -762,7 +765,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackError -> WooPayload(response.error.toWooError())
             is JetpackSuccess -> response.data?.let { orderDto ->
-                WooPayload(orderDto.toDomainModel(site.localId()))
+                WooPayload(orderDtoMapper.toDatabaseEntity(orderDto, site.localId()))
             } ?: WooPayload(
                     error = WooError(
                             type = WooErrorType.GENERIC_ERROR,
@@ -792,7 +795,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackError -> WooPayload(response.error.toWooError())
             is JetpackSuccess -> response.data?.let { orderDto ->
-                WooPayload(orderDto.toDomainModel(site.localId()))
+                WooPayload(orderDtoMapper.toDatabaseEntity(orderDto, site.localId()))
             } ?: WooPayload(
                     error = WooError(
                             type = WooErrorType.GENERIC_ERROR,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 import com.google.gson.Gson
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.model.order.LineItemDto
+import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isNotInternalAttributeData
@@ -12,7 +12,7 @@ import javax.inject.Inject
 internal class StripOrder @Inject constructor(private val gson: Gson) {
     operator fun invoke(fatModel: OrderEntity): OrderEntity {
         return fatModel.copy(
-                lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItemDto ->
+                lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItem ->
                     lineItemDto.copy(
                             metaData = lineItemDto.metaData?.filter { it.isNotInternalAttributeData }
                     )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import com.google.gson.Gson
 import org.wordpress.android.fluxc.model.OrderEntity
-import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
@@ -23,9 +22,7 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                 metaData = gson.toJson(
                         fatModel.getMetaDataList()
                                 .filter {
-                                    it.key == WCProductModel.ADDONS_METADATA_KEY ||
-                                            it.key == CHARGE_ID_KEY ||
-                                            it.key == SHIPPING_PHONE_KEY
+                                            it.key == CHARGE_ID_KEY || it.key == SHIPPING_PHONE_KEY
                                 }
                 )
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
+
+import com.google.gson.Gson
+import org.wordpress.android.fluxc.model.OrderEntity
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.order.LineItemDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isNotInternalAttributeData
+import javax.inject.Inject
+
+internal class StripOrder @Inject constructor(private val gson: Gson) {
+    operator fun invoke(fatModel: OrderEntity): OrderEntity {
+        return fatModel.copy(
+                lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItemDto ->
+                    lineItemDto.copy(
+                            metaData = lineItemDto.metaData?.filter { it.isNotInternalAttributeData }
+                    )
+                }),
+                shippingLines = gson.toJson(fatModel.getShippingLineList()),
+                feeLines = gson.toJson(fatModel.getFeeLineList()),
+                taxLines = gson.toJson(fatModel.getTaxLineList()),
+                metaData = gson.toJson(
+                        fatModel.getMetaDataList()
+                                .filter {
+                                    it.key == WCProductModel.ADDONS_METADATA_KEY ||
+                                            it.key == CHARGE_ID_KEY ||
+                                            it.key == SHIPPING_PHONE_KEY
+                                }
+                )
+        )
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.model.order.OrderAddress.Billing
 import org.wordpress.android.fluxc.model.order.OrderAddress.Shipping
 import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDtoMapper.toDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDtoMapper.Companion.toDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -40,7 +40,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WCOrderStore @Inject internal constructor(
+class WCOrderStore @Inject constructor(
     dispatcher: Dispatcher,
     private val wcOrderRestClient: OrderRestClient,
     private val wcOrderFetcher: WCOrderFetcher,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -40,7 +40,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WCOrderStore @Inject constructor(
+class WCOrderStore @Inject internal constructor(
     dispatcher: Dispatcher,
     private val wcOrderRestClient: OrderRestClient,
     private val wcOrderFetcher: WCOrderFetcher,

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
@@ -1,0 +1,188 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
+
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.model.OrderEntity
+import org.wordpress.android.fluxc.model.WCProductModel.Companion.ADDONS_METADATA_KEY
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
+import org.wordpress.android.fluxc.utils.json
+
+internal class StripOrderTest {
+    lateinit var sut: StripOrder
+
+    @Before
+    fun setUp() {
+        sut = StripOrder(Gson())
+    }
+
+    @Test
+    fun `ignore additional members in line item`() {
+        // given
+        val lineItemsFromRemote = JsonArray().apply {
+            add(
+                    json {
+                        "id" To 1234
+                        "name" To "iPhone"
+                        redundantMemberKey To "not needed parameter"
+                    }
+            )
+        }.toString()
+        val fatModel = emptyOrder.copy(lineItems = lineItemsFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(fatModel.lineItems).contains(redundantMemberKey)
+        assertThat(strippedOrder.lineItems).doesNotContain(redundantMemberKey)
+    }
+
+    @Test
+    fun `ignore internal-only remote line item attributes if applied to metadata key`() {
+        // given
+        val internalOnlyAttributeMemberKey = "_internal_attribute_key"
+        val lineItemsFromRemote = JsonArray().apply {
+            add(
+                    json {
+                        "id" To 1234
+                        "name" To "iPhone"
+                        "meta_data" To listOf(
+                                json {
+                                    "key" To internalOnlyAttributeMemberKey
+                                    "value" To "sample value"
+                                }
+                        )
+                    }
+            )
+        }.toString()
+        val fatModel = emptyOrder.copy(lineItems = lineItemsFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(fatModel.lineItems).contains(internalOnlyAttributeMemberKey)
+        assertThat(strippedOrder.lineItems).doesNotContain(internalOnlyAttributeMemberKey)
+    }
+
+    @Test
+    fun `ignore additional members in shipping item`() {
+        // given
+        val shippingLineItemsFromRemote = JsonArray().apply {
+            add(
+                    json {
+                        "id" To "1234"
+                        "method_id" To "3"
+                        redundantMemberKey To "not needed parameter"
+                    }
+            )
+        }.toString()
+        val fatModel = emptyOrder.copy(shippingLines = shippingLineItemsFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(fatModel.shippingLines).contains(redundantMemberKey)
+        assertThat(strippedOrder.shippingLines).doesNotContain(redundantMemberKey)
+    }
+
+    @Test
+    fun `ignore additional members in fee item`() {
+        // given
+        val feeLineItemsFromRemote = JsonArray().apply {
+            add(
+                    json {
+                        "id" To "1234"
+                        "totalTax" To "123$"
+                        redundantMemberKey To "not needed parameter"
+                    }
+            )
+        }.toString()
+        val fatModel = emptyOrder.copy(feeLines = feeLineItemsFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(fatModel.feeLines).contains(redundantMemberKey)
+        assertThat(strippedOrder.feeLines).doesNotContain(redundantMemberKey)
+    }
+
+    @Test
+    fun `ignore additional members in tax item`() {
+        // given
+        val taxLineItemsFromRemote = JsonArray().apply {
+            add(
+                    json {
+                        "id" To "1234"
+                        "rate_code" To "CODE"
+                        redundantMemberKey To "not needed parameter"
+                    }
+            )
+        }.toString()
+        val fatModel = emptyOrder.copy(taxLines = taxLineItemsFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(fatModel.taxLines).contains(redundantMemberKey)
+        assertThat(strippedOrder.taxLines).doesNotContain(redundantMemberKey)
+    }
+
+    @Test
+    fun `drop any not needed meta data`() {
+        // given
+        val metaDataFromRemote = JsonArray().apply {
+            add(json {
+                "id" To "1"
+                "key" To redundantMemberKey
+            })
+            add(json {
+                "id" To "2"
+                "key" To CHARGE_ID_KEY
+            })
+            add(json {
+                "id" To "3"
+                "key" To SHIPPING_PHONE_KEY
+            })
+            add(json {
+                "id" To "4"
+                "key" To ADDONS_METADATA_KEY
+            })
+        }.toString()
+        val fatModel = emptyOrder.copy(metaData = metaDataFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(fatModel.metaData).contains(
+                redundantMemberKey,
+                CHARGE_ID_KEY,
+                SHIPPING_PHONE_KEY,
+                ADDONS_METADATA_KEY
+        )
+        assertThat(strippedOrder.metaData).doesNotContain(redundantMemberKey)
+                .contains(
+                        CHARGE_ID_KEY,
+                        SHIPPING_PHONE_KEY,
+                        ADDONS_METADATA_KEY
+                )
+    }
+
+    companion object {
+        const val redundantMemberKey = "not_needed_parameter"
+
+        val emptyOrder = OrderEntity(
+                localSiteId = LocalOrRemoteId.LocalId(0),
+                orderId = 0
+        )
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
@@ -7,7 +7,6 @@ import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.OrderEntity
-import org.wordpress.android.fluxc.model.WCProductModel.Companion.ADDONS_METADATA_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
 import org.wordpress.android.fluxc.utils.json
@@ -152,10 +151,6 @@ internal class StripOrderTest {
                 "id" To "3"
                 "key" To SHIPPING_PHONE_KEY
             })
-            add(json {
-                "id" To "4"
-                "key" To ADDONS_METADATA_KEY
-            })
         }.toString()
         val fatModel = emptyOrder.copy(metaData = metaDataFromRemote)
 
@@ -166,14 +161,12 @@ internal class StripOrderTest {
         assertThat(fatModel.metaData).contains(
                 redundantMemberKey,
                 CHARGE_ID_KEY,
-                SHIPPING_PHONE_KEY,
-                ADDONS_METADATA_KEY
+                SHIPPING_PHONE_KEY
         )
         assertThat(strippedOrder.metaData).doesNotContain(redundantMemberKey)
                 .contains(
                         CHARGE_ID_KEY,
-                        SHIPPING_PHONE_KEY,
-                        ADDONS_METADATA_KEY
+                        SHIPPING_PHONE_KEY
                 )
     }
 

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonObjectBuilder.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonObjectBuilder.kt
@@ -1,0 +1,52 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import java.util.ArrayDeque
+import java.util.Deque
+
+internal fun json(build: JsonObjectBuilder.() -> Unit): JsonObject {
+    return JsonObjectBuilder().json(build)
+}
+
+internal class JsonObjectBuilder {
+    private val deque: Deque<JsonObject> = ArrayDeque()
+
+    fun json(build: JsonObjectBuilder.() -> Unit): JsonObject {
+        deque.push(JsonObject())
+        this.build()
+        return deque.pop()
+    }
+
+    infix fun String.To(value: Int) {
+        deque.peek().addProperty(this, value)
+    }
+
+    infix fun String.To(value: String) {
+        deque.peek().addProperty(this, value)
+    }
+
+    infix fun String.To(value: JsonElement) {
+        deque.peek().add(this, value)
+    }
+
+    infix fun String.To(value: Collection<JsonElement>) {
+        deque.peek().add(
+                this,
+                JsonArray().apply {
+                    value.forEach { item -> add(item) }
+                }
+        )
+    }
+
+    infix fun String.To(value: Array<Int>) {
+        deque.peek().add(this,
+                JsonArray().apply {
+                    value.forEach { item ->
+                        add(item)
+                    }
+                }
+        )
+    }
+}


### PR DESCRIPTION
Closes: #2305 

**Description**

This PR reduces payload of OrderEntities, raw `JSON` fields by filtering them before saving in database. For details, please see comments.

**Test cases**
See corresponding Woo PR for area of tests: https://github.com/woocommerce/woocommerce-android/pull/6020