### PR TITLE
Use the same version of a dependencies across modules

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -135,10 +135,10 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$gradle.ext.kotlinVersion"
     testImplementation 'org.robolectric:robolectric:4.7.3'
-    testImplementation 'androidx.test:core:1.3.0'
+    testImplementation 'androidx.test:core:1.4.0'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation "org.assertj:assertj-core:$assertJVersion"
@@ -151,7 +151,7 @@ dependencies {
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
     androidTestCompileOnly 'org.glassfish:javax.annotation:10.0-b28'
     // Test orchestrator
-    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestUtil 'androidx.test:orchestrator:1.2.0'
 
     androidTestImplementation "com.goterl:lazysodium-android:5.0.2@aar"

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     api fluxcAnnotationsProjectDependency
     kapt fluxcProcessorProjectDependency
 
-    implementation 'com.google.code.gson:gson:2.8.0'
+    implementation 'com.google.code.gson:gson:2.8.5'
 
     // Dagger
     implementation "com.google.dagger:dagger:$daggerVersion"

--- a/tests/api/build.gradle
+++ b/tests/api/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 dependencies {
     testImplementation 'io.rest-assured:rest-assured:4.2.0' 
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.json:json:20190722'
 }
 


### PR DESCRIPTION
We are using different versions of a few dependencies across modules. We don't want this inconsistency as they'll end up overriding each other. It also makes it harder to introduce a [version catalog](https://docs.gradle.org/current/userguide/platforms.html).

While resolving the conflict, I opted to for the more up to date version. Here is the breakdown:
* `androidx.test:core` is set to `1.4.0` in `plugins/woocommerce/build.gradle` as opposed to `1.3.0` in `example/build.gradle`
* `androidx.test:runner` is set to `1.4.0` in `plugins/woocommerce/build.gradle` as opposed to `1.2.0` in `example/build.gradle`
* `gson` is set to `2.8.5` in `fluxc/build.gradle` & `example/build.gradle` as opposed to `2.8` in `plugins/woocommerce/build.gradle`
* `junit` is set to `4.13.2` in `plugins/woocommerce/build.gradle` as opposed to `4.13` in `tests/api/build.gradle` & `example/build.gradle`.

**To test**

I think the tests from CI is enough for this PR. The version upgrades are minor and mostly affecting the tests.