### PR TITLE
Issue/woo 6119 fetch variations list

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.action.WCProductAction.DELETED_PRODUCT
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCTS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_CATEGORIES
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_TAGS
-import org.wordpress.android.fluxc.action.WCProductAction.FETCH_PRODUCT_VARIATIONS
 import org.wordpress.android.fluxc.action.WCProductAction.FETCH_SINGLE_PRODUCT_SHIPPING_CLASS
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
@@ -190,11 +189,24 @@ class WooProductsFragment : StoreSelectingFragment() {
                         activity,
                         "Enter the remoteProductId of product to fetch variations:"
                 ) { editText ->
-                    pendingFetchProductVariationsProductRemoteId = editText.text.toString().toLongOrNull()
-                    pendingFetchProductVariationsProductRemoteId?.let { id ->
-                        prependToLog("Submitting request to fetch product variations by remoteProductID $id")
-                        val payload = FetchProductVariationsPayload(site, id)
-                        dispatcher.dispatch(WCProductActionBuilder.newFetchProductVariationsAction(payload))
+                    editText.text.toString().toLongOrNull()?.let { id ->
+                        coroutineScope.launch {
+                            pendingFetchProductVariationsProductRemoteId = id
+                            prependToLog("Submitting request to fetch product variations by remoteProductID $id")
+                            val result = wcProductStore.fetchProductVariations(FetchProductVariationsPayload(site, id))
+                            prependToLog(
+                                "Fetched ${result.rowsAffected} product variants. " +
+                                        "More variants available ${result.canLoadMore}"
+                            )
+                            if (result.canLoadMore) {
+                                pendingFetchSingleProductVariationOffset += result.rowsAffected
+                                load_more_product_variations.visibility = View.VISIBLE
+                                load_more_product_variations.isEnabled = true
+                            } else {
+                                pendingFetchSingleProductVariationOffset = 0
+                                load_more_product_variations.isEnabled = false
+                            }
+                        }
                     } ?: prependToLog("No valid remoteProductId defined...doing nothing")
                 }
             }
@@ -518,18 +530,6 @@ class WooProductsFragment : StoreSelectingFragment() {
             when (event.causeOfChange) {
                 FETCH_PRODUCTS -> {
                     prependToLog("Fetched ${event.rowsAffected} products")
-                }
-                FETCH_PRODUCT_VARIATIONS -> {
-                    prependToLog("Fetched ${event.rowsAffected} product variants. " +
-                            "More variants available ${event.canLoadMore}")
-                    if (event.canLoadMore) {
-                        pendingFetchSingleProductVariationOffset += event.rowsAffected
-                        load_more_product_variations.visibility = View.VISIBLE
-                        load_more_product_variations.isEnabled = true
-                    } else {
-                        pendingFetchSingleProductVariationOffset = 0
-                        load_more_product_variations.isEnabled = false
-                    }
                 }
                 DELETED_PRODUCT -> {
                     prependToLog("${event.rowsAffected} product deleted")

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -12,7 +12,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayl
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductShippingClassListPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductSkuAvailabilityPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductTagsPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.FetchProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload;
@@ -26,7 +25,6 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingCla
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductShippingClassPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductSkuAvailabilityPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductTagsPayload;
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteProductVariationsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteSearchProductsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductImagesPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPayload;
@@ -43,8 +41,6 @@ public enum WCProductAction implements IAction {
     FETCH_PRODUCTS,
     @Action(payloadType = SearchProductsPayload.class)
     SEARCH_PRODUCTS,
-    @Action(payloadType = FetchProductVariationsPayload.class)
-    FETCH_PRODUCT_VARIATIONS,
     @Action(payloadType = FetchProductShippingClassListPayload.class)
     FETCH_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = FetchSingleProductShippingClassPayload.class)
@@ -77,8 +73,6 @@ public enum WCProductAction implements IAction {
     FETCHED_PRODUCTS,
     @Action(payloadType = RemoteSearchProductsPayload.class)
     SEARCHED_PRODUCTS,
-    @Action(payloadType = RemoteProductVariationsPayload.class)
-    FETCHED_PRODUCT_VARIATIONS,
     @Action(payloadType = RemoteProductShippingClassListPayload.class)
     FETCHED_PRODUCT_SHIPPING_CLASS_LIST,
     @Action(payloadType = RemoteProductShippingClassPayload.class)


### PR DESCRIPTION
Implements  https://github.com/woocommerce/woocommerce-android/issues/6119 partially

**Merge when [the WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/6294) is approved.**

This PR refactors fetchProductVariations into a suspendable function - removes usage of the event bus.

There are two reasons for this change

1. [The event bus architecture is considered as legacy/deprecated](https://github.com/wordpress-mobile/WordPress-FluxC-Android/wiki/%5BDeprecated%5D-Architecture)
2. WCAndroid app uses stateful repositories which need to be registered to the event bus - this leads to memory leaks when the repository doesn't unregister from the event bus. It also causes side-effects when multiple instances of a repository are created - eg. duplicate tracking events.


## How to test
1. Run ReleaseStack_WCProductTest - testFetchProductVariations()
2. Test `Woo -> Product -> Fetch Product Variations` action in the example app