### PR TITLE
Convert Update Variation action into suspendable

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -39,7 +39,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsP
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPayload
 import org.wordpress.android.fluxc.utils.DateUtils
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -623,20 +622,14 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testDeleteProductVariationImageSuccess() {
+    fun testDeleteProductVariationImageSuccess() = runBlocking {
         interceptor.respondWith("wc-delete-product-variation-image-success.json")
 
         val testVariation = generateSampleVariation()
         val updateVariation = testVariation.copy().apply {
             image = "{id:0}"
         }
-        productRestClient.updateVariation(siteModel, testVariation, updateVariation)
-
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCProductAction.UPDATED_VARIATION, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteUpdateVariationPayload
+        val payload = productRestClient.updateVariation(siteModel, testVariation, updateVariation)
         with(payload) {
             assertNull(error)
             assertNotNull(variation.image)
@@ -645,20 +638,15 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testDeleteProductVariationImageError() {
+    fun testDeleteProductVariationImageError() = runBlocking {
         interceptor.respondWithError("wc-delete-product-variation-image-failure.json", 400)
 
         val testVariation = generateSampleVariation()
         val updateVariation = testVariation.copy().apply {
             image = "{id:0}"
         }
-        productRestClient.updateVariation(siteModel, testVariation, updateVariation)
+        val payload = productRestClient.updateVariation(siteModel, testVariation, updateVariation)
 
-        countDownLatch = CountDownLatch(1)
-        assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
-
-        assertEquals(WCProductAction.UPDATED_VARIATION, lastAction!!.type)
-        val payload = lastAction!!.payload as RemoteUpdateVariationPayload
         with(payload) {
             assertNotNull("Error should not be null", error)
             assertEquals(

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release
 
 import com.google.gson.JsonArray
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.junit.Assert.assertEquals
@@ -51,7 +52,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.OnProductShippingClasses
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductTagChanged
 import org.wordpress.android.fluxc.store.WCProductStore.OnProductUpdated
 import org.wordpress.android.fluxc.store.WCProductStore.OnVariationChanged
-import org.wordpress.android.fluxc.store.WCProductStore.OnVariationUpdated
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload
@@ -653,7 +653,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
     @Throws(InterruptedException::class)
     @Test
-    fun testUpdateVariation() {
+    fun testUpdateVariation() = runBlocking {
         val updatedVariationStatus = CoreProductStatus.PUBLISH.value
         variationModel.status = updatedVariationStatus
 
@@ -666,12 +666,9 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         val updatedVariationSalePrice = "12"
         variationModel.salePrice = updatedVariationSalePrice
 
-        nextEvent = TestEvent.UPDATED_VARIATION
-        mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(
-                WCProductActionBuilder.newUpdateVariationAction(UpdateVariationPayload(sSite, variationModel))
-        )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        withTimeout(TestUtils.DEFAULT_TIMEOUT_MS.toLong()) {
+            productStore.updateVariation(UpdateVariationPayload(sSite, variationModel))
+        }
 
         val updatedVariation = productStore.getVariationByRemoteId(
                 sSite,
@@ -859,17 +856,6 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         }
 
         assertEquals(TestEvent.UPDATED_PRODUCT, nextEvent)
-        mCountDownLatch.countDown()
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onVariationUpdated(event: OnVariationUpdated) {
-        event.error?.let {
-            throw AssertionError("OnVariationUpdated has unexpected error: ${it.type}, ${it.message}")
-        }
-
-        assertEquals(TestEvent.UPDATED_VARIATION, nextEvent)
         mCountDownLatch.countDown()
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateVariationFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateVariationFragment.kt
@@ -13,6 +13,9 @@ import android.widget.EditText
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_update_variation.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -23,7 +26,6 @@ import org.wordpress.android.fluxc.example.ui.ListSelectorDialog
 import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.ARG_LIST_SELECTED_ITEM
 import org.wordpress.android.fluxc.example.ui.ListSelectorDialog.Companion.LIST_SELECTOR_REQUEST_CODE
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
-import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductBackOrders
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
@@ -46,6 +48,8 @@ class WooUpdateVariationFragment : Fragment() {
     private var selectedRemoteProductId: Long? = null
     private var selectedRemoteVariationId: Long? = null
     private var selectedVariationModel: WCProductVariationModel? = null
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     companion object {
         const val ARG_SELECTED_SITE_POS = "ARG_SELECTED_SITE_POS"
@@ -178,9 +182,20 @@ class WooUpdateVariationFragment : Fragment() {
         product_update.setOnClickListener {
             getWCSite()?.let { site ->
                 if (selectedVariationModel?.remoteProductId != null &&
-                        selectedVariationModel?.remoteVariationId != null) {
-                    val payload = UpdateVariationPayload(site, selectedVariationModel!!)
-                    dispatcher.dispatch(WCProductActionBuilder.newUpdateVariationAction(payload))
+                    selectedVariationModel?.remoteVariationId != null) {
+                    coroutineScope.launch {
+                        val result = wcProductStore.updateVariation(
+                            UpdateVariationPayload(
+                                site,
+                                selectedVariationModel!!
+                            )
+                        )
+                        if (result.isError) {
+                            prependToLog("Updating Variation Failed: " + result.error.type)
+                        } else {
+                            prependToLog("Variation updated ${result.rowsAffected}")
+                        }
+                    }
                 } else {
                     prependToLog("No valid remoteProductId or remoteVariationId defined...doing nothing")
                 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPayload
+import org.wordpress.android.fluxc.store.WCProductStore.UpdateVariationPayload
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.utils.ProductCategoriesDbHelper
 import org.wordpress.android.fluxc.utils.ProductsDbHelper
@@ -149,18 +150,15 @@ class WCProductStoreTest {
     }
 
     @Test
-    fun testUpdateVariation() {
+    fun testUpdateVariation() = runBlocking {
         val variationModel = ProductTestUtils.generateSampleVariation(42, 24).apply {
             description = "test description"
         }
         val site = SiteModel().apply { id = variationModel.localSiteId }
-        ProductSqlUtils.insertOrUpdateProductVariation(variationModel)
+        whenever(productRestClient.updateVariation(site, null, variationModel))
+            .thenReturn(RemoteUpdateVariationPayload(site, variationModel))
 
-        // Simulate incoming action with updated product model
-        val payload = RemoteUpdateVariationPayload(site, variationModel.apply {
-            description = "Updated description"
-        })
-        productStore.onAction(WCProductActionBuilder.newUpdatedVariationAction(payload))
+        productStore.updateVariation(UpdateVariationPayload(site, variationModel))
 
         with(productStore.getVariationByRemoteId(
                 site,

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -32,7 +32,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsP
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.SearchProductsPayload;
@@ -40,7 +39,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductImagesPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPasswordPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.UpdateProductReviewStatusPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.UpdateVariationPayload;
 
 @ActionEnum
 public enum WCProductAction implements IAction {
@@ -63,8 +61,6 @@ public enum WCProductAction implements IAction {
     UPDATE_PRODUCT_IMAGES,
     @Action(payloadType = UpdateProductPayload.class)
     UPDATE_PRODUCT,
-    @Action(payloadType = UpdateVariationPayload.class)
-    UPDATE_VARIATION,
     @Action(payloadType = FetchProductSkuAvailabilityPayload.class)
     FETCH_PRODUCT_SKU_AVAILABILITY,
     @Action(payloadType = FetchProductPasswordPayload.class)
@@ -103,8 +99,6 @@ public enum WCProductAction implements IAction {
     UPDATED_PRODUCT_IMAGES,
     @Action(payloadType = RemoteUpdateProductPayload.class)
     UPDATED_PRODUCT,
-    @Action(payloadType = RemoteUpdateVariationPayload.class)
-    UPDATED_VARIATION,
     @Action(payloadType = RemoteProductSkuAvailabilityPayload.class)
     FETCHED_PRODUCT_SKU_AVAILABILITY,
     @Action(payloadType = RemoteProductPasswordPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1095,7 +1095,6 @@ class WCProductStore @Inject constructor(
                     storedVariation,
                     variation
                 )
-//                onVariationUpdated.causeOfChange = WCProductAction.UPDATED_VARIATION
                 return@withDefaultContext if (result.isError) {
                     OnVariationUpdated(
                         0,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -784,8 +784,6 @@ class WCProductStore @Inject constructor(
                 updateProductImages(action.payload as UpdateProductImagesPayload)
             WCProductAction.UPDATE_PRODUCT ->
                 updateProduct(action.payload as UpdateProductPayload)
-            WCProductAction.UPDATE_VARIATION ->
-                updateVariation(action.payload as UpdateVariationPayload)
             WCProductAction.FETCH_SINGLE_PRODUCT_SHIPPING_CLASS ->
                 fetchProductShippingClass(action.payload as FetchSingleProductShippingClassPayload)
             WCProductAction.FETCH_PRODUCT_SHIPPING_CLASS_LIST ->
@@ -824,8 +822,6 @@ class WCProductStore @Inject constructor(
                 handleUpdateProductImages(action.payload as RemoteUpdateProductImagesPayload)
             WCProductAction.UPDATED_PRODUCT ->
                 handleUpdateProduct(action.payload as RemoteUpdateProductPayload)
-            WCProductAction.UPDATED_VARIATION ->
-                handleUpdateVariation(action.payload as RemoteUpdateVariationPayload)
             WCProductAction.FETCHED_PRODUCT_SHIPPING_CLASS_LIST ->
                 handleFetchProductShippingClassesCompleted(action.payload as RemoteProductShippingClassListPayload)
             WCProductAction.FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS ->
@@ -1086,10 +1082,35 @@ class WCProductStore @Inject constructor(
         }
     }
 
-    private fun updateVariation(payload: UpdateVariationPayload) {
-        with(payload) {
-            val storedVariation = getVariationByRemoteId(site, variation.remoteProductId, variation.remoteVariationId)
-            wcProductRestClient.updateVariation(site, storedVariation, variation)
+    suspend fun updateVariation(payload: UpdateVariationPayload): OnVariationUpdated {
+        return coroutineEngine.withDefaultContext(API, this, "updateVariation") {
+            with(payload) {
+                val storedVariation = getVariationByRemoteId(
+                    site,
+                    variation.remoteProductId,
+                    variation.remoteVariationId
+                )
+                val result: RemoteUpdateVariationPayload = wcProductRestClient.updateVariation(
+                    site,
+                    storedVariation,
+                    variation
+                )
+//                onVariationUpdated.causeOfChange = WCProductAction.UPDATED_VARIATION
+                return@withDefaultContext if (result.isError) {
+                    OnVariationUpdated(
+                        0,
+                        result.variation.remoteProductId,
+                        result.variation.remoteVariationId
+                    ).also { it.error = result.error }
+                } else {
+                    val rowsAffected = insertOrUpdateProductVariation(result.variation)
+                    OnVariationUpdated(
+                        rowsAffected,
+                        result.variation.remoteProductId,
+                        result.variation.remoteVariationId
+                    )
+                }
+            }
         }
     }
 
@@ -1321,29 +1342,6 @@ class WCProductStore @Inject constructor(
             onProductUpdated.causeOfChange = WCProductAction.UPDATED_PRODUCT
             emitChange(onProductUpdated)
         }
-    }
-
-    private fun handleUpdateVariation(payload: RemoteUpdateVariationPayload) {
-        val onVariationUpdated: OnVariationUpdated
-
-        if (payload.isError) {
-            onVariationUpdated = OnVariationUpdated(
-                    0,
-                    payload.variation.remoteProductId,
-                    payload.variation.remoteVariationId
-            )
-                    .also { it.error = payload.error }
-        } else {
-            val rowsAffected = insertOrUpdateProductVariation(payload.variation)
-            onVariationUpdated = OnVariationUpdated(
-                    rowsAffected,
-                    payload.variation.remoteProductId,
-                    payload.variation.remoteVariationId
-            )
-        }
-
-        onVariationUpdated.causeOfChange = WCProductAction.UPDATED_VARIATION
-        emitChange(onVariationUpdated)
     }
 
     private fun handleFetchProductCategories(payload: RemoteProductCategoriesPayload) {


### PR DESCRIPTION
Implements  https://github.com/woocommerce/woocommerce-android/issues/6064 partially

**Merge when [the WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/6065) is approved.**

This PR refactors updateVariation into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.


## How to test
1. Run ReleaseStack_WCProductTest - testUpdateVariation()
2. Test `Woo -> Product -> Update Variation` action in the example app