### PR TITLE
Fix Woo 11 to 12 database migration

### DIFF
--- a/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
+++ b/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
@@ -8,6 +8,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_10_11
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_11_12
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
@@ -102,6 +103,14 @@ class MigrationTests {
         helper.apply {
             createDatabase(TEST_DB, 10).close()
             runMigrationsAndValidate(TEST_DB, 11, true, MIGRATION_10_11)
+        }
+    }
+
+    @Test
+    fun testMigrate11to12() {
+        helper.apply {
+            createDatabase(TEST_DB, 11).close()
+            runMigrationsAndValidate(TEST_DB, 12, true, MIGRATION_11_12)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -477,7 +477,7 @@ internal val MIGRATION_11_12 = object : Migration(11, 12) {
 
             execSQL(
                 // language=RoomSql
-                """CREATE INDEX IF NOT EXISTS `index_InboxNotes_id_siteId` ON `InboxNotes` (`remoteId`, `siteId`);
+                """CREATE UNIQUE INDEX IF NOT EXISTS `index_InboxNotes_remoteId_siteId` ON `InboxNotes` (`remoteId`, `siteId`)
                 """.trimIndent()
             )
 
@@ -485,7 +485,7 @@ internal val MIGRATION_11_12 = object : Migration(11, 12) {
                 // language=RoomSql
                 """CREATE TABLE IF NOT EXISTS `InboxNoteActions` (
                     `remoteId` INTEGER NOT NULL,
-                    `inboxNoteId` INTEGER NOT NULL,
+                    `inboxNoteLocalId` INTEGER NOT NULL,
                     `siteId` INTEGER NOT NULL,
                     `name` TEXT NOT NULL,
                     `label` TEXT NOT NULL,


### PR DESCRIPTION
Connected PR: #2335 

I think that we ended up with a broken 11 to 12 migration, I've noticed this as it broke some Optional Tests 😅 .

**To test**
Run `testMigrate11to12` test locally.