### PR TITLE
Removes the unneeded validation from sites/new call

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -284,75 +284,15 @@ class SiteRestClientTest {
                 "public" to "1",
                 "validate" to "0",
                 "find_available_url" to "1",
-                "site_creation_flow" to "with-design-picker",
                 "client_id" to appId,
                 "client_secret" to appSecret,
                 "options" to mapOf<String, Any>(
                     "site_segment" to segmentId,
                     "template" to siteDesign,
+                    "site_creation_flow" to "with-design-picker",
                     "timezone_string" to timeZoneId
                 )
             )
-        )
-    }
-
-    @Test
-    fun `creates new site without a site name and an invalid site title`() = test {
-        val data = NewSiteResponse()
-        val blogDetails = BlogDetails()
-        blogDetails.blogid = siteId.toString()
-        data.blog_details = blogDetails
-        val appId = "app_id"
-        whenever(appSecrets.appId).thenReturn(appId)
-        val appSecret = "app_secret"
-        whenever(appSecrets.appSecret).thenReturn(appSecret)
-
-        initNewSiteResponse(data)
-
-        val dryRun = false
-        val username = "username"
-        val siteName = null
-        val siteTitle = "..."
-        val language = "CZ"
-        val visibility = PUBLIC
-        val segmentId = 123L
-        val siteDesign = "design"
-        val timeZoneId = "Europe/London"
-
-        val result = restClient.newSite(
-                username,
-                siteName,
-                siteTitle,
-                language,
-                timeZoneId,
-                visibility,
-                segmentId,
-                siteDesign,
-                dryRun
-        )
-
-        assertThat(result.newSiteRemoteId).isEqualTo(siteId)
-        assertThat(result.dryRun).isEqualTo(dryRun)
-
-        assertThat(urlCaptor.lastValue)
-                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/new/")
-        assertThat(bodyCaptor.lastValue).isEqualTo(
-                mapOf(
-                        "blog_name" to username,
-                        "blog_title" to siteTitle,
-                        "lang_id" to language,
-                        "public" to "1",
-                        "validate" to "0",
-                        "find_available_url" to "1",
-                        "site_creation_flow" to "with-design-picker",
-                        "client_id" to appId,
-                        "client_secret" to appSecret,
-                        "options" to mapOf<String, Any>(
-                                "site_segment" to segmentId,
-                                "template" to siteDesign,
-                                "timezone_string" to timeZoneId
-                        )
-                )
         )
     }
 
@@ -403,12 +343,12 @@ class SiteRestClientTest {
                 "public" to "1",
                 "validate" to "0",
                 "find_available_url" to "1",
-                "site_creation_flow" to "with-design-picker",
                 "client_id" to appId,
                 "client_secret" to appSecret,
                 "options" to mapOf<String, Any>(
                     "site_segment" to segmentId,
                     "template" to siteDesign,
+                    "site_creation_flow" to "with-design-picker",
                     "timezone_string" to timeZoneId
                 )
             )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -201,7 +201,7 @@ class SiteRestClient @Inject constructor(
      * Note: The [siteTitle] can be used only if it contains latin alphanumeric characters
      *
      * In the cases 2 and 3 two extra parameters are passed:
-     * - `site_creation_flow` with value `with-design-picker`
+     * - `options.site_creation_flow` with value `with-design-picker`
      * - `find_available_url` with value `1`
      *
      * @return the response of the API call  as [NewSiteResponsePayload]
@@ -219,6 +219,8 @@ class SiteRestClient @Inject constructor(
     ): NewSiteResponsePayload {
         val url = WPCOMREST.sites.new_.urlV1_1
         val body = mutableMapOf<String, Any>()
+        val options = mutableMapOf<String, Any>()
+
         body["lang_id"] = language
         body["public"] = visibility.value().toString()
         body["validate"] = if (dryRun) "1" else "0"
@@ -230,12 +232,10 @@ class SiteRestClient @Inject constructor(
         }
         body["blog_name"] = siteName ?: if (siteTitle?.containsAlphaNumericCharacters == true) siteTitle else username
         siteName ?: run {
-            body["site_creation_flow"] = "with-design-picker"
             body["find_available_url"] = "1"
+            options["site_creation_flow"] = "with-design-picker"
         }
 
-        // Add site options if available
-        val options = mutableMapOf<String, Any>()
         if (segmentId != null) {
             options["site_segment"] = segmentId
         }
@@ -246,6 +246,7 @@ class SiteRestClient @Inject constructor(
             options["timezone_string"] = timeZoneId
         }
 
+        // Add site options if available
         if (options.isNotEmpty()) {
             body["options"] = options
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -230,7 +230,7 @@ class SiteRestClient @Inject constructor(
         if (siteTitle != null) {
             body["blog_title"] = siteTitle
         }
-        body["blog_name"] = siteName ?: if (siteTitle?.containsAlphaNumericCharacters == true) siteTitle else username
+        body["blog_name"] = siteName ?: siteTitle ?: username
         siteName ?: run {
             body["find_available_url"] = "1"
             options["site_creation_flow"] = "with-design-picker"
@@ -277,9 +277,6 @@ class SiteRestClient @Inject constructor(
             }
         }
     }
-
-    private val String.containsAlphaNumericCharacters: Boolean
-        get() = this.replace("[^a-zA-Z0-9]".toRegex(), "").isNotEmpty()
 
     fun fetchSiteEditors(site: SiteModel) {
         val params = mutableMapOf<String, String>()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -198,8 +198,6 @@ class SiteRestClient @Inject constructor(
      * 2. If the [siteName] is not provided the [siteTitle] is passed and the API generates the domain from it
      * 3. If neither the [siteName] or the [siteTitle] is passed the [username] is used by the API to generate a domain
      *
-     * Note: The [siteTitle] can be used only if it contains latin alphanumeric characters
-     *
      * In the cases 2 and 3 two extra parameters are passed:
      * - `options.site_creation_flow` with value `with-design-picker`
      * - `find_available_url` with value `1`


### PR DESCRIPTION
`WordPress-Android` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/16324

# Description
This PR [moves the `site_creation_flow` parameter inside the options dictionary](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2360/commits/7eb7bf697ec43ef98cb25c7a3e68adf7525ef6e5) and [removes the unneeded site_title validation](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2360/commits/70e2e8b4024b3f2fbff232fbced8fe7307fd9942) (introduced with https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2356) 

## To test
Use the test cases [of the Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16324) and verify that the unit tests and connected tests pass