### PR TITLE
Revert "Update configure plugin to 0.6.2"

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -10,14 +10,12 @@ pluginManagement {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
         id "com.automattic.android.publish-to-s3" version "0.7.0"
-        id "com.automattic.android.configure" version "0.6.2"
     }
     repositories {
         maven {
             url 'https://a8c-libs.s3.amazonaws.com/android' 
             content {
                 includeGroup "com.automattic.android"
-                includeGroup "com.automattic.android.configure"
                 includeGroup "com.automattic.android.publish-to-s3"
             }
         }
@@ -29,6 +27,10 @@ pluginManagement {
             // TODO: Remove this as soon as fetchstyle starts supporting Plugin Marker Artifacts
             if (requested.id.id == "com.automattic.android.fetchstyle") {
                 useModule("com.automattic.android:fetchstyle:1.1")
+            }
+            // TODO: Remove this as soon as configure starts supporting Plugin Marker Artifacts
+            if (requested.id.id == "com.automattic.android.configure") {
+                useModule("com.automattic.android:configure:0.6.1")
             }
         }
     }


### PR DESCRIPTION
I forgot to disable auto-merge for wordpress-mobile/WordPress-FluxC-Android#2324, so this PR reverts it until we are ready to merge it.

