### PR TITLE
Convert updateProductReviewStatus into suspendable function

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -494,7 +494,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     @Test
     fun testUpdateProductReviewStatusSuccess() {
         interceptor.respondWith("wc-update-product-review-response-success.json")
-        productRestClient.updateProductReviewStatus(siteModel, 0, "spam")
+        productRestClient.legacyUpdateProductReviewStatus(siteModel, 0, "spam")
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
@@ -524,7 +524,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     @Test
     fun testUpdateProductReviewStatusFailed() {
         interceptor.respondWithError("wc-response-failure-invalid-param.json")
-        productRestClient.updateProductReviewStatus(siteModel, 0, "spam")
+        productRestClient.legacyUpdateProductReviewStatus(siteModel, 0, "spam")
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -56,7 +56,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload
-import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductReviewStatusPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateVariationPayload
 import java.util.Date
 import java.util.concurrent.CountDownLatch
@@ -427,14 +426,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         // Update review status to spam - should get deleted from db
         review?.let {
             val newStatus = "spam"
-            nextEvent = TestEvent.UPDATED_PRODUCT_REVIEW_STATUS
-            mCountDownLatch = CountDownLatch(1)
-            mDispatcher.dispatch(
-                    WCProductActionBuilder.newUpdateProductReviewStatusAction(
-                            UpdateProductReviewStatusPayload(sSite, review.remoteProductReviewId, newStatus)
-                    )
-            )
-            assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+            productStore.updateProductReviewStatus(sSite, it.remoteProductReviewId, newStatus)
 
             // Verify results - review should be deleted from db
             val savedReview = productStore
@@ -446,13 +438,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         review?.let {
             val newStatus = "approved"
             nextEvent = TestEvent.UPDATED_PRODUCT_REVIEW_STATUS
-            mCountDownLatch = CountDownLatch(1)
-            mDispatcher.dispatch(
-                    WCProductActionBuilder.newUpdateProductReviewStatusAction(
-                            UpdateProductReviewStatusPayload(sSite, review.remoteProductReviewId, newStatus)
-                    )
-            )
-            assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+            productStore.updateProductReviewStatus(sSite, it.remoteProductReviewId, newStatus)
 
             // Verify results
             val savedReview = productStore
@@ -464,14 +450,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         // Update review status to trash - should get deleted from db
         review?.let {
             val newStatus = "trash"
-            nextEvent = TestEvent.UPDATED_PRODUCT_REVIEW_STATUS
-            mCountDownLatch = CountDownLatch(1)
-            mDispatcher.dispatch(
-                    WCProductActionBuilder.newUpdateProductReviewStatusAction(
-                            UpdateProductReviewStatusPayload(sSite, review.remoteProductReviewId, newStatus)
-                    )
-            )
-            assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+            productStore.updateProductReviewStatus(sSite, it.remoteProductReviewId, newStatus)
 
             // Verify results - review should be deleted from db
             val savedReview = productStore
@@ -482,14 +461,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         // Update review status to hold - should get added to db
         review?.let {
             val newStatus = "hold"
-            nextEvent = TestEvent.UPDATED_PRODUCT_REVIEW_STATUS
-            mCountDownLatch = CountDownLatch(1)
-            mDispatcher.dispatch(
-                    WCProductActionBuilder.newUpdateProductReviewStatusAction(
-                            UpdateProductReviewStatusPayload(sSite, review.remoteProductReviewId, newStatus)
-                    )
-            )
-            assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+            productStore.updateProductReviewStatus(sSite, it.remoteProductReviewId, newStatus)
 
             // Verify results
             val savedReview = productStore
@@ -807,24 +779,6 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
                 assertEquals(TestEvent.FETCHED_SINGLE_VARIATION, nextEvent)
                 assertEquals(event.remoteProductId, variationModel.remoteProductId)
                 assertEquals(event.remoteVariationId, variationModel.remoteVariationId)
-                mCountDownLatch.countDown()
-            }
-            else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)
-        }
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onProductReviewChanged(event: OnProductReviewChanged) {
-        event.error?.let {
-            throw AssertionError("OnProductReviewChanged has unexpected error: " + it.type)
-        }
-
-        lastReviewEvent = event
-
-        when (event.causeOfChange) {
-            WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS -> {
-                assertEquals(TestEvent.UPDATED_PRODUCT_REVIEW_STATUS, nextEvent)
                 mCountDownLatch.countDown()
             }
             else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_TAGS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_VARIATIONS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_SHIPPING_CLASS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_VARIATION
-import org.wordpress.android.fluxc.action.WCProductAction.UPDATE_PRODUCT_REVIEW_STATUS
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.replaceFragment
@@ -485,9 +484,6 @@ class WooProductsFragment : StoreSelectingFragment() {
                         pendingFetchSingleProductVariationOffset = 0
                         load_more_product_variations.isEnabled = false
                     }
-                }
-                UPDATE_PRODUCT_REVIEW_STATUS -> {
-                    prependToLog("${event.rowsAffected} product reviews updated")
                 }
                 DELETED_PRODUCT -> {
                     prependToLog("${event.rowsAffected} product deleted")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -260,6 +260,43 @@ class WooProductsFragment : StoreSelectingFragment() {
             }
         }
 
+        update_review_status.setOnClickListener {
+            selectedSite?.let { site ->
+                coroutineScope.launch {
+                    val id = showSingleLineDialog(
+                        activity = requireActivity(),
+                        message = "Enter the remoteReviewId of the review",
+                        isNumeric = true
+                    )?.toLongOrNull()
+                    if (id == null) {
+                        prependToLog("Please enter a valid id")
+                        return@launch
+                    }
+                    val newStatus = showSingleLineDialog(
+                        activity = requireActivity(),
+                        message = "Enter the new status: (approved|hold|spam|trash)"
+                    )
+                    if (newStatus == null) {
+                        prependToLog("Please enter a valid status")
+                        return@launch
+                    }
+
+                    val result = wcProductStore.updateProductReviewStatus(
+                        site = site, reviewId = id, newStatus = newStatus
+                    )
+
+                    if (!result.isError) {
+                        prependToLog("Product Review status updated successfully")
+                    } else {
+                        prependToLog(
+                            "Product Review status update failed, " +
+                                "${result.error.type} ${result.error.message}"
+                        )
+                    }
+                }
+            }
+        }
+
         fetch_product_shipping_class.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -91,6 +91,13 @@
             android:text="Fetch Product Review by ID"/>
 
         <Button
+            android:id="@+id/update_review_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Update Product Review Status" />
+
+        <Button
             android:id="@+id/fetch_product_shipping_class"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -23,7 +23,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteDeleteProductPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductCategoriesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductPasswordPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductSkuAvailabilityPayload;
@@ -39,7 +38,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductReviewStatusPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateVariationPayload;
 
 @ActionEnum
@@ -57,8 +55,6 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = FetchSingleProductShippingClassPayload.class)
     FETCH_SINGLE_PRODUCT_SHIPPING_CLASS,
-    @Action(payloadType = UpdateProductReviewStatusPayload.class)
-    UPDATE_PRODUCT_REVIEW_STATUS,
     @Action(payloadType = UpdateProductImagesPayload.class)
     UPDATE_PRODUCT_IMAGES,
     @Action(payloadType = UpdateProductPayload.class)
@@ -97,8 +93,6 @@ public enum WCProductAction implements IAction {
     FETCHED_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = RemoteProductShippingClassPayload.class)
     FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS,
-    @Action(payloadType = RemoteProductReviewPayload.class)
-    UPDATED_PRODUCT_REVIEW_STATUS,
     @Action(payloadType = RemoteUpdateProductImagesPayload.class)
     UPDATED_PRODUCT_IMAGES,
     @Action(payloadType = RemoteUpdateProductPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -76,7 +76,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPass
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload
 import org.wordpress.android.fluxc.utils.handleResult
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
-import java.util.HashMap
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -1129,34 +1128,13 @@ class ProductRestClient @Inject constructor(
      * Makes a PUT call to `/wc/v3/products/reviews/<id>` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * updating the status for the given product review to [newStatus].
      *
-     * Dispatches a [WCProductAction.UPDATED_PRODUCT_REVIEW_STATUS]
      *
      * @param [site] The site to fetch product reviews for
      * @param [remoteReviewId] The remote ID of the product review to be updated
      * @param [newStatus] The new status to update the product review to
+     *
+     * @return [WooPayload] with the updated [WCProductReviewModel]
      */
-    fun legacyUpdateProductReviewStatus(site: SiteModel, remoteReviewId: Long, newStatus: String) {
-        val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
-        val responseType = object : TypeToken<ProductReviewApiResponse>() {}.type
-        val params = mapOf("status" to newStatus)
-        val request = JetpackTunnelGsonRequest.buildPutRequest(url, site.siteId, params, responseType,
-                { response: ProductReviewApiResponse? ->
-                    response?.let {
-                        val review = productReviewResponseToProductReviewModel(response).apply {
-                            localSiteId = site.id
-                        }
-                        val payload = RemoteProductReviewPayload(site, review)
-                        dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductReviewStatusAction(payload))
-                    }
-                },
-                { networkError ->
-                    val productReviewError = networkErrorToProductError(networkError)
-                    val payload = RemoteProductReviewPayload(productReviewError, site)
-                    dispatcher.dispatch(WCProductActionBuilder.newUpdatedProductReviewStatusAction(payload))
-                })
-        add(request)
-    }
-
     suspend fun updateProductReviewStatus(
         site: SiteModel,
         remoteReviewId: Long,


### PR DESCRIPTION
⚠️ Please don't merge until https://github.com/woocommerce/woocommerce-android/pull/6037 is approved

This is part of https://github.com/woocommerce/woocommerce-android/issues/5647, it just converts `updateProductReviewStatus` to a suspendable function, and removes old code.

### Testing
1. Open the example app
2. Click on Woo, then Products.
3. Click on "Update Product Review Status"
4. Type a review ID and a new status.
5. Confirm the API call functions as expected