### PR TITLE
Bump Kotlin to `1.5.32`

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequestBuilder.kt
@@ -37,6 +37,7 @@ class XMLRPCRequestBuilder
             method,
             params,
             // **Do not** convert it to lambda! See https://youtrack.jetbrains.com/issue/KT-51868
+            @Suppress("RedundantSamConstructor")
             Listener<Any> { obj: Any? ->
                 if (obj == null) {
                     errorListener.invoke(BaseNetworkError(INVALID_RESPONSE))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequestBuilder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.xmlrpc
 
+import com.android.volley.Response.Listener
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.fluxc.generated.endpoint.XMLRPC
 import org.wordpress.android.fluxc.network.BaseRequest
@@ -31,16 +32,28 @@ class XMLRPCRequestBuilder
         listener: (T) -> Unit,
         errorListener: (BaseNetworkError) -> Unit
     ): XMLRPCRequest {
-        return XMLRPCRequest(url, method, params, { obj: Any? ->
-            if (obj == null) {
-                errorListener.invoke(BaseNetworkError(INVALID_RESPONSE))
-            }
-            try {
-                clazz.cast(obj)?.let { listener(it) }
-            } catch (e: ClassCastException) {
-                errorListener.invoke(BaseNetworkError(INVALID_RESPONSE, XmlRpcErrorType.UNABLE_TO_READ_SITE))
-            }
-        }, errorListener)
+        return XMLRPCRequest(
+            url,
+            method,
+            params,
+            // **Do not** convert it to lambda! See https://youtrack.jetbrains.com/issue/KT-51868
+            Listener<Any> { obj: Any? ->
+                if (obj == null) {
+                    errorListener.invoke(BaseNetworkError(INVALID_RESPONSE))
+                }
+                try {
+                    clazz.cast(obj)?.let { listener(it) }
+                } catch (e: ClassCastException) {
+                    errorListener.invoke(
+                        BaseNetworkError(
+                            INVALID_RESPONSE,
+                            XmlRpcErrorType.UNABLE_TO_READ_SITE
+                        )
+                    )
+                }
+            },
+            errorListener
+        )
     }
 
     /**

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.4.10'
+    gradle.ext.kotlinVersion = '1.5.32'
     gradle.ext.agpVersion = '7.1.1'
 
     plugins {


### PR DESCRIPTION
Part of: #2279

### Description

This PR bumps Kotlin to the last `1.5.x` stable version (`1.5.32`). It also contains a fix for changed Kotlin behaviour. For details please see this post in internal communication: paqN3M-ti-p2

**Why not bump to Kotlin `1.6.x`?**

The currently used Room version is not supporting Kotlin `1.6.x` - there's a kapt crash during compilation. I think we can bump Kotlin to `1.5.x` here and then in #2287 both Kotlin and Room.