### PR TITLE
Add getRevisionById method to PostStore

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.PostStore.PostListItem
-import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
 
 @RunWith(MockitoJUnitRunner::class)
 class PostStoreTest {

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Before
 import org.junit.Test
+import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
@@ -20,6 +21,9 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.list.PostListDescriptor
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
+import org.wordpress.android.fluxc.model.revisions.LocalDiffModel
+import org.wordpress.android.fluxc.model.revisions.LocalRevisionModel
+import org.wordpress.android.fluxc.model.revisions.RevisionModel
 import org.wordpress.android.fluxc.persistence.PostSqlUtils
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 import org.wordpress.android.fluxc.store.PostStore
@@ -290,6 +294,61 @@ class PostStoreTest {
             (this.type == ListAction.FETCHED_LIST_ITEMS)
         })
         verifyNoMoreInteractions(dispatcher)
+    }
+
+//        @Nullable
+//    public RevisionModel getRevisionById(final long revisionId) {
+//        final String revisionIdString = String.valueOf(revisionId);
+//        final LocalRevisionModel localRevision = mPostSqlUtils.getRevisionById(revisionIdString);
+//
+//        if (localRevision == null) {
+//            return null;
+//        }
+//
+//        List<LocalDiffModel> localDiffs = mPostSqlUtils.getLocalRevisionDiffs(localRevision);
+//
+//        return RevisionModel.fromLocalRevisionAndDiffs(localRevision, localDiffs);
+//    }
+
+    @Test
+    fun `Should return mapped RevisionModel when getRevisionById is called`() {
+        // Arrange
+        val localRevision = LocalRevisionModel(1)
+        val localDiffs = listOf<LocalDiffModel>(LocalDiffModel(1))
+        whenever(postSqlUtils.getRevisionById(any())).thenReturn(localRevision)
+        whenever(postSqlUtils.getLocalRevisionDiffs(any())).thenReturn(localDiffs)
+
+        // Act
+        val expected = RevisionModel.fromLocalRevisionAndDiffs(localRevision, localDiffs)
+        val actual = store.getRevisionById(1L)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should return null when PostSqlUtils getRevisionById returns null`() {
+        // Arrange
+        whenever(postSqlUtils.getRevisionById(any())).thenReturn(null)
+
+        // Act
+        val expected = null
+        val actual = store.getRevisionById(1L)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should call PostSqlUtils getRevisionById when getRevisionById is called`() {
+        // Arrange
+        whenever(postSqlUtils.getRevisionById(any())).thenReturn(LocalRevisionModel())
+
+        // Act
+        store.getRevisionById(1L)
+
+        // Assert
+        verify(postSqlUtils).getRevisionById("1")
     }
 
     private fun createFetchedPostListAction(

--- a/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/post/PostStoreTest.kt
@@ -296,20 +296,6 @@ class PostStoreTest {
         verifyNoMoreInteractions(dispatcher)
     }
 
-//        @Nullable
-//    public RevisionModel getRevisionById(final long revisionId) {
-//        final String revisionIdString = String.valueOf(revisionId);
-//        final LocalRevisionModel localRevision = mPostSqlUtils.getRevisionById(revisionIdString);
-//
-//        if (localRevision == null) {
-//            return null;
-//        }
-//
-//        List<LocalDiffModel> localDiffs = mPostSqlUtils.getLocalRevisionDiffs(localRevision);
-//
-//        return RevisionModel.fromLocalRevisionAndDiffs(localRevision, localDiffs);
-//    }
-
     @Test
     fun `Should return mapped RevisionModel when getRevisionById is called`() {
         // Arrange

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -341,6 +341,19 @@ public class PostSqlUtils {
                 .endGroup().endWhere().getAsModel();
     }
 
+    @Nullable
+    public LocalRevisionModel getRevisionById(@NonNull final String revisionId) {
+        final List<LocalRevisionModel> localRevisionModels = WellSql.select(LocalRevisionModel.class)
+                      .where().beginGroup()
+                      .equals(LocalRevisionModelTable.REVISION_ID, revisionId)
+                      .endGroup().endWhere().getAsModel();
+        if (localRevisionModels != null && !localRevisionModels.isEmpty()) {
+            return localRevisionModels.get(0);
+        } else {
+            return null;
+        }
+    }
+
     public List<LocalDiffModel> getLocalRevisionDiffs(LocalRevisionModel revision) {
         return WellSql.select(LocalDiffModel.class)
                 .where().beginGroup()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -342,10 +342,12 @@ public class PostSqlUtils {
     }
 
     @Nullable
-    public LocalRevisionModel getRevisionById(@NonNull final String revisionId) {
+    public LocalRevisionModel getRevisionById(@NonNull final String revisionId, final long postId, final long siteId) {
         final List<LocalRevisionModel> localRevisionModels = WellSql.select(LocalRevisionModel.class)
                       .where().beginGroup()
                       .equals(LocalRevisionModelTable.REVISION_ID, revisionId)
+                      .equals(LocalRevisionModelTable.POST_ID, postId)
+                      .equals(LocalRevisionModelTable.SITE_ID, siteId)
                       .endGroup().endWhere().getAsModel();
         if (localRevisionModels != null && !localRevisionModels.isEmpty()) {
             return localRevisionModels.get(0);
@@ -391,6 +393,11 @@ public class PostSqlUtils {
                 .equals(LocalRevisionModelTable.POST_ID, post.getRemotePostId())
                 .equals(LocalRevisionModelTable.SITE_ID, post.getRemoteSiteId())
                 .endGroup().endWhere().execute();
+    }
+
+    public void deleteAllLocalRevisionsAndDiffs() {
+        WellSql.delete(LocalRevisionModel.class).execute();
+        WellSql.delete(LocalDiffModel.class).execute();
     }
 
     public List<LocalId> getLocalPostIdsForFilter(SiteModel site, boolean isPage, String searchQuery,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1144,6 +1144,7 @@ public class PostStore extends Store {
                 new ListItemsRemovedPayload(PostListDescriptor.calculateTypeIdentifier(post.getLocalSiteId()),
                         Collections.singletonList(post.getRemotePostId()))));
         int rowsAffected = mPostSqlUtils.deletePost(post);
+        deleteLocalRevisionOfAPostOrPage(post);
 
         CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.RemovePost(post.getId(), post.getRemotePostId());
         OnPostChanged onPostChanged = new OnPostChanged(causeOfChange, rowsAffected);
@@ -1152,6 +1153,7 @@ public class PostStore extends Store {
 
     private void removeAllPosts() {
         int rowsAffected = mPostSqlUtils.deleteAllPosts();
+        deleteAllLocalRevisionAndDiffs();
         OnPostChanged event = new OnPostChanged(RemoveAllPosts.INSTANCE, rowsAffected);
         emitChange(event);
     }
@@ -1238,9 +1240,9 @@ public class PostStore extends Store {
     }
 
     @Nullable
-    public RevisionModel getRevisionById(final long revisionId) {
+    public RevisionModel getRevisionById(final long revisionId, final long postId, final long siteId) {
         final String revisionIdString = String.valueOf(revisionId);
-        final LocalRevisionModel localRevision = mPostSqlUtils.getRevisionById(revisionIdString);
+        final LocalRevisionModel localRevision = mPostSqlUtils.getRevisionById(revisionIdString, postId, siteId);
 
         if (localRevision == null) {
             return null;
@@ -1258,5 +1260,9 @@ public class PostStore extends Store {
 
     public void deleteLocalRevisionOfAPostOrPage(PostModel post) {
         mPostSqlUtils.deleteLocalRevisionAndDiffsOfAPostOrPage(post);
+    }
+
+    public void deleteAllLocalRevisionAndDiffs() {
+        mPostSqlUtils.deleteAllLocalRevisionsAndDiffs();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1237,6 +1237,20 @@ public class PostStore extends Store {
         return RevisionModel.fromLocalRevisionAndDiffs(localRevision, localDiffs);
     }
 
+    @Nullable
+    public RevisionModel getRevisionById(final long revisionId) {
+        final String revisionIdString = String.valueOf(revisionId);
+        final LocalRevisionModel localRevision = mPostSqlUtils.getRevisionById(revisionIdString);
+
+        if (localRevision == null) {
+            return null;
+        }
+
+        List<LocalDiffModel> localDiffs = mPostSqlUtils.getLocalRevisionDiffs(localRevision);
+
+        return RevisionModel.fromLocalRevisionAndDiffs(localRevision, localDiffs);
+    }
+
     public void deleteLocalRevision(RevisionModel revisionModel, SiteModel site, PostModel post) {
         mPostSqlUtils.deleteLocalRevisionAndDiffs(
                 LocalRevisionModel.fromRevisionModel(revisionModel, site, post));


### PR DESCRIPTION
Implements `getRevisionById` method to `PostStore`. Currently we have a method that returns a single revision (`getLocalRevision`), but always the index 0 element of the returned DB list. There is currently no way to get a revision by ID.