### PR TITLE
WC Coupons: fetching performance reports

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/coupons/WooCouponsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/coupons/WooCouponsFragment.kt
@@ -113,7 +113,7 @@ class WooCouponsFragment : StoreSelectingFragment() {
                         )
                         prependToLog(
                             "Coupon was used ${report.ordersCount} times and " +
-                                "resulted in ${usageAmountFormatted} savings"
+                                "resulted in $usageAmountFormatted savings"
                         )
                     }
                 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/coupons/WooCouponsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/coupons/WooCouponsFragment.kt
@@ -19,10 +19,12 @@ import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.CouponStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 class WooCouponsFragment : StoreSelectingFragment() {
     @Inject internal lateinit var store: CouponStore
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
@@ -82,6 +84,39 @@ class WooCouponsFragment : StoreSelectingFragment() {
                         )
                     }
                 } ?: prependToLog("Invalid coupon ID")
+            }
+        }
+
+        btnFetchCouponReport.setOnClickListener {
+            coroutineScope.launch {
+                val couponId = showSingleLineDialog(
+                    requireActivity(),
+                    "Enter the coupon Id:",
+                    isNumeric = true
+                )?.toLongOrNull()
+                    ?: run {
+                        prependToLog("Please enter a valid id")
+                        return@launch
+                    }
+
+                val reportResult = store.fetchCouponReport(selectedSite!!, couponId)
+
+                when {
+                    reportResult.isError ->
+                        prependToLog("Fetching report failed, ${reportResult.error.message}")
+                    else -> {
+                        val report = reportResult.model!!
+                        val usageAmountFormatted = wooCommerceStore.formatCurrencyForDisplay(
+                            report.amount.toDouble(),
+                            selectedSite!!,
+                            applyDecimalFormatting = true
+                        )
+                        prependToLog(
+                            "Coupon was used ${report.ordersCount} times and " +
+                                "resulted in ${usageAmountFormatted} savings"
+                        )
+                    }
+                }
             }
         }
     }

--- a/example/src/main/res/layout/fragment_woo_coupons.xml
+++ b/example/src/main/res/layout/fragment_woo_coupons.xml
@@ -36,5 +36,13 @@
             android:layout_marginTop="8dp"
             android:enabled="false"
             android:text="Delete coupon" />
+
+        <Button
+            android:id="@+id/btnFetchCouponReport"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Fetch Coupon Report" />
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/store/CouponStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/CouponStoreTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -32,7 +33,6 @@ import org.wordpress.android.fluxc.persistence.entity.ProductEntity
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import java.math.BigDecimal
-import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 class CouponStoreTest {
@@ -411,7 +411,7 @@ class CouponStoreTest {
 
     @Test
     fun `fetching coupon report should return the correct data`() = test {
-        whenever(restClient.fetchCouponReport(site, expectedCoupon.id, Date(0))).thenReturn(
+        whenever(restClient.fetchCouponReport(any(), any(), any())).thenReturn(
             WooPayload(
                 CouponReportDto(
                     couponId = expectedCoupon.id,

--- a/example/src/test/java/org/wordpress/android/fluxc/store/CouponStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/CouponStoreTest.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.coupons.CouponDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.coupons.CouponReportDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.coupons.CouponRestClient
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.CouponsDao
@@ -30,6 +31,8 @@ import org.wordpress.android.fluxc.persistence.entity.ProductCategoryEntity
 import org.wordpress.android.fluxc.persistence.entity.ProductEntity
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import java.math.BigDecimal
+import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 class CouponStoreTest {
@@ -404,5 +407,24 @@ class CouponStoreTest {
         val observedDataModel = couponStore.observeCoupon(site, expectedCoupon.id).first()
 
         assertThat(observedDataModel).isEqualTo(expectedDataModel)
+    }
+
+    @Test
+    fun `fetching coupon report should return the correct data`() = test {
+        whenever(restClient.fetchCouponReport(site, expectedCoupon.id, Date(0))).thenReturn(
+            WooPayload(
+                CouponReportDto(
+                    couponId = expectedCoupon.id,
+                    amount = "10",
+                    ordersCount = 2
+                )
+            )
+        )
+
+        val couponReport = couponStore.fetchCouponReport(site, expectedCoupon.id).model!!
+
+        assertThat(couponReport.couponId).isEqualTo(expectedCoupon.id)
+        assertThat(couponReport.amount).isEqualByComparingTo(BigDecimal.TEN)
+        assertThat(couponReport.ordersCount).isEqualTo(2)
     }
 }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -82,6 +82,7 @@
 
 /coupons
 /coupons/<id>
+/reports/coupons
 
 /admin/notes
 /admin/notes/<note_id>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/coupons/CouponReport.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/coupons/CouponReport.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.model.coupons
+
+import java.math.BigDecimal
+
+data class CouponReport(
+    val couponId: Long,
+    val amount: BigDecimal,
+    val ordersCount: Int
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponReportDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponReportDto.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.coupons
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.model.coupons.CouponReport
+import java.math.BigDecimal
+
+data class CouponReportDto(
+    @SerializedName("coupon_id") val couponId: Long,
+    @SerializedName("amount") val amount: String?,
+    @SerializedName("orders_count") val ordersCount: Int?
+)
+
+fun CouponReportDto.toDataModel() = CouponReport(
+    couponId = couponId,
+    amount = amount?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+    ordersCount = ordersCount ?: 0
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
@@ -16,8 +16,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
-import org.wordpress.android.util.DateTimeUtils
+import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -108,9 +109,10 @@ class CouponRestClient @Inject constructor(
         after: Date
     ): WooPayload<List<CouponReportDto>> {
         val url = WOOCOMMERCE.reports.coupons.pathV4Analytics
+        val dateFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT)
 
         val params = mapOf(
-            "after" to DateTimeUtils.iso8601FromDate(after),
+            "after" to dateFormatter.format(after),
             "coupons" to couponsIds.joinToString(",")
         )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
@@ -5,14 +5,19 @@ import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -94,6 +99,52 @@ class CouponRestClient @Inject constructor(
         return when (response) {
             is JetpackError -> WooPayload(response.error.toWooError())
             is JetpackSuccess -> WooPayload(Unit)
+        }
+    }
+
+    suspend fun fetchCouponsReports(
+        site: SiteModel,
+        couponsIds: Array<Long> = emptyArray(),
+        after: Date
+    ): WooPayload<List<CouponReportDto>> {
+        val url = WOOCOMMERCE.reports.coupons.pathV4Analytics
+
+        val params = mapOf(
+            "after" to DateTimeUtils.iso8601FromDate(after),
+            "coupons" to couponsIds.joinToString(",")
+        )
+
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+            restClient = this,
+            site = site,
+            url = url,
+            params = params,
+            clazz = Array<CouponReportDto>::class.java
+        )
+
+        return when (response) {
+            is JetpackError -> WooPayload(response.error.toWooError())
+            is JetpackSuccess -> WooPayload(response.data?.toList())
+        }
+    }
+
+    suspend fun fetchCouponReport(
+        site: SiteModel,
+        couponId: Long,
+        after: Date
+    ): WooPayload<CouponReportDto> {
+        return fetchCouponsReports(
+            site = site,
+            couponsIds = arrayOf(couponId),
+            after = after
+        ).let {
+            when {
+                it.isError -> WooPayload(it.error)
+                it.result.isNullOrEmpty() -> WooPayload(
+                    WooError(API_ERROR, UNKNOWN, "Empty coupons report response")
+                )
+                else -> WooPayload(it.result.first())
+            }
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.AppLog.T.API
 import org.wordpress.android.util.AppLog.T.DB
 import java.util.Date
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -204,8 +205,8 @@ class CouponStore @Inject constructor(
 
     suspend fun fetchCouponReport(site: SiteModel, couponId: Long): WooResult<CouponReport> =
         coroutineEngine.withDefaultContext(T.API, this, "fetchCouponReport") {
-            // Old date
-            val date = Date(0)
+            // Old date, 1 second since epoch
+            val date = Date(TimeUnit.SECONDS.toMillis(1))
 
             return@withDefaultContext restClient.fetchCouponReport(site, couponId, date)
                 .let { result ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
@@ -218,7 +218,6 @@ class CouponStore @Inject constructor(
                 }
         }
 
-
     private fun assembleCouponDataModel(
         site: SiteModel,
         it: CouponWithEmails


### PR DESCRIPTION
This work is needed for https://github.com/woocommerce/woocommerce-android/issues/5530, it adds support for fetching performance report for given coupons using `wc-analytics` endpoint.

For information, I decided to not cache this data since for the following reasons:
1. As it's about analytics, it needs to be up-to-date always.
2. It's accessed only inside the coupons details screen, so whenever the user opens this screen, we will fetch it no matter what.
3. If the device is offline, it doesn't hurt to not have it (maybe 🤔).

If you don't agree with those arguments, please let me know, and just for the record, iOS seem to be doing the same.

#### Testing
1. Open the example app.
2. Click on Woo.
3. Click on Coupons.
4. Select a site.
5. Click on "Fetch coupon report"
6. Enter a coupon id.
7. Confirm the report result is printed to the log.