### PR TITLE
Coupons: Fix coupons ordering

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
@@ -16,11 +16,11 @@ import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
 @Dao
 abstract class CouponsDao {
     @Transaction
-    @Query("SELECT * FROM Coupons WHERE siteId = :siteId ORDER BY id")
+    @Query("SELECT * FROM Coupons WHERE siteId = :siteId")
     abstract fun observeCoupons(siteId: Long): Flow<List<CouponWithEmails>>
 
     @Transaction
-    @Query("SELECT * FROM Coupons WHERE siteId = :siteId AND id IN (:couponIds) ORDER BY id")
+    @Query("SELECT * FROM Coupons WHERE siteId = :siteId AND id IN (:couponIds)")
     abstract fun getCoupons(siteId: Long, couponIds: List<Long>): List<CouponWithEmails>
 
     @Transaction

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
@@ -20,11 +20,13 @@ abstract class CouponsDao {
     abstract fun observeCoupons(siteId: Long): Flow<List<CouponWithEmails>>
 
     @Transaction
-    @Query("SELECT * FROM Coupons WHERE siteId = :siteId AND id IN (:couponIds)")
+    @Query("SELECT * FROM Coupons " +
+        "WHERE siteId = :siteId AND id IN (:couponIds) ORDER BY dateCreated")
     abstract fun getCoupons(siteId: Long, couponIds: List<Long>): List<CouponWithEmails>
 
     @Transaction
-    @Query("SELECT * FROM Coupons WHERE siteId = :siteId AND id = :couponId")
+    @Query("SELECT * FROM Coupons " +
+        "WHERE siteId = :siteId AND id = :couponId ORDER BY dateCreated")
     abstract fun observeCoupon(siteId: Long, couponId: Long): Flow<CouponWithEmails?>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
 @Dao
 abstract class CouponsDao {
     @Transaction
-    @Query("SELECT * FROM Coupons WHERE siteId = :siteId")
+    @Query("SELECT * FROM Coupons WHERE siteId = :siteId ORDER BY dateCreated")
     abstract fun observeCoupons(siteId: Long): Flow<List<CouponWithEmails>>
 
     @Transaction
@@ -25,8 +25,7 @@ abstract class CouponsDao {
     abstract fun getCoupons(siteId: Long, couponIds: List<Long>): List<CouponWithEmails>
 
     @Transaction
-    @Query("SELECT * FROM Coupons " +
-        "WHERE siteId = :siteId AND id = :couponId ORDER BY dateCreated")
+    @Query("SELECT * FROM Coupons WHERE siteId = :siteId AND id = :couponId")
     abstract fun observeCoupon(siteId: Long, couponId: Long): Flow<CouponWithEmails?>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)


### PR DESCRIPTION
This PR removes the custom ordering of coupons when observing the DB. The default ordering is by date.