### PR TITLE
Updates the sites/new call to use the username and site title

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -171,7 +171,9 @@ public class SitesFragment extends Fragment {
         String defaultTimeZoneId = "Europe/London";
 
         NewSitePayload newSitePayload = new NewSitePayload(
+                "username",
                 name,
+                null,
                 defaultLanguage,
                 defaultTimeZoneId,
                 SiteVisibility.PUBLIC,

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -201,7 +201,17 @@ class SiteRestClientTest {
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
 
-        val result = restClient.newSite(username, siteName, siteTitle, language, timeZoneId, visibility, segmentId, siteDesign, dryRun)
+        val result = restClient.newSite(
+            username,
+            siteName,
+            siteTitle,
+            language,
+            timeZoneId,
+            visibility,
+            segmentId,
+            siteDesign,
+            dryRun
+        )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
         assertThat(result.dryRun).isEqualTo(dryRun)
@@ -249,7 +259,17 @@ class SiteRestClientTest {
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
 
-        val result = restClient.newSite(username, siteName, siteTitle, language, timeZoneId, visibility, segmentId, siteDesign, dryRun)
+        val result = restClient.newSite(
+            username,
+            siteName,
+            siteTitle,
+            language,
+            timeZoneId,
+            visibility,
+            segmentId,
+            siteDesign,
+            dryRun
+        )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
         assertThat(result.dryRun).isEqualTo(dryRun)
@@ -299,7 +319,17 @@ class SiteRestClientTest {
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
 
-        val result = restClient.newSite(username, siteName, siteTitle, language, timeZoneId, visibility, segmentId, siteDesign, dryRun)
+        val result = restClient.newSite(
+            username,
+            siteName,
+            siteTitle,
+            language,
+            timeZoneId,
+            visibility,
+            segmentId,
+            siteDesign,
+            dryRun
+        )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
         assertThat(result.dryRun).isEqualTo(dryRun)
@@ -346,7 +376,17 @@ class SiteRestClientTest {
         val visibility = SiteVisibility.PRIVATE
         val timeZoneId = "Europe/London"
 
-        val result = restClient.newSite(username, siteName, siteTitle, language, timeZoneId, visibility, null, null, dryRun)
+        val result = restClient.newSite(
+            username,
+            siteName,
+            siteTitle,
+            language,
+            timeZoneId,
+            visibility,
+            null,
+            null,
+            dryRun
+        )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
         assertThat(result.dryRun).isEqualTo(dryRun)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -192,14 +192,16 @@ class SiteRestClientTest {
         initNewSiteResponse(data)
 
         val dryRun = false
+        val username = "username"
         val siteName = "Site name"
+        val siteTitle = "site title"
         val language = "CZ"
         val visibility = PUBLIC
         val segmentId = 123L
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
 
-        val result = restClient.newSite(siteName, language, timeZoneId, visibility, segmentId, siteDesign, dryRun)
+        val result = restClient.newSite(username, siteName, siteTitle, language, timeZoneId, visibility, segmentId, siteDesign, dryRun)
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
         assertThat(result.dryRun).isEqualTo(dryRun)
@@ -209,6 +211,7 @@ class SiteRestClientTest {
         assertThat(bodyCaptor.lastValue).isEqualTo(
                 mapOf(
                         "blog_name" to siteName,
+                        "blog_title" to siteTitle,
                         "lang_id" to language,
                         "public" to "1",
                         "validate" to "0",
@@ -220,6 +223,105 @@ class SiteRestClientTest {
                                 "timezone_string" to timeZoneId
                         )
                 )
+        )
+    }
+
+    @Test
+    fun `creates new site without a site name`() = test {
+        val data = NewSiteResponse()
+        val blogDetails = BlogDetails()
+        blogDetails.blogid = siteId.toString()
+        data.blog_details = blogDetails
+        val appId = "app_id"
+        whenever(appSecrets.appId).thenReturn(appId)
+        val appSecret = "app_secret"
+        whenever(appSecrets.appSecret).thenReturn(appSecret)
+
+        initNewSiteResponse(data)
+
+        val dryRun = false
+        val username = "username"
+        val siteName = null
+        val siteTitle = "site title"
+        val language = "CZ"
+        val visibility = PUBLIC
+        val segmentId = 123L
+        val siteDesign = "design"
+        val timeZoneId = "Europe/London"
+
+        val result = restClient.newSite(username, siteName, siteTitle, language, timeZoneId, visibility, segmentId, siteDesign, dryRun)
+
+        assertThat(result.newSiteRemoteId).isEqualTo(siteId)
+        assertThat(result.dryRun).isEqualTo(dryRun)
+
+        assertThat(urlCaptor.lastValue)
+            .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/new/")
+        assertThat(bodyCaptor.lastValue).isEqualTo(
+            mapOf(
+                "blog_name" to siteTitle,
+                "blog_title" to siteTitle,
+                "lang_id" to language,
+                "public" to "1",
+                "validate" to "0",
+                "find_available_url" to "1",
+                "site_creation_flow" to "with-design-picker",
+                "client_id" to appId,
+                "client_secret" to appSecret,
+                "options" to mapOf<String, Any>(
+                    "site_segment" to segmentId,
+                    "template" to siteDesign,
+                    "timezone_string" to timeZoneId
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `creates new site without a site name and site title`() = test {
+        val data = NewSiteResponse()
+        val blogDetails = BlogDetails()
+        blogDetails.blogid = siteId.toString()
+        data.blog_details = blogDetails
+        val appId = "app_id"
+        whenever(appSecrets.appId).thenReturn(appId)
+        val appSecret = "app_secret"
+        whenever(appSecrets.appSecret).thenReturn(appSecret)
+
+        initNewSiteResponse(data)
+
+        val dryRun = false
+        val username = "username"
+        val siteName = null
+        val siteTitle = null
+        val language = "CZ"
+        val visibility = PUBLIC
+        val segmentId = 123L
+        val siteDesign = "design"
+        val timeZoneId = "Europe/London"
+
+        val result = restClient.newSite(username, siteName, siteTitle, language, timeZoneId, visibility, segmentId, siteDesign, dryRun)
+
+        assertThat(result.newSiteRemoteId).isEqualTo(siteId)
+        assertThat(result.dryRun).isEqualTo(dryRun)
+
+        assertThat(urlCaptor.lastValue)
+            .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/new/")
+        assertThat(bodyCaptor.lastValue).isEqualTo(
+            mapOf(
+                "blog_name" to username,
+                "lang_id" to language,
+                "public" to "1",
+                "validate" to "0",
+                "find_available_url" to "1",
+                "site_creation_flow" to "with-design-picker",
+                "client_id" to appId,
+                "client_secret" to appSecret,
+                "options" to mapOf<String, Any>(
+                    "site_segment" to segmentId,
+                    "template" to siteDesign,
+                    "timezone_string" to timeZoneId
+                )
+            )
         )
     }
 
@@ -237,12 +339,14 @@ class SiteRestClientTest {
         initNewSiteResponse(data)
 
         val dryRun = true
+        val username = "username"
         val siteName = "Site name"
+        val siteTitle = null
         val language = "CZ"
         val visibility = SiteVisibility.PRIVATE
         val timeZoneId = "Europe/London"
 
-        val result = restClient.newSite(siteName, language, timeZoneId, visibility, null, null, dryRun)
+        val result = restClient.newSite(username, siteName, siteTitle, language, timeZoneId, visibility, null, null, dryRun)
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
         assertThat(result.dryRun).isEqualTo(dryRun)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -170,7 +170,7 @@ class SiteStoreTest {
         val dryRun = false
         val payload = NewSitePayload("UserName", "New site", "CZ", "Europe/London", PUBLIC, dryRun)
         val newSiteRemoteId: Long = 123
-        val response = NewSiteResponsePayload(newSiteRemoteId, dryRun)
+        val response = NewSiteResponsePayload(newSiteRemoteId, dryRun = dryRun)
         whenever(
                 siteRestClient.newSite(
                         payload.username,

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -168,12 +168,14 @@ class SiteStoreTest {
     @Test
     fun `creates a new site`() = test {
         val dryRun = false
-        val payload = NewSitePayload("New site", "CZ", "Europe/London", PUBLIC, dryRun)
+        val payload = NewSitePayload("UserName", "New site", "CZ", "Europe/London", PUBLIC, dryRun)
         val newSiteRemoteId: Long = 123
         val response = NewSiteResponsePayload(newSiteRemoteId, dryRun)
         whenever(
                 siteRestClient.newSite(
+                        payload.username,
                         payload.siteName,
+                        null,
                         payload.language,
                         payload.timeZoneId,
                         payload.visibility,
@@ -192,13 +194,15 @@ class SiteStoreTest {
     @Test
     fun `fails to create a new site`() = test {
         val dryRun = false
-        val payload = NewSitePayload("New site", "CZ", "Europe/London", PUBLIC, dryRun)
+        val payload = NewSitePayload("UserName", "New site", "CZ", "Europe/London", PUBLIC, dryRun)
         val response = NewSiteResponsePayload()
         val newSiteError = NewSiteError(SITE_NAME_INVALID, "Site name invalid")
         response.error = newSiteError
         whenever(
                 siteRestClient.newSite(
+                        payload.username,
                         payload.siteName,
+                        null,
                         payload.language,
                         payload.timeZoneId,
                         payload.visibility,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -226,14 +226,8 @@ class SiteRestClient @Inject constructor(
         if (siteTitle != null) {
             body["blog_title"] = siteTitle
         }
-        if (siteName != null) {
-            body["blog_name"] = siteName
-        } else {
-            if (siteTitle != null) {
-                body["blog_name"] = siteTitle
-            } else {
-                body["blog_name"] = username
-            }
+        body["blog_name"] = siteName ?: siteTitle ?: username
+        siteName ?: run {
             body["site_creation_flow"] = "with-design-picker"
             body["find_available_url"] = "1"
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -179,8 +179,34 @@ class SiteRestClient @Inject constructor(
         }
     }
 
+    /**
+     * Calls the API at https://public-api.wordpress.com/rest/v1.1/sites/new/ to create a new site
+     * @param username The username of the user
+     * @param siteName The domain of the site
+     * @param siteTitle The title of the site
+     * @param language The language of the site
+     * @param timeZoneId The timezone of the site
+     * @param visibility The visibility of the site (public or private)
+     * @param segmentId The segment that the site belongs to
+     * @param siteDesign The design template of the site
+     * @param dryRun If set to true the call only validates the parameters passed
+     *
+     * The domain of the site is generated with the following logic:
+     *
+     * 1. If the [siteName] is provided it is used as a domain
+     * 2. If the [siteName] is not provided the [siteTitle] is passed and the API generates the domain from it
+     * 3. If neither the [siteName] or the [siteTitle] is passed the [username] is used by the API to generate a domain
+     *
+     * In the cases 2 and 3 two extra parameters are passed:
+     * - `site_creation_flow` with value `with-design-picker`
+     * - `find_available_url` with value `1`
+     *
+     * @return the response of the API call  as [NewSiteResponsePayload]
+     */
     suspend fun newSite(
-        siteName: String,
+        username: String,
+        siteName: String?,
+        siteTitle: String?,
         language: String,
         timeZoneId: String?,
         visibility: SiteVisibility,
@@ -190,12 +216,26 @@ class SiteRestClient @Inject constructor(
     ): NewSiteResponsePayload {
         val url = WPCOMREST.sites.new_.urlV1_1
         val body = mutableMapOf<String, Any>()
-        body["blog_name"] = siteName
         body["lang_id"] = language
         body["public"] = visibility.value().toString()
         body["validate"] = if (dryRun) "1" else "0"
         body["client_id"] = appSecrets.appId
         body["client_secret"] = appSecrets.appSecret
+
+        if (siteTitle != null) {
+            body["blog_title"] = siteTitle
+        }
+        if (siteName != null) {
+            body["blog_name"] = siteName
+        } else {
+            if (siteTitle != null) {
+                body["blog_name"] = siteTitle
+            } else {
+                body["blog_name"] = username
+            }
+            body["site_creation_flow"] = "with-design-picker"
+            body["find_available_url"] = "1"
+        }
 
         // Add site options if available
         val options = mutableMapOf<String, Any>()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -110,6 +110,7 @@ class SiteRestClient @Inject constructor(
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     data class NewSiteResponsePayload(
         val newSiteRemoteId: Long = 0,
+        val siteUrl: String? = null,
         val dryRun: Boolean = false
     ) : Payload<NewSiteError>()
 
@@ -272,7 +273,7 @@ class SiteRestClient @Inject constructor(
                         // No op: In dry run mode, returned newSiteRemoteId is "Array"
                     }
                 }
-                NewSiteResponsePayload(siteId, dryRun)
+                NewSiteResponsePayload(siteId, response.data.blog_details?.url, dryRun)
             }
             is Error -> {
                 volleyErrorToAccountResponsePayload(response.error.volleyError, dryRun)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1490,7 +1490,9 @@ open class SiteStore
     @VisibleForTesting
     suspend fun createNewSite(payload: NewSitePayload): OnNewSiteCreated {
         val result = siteRestClient.newSite(
+                payload.username,
                 payload.siteName,
+                payload.siteTitle,
                 payload.language,
                 payload.timeZoneId,
                 payload.visibility,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -526,9 +526,14 @@ open class SiteStore
 
     data class OnNewSiteCreated(
         @JvmField val dryRun: Boolean = false,
+        @JvmField val url: String? = null,
         @JvmField val newSiteRemoteId: Long = 0
     ) : OnChanged<NewSiteError>() {
-        constructor(dryRun: Boolean, newSiteRemoteId: Long, error: NewSiteError?) : this(dryRun, newSiteRemoteId) {
+        constructor(dryRun: Boolean, url: String?, newSiteRemoteId: Long, error: NewSiteError?) : this(
+                dryRun,
+                url,
+                newSiteRemoteId
+        ) {
             this.error = error
         }
     }
@@ -1506,7 +1511,7 @@ open class SiteStore
     }
 
     private fun handleCreateNewSiteCompleted(payload: NewSiteResponsePayload): OnNewSiteCreated {
-        return OnNewSiteCreated(payload.dryRun, payload.newSiteRemoteId, payload.error)
+        return OnNewSiteCreated(payload.dryRun, payload.siteUrl, payload.newSiteRemoteId, payload.error)
     }
 
     suspend fun fetchPostFormats(site: SiteModel): OnPostFormatsChanged {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -148,8 +148,23 @@ open class SiteStore
         @JvmField val filterJetpackConnectedPackageSite: Boolean = false
     ) : Payload<BaseNetworkError>()
 
+    /**
+     * Holds the new site parameters for site creation
+     *
+     * @param username The username of the user
+     * @param siteName The domain of the site
+     * @param siteTitle The title of the site
+     * @param language The language of the site
+     * @param timeZoneId The timezone of the site
+     * @param visibility The visibility of the site (public or private)
+     * @param segmentId The segment that the site belongs to
+     * @param siteDesign The design template of the site
+     * @param dryRun If set to true the call only validates the parameters passed
+     */
     data class NewSitePayload(
-        @JvmField val siteName: String,
+        @JvmField val username: String,
+        @JvmField val siteName: String?,
+        @JvmField val siteTitle: String?,
         @JvmField val language: String,
         @JvmField val timeZoneId: String?,
         @JvmField val visibility: SiteVisibility,
@@ -158,27 +173,40 @@ open class SiteStore
         @JvmField val dryRun: Boolean
     ) : Payload<BaseNetworkError>() {
         constructor(
-            siteName: String,
+            username: String,
+            siteName: String?,
             language: String,
             visibility: SiteVisibility,
             dryRun: Boolean
-        ) : this(siteName, language, null, visibility, null, null, dryRun)
+        ) : this(username, siteName, null, language, null, visibility, null, null, dryRun)
 
         constructor(
-            siteName: String,
+            username: String,
+            siteName: String?,
             language: String,
             visibility: SiteVisibility,
             segmentId: Long?,
             dryRun: Boolean
-        ) : this(siteName, language, null, visibility, segmentId, null, dryRun)
+        ) : this(username, siteName, null, language, null, visibility, segmentId, null, dryRun)
 
         constructor(
-            siteName: String,
+            username: String,
+            siteName: String?,
             language: String,
             timeZoneId: String,
             visibility: SiteVisibility,
             dryRun: Boolean
-        ) : this(siteName, language, timeZoneId, visibility, null, null, dryRun)
+        ) : this(username, siteName, null, language, timeZoneId, visibility, null, null, dryRun)
+
+        constructor(
+            username: String,
+            siteName: String?,
+            siteTitle: String?,
+            language: String,
+            timeZoneId: String,
+            visibility: SiteVisibility,
+            dryRun: Boolean
+        ) : this(username, siteName, siteTitle, language, timeZoneId, visibility, null, null, dryRun)
     }
 
     data class FetchedPostFormatsPayload(


### PR DESCRIPTION
`WordPress-Android` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/16278

**WARNING** Please merge along the `WordPress-Android` PR above

Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/16283 and https://github.com/wordpress-mobile/WordPress-Android/issues/16249

## Description
Updates the `sites/new` api call that creates a new site to pass on the Site Title (`blog_title`) when set uses this title along with the `username` to generate the site domain when this is not provided.

The domain of the site is generated with the following logic:
1. If the [siteName] is provided it is used as a domain (current behavior)
2. If the [siteName] is not provided the [siteTitle] is passed and the API generates the domain from it
3. If neither the [siteName] or the [siteTitle] is passed the [username] is used by the API to generate a domain

In the cases 2 and 3 two extra parameters are passed:
- `site_creation_flow` with value `with-design-picker`
- `find_available_url` with value `1`

It also [adds the created site url to the response payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2344/commits/684feaf17b17c34945d674524ad74cfffccb4d1e)

## To test
Use the test cases [of the Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16278) and verify that the unit tests and connected tests pass