### PR TITLE
[Coupons] some fixes

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
@@ -16,12 +16,12 @@ import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
 @Dao
 abstract class CouponsDao {
     @Transaction
-    @Query("SELECT * FROM Coupons WHERE siteId = :siteId ORDER BY dateCreated")
+    @Query("SELECT * FROM Coupons WHERE siteId = :siteId ORDER BY dateCreated DESC")
     abstract fun observeCoupons(siteId: Long): Flow<List<CouponWithEmails>>
 
     @Transaction
     @Query("SELECT * FROM Coupons " +
-        "WHERE siteId = :siteId AND id IN (:couponIds) ORDER BY dateCreated")
+        "WHERE siteId = :siteId AND id IN (:couponIds) ORDER BY dateCreated DESC")
     abstract fun getCoupons(siteId: Long, couponIds: List<Long>): List<CouponWithEmails>
 
     @Transaction

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
@@ -5,7 +5,6 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
-import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.persistence.entity.CouponAndProductCategoryEntity
 import org.wordpress.android.fluxc.persistence.entity.CouponAndProductEntity
@@ -28,65 +27,19 @@ abstract class CouponsDao {
     @Query("SELECT * FROM Coupons WHERE siteId = :siteId AND id = :couponId")
     abstract fun observeCoupon(siteId: Long, couponId: Long): Flow<CouponWithEmails?>
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertCoupon(entity: CouponEntity): Long
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertOrUpdateCoupon(entity: CouponEntity): Long
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertCouponAndProductCategory(
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertOrUpdateCouponAndProductCategory(
         entity: CouponAndProductCategoryEntity
     ): Long
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertCouponAndProduct(entity: CouponAndProductEntity): Long
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertOrUpdateCouponAndProduct(entity: CouponAndProductEntity): Long
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertCouponEmail(entity: CouponEmailEntity): Long
-
-    @Update
-    abstract suspend fun updateCoupon(entity: CouponEntity)
-
-    @Update
-    abstract suspend fun updateCouponEmail(entity: CouponEmailEntity)
-
-    @Update
-    abstract suspend fun updateCouponAndProductCategory(entity: CouponAndProductCategoryEntity)
-
-    @Update
-    abstract suspend fun updateCouponAndProduct(entity: CouponAndProductEntity)
-
-    @Transaction
-    open suspend fun insertOrUpdateCoupon(entity: CouponEntity) {
-        val id = insertCoupon(entity)
-        if (id == -1L) {
-            updateCoupon(entity)
-        }
-    }
-
-    @Transaction
-    open suspend fun insertOrUpdateCouponAndProductCategory(
-        entity: CouponAndProductCategoryEntity
-    ) {
-        val id = insertCouponAndProductCategory(entity)
-        if (id == -1L) {
-            updateCouponAndProductCategory(entity)
-        }
-    }
-
-    @Transaction
-    open suspend fun insertOrUpdateCouponAndProduct(entity: CouponAndProductEntity) {
-        val id = insertCouponAndProduct(entity)
-        if (id == -1L) {
-            updateCouponAndProduct(entity)
-        }
-    }
-
-    @Transaction
-    open suspend fun insertOrUpdateCouponEmail(entity: CouponEmailEntity) {
-        val id = insertCouponEmail(entity)
-        if (id == -1L) {
-            updateCouponEmail(entity)
-        }
-    }
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertOrUpdateCouponEmail(entity: CouponEmailEntity): Long
 
     @Query("DELETE FROM Coupons WHERE siteId = :siteId AND id = :couponId")
     abstract suspend fun deleteCoupon(siteId: Long, couponId: Long)

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/CouponsDaoTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/CouponsDaoTest.kt
@@ -61,6 +61,7 @@ class CouponsDaoTest {
         val newCoupon = coupon.copy(description = "Updated", usageLimit = 2)
         val newExpected = CouponWithEmails(newCoupon, listOf(email))
         couponsDao.insertOrUpdateCoupon(newCoupon)
+        couponsDao.insertOrUpdateCouponEmail(email)
         observedCoupon = couponsDao.observeCoupons(coupon.siteId).first()
 
         // then
@@ -92,6 +93,7 @@ class CouponsDaoTest {
         val newCoupon = coupon.copy(description = "Updated", usageLimit = 2)
         expected = CouponWithEmails(newCoupon, listOf(email))
         couponsDao.insertOrUpdateCoupon(newCoupon)
+        couponsDao.insertOrUpdateCouponEmail(email)
 
         // then
         assertThat(observedCoupon.first()).isEqualTo(expected)


### PR DESCRIPTION
This PR attempts to fix two issues: https://github.com/woocommerce/woocommerce-android/issues/6329 and https://github.com/woocommerce/woocommerce-android/issues/6330, with the following changes:

1. Making the sort logic in the DB the same as the API, meaning it's using a descending order using the "created_date".
2. Reverts to using a destructive update logic, meaning if an item exists, then it will be deleted before inserting the new item.

@0nko regarding point two, I know this was the behavior before, and you updated it in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2337, do you remember what was the reason? I checked the code, and it seems all of the tables that has a foreign key with the "Coupons" table are tables that normally should be cleared on each update, so it should be the behavior we want.

#### Testing
You can use the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/6331 to test changes of this PR, and confirm the following:
1. Sorting matches what the API returns now (and matches iOS).
2. The steps explained in https://github.com/woocommerce/woocommerce-android/issues/6330 are not reproducible anymore.