### PR TITLE
Revert "Bump Kotlin to `1.5.32`"

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequestBuilder.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.xmlrpc
 
-import com.android.volley.Response.Listener
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.fluxc.generated.endpoint.XMLRPC
 import org.wordpress.android.fluxc.network.BaseRequest
@@ -32,29 +31,16 @@ class XMLRPCRequestBuilder
         listener: (T) -> Unit,
         errorListener: (BaseNetworkError) -> Unit
     ): XMLRPCRequest {
-        return XMLRPCRequest(
-            url,
-            method,
-            params,
-            // **Do not** convert it to lambda! See https://youtrack.jetbrains.com/issue/KT-51868
-            @Suppress("RedundantSamConstructor")
-            Listener<Any> { obj: Any? ->
-                if (obj == null) {
-                    errorListener.invoke(BaseNetworkError(INVALID_RESPONSE))
-                }
-                try {
-                    clazz.cast(obj)?.let { listener(it) }
-                } catch (e: ClassCastException) {
-                    errorListener.invoke(
-                        BaseNetworkError(
-                            INVALID_RESPONSE,
-                            XmlRpcErrorType.UNABLE_TO_READ_SITE
-                        )
-                    )
-                }
-            },
-            errorListener
-        )
+        return XMLRPCRequest(url, method, params, { obj: Any? ->
+            if (obj == null) {
+                errorListener.invoke(BaseNetworkError(INVALID_RESPONSE))
+            }
+            try {
+                clazz.cast(obj)?.let { listener(it) }
+            } catch (e: ClassCastException) {
+                errorListener.invoke(BaseNetworkError(INVALID_RESPONSE, XmlRpcErrorType.UNABLE_TO_READ_SITE))
+            }
+        }, errorListener)
     }
 
     /**

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.5.32'
+    gradle.ext.kotlinVersion = '1.4.10'
     gradle.ext.agpVersion = '7.1.1'
 
     plugins {


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-FluxC-Android#2345

Sorry @ParaskP7 , I think I've missed that `Optional Connected Tests` failed. I'm investigating it now this can take some time - let's revert the bump.