### PR TITLE
woo/2351-add-searched-products-to-db

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1215,14 +1215,14 @@ class WCProductStore @Inject constructor(
                     payload.site,
                     payload.products
                 )
-                emitChange(
-                    OnProductsSearched(
-                        payload.searchQuery,
-                        payload.products,
-                        payload.canLoadMore
-                    )
-                )
             }
+            emitChange(
+                OnProductsSearched(
+                    payload.searchQuery,
+                    payload.products,
+                    payload.canLoadMore
+                )
+            )
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1215,14 +1215,14 @@ class WCProductStore @Inject constructor(
                     payload.site,
                     payload.products
                 )
-            }
-            emitChange(
-                OnProductsSearched(
-                    payload.searchQuery,
-                    payload.products,
-                    payload.canLoadMore
+                emitChange(
+                    OnProductsSearched(
+                        payload.searchQuery,
+                        payload.products,
+                        payload.canLoadMore
+                    )
                 )
-            )
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #2351 - in WCAndroid's order creation, if the user searches for a product and chooses one that's not already in the database, it fails to be added to the order because product search doesn't store its results in the database. This PR corrects this by storing the searched products.

Related Slack thread: p1649443131016309-slack-CGPNUU63E