### PR TITLE
Fix robolectric test running locally on M1 mac

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -55,7 +55,7 @@ android {
         // pressure on the API (authentication/fetch profile/fetch sites).
         // Uncomment the next line to enable the Orchestrator.
         // execution 'ANDROID_TEST_ORCHESTRATOR'
-
+        unitTests.includeAndroidResources  = true
         unitTests.all {
             if (project.hasProperty('testsMaxHeapSize')) {
                 // maxHeapSize for tests is not limited unless we give an explicit value
@@ -137,7 +137,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13'
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$gradle.ext.kotlinVersion"
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'org.robolectric:robolectric:4.7.3'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/ExampleDebugApp.kt
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/ExampleDebugApp.kt
@@ -8,12 +8,14 @@ import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import com.facebook.soloader.SoLoader
 import org.wordpress.android.fluxc.example.di.AppComponent
 import org.wordpress.android.fluxc.example.di.DaggerAppComponentDebug
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.UTILS
 
 class ExampleDebugApp : ExampleApp() {
     override val component: AppComponent by lazy {
         DaggerAppComponentDebug.builder()
-                .application(this)
-                .build()
+            .application(this)
+            .build()
     }
 
     override fun onCreate() {
@@ -21,11 +23,16 @@ class ExampleDebugApp : ExampleApp() {
         component.inject(this)
 
         if (FlipperUtils.shouldEnableFlipper(this)) {
-//            SoLoader.init(this, false)
-//            AndroidFlipperClient.getInstance(this).apply {
-//                addPlugin(InspectorFlipperPlugin(applicationContext, DescriptorMapping.withDefaults()))
-//                addPlugin(NetworkFlipperPlugin())
-//            }.start()
+            runCatching { // Needs runCatching to avoid crashes in robolectric tests
+                SoLoader.init(this, false)
+                AndroidFlipperClient.getInstance(this).apply {
+                    addPlugin(InspectorFlipperPlugin(applicationContext, DescriptorMapping.withDefaults()))
+                    addPlugin(NetworkFlipperPlugin())
+                }.start()
+            }.also {
+                AppLog.w(UTILS, "Failed to initialise Flipper. Probably due to trying to " +
+                    "initialising Flipper during robolectric tests execution")
+            }
         }
     }
 }

--- a/example/src/debug/java/org/wordpress/android/fluxc/example/ExampleDebugApp.kt
+++ b/example/src/debug/java/org/wordpress/android/fluxc/example/ExampleDebugApp.kt
@@ -21,11 +21,11 @@ class ExampleDebugApp : ExampleApp() {
         component.inject(this)
 
         if (FlipperUtils.shouldEnableFlipper(this)) {
-            SoLoader.init(this, false)
-            AndroidFlipperClient.getInstance(this).apply {
-                addPlugin(InspectorFlipperPlugin(applicationContext, DescriptorMapping.withDefaults()))
-                addPlugin(NetworkFlipperPlugin())
-            }.start()
+//            SoLoader.init(this, false)
+//            AndroidFlipperClient.getInstance(this).apply {
+//                addPlugin(InspectorFlipperPlugin(applicationContext, DescriptorMapping.withDefaults()))
+//                addPlugin(NetworkFlipperPlugin())
+//            }.start()
         }
     }
 }

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+android.jetifier.blacklist=bcprov

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
-android.jetifier.blacklist=bcprov
+android.jetifier.ignorelist=bcprov

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     api "androidx.room:room-ktx:$roomVersion"
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation 'org.robolectric:robolectric:4.7.3'
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -42,6 +42,10 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This PR intends to fix the issues with running Robolectric tests on Apple silicon chips. Several crashes needed to be fixed to get the test running: 

1. Fix the original problem. The version we were using of Robolectric did not support Mac M1 chips. Support [was added recently](https://github.com/robolectric/robolectric/issues/6311). Updating to the latest version of robolectric `4.7.3` fixed it.
2. After updating Robolectric version a new problem appeared with this new version. The issue is [described here](https://github.com/robolectric/robolectric/issues/6521). Problems with android jetifier. The solution was making jetifier ignore bouncy castle lib through adding to `gradle.properties` -> `android.jetifier.ignorelist=bcprov`. In this case this has to be added locally, but I've updated `gradle.properties-example` to fix this issue in CI enviroment. 
3. Next issue is that with the newer version of Robolectric we need to do a few tweaking in gradle `testOptions` to make android resources available and [fix this problem](https://github.com/touchlab/KaMPKit/issues/225). Solution was to add this to build.gradle of modules that have robolectric tests: `unitTests.includeAndroidResources  = true` 
4. There is an issue when running robolectric tests and trying to initialize Flipper. More on this [here](https://github.com/facebook/flipper/issues/2075). The solution was to catch with the `NullPointerException` that occurs in that context, so that the tests run successfully. This won't have an impact on initializing Flipper when launching the Example App. 

This PR contains all those changes that enabled fro Robolectric tests to work again in Apple Silicon chips