### PR TITLE
Add Gradle Enterprise to Project

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -48,6 +48,7 @@ gradleEnterprise {
         capture {
             taskInputFiles = true
         }
+        uploadInBackground = System.getenv("CI") == null
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -53,6 +53,17 @@ gradleEnterprise {
     }
 }
 
+if (System.getenv().containsKey("CI")) {
+    buildCache {
+        remote(HttpBuildCache) {
+            url = "http://10.0.2.215:5071/cache/"
+            allowUntrustedServer = true
+            allowInsecureProtocol = true
+            push = true
+        }
+    }
+}
+
 rootProject.name = 'FluxC'
 
 include ':fluxc',

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,10 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
+gradleEnterprise {
+    server = "https://gradle.a8c.com"
+}
+
 rootProject.name = 'FluxC'
 
 include ':fluxc',

--- a/settings.gradle
+++ b/settings.gradle
@@ -61,15 +61,3 @@ include ':fluxc',
         ':plugins:woocommerce',
         ':example',
         ':tests:api'
-
-// Build cache is only enabled for CI, at least for now
-if (System.getenv().containsKey("CI")) {
-    buildCache {
-        remote(HttpBuildCache) {
-            url = "http://10.0.2.215:5071/cache/"
-            allowUntrustedServer = true
-            allowInsecureProtocol = true
-            push = true
-        }
-    }
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,6 +36,8 @@ pluginManagement {
     }
 }
 
+rootProject.name = 'FluxC'
+
 include ':fluxc',
         ':fluxc-processor',
         ':fluxc-annotations',

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,6 +36,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id 'com.gradle.enterprise' version '3.9'
+}
+
 rootProject.name = 'FluxC'
 
 include ':fluxc',

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,9 @@ gradleEnterprise {
     allowUntrustedServer = false
     buildScan {
         publishAlways()
+        capture {
+            taskInputFiles = true
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ pluginManagement {
 
 plugins {
     id 'com.gradle.enterprise' version '3.9'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.5'
 }
 
 gradleEnterprise {

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,6 +42,7 @@ plugins {
 
 gradleEnterprise {
     server = "https://gradle.a8c.com"
+    allowUntrustedServer = false
 }
 
 rootProject.name = 'FluxC'

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,6 +43,9 @@ plugins {
 gradleEnterprise {
     server = "https://gradle.a8c.com"
     allowUntrustedServer = false
+    buildScan {
+        publishAlways()
+    }
 }
 
 rootProject.name = 'FluxC'


### PR DESCRIPTION
The goal of this PR is to test the `Gradle Enterprise` configuration in order for the GE trial to begin.

To test:

- Verify builds on [gradle.a8c.com](https://gradle.a8c.com/) (ie `Dashboard`, `Build Scan`, etc).
- CI should also publish to GE (ie `Build Scan` urls, etc).
- Additionally, you could also build and test GE locally (ie `Build Scan` urls, etc).