### PR TITLE
Use the Android AMI instead of Docker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,9 @@
+# Nodes with values to reuse in the pipeline.
+common_params:
+  # Common plugin settings to use with the `plugins` key.
+  - &common_plugins
+    - automattic/bash-cache#2.3.0
+
 agents:
   queue: "android"
 
@@ -5,12 +11,14 @@ steps:
   - label: "Publish :fluxc-annotations"
     key: "publish-fluxc-annotations"
     command: .buildkite/publish-fluxc-annotations.sh
+    plugins: *common_plugins
 
   - label: "Publish :fluxc-processor"
     key: "publish-fluxc-processor"
     depends_on:
       - "publish-fluxc-annotations"
     command: .buildkite/publish-fluxc-processor.sh
+    plugins: *common_plugins
 
   - label: "Publish :fluxc"
     key: "publish-fluxc"
@@ -18,6 +26,7 @@ steps:
       - "publish-fluxc-processor"
       - "publish-fluxc-annotations"
     command: .buildkite/publish-fluxc.sh
+    plugins: *common_plugins
 
   - label: "Publish :plugins:woocommerce"
     key: "publish-plugins-woocommerce"
@@ -26,3 +35,4 @@ steps:
       - "publish-fluxc-annotations"
       - "publish-fluxc"
     command: .buildkite/publish-plugins-woocommerce.sh
+    plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,40 +1,23 @@
-common-params:
-  &publish-android-artifacts-docker-container
-  docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:v1.2.0"
-    propagate-environment: true
-    environment:
-      # DO NOT MANUALLY SET THESE VALUES!
-      # They are passed from the Buildkite agent to the Docker container
-      - "AWS_ACCESS_KEY"
-      - "AWS_SECRET_KEY"
+agents:
+  queue: "android"
 
 steps:
   - label: "Publish :fluxc-annotations"
     key: "publish-fluxc-annotations"
-    plugins:
-      - *publish-android-artifacts-docker-container
-    command: |
-      .buildkite/publish-fluxc-annotations.sh
+    command: .buildkite/publish-fluxc-annotations.sh
 
   - label: "Publish :fluxc-processor"
     key: "publish-fluxc-processor"
     depends_on:
       - "publish-fluxc-annotations"
-    plugins:
-      - *publish-android-artifacts-docker-container
-    command: |
-      .buildkite/publish-fluxc-processor.sh
+    command: .buildkite/publish-fluxc-processor.sh
 
   - label: "Publish :fluxc"
     key: "publish-fluxc"
     depends_on:
       - "publish-fluxc-processor"
       - "publish-fluxc-annotations"
-    plugins:
-      - *publish-android-artifacts-docker-container
-    command: |
-      .buildkite/publish-fluxc.sh
+    command: .buildkite/publish-fluxc.sh
 
   - label: "Publish :plugins:woocommerce"
     key: "publish-plugins-woocommerce"
@@ -42,7 +25,4 @@ steps:
       - "publish-fluxc-processor"
       - "publish-fluxc-annotations"
       - "publish-fluxc"
-    plugins:
-      - *publish-android-artifacts-docker-container
-    command: |
-      .buildkite/publish-plugins-woocommerce.sh
+    command: .buildkite/publish-plugins-woocommerce.sh


### PR DESCRIPTION
Run directly on the AWS VM instead of via Docker. This will allow us to use the caching plugin, and should also fix a `glibc` issue.