### PR TITLE
Updates the sites/new call to validate the site title

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -297,6 +297,66 @@ class SiteRestClientTest {
     }
 
     @Test
+    fun `creates new site without a site name and an invalid site title`() = test {
+        val data = NewSiteResponse()
+        val blogDetails = BlogDetails()
+        blogDetails.blogid = siteId.toString()
+        data.blog_details = blogDetails
+        val appId = "app_id"
+        whenever(appSecrets.appId).thenReturn(appId)
+        val appSecret = "app_secret"
+        whenever(appSecrets.appSecret).thenReturn(appSecret)
+
+        initNewSiteResponse(data)
+
+        val dryRun = false
+        val username = "username"
+        val siteName = null
+        val siteTitle = "..."
+        val language = "CZ"
+        val visibility = PUBLIC
+        val segmentId = 123L
+        val siteDesign = "design"
+        val timeZoneId = "Europe/London"
+
+        val result = restClient.newSite(
+                username,
+                siteName,
+                siteTitle,
+                language,
+                timeZoneId,
+                visibility,
+                segmentId,
+                siteDesign,
+                dryRun
+        )
+
+        assertThat(result.newSiteRemoteId).isEqualTo(siteId)
+        assertThat(result.dryRun).isEqualTo(dryRun)
+
+        assertThat(urlCaptor.lastValue)
+                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/new/")
+        assertThat(bodyCaptor.lastValue).isEqualTo(
+                mapOf(
+                        "blog_name" to username,
+                        "blog_title" to siteTitle,
+                        "lang_id" to language,
+                        "public" to "1",
+                        "validate" to "0",
+                        "find_available_url" to "1",
+                        "site_creation_flow" to "with-design-picker",
+                        "client_id" to appId,
+                        "client_secret" to appSecret,
+                        "options" to mapOf<String, Any>(
+                                "site_segment" to segmentId,
+                                "template" to siteDesign,
+                                "timezone_string" to timeZoneId
+                        )
+                )
+        )
+    }
+
+    @Test
     fun `creates new site without a site name and site title`() = test {
         val data = NewSiteResponse()
         val blogDetails = BlogDetails()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -198,6 +198,8 @@ class SiteRestClient @Inject constructor(
      * 2. If the [siteName] is not provided the [siteTitle] is passed and the API generates the domain from it
      * 3. If neither the [siteName] or the [siteTitle] is passed the [username] is used by the API to generate a domain
      *
+     * Note: The [siteTitle] can be used only if it contains latin alphanumeric characters
+     *
      * In the cases 2 and 3 two extra parameters are passed:
      * - `site_creation_flow` with value `with-design-picker`
      * - `find_available_url` with value `1`
@@ -226,7 +228,7 @@ class SiteRestClient @Inject constructor(
         if (siteTitle != null) {
             body["blog_title"] = siteTitle
         }
-        body["blog_name"] = siteName ?: siteTitle ?: username
+        body["blog_name"] = siteName ?: if (siteTitle?.containsAlphaNumericCharacters == true) siteTitle else username
         siteName ?: run {
             body["site_creation_flow"] = "with-design-picker"
             body["find_available_url"] = "1"
@@ -274,6 +276,9 @@ class SiteRestClient @Inject constructor(
             }
         }
     }
+
+    private val String.containsAlphaNumericCharacters: Boolean
+        get() = this.replace("[^a-zA-Z0-9]".toRegex(), "").isNotEmpty()
 
     fun fetchSiteEditors(site: SiteModel) {
         val params = mutableMapOf<String, String>()


### PR DESCRIPTION
`WordPress-Android` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/16308

**WARNING** Please merge along the `WordPress-Android` PR above

# Description
This PR compliments https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2344 by validating that the provided site title contains latin alphanumerics before passing as a blog_name. If the site title is not valid the username is used.

## To test
Use the test cases [of the Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16308) and verify that the unit tests and connected tests pass