### PR TITLE
Wait for api response success before deleting all notes from DB

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/inbox/InboxRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/inbox/InboxRestClient.kt
@@ -102,7 +102,7 @@ class InboxRestClient @Inject constructor(
             this,
             site,
             url,
-            Unit::class.java,
+            Array<InboxNoteDto>::class.java,
             mapOf(
                 "page" to page.toString(),
                 "per_page" to pageSize.toString(),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInboxStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInboxStore.kt
@@ -104,10 +104,11 @@ class WCInboxStore @Inject constructor(
             }
             val results = mutableListOf<WooResult<Unit>>()
             for (page in 1..numberOfPagesToDelete) {
-                results.add(
-                    restClient.deleteAllNotesForSite(site, page, pageSize, inboxNoteTypes)
-                        .asWooResult()
-                )
+                val response = restClient
+                    .deleteAllNotesForSite(site, page, pageSize, inboxNoteTypes)
+                results.add(response.asWooResult())
+
+                if (response.isError) break
             }
             if (!results.any { it.isError }) {
                 inboxNotesDao.deleteInboxNotesForSite(site.siteId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInboxStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInboxStore.kt
@@ -102,13 +102,15 @@ class WCInboxStore @Inject constructor(
             if (sizeOfCachedNotesForSite % MAX_PAGE_SIZE_FOR_DELETING_NOTES > 0) {
                 numberOfPagesToDelete++
             }
-            inboxNotesDao.deleteInboxNotesForSite(site.siteId)
             val results = mutableListOf<WooResult<Unit>>()
             for (page in 1..numberOfPagesToDelete) {
                 results.add(
                     restClient.deleteAllNotesForSite(site, page, pageSize, inboxNoteTypes)
                         .asWooResult()
                 )
+            }
+            if (!results.any { it.isError }) {
+                inboxNotesDao.deleteInboxNotesForSite(site.siteId)
             }
             results
         }


### PR DESCRIPTION
Small fixes and refactor to: 
- Ensure API request was successful before clearing the inbox notes from DB
- Fix json parsing error in `InboxRestClient.deleteAllNotesForSite()` as the response was expecting an `array` instead of an `object` and previous implementation was making the function return error always even if the request was succesful.
- Minor refactor to simplify `deleteNotesForSite` function