### PR TITLE
Update configure plugin to 0.6.2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -10,12 +10,14 @@ pluginManagement {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
         id "com.automattic.android.publish-to-s3" version "0.7.0"
+        id "com.automattic.android.configure" version "0.6.2"
     }
     repositories {
         maven {
             url 'https://a8c-libs.s3.amazonaws.com/android' 
             content {
                 includeGroup "com.automattic.android"
+                includeGroup "com.automattic.android.configure"
                 includeGroup "com.automattic.android.publish-to-s3"
             }
         }
@@ -27,10 +29,6 @@ pluginManagement {
             // TODO: Remove this as soon as fetchstyle starts supporting Plugin Marker Artifacts
             if (requested.id.id == "com.automattic.android.fetchstyle") {
                 useModule("com.automattic.android:fetchstyle:1.1")
-            }
-            // TODO: Remove this as soon as configure starts supporting Plugin Marker Artifacts
-            if (requested.id.id == "com.automattic.android.configure") {
-                useModule("com.automattic.android:configure:0.6.1")
             }
         }
     }


### PR DESCRIPTION
This PR updates the `configure` plugin to `0.6.2` using the plugin DSL syntax. The new version comes with M1 chip support, thanks to @jkmassel.

**To test:**
* Delete the `vendor` folder, as there is still an issue with updating this plugin: `rm -rf vendor/`
* Run `./gradlew applyConfiguration` and verify that it's successful (preferably on an M1 machine)