### PR TITLE
Removes username from the sites/new call parameters

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -171,7 +171,6 @@ public class SitesFragment extends Fragment {
         String defaultTimeZoneId = "Europe/London";
 
         NewSitePayload newSitePayload = new NewSitePayload(
-                "username",
                 name,
                 null,
                 defaultLanguage,

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -192,7 +192,6 @@ class SiteRestClientTest {
         initNewSiteResponse(data)
 
         val dryRun = false
-        val username = "username"
         val siteName = "Site name"
         val siteTitle = "site title"
         val language = "CZ"
@@ -202,7 +201,6 @@ class SiteRestClientTest {
         val timeZoneId = "Europe/London"
 
         val result = restClient.newSite(
-            username,
             siteName,
             siteTitle,
             language,
@@ -250,7 +248,6 @@ class SiteRestClientTest {
         initNewSiteResponse(data)
 
         val dryRun = false
-        val username = "username"
         val siteName = null
         val siteTitle = "site title"
         val language = "CZ"
@@ -260,7 +257,6 @@ class SiteRestClientTest {
         val timeZoneId = "Europe/London"
 
         val result = restClient.newSite(
-            username,
             siteName,
             siteTitle,
             language,
@@ -310,7 +306,6 @@ class SiteRestClientTest {
         initNewSiteResponse(data)
 
         val dryRun = false
-        val username = "username"
         val siteName = null
         val siteTitle = null
         val language = "CZ"
@@ -320,7 +315,6 @@ class SiteRestClientTest {
         val timeZoneId = "Europe/London"
 
         val result = restClient.newSite(
-            username,
             siteName,
             siteTitle,
             language,
@@ -338,7 +332,7 @@ class SiteRestClientTest {
             .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/new/")
         assertThat(bodyCaptor.lastValue).isEqualTo(
             mapOf(
-                "blog_name" to username,
+                "blog_name" to "",
                 "lang_id" to language,
                 "public" to "1",
                 "validate" to "0",
@@ -369,7 +363,6 @@ class SiteRestClientTest {
         initNewSiteResponse(data)
 
         val dryRun = true
-        val username = "username"
         val siteName = "Site name"
         val siteTitle = null
         val language = "CZ"
@@ -377,7 +370,6 @@ class SiteRestClientTest {
         val timeZoneId = "Europe/London"
 
         val result = restClient.newSite(
-            username,
             siteName,
             siteTitle,
             language,

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -168,12 +168,11 @@ class SiteStoreTest {
     @Test
     fun `creates a new site`() = test {
         val dryRun = false
-        val payload = NewSitePayload("UserName", "New site", "CZ", "Europe/London", PUBLIC, dryRun)
+        val payload = NewSitePayload("New site", "CZ", "Europe/London", PUBLIC, dryRun)
         val newSiteRemoteId: Long = 123
         val response = NewSiteResponsePayload(newSiteRemoteId, dryRun = dryRun)
         whenever(
                 siteRestClient.newSite(
-                        payload.username,
                         payload.siteName,
                         null,
                         payload.language,
@@ -194,13 +193,12 @@ class SiteStoreTest {
     @Test
     fun `fails to create a new site`() = test {
         val dryRun = false
-        val payload = NewSitePayload("UserName", "New site", "CZ", "Europe/London", PUBLIC, dryRun)
+        val payload = NewSitePayload("New site", "CZ", "Europe/London", PUBLIC, dryRun)
         val response = NewSiteResponsePayload()
         val newSiteError = NewSiteError(SITE_NAME_INVALID, "Site name invalid")
         response.error = newSiteError
         whenever(
                 siteRestClient.newSite(
-                        payload.username,
                         payload.siteName,
                         null,
                         payload.language,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -182,7 +182,6 @@ class SiteRestClient @Inject constructor(
 
     /**
      * Calls the API at https://public-api.wordpress.com/rest/v1.1/sites/new/ to create a new site
-     * @param username The username of the user
      * @param siteName The domain of the site
      * @param siteTitle The title of the site
      * @param language The language of the site
@@ -196,7 +195,7 @@ class SiteRestClient @Inject constructor(
      *
      * 1. If the [siteName] is provided it is used as a domain
      * 2. If the [siteName] is not provided the [siteTitle] is passed and the API generates the domain from it
-     * 3. If neither the [siteName] or the [siteTitle] is passed the [username] is used by the API to generate a domain
+     * 3. If neither the [siteName] or the [siteTitle] is passed the api generates a domain of the form siteXXXXXX
      *
      * In the cases 2 and 3 two extra parameters are passed:
      * - `options.site_creation_flow` with value `with-design-picker`
@@ -205,7 +204,6 @@ class SiteRestClient @Inject constructor(
      * @return the response of the API call  as [NewSiteResponsePayload]
      */
     suspend fun newSite(
-        username: String,
         siteName: String?,
         siteTitle: String?,
         language: String,
@@ -228,7 +226,7 @@ class SiteRestClient @Inject constructor(
         if (siteTitle != null) {
             body["blog_title"] = siteTitle
         }
-        body["blog_name"] = siteName ?: siteTitle ?: username
+        body["blog_name"] = siteName ?: siteTitle ?: ""
         siteName ?: run {
             body["find_available_url"] = "1"
             options["site_creation_flow"] = "with-design-picker"

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -151,7 +151,6 @@ open class SiteStore
     /**
      * Holds the new site parameters for site creation
      *
-     * @param username The username of the user
      * @param siteName The domain of the site
      * @param siteTitle The title of the site
      * @param language The language of the site
@@ -162,7 +161,6 @@ open class SiteStore
      * @param dryRun If set to true the call only validates the parameters passed
      */
     data class NewSitePayload(
-        @JvmField val username: String,
         @JvmField val siteName: String?,
         @JvmField val siteTitle: String?,
         @JvmField val language: String,
@@ -173,40 +171,36 @@ open class SiteStore
         @JvmField val dryRun: Boolean
     ) : Payload<BaseNetworkError>() {
         constructor(
-            username: String,
             siteName: String?,
             language: String,
             visibility: SiteVisibility,
             dryRun: Boolean
-        ) : this(username, siteName, null, language, null, visibility, null, null, dryRun)
+        ) : this(siteName, null, language, null, visibility, null, null, dryRun)
 
         constructor(
-            username: String,
             siteName: String?,
             language: String,
             visibility: SiteVisibility,
             segmentId: Long?,
             dryRun: Boolean
-        ) : this(username, siteName, null, language, null, visibility, segmentId, null, dryRun)
+        ) : this(siteName, null, language, null, visibility, segmentId, null, dryRun)
 
         constructor(
-            username: String,
             siteName: String?,
             language: String,
             timeZoneId: String,
             visibility: SiteVisibility,
             dryRun: Boolean
-        ) : this(username, siteName, null, language, timeZoneId, visibility, null, null, dryRun)
+        ) : this(siteName, null, language, timeZoneId, visibility, null, null, dryRun)
 
         constructor(
-            username: String,
             siteName: String?,
             siteTitle: String?,
             language: String,
             timeZoneId: String,
             visibility: SiteVisibility,
             dryRun: Boolean
-        ) : this(username, siteName, siteTitle, language, timeZoneId, visibility, null, null, dryRun)
+        ) : this(siteName, siteTitle, language, timeZoneId, visibility, null, null, dryRun)
     }
 
     data class FetchedPostFormatsPayload(
@@ -1495,7 +1489,6 @@ open class SiteStore
     @VisibleForTesting
     suspend fun createNewSite(payload: NewSitePayload): OnNewSiteCreated {
         val result = siteRestClient.newSite(
-                payload.username,
                 payload.siteName,
                 payload.siteTitle,
                 payload.language,


### PR DESCRIPTION
`WordPress-Android` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/16339

# Description
This PR removes username from the sites/new call parameters. This has the effect that when the user does not select a domain or enter a site title a generic site of the form siteXXXX.wordpress.com will be created.
This PR builds on top of https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2356 that was modified with https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2360

## To test
Use the test cases [of the Android PR](wordpress-mobile/WordPress-Android/pull/16339) and verify that the unit tests and connected tests pass