### PR TITLE
Issue/handle non numerical ID in notification range

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
@@ -124,4 +124,18 @@ class FormattableContentMapperTest {
         val formattableContent = formattableContentMapper.mapToFormattableContent(response)
         assertEquals(FormattableRangeType.REWIND_DOWNLOAD_READY, formattableContent.ranges!![0].rangeType())
     }
+
+    @Test
+    fun `getting non numerical ID from FormattableRange returns null `() {
+        val notificationCommentBodyResponse = UnitTestUtils
+                .getStringFromResourceFile(this.javaClass, "notifications/comment-response.json")
+        val formattableContent = formattableContentMapper.mapToFormattableContent(notificationCommentBodyResponse)
+        assertEquals(4, formattableContent.ranges!!.size)
+        with(formattableContent.ranges!![1]) {
+            assertEquals(16, this.id)
+        }
+        with(formattableContent.ranges!![2]) {
+            assertEquals(null, this.id)
+        }
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/tools/FormattableContentMapperTest.kt
@@ -126,14 +126,20 @@ class FormattableContentMapperTest {
     }
 
     @Test
-    fun `getting non numerical ID from FormattableRange returns null `() {
+    fun `getting ID from FormattableRange returns correct value depending on value type `() {
         val notificationCommentBodyResponse = UnitTestUtils
                 .getStringFromResourceFile(this.javaClass, "notifications/comment-response.json")
         val formattableContent = formattableContentMapper.mapToFormattableContent(notificationCommentBodyResponse)
         assertEquals(4, formattableContent.ranges!!.size)
+        // ID is missing
+        with(formattableContent.ranges!![0]) {
+            assertEquals(null, this.id)
+        }
+        // ID is numerical
         with(formattableContent.ranges!![1]) {
             assertEquals(16, this.id)
         }
+        // ID is non-numerical
         with(formattableContent.ranges!![2]) {
             assertEquals(null, this.id)
         }

--- a/example/src/test/resources/notifications/comment-response.json
+++ b/example/src/test/resources/notifications/comment-response.json
@@ -1,0 +1,70 @@
+{
+  "text": "Hello. Attached is the fancy GB file block.\n\nimageDownload",
+  "ranges": [
+    {
+      "type": "div",
+      "indices": [
+        45,
+        58
+      ],
+      "id": "13",
+      "parent": null,
+      "class": "wp-block-file"
+    },
+    {
+      "url": "https://wordpress.org/image.png",
+      "indices": [
+        50,
+        58
+      ],
+      "id": "16",
+      "parent": "13",
+      "type": "a",
+      "class": "wp-block-file__button"
+    },
+    {
+      "url": "https://wordpress.org/image.png",
+      "indices": [
+        45,
+        50
+      ],
+      "id": "wp-block-file--media-5c443d80-5da6",
+      "parent": "13",
+      "type": "a"
+    },
+    {
+      "type": "p",
+      "indices": [
+        0,
+        43
+      ],
+      "id": "10",
+      "parent": null
+    }
+  ],
+  "actions": {
+    "spam-comment": false,
+    "trash-comment": false,
+    "approve-comment": true,
+    "edit-comment": true,
+    "replyto-comment": true,
+    "like-comment": false
+  },
+  "meta": {
+    "ids": {
+      "comment": 437,
+      "user": 121310380,
+      "post": 35,
+      "site": 185525191
+    },
+    "links": {
+      "comment": "https://public-api.wordpress.com/rest/v1/comments/456",
+      "user": "https://public-api.wordpress.com/rest/v1/users/123",
+      "post": "https://public-api.wordpress.com/rest/v1/posts/789",
+      "site": "https://public-api.wordpress.com/rest/v1/sites/000"
+    }
+  },
+  "type": "comment",
+  "nest_level": 0,
+  "edit_comment_link": "https://wordpress.org/comment/1?action=edit"
+}

--- a/example/src/test/resources/notifications/comment-response.json
+++ b/example/src/test/resources/notifications/comment-response.json
@@ -7,7 +7,6 @@
         45,
         58
       ],
-      "id": "13",
       "parent": null,
       "class": "wp-block-file"
     },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
@@ -82,7 +82,7 @@ data class FormattableRange(
     @SerializedName("value") val value: String? = null,
     @SerializedName("indices") val indices: List<Int>? = null
 ) {
-    // IS in json response is string, and can be non numerical.
+    // ID in json response is string, and can be non numerical.
     // we only use numerical ID at the moment, and can safely ignore non-numerical values
     val id: Long?
         get() = try {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
@@ -70,7 +70,7 @@ data class FormattableMeta(
 }
 
 data class FormattableRange(
-    @SerializedName("id") val id: Long? = null,
+    @SerializedName("id") private val stringId: String? = null,
     @SerializedName("site_id") val siteId: Long? = null,
     @SerializedName("post_id") val postId: Long? = null,
     @SerializedName("root_id") val rootId: Long? = null,
@@ -82,6 +82,15 @@ data class FormattableRange(
     @SerializedName("value") val value: String? = null,
     @SerializedName("indices") val indices: List<Int>? = null
 ) {
+    // IS in json response is string, and can be non numerical.
+    // we only use numerical ID at the moment, and can safely ignore non-numerical values
+    val id: Long?
+        get() = try {
+            stringId?.toLong() ?: 0
+        } catch (e: NumberFormatException) {
+            null
+        }
+
     fun rangeType(): FormattableRangeType {
         return if (type != null) FormattableRangeType.fromString(type) else FormattableRangeType.fromString(section)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
@@ -86,7 +86,7 @@ data class FormattableRange(
     // we only use numerical ID at the moment, and can safely ignore non-numerical values
     val id: Long?
         get() = try {
-            stringId?.toLong() ?: 0
+            stringId?.toLong()
         } catch (e: NumberFormatException) {
             null
         }


### PR DESCRIPTION
This PR adds a handling logic for non numerical ID's in the forgettable notification ranges.
We can safely ignore the non-numerical values, so instead of adding a special parsing logic, I just concealed the string ID behind custom getter, that will return null if it fails to parse String into Long.

This PR can be tested with [this](https://github.com/wordpress-mobile/WordPress-Android/pull/16314) client-side PR.