### PR TITLE
Fixed failing testInstantiateAndCreateReplyComment test

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -164,7 +164,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
         assertEquals(comment.getContent(), mNewComment.getContent());
         assertEquals(comment.getAuthorId(), firstComment.getAuthorId());
-        assertEquals(comment.getParentId(), firstComment.getParentId());
+        assertEquals(comment.getParentId(), firstComment.getRemoteCommentId());
     }
 
     @Test


### PR DESCRIPTION
Test condition got messed up in #2333. This PR fixes is.

To test:
 - I will run connected tests for this PR. Make sure the `testInstantiateAndCreateReplyComment` is not failing (there are some toher flaky tests that might fail tho).