### PR TITLE
Fix crash on empty item attribute key

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
@@ -6,5 +6,5 @@ object OrderMappingConst {
     const val CHARGE_ID_KEY = "_charge_id"
     const val SHIPPING_PHONE_KEY = "_shipping_phone"
     internal val WCMetaData.isNotInternalAttributeData
-        get() = key.first() != '_'
+        get() = key.isNotEmpty() && key.first() != '_'
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
@@ -5,6 +5,6 @@ import org.wordpress.android.fluxc.model.WCMetaData
 object OrderMappingConst {
     const val CHARGE_ID_KEY = "_charge_id"
     const val SHIPPING_PHONE_KEY = "_shipping_phone"
-    internal val WCMetaData.isNotInternalAttributeData
-        get() = key.isNotEmpty() && key.first() != '_'
+    internal val WCMetaData.isInternalAttribute
+        get() = key.startsWith('_')
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isNotInternalAttributeData
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isInternalAttribute
 import javax.inject.Inject
 
 internal class StripOrder @Inject constructor(private val gson: Gson) {
@@ -13,7 +13,7 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
         return fatModel.copy(
                 lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItem ->
                     lineItemDto.copy(
-                        metaData = lineItemDto.metaData?.filter { it.isNotInternalAttributeData }
+                        metaData = lineItemDto.metaData?.filter { it.isInternalAttribute.not() }
                     )
                 }),
                 shippingLines = gson.toJson(fatModel.getShippingLineList()),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -13,7 +13,9 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
         return fatModel.copy(
                 lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItem ->
                     lineItemDto.copy(
-                            metaData = lineItemDto.metaData?.filter { it.isNotInternalAttributeData }
+                            metaData = lineItemDto.metaData?.filter {
+                                it.key.isNotBlank() && it.isNotInternalAttributeData
+                            }
                     )
                 }),
                 shippingLines = gson.toJson(fatModel.getShippingLineList()),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -13,9 +13,7 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
         return fatModel.copy(
                 lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItem ->
                     lineItemDto.copy(
-                            metaData = lineItemDto.metaData?.filter {
-                                it.key.isNotBlank() && it.isNotInternalAttributeData
-                            }
+                        metaData = lineItemDto.metaData?.filter { it.isNotInternalAttributeData }
                     )
                 }),
                 shippingLines = gson.toJson(fatModel.getShippingLineList()),

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
@@ -20,7 +20,7 @@ internal class StripOrderTest {
     }
 
     @Test
-    fun `ignore additional members in line item`() {
+    fun `should ignore additional members in line item`() {
         // given
         val lineItemsFromRemote = JsonArray().apply {
             add(
@@ -42,7 +42,7 @@ internal class StripOrderTest {
     }
 
     @Test
-    fun `ignore internal-only remote line item attributes if applied to metadata key`() {
+    fun `should ignore internal-only remote line item attributes if applied to metadata key`() {
         // given
         val internalOnlyAttributeMemberKey = "_internal_attribute_key"
         val lineItemsFromRemote = JsonArray().apply {
@@ -70,7 +70,7 @@ internal class StripOrderTest {
     }
 
     @Test
-    fun `ignore additional members in shipping item`() {
+    fun `should ignore additional members in shipping item`() {
         // given
         val shippingLineItemsFromRemote = JsonArray().apply {
             add(
@@ -92,7 +92,7 @@ internal class StripOrderTest {
     }
 
     @Test
-    fun `ignore additional members in fee item`() {
+    fun `should ignore additional members in fee item`() {
         // given
         val feeLineItemsFromRemote = JsonArray().apply {
             add(
@@ -114,7 +114,7 @@ internal class StripOrderTest {
     }
 
     @Test
-    fun `ignore additional members in tax item`() {
+    fun `should ignore additional members in tax item`() {
         // given
         val taxLineItemsFromRemote = JsonArray().apply {
             add(
@@ -136,7 +136,7 @@ internal class StripOrderTest {
     }
 
     @Test
-    fun `drop any not needed meta data`() {
+    fun `should drop any not needed meta data`() {
         // given
         val metaDataFromRemote = JsonArray().apply {
             add(json {
@@ -168,6 +168,33 @@ internal class StripOrderTest {
                         CHARGE_ID_KEY,
                         SHIPPING_PHONE_KEY
                 )
+    }
+
+    @Test
+    fun `should filter out item attribute if its key is empty`() {
+        val emptyAttributeValue = "sample value"
+        val lineItemsFromRemote = JsonArray().apply {
+            add(
+                json {
+                    "id" To 1234
+                    "name" To "iPhone"
+                    "meta_data" To listOf(
+                        json {
+                            "key" To ""
+                            "value" To emptyAttributeValue
+                        }
+                    )
+                }
+            )
+        }.toString()
+        val fatModel = emptyOrder.copy(lineItems = lineItemsFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(fatModel.lineItems).contains(emptyAttributeValue)
+        assertThat(strippedOrder.lineItems).doesNotContain(emptyAttributeValue)
     }
 
     companion object {

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
@@ -171,7 +171,7 @@ internal class StripOrderTest {
     }
 
     @Test
-    fun `should filter out item attribute if its key is empty`() {
+    fun `should not crash when item attribute key is empty`() {
         // given
         val emptyAttributeValue = "sample value"
         val lineItemsFromRemote = JsonArray().apply {
@@ -195,7 +195,7 @@ internal class StripOrderTest {
 
         // then
         assertThat(fatModel.lineItems).contains(emptyAttributeValue)
-        assertThat(strippedOrder.lineItems).doesNotContain(emptyAttributeValue)
+        assertThat(strippedOrder.lineItems).contains(emptyAttributeValue)
     }
 
     companion object {

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
@@ -172,6 +172,7 @@ internal class StripOrderTest {
 
     @Test
     fun `should filter out item attribute if its key is empty`() {
+        // given
         val emptyAttributeValue = "sample value"
         val lineItemsFromRemote = JsonArray().apply {
             add(


### PR DESCRIPTION
Closes: #2321 

This PR fixes a bug which occurs when `Item`'s `Attribute` (taken from `meta_data` remote key) has an empty `key`.

Possible area of impact:
- Add ons (tested already)
- Variations (I don't suspect but just for double check) 

**If you think there's some valid case when `key` can be empty and used in the app, please share this.**

### Testing instructions

1. Checkout WooCommerce `c85e393` commit (it's `8.8-rc1` commit)
2. Use FluxC from this PR - either by updating `fluxCVersion` or using composite build
3. Smoke tests variations and/or add-ons (focus on possible cases for a valid empty `key` for Attributes)