### PR TITLE
[Issue-2320] Add Product variation batch update support

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductCategoryApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductReviewApiResponse
+import kotlin.random.Random
 
 object ProductTestUtils {
     fun generateSampleProduct(
@@ -51,6 +52,17 @@ object ProductTestUtils {
             localSiteId = siteId
             this.status = status
             this.stockQuantity = stockQuantity
+        }
+    }
+
+    fun generateSampleVariations(number: Int, productId: Long, siteId: Int): List<WCProductVariationModel> {
+        return (0 until number).map {
+            generateSampleVariation(
+                remoteId = productId,
+                variationId = Random.nextLong(),
+                siteId = siteId,
+                stockQuantity = Random.nextDouble()
+            )
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.wc.product
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.yarolegovich.wellsql.WellSql
@@ -19,12 +21,20 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsUpdateApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductVariationApiResponse
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.persistence.dao.ProductCategoriesDao
 import org.wordpress.android.fluxc.persistence.dao.ProductsDao
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.BatchUpdateVariationsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductReviewPayload
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
@@ -35,7 +45,9 @@ import org.wordpress.android.fluxc.store.WCProductStore.UpdateVariationPayload
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.utils.ProductCategoriesDbHelper
 import org.wordpress.android.fluxc.utils.ProductsDbHelper
+import org.wordpress.android.fluxc.wc.product.ProductTestUtils.generateSampleVariations
 import org.wordpress.android.fluxc.wc.utils.SiteTestUtils
+import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -298,5 +310,192 @@ class WCProductStoreTest {
 
         assertThat(productStore.getProductReviewByRemoteId(site.id, reviewModel.remoteProductReviewId)).isNotNull
         Unit
+    }
+
+    @Test
+    fun `batch variations update should return positive result on successful backend request`() =
+        runBlocking {
+            // given
+            val product = ProductTestUtils.generateSampleProduct(Random.nextLong())
+            val site = SiteModel().apply { id = product.localSiteId }
+            val variations = generateSampleVariations(
+                number = 64,
+                productId = product.remoteProductId,
+                siteId = site.id
+            )
+
+            // when
+            val variationsIds = variations.map { it.remoteVariationId }
+            val variationsUpdatePayload = BatchUpdateVariationsPayload.Builder(site, product.remoteProductId, variationsIds).build()
+            val response = BatchProductVariationsUpdateApiResponse().apply { updatedVariations = emptyList() }
+            whenever(productRestClient.batchUpdateVariations(any(), any(), any(), any())) doReturn WooPayload(response)
+            val result = productStore.batchUpdateVariations(variationsUpdatePayload)
+
+            // then
+            assertThat(result.isError).isFalse
+            assertThat(result.model).isNotNull
+            Unit
+        }
+
+    @Test
+    fun `batch variations update should return negative result on failed backend request`() = runBlocking {
+        // given
+        val product = ProductTestUtils.generateSampleProduct(Random.nextLong())
+        val site = SiteModel().apply { id = product.localSiteId }
+        val variations = generateSampleVariations(
+            number = 64,
+            productId = product.remoteProductId,
+            siteId = site.id
+        )
+
+        // when
+        val variationsIds = variations.map { it.remoteVariationId }
+        val variationsUpdatePayload =
+            BatchUpdateVariationsPayload.Builder(site, product.remoteProductId, variationsIds).build()
+        val errorResponse = WooError(GENERIC_ERROR, NETWORK_ERROR, "🔴")
+        whenever(productRestClient.batchUpdateVariations(any(), any(), any(), any())) doReturn WooPayload(errorResponse)
+        val result = productStore.batchUpdateVariations(variationsUpdatePayload)
+
+        // then
+        assertThat(result.isError).isTrue
+        Unit
+    }
+
+    @Test
+    fun `batch variations update should update variations locally after successful backend request`() =
+        runBlocking {
+            // given
+            val product = ProductTestUtils.generateSampleProduct(Random.nextLong())
+            ProductSqlUtils.insertOrUpdateProduct(product)
+            val site = SiteTestUtils.insertTestAccountAndSiteIntoDb()
+            val variations = generateSampleVariations(
+                number = 64,
+                productId = product.remoteProductId,
+                siteId = site.id
+            )
+            ProductSqlUtils.insertOrUpdateProductVariations(variations)
+
+            // when
+            val variationsIds = variations.map { it.remoteVariationId }
+            val newRegularPrice = "1.234 💰"
+            val newSalePrice = "0.234 💰"
+            val variationsUpdatePayload =
+                BatchUpdateVariationsPayload.Builder(site, product.remoteProductId, variationsIds)
+                    .regularPrice(newRegularPrice)
+                    .salePrice(newSalePrice)
+                    .build()
+            val modifications = variationsUpdatePayload.modifiedProperties
+            val variationsReturnedFromBackend = variations.map {
+                ProductVariationApiResponse().apply {
+                    id = it.remoteVariationId
+                    regular_price = newRegularPrice
+                    sale_price = newSalePrice
+                }
+            }
+            val response = BatchProductVariationsUpdateApiResponse().apply { updatedVariations = variationsReturnedFromBackend }
+            whenever(productRestClient.batchUpdateVariations(any(), any(), any(), any())) doReturn WooPayload(response)
+            val result = productStore.batchUpdateVariations(variationsUpdatePayload)
+
+            // then
+            assertThat(result.isError).isFalse
+            assertThat(result.model).isNotNull
+            with(ProductSqlUtils.getVariationsForProduct(site, product.remoteProductId)) {
+                forEach { variation ->
+                    assertThat(variation.regularPrice).isEqualTo(newRegularPrice)
+                    assertThat(variation.salePrice).isEqualTo(newSalePrice)
+                }
+            }
+            Unit
+        }
+
+    @Test
+    fun `batch variations update should not update variations locally after failed backend request`() =
+        runBlocking {
+            // given
+            val product = ProductTestUtils.generateSampleProduct(Random.nextLong())
+            ProductSqlUtils.insertOrUpdateProduct(product)
+            val site = SiteTestUtils.insertTestAccountAndSiteIntoDb()
+            val variations = generateSampleVariations(
+                number = 64,
+                productId = product.remoteProductId,
+                siteId = site.id
+            )
+            ProductSqlUtils.insertOrUpdateProductVariations(variations)
+
+            // when
+            val variationsIds = variations.map { it.remoteVariationId }
+            val newRegularPrice = "1.234 💰"
+            val newSalePrice = "0.234 💰"
+            val variationsUpdatePayload =
+                BatchUpdateVariationsPayload.Builder(site, product.remoteProductId, variationsIds)
+                    .regularPrice(newRegularPrice)
+                    .salePrice(newSalePrice)
+                    .build()
+            val errorResponse = WooError(GENERIC_ERROR, NETWORK_ERROR, "🔴")
+            whenever(productRestClient.batchUpdateVariations(any(), any(), any(), any())) doReturn WooPayload(errorResponse)
+            val result = productStore.batchUpdateVariations(variationsUpdatePayload)
+
+            // then
+            assertThat(result.isError).isTrue
+            with(ProductSqlUtils.getVariationsForProduct(site, product.remoteProductId)) {
+                forEach { variation ->
+                    assertThat(variation.regularPrice).isNotEqualTo(newRegularPrice)
+                    assertThat(variation.salePrice).isNotEqualTo(newSalePrice)
+                }
+            }
+            Unit
+        }
+
+    @Test
+    fun `BatchUpdateVariationsPayload_Builder should produce correct variations modifications map`() {
+        // given
+        val product = ProductTestUtils.generateSampleProduct(Random.nextLong())
+        val site = SiteModel().apply { id = 23 }
+        val variations = generateSampleVariations(number = 64, productId = product.remoteProductId, siteId = site.id)
+        val builder = BatchUpdateVariationsPayload.Builder(site, product.remoteProductId, variations.map { it.remoteVariationId })
+
+        val modifiedRegularPrice = "11234.234"
+        val modifiedSalePrice = "123,2.4"
+        val modifiedStartOfSale = "tomorrow"
+        val modifiedEndOfSale = "next week"
+        val modifiedStartOfSaleGmt = "tomorrow"
+        val modifiedEndOfSaleGmt = "next week"
+        val modifiedStockQuantity = 1234
+        val modifiedStockStatus = CoreProductStockStatus.IN_STOCK
+        val modifiedWeight = "1234 kg"
+        val modifiedDimensions = "10x12x10 cm"
+        val modifiedShippingClassId = "1234"
+        val modifiedShippingClassSlug = "DHL"
+
+        // when
+        builder.regularPrice(modifiedRegularPrice)
+            .salePrice(modifiedSalePrice)
+            .startOfSale(modifiedStartOfSale)
+            .endOfSale(modifiedEndOfSale)
+            .startOfSaleGmt(modifiedStartOfSaleGmt)
+            .endOfSaleGmt(modifiedEndOfSaleGmt)
+            .stockQuantity(modifiedStockQuantity)
+            .stockStatus(modifiedStockStatus)
+            .weight(modifiedWeight)
+            .dimensions(modifiedDimensions)
+            .shippingClassId(modifiedShippingClassId)
+            .shippingClassSlug(modifiedShippingClassSlug)
+        val payload = builder.build()
+
+        // then
+        with(payload.modifiedProperties) {
+            assertThat(get("regular_price")).isEqualTo(modifiedRegularPrice)
+            assertThat(get("sale_price")).isEqualTo(modifiedSalePrice)
+            assertThat(get("date_on_sale_from")).isEqualTo(modifiedStartOfSale)
+            assertThat(get("date_on_sale_to")).isEqualTo(modifiedEndOfSale)
+            assertThat(get("date_on_sale_from_gmt")).isEqualTo(modifiedStartOfSaleGmt)
+            assertThat(get("date_on_sale_to_gmt")).isEqualTo(modifiedEndOfSaleGmt)
+            assertThat(get("stock_quantity")).isEqualTo(modifiedStockQuantity)
+            assertThat(get("stock_status")).isEqualTo(modifiedStockStatus)
+            assertThat(get("weight")).isEqualTo(modifiedWeight)
+            assertThat(get("dimensions")).isEqualTo(modifiedDimensions)
+            assertThat(get("shipping_class_id")).isEqualTo(modifiedShippingClassId)
+            assertThat(get("shipping_class")).isEqualTo(modifiedShippingClassSlug)
+        }
     }
 }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -8,6 +8,7 @@
 /products/<id>/
 /products/<id>/variations/
 /products/<id>/variations/<variation_id>
+/products/<id>/variations/batch
 /products/
 /products/shipping_classes
 /products/shipping_classes/<id>/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/BatchProductVariationsUpdateApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/BatchProductVariationsUpdateApiResponse.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.Response
+
+/**
+ * Representation of Batch Update Product Variations API response.
+ */
+class BatchProductVariationsUpdateApiResponse : Response {
+    @SerializedName("update")
+    var updatedVariations: List<ProductVariationApiResponse>? = null
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.fluxc.network.utils.toMap
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE
@@ -213,7 +214,7 @@ class ProductRestClient @Inject constructor(
      * Makes a POST request to `POST /wp-json/wc/v3/products/tags/batch` to add
      * product tags for a site
      *
-     * Dispatches a WCProductAction.ADDED_PRODUCT_TAGS action with the result
+     * Dispatches a [WCProductAction.ADDED_PRODUCT_TAGS] action with the result
      *
      * @param [site] The site to fetch product shipping class list for
      * @param [tags] The list of tag names that needed to be added to the site
@@ -801,6 +802,39 @@ class ProductRestClient @Inject constructor(
             }
         }
     }
+
+    /**
+     * Makes a POST request to `/wp-json/wc/v3/products/[WCProductModel.remoteProductId]/variations/batch`
+     * to batch update product variations.
+     *
+     * @param productId Id of the product.
+     * @param variationsIds Ids of variations that are going to be updated.
+     * @param modifiedProperties Map of the properties of variation that are going to be updated.
+     * Keys correspond to the names of variation properties. Values are the updated properties values.
+     *
+     * @return Instance of [BatchProductVariationsUpdateApiResponse].
+     */
+    suspend fun batchUpdateVariations(
+        site: SiteModel,
+        productId: Long,
+        variationsIds: Collection<Long>,
+        modifiedProperties: Map<String, Any>,
+    ): WooPayload<BatchProductVariationsUpdateApiResponse> = WOOCOMMERCE.products.id(productId).variations.batch.pathV3
+        .let { url ->
+            val variationsUpdates: List<Map<String, Any>> = variationsIds.map { variationId ->
+                modifiedProperties.toMutableMap()
+                    .also { properties -> properties["id"] = variationId }
+                    .toMap()
+            }
+            jetpackTunnelGsonRequestBuilder.syncPostRequest(
+                this@ProductRestClient,
+                site,
+                url,
+                mapOf("update" to variationsUpdates),
+                BatchProductVariationsUpdateApiResponse::class.java
+            ).handleResult()
+        }
+
 
     /**
      * Makes a POST request to `/wp-json/wc/v3/products` to create

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
@@ -16,12 +16,12 @@ import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
 @Dao
 abstract class CouponsDao {
     @Transaction
-    @Query("SELECT * FROM Coupons WHERE siteId = :siteId ORDER BY dateCreated")
+    @Query("SELECT * FROM Coupons WHERE siteId = :siteId ORDER BY dateCreated DESC")
     abstract fun observeCoupons(siteId: Long): Flow<List<CouponWithEmails>>
 
     @Transaction
     @Query("SELECT * FROM Coupons " +
-        "WHERE siteId = :siteId AND id IN (:couponIds) ORDER BY dateCreated")
+        "WHERE siteId = :siteId AND id IN (:couponIds) ORDER BY dateCreated DESC")
     abstract fun getCoupons(siteId: Long, couponIds: List<Long>): List<CouponWithEmails>
 
     @Transaction

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
@@ -5,7 +5,6 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
-import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.persistence.entity.CouponAndProductCategoryEntity
 import org.wordpress.android.fluxc.persistence.entity.CouponAndProductEntity
@@ -28,65 +27,19 @@ abstract class CouponsDao {
     @Query("SELECT * FROM Coupons WHERE siteId = :siteId AND id = :couponId")
     abstract fun observeCoupon(siteId: Long, couponId: Long): Flow<CouponWithEmails?>
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertCoupon(entity: CouponEntity): Long
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertOrUpdateCoupon(entity: CouponEntity): Long
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertCouponAndProductCategory(
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertOrUpdateCouponAndProductCategory(
         entity: CouponAndProductCategoryEntity
     ): Long
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertCouponAndProduct(entity: CouponAndProductEntity): Long
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertOrUpdateCouponAndProduct(entity: CouponAndProductEntity): Long
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertCouponEmail(entity: CouponEmailEntity): Long
-
-    @Update
-    abstract suspend fun updateCoupon(entity: CouponEntity)
-
-    @Update
-    abstract suspend fun updateCouponEmail(entity: CouponEmailEntity)
-
-    @Update
-    abstract suspend fun updateCouponAndProductCategory(entity: CouponAndProductCategoryEntity)
-
-    @Update
-    abstract suspend fun updateCouponAndProduct(entity: CouponAndProductEntity)
-
-    @Transaction
-    open suspend fun insertOrUpdateCoupon(entity: CouponEntity) {
-        val id = insertCoupon(entity)
-        if (id == -1L) {
-            updateCoupon(entity)
-        }
-    }
-
-    @Transaction
-    open suspend fun insertOrUpdateCouponAndProductCategory(
-        entity: CouponAndProductCategoryEntity
-    ) {
-        val id = insertCouponAndProductCategory(entity)
-        if (id == -1L) {
-            updateCouponAndProductCategory(entity)
-        }
-    }
-
-    @Transaction
-    open suspend fun insertOrUpdateCouponAndProduct(entity: CouponAndProductEntity) {
-        val id = insertCouponAndProduct(entity)
-        if (id == -1L) {
-            updateCouponAndProduct(entity)
-        }
-    }
-
-    @Transaction
-    open suspend fun insertOrUpdateCouponEmail(entity: CouponEmailEntity) {
-        val id = insertCouponEmail(entity)
-        if (id == -1L) {
-            updateCouponEmail(entity)
-        }
-    }
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertOrUpdateCouponEmail(entity: CouponEmailEntity): Long
 
     @Query("DELETE FROM Coupons WHERE siteId = :siteId AND id = :couponId")
     abstract suspend fun deleteCoupon(siteId: Long, couponId: Long)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -24,9 +24,12 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.mappers.MappingRemoteException
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.mappers.RemoteAddonMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsUpdateApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils.deleteVariationsForProduct
@@ -168,6 +171,87 @@ class WCProductStore @Inject constructor(
         var site: SiteModel,
         val variation: WCProductVariationModel
     ) : Payload<BaseNetworkError>()
+
+    /**
+     * Payload used by [batchUpdateVariations] function.
+     *
+     * @param remoteProductId Id of the product.
+     * @param remoteVariationsIds Ids of variations that are going to be updated.
+     * @param modifiedProperties Map of the properties of variation that are going to be updated.
+     * Keys correspond to the names of variation properties. Values are the updated properties values.
+     */
+    class BatchUpdateVariationsPayload(
+        val site: SiteModel,
+        val remoteProductId: Long,
+        val remoteVariationsIds: Collection<Long>,
+        val modifiedProperties: Map<String, Any>
+    ) : Payload<BaseNetworkError>() {
+        /**
+         * Builder class used for instantiating [BatchUpdateVariationsPayload].
+         */
+        class Builder(
+            private val site: SiteModel,
+            private val remoteProductId: Long,
+            private val variationsIds: Collection<Long>,
+        ) {
+            private val variationsModifications = mutableMapOf<String, Any>()
+
+            fun regularPrice(regularPrice: String) = apply {
+                variationsModifications["regular_price"] = regularPrice
+            }
+
+            fun salePrice(salePrice: String) = apply {
+                variationsModifications["sale_price"] = salePrice
+            }
+
+            fun startOfSale(startOfSale: String) = apply {
+                variationsModifications["date_on_sale_from"] = startOfSale
+            }
+
+            fun endOfSale(endOfSale: String) = apply {
+                variationsModifications["date_on_sale_to"] = endOfSale
+            }
+
+            fun startOfSaleGmt(startOfSale: String) = apply {
+                variationsModifications["date_on_sale_from_gmt"] = startOfSale
+            }
+
+            fun endOfSaleGmt(startOfSale: String) = apply {
+                variationsModifications["date_on_sale_to_gmt"] = startOfSale
+            }
+
+            fun stockQuantity(stockQuantity: Int) = apply {
+                variationsModifications["stock_quantity"] = stockQuantity
+            }
+
+            fun stockStatus(stockStatus: CoreProductStockStatus) = apply {
+                variationsModifications["stock_status"] = stockStatus
+            }
+
+            fun weight(weight: String) = apply {
+                variationsModifications["weight"] = weight
+            }
+
+            fun dimensions(dimensions: String) = apply {
+                variationsModifications["dimensions"] = dimensions
+            }
+
+            fun shippingClassId(shippingClassId: String) = apply {
+                variationsModifications["shipping_class_id"] = shippingClassId
+            }
+
+            fun shippingClassSlug(shippingClassSlug: String) = apply {
+                variationsModifications["shipping_class"] = shippingClassSlug
+            }
+
+            fun build() = BatchUpdateVariationsPayload(
+                site,
+                remoteProductId,
+                variationsIds,
+                variationsModifications
+            )
+        }
+    }
 
     class FetchProductCategoriesPayload(
         var site: SiteModel,
@@ -1131,6 +1215,37 @@ class WCProductStore @Inject constructor(
             }
         }
     }
+
+    /**
+     * Batch updates variations on the backend and updates variations locally after successful request.
+     *
+     * @param payload Instance of [BatchUpdateVariationsPayload]. It can be produced using [BatchUpdateVariationsPayload.Builder] class.
+     */
+    suspend fun batchUpdateVariations(payload: BatchUpdateVariationsPayload): WooResult<BatchProductVariationsUpdateApiResponse> =
+        coroutineEngine.withDefaultContext(API, this, "batchUpdateVariations") {
+            with(payload) {
+                val result: WooPayload<BatchProductVariationsUpdateApiResponse> =
+                    wcProductRestClient.batchUpdateVariations(
+                        site,
+                        remoteProductId,
+                        remoteVariationsIds,
+                        modifiedProperties
+                    )
+
+                return@withDefaultContext if (result.isError) {
+                    WooResult(result.error)
+                } else {
+                    val updatedVariations = result.result?.updatedVariations?.map { response ->
+                        response.asProductVariationModel().apply {
+                            remoteProductId = payload.remoteProductId
+                            localSiteId = payload.site.id
+                        }
+                    } ?: emptyList()
+                    ProductSqlUtils.insertOrUpdateProductVariations(updatedVariations)
+                    WooResult(result.result)
+                }
+            }
+        }
 
     private fun addProduct(payload: AddProductPayload) {
         with(payload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -216,8 +216,8 @@ class WCProductStore @Inject constructor(
                 variationsModifications["date_on_sale_from_gmt"] = startOfSale
             }
 
-            fun endOfSaleGmt(startOfSale: String) = apply {
-                variationsModifications["date_on_sale_to_gmt"] = startOfSale
+            fun endOfSaleGmt(endOfSale: String) = apply {
+                variationsModifications["date_on_sale_to_gmt"] = endOfSale
             }
 
             fun stockQuantity(stockQuantity: Int) = apply {

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/CouponsDaoTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/CouponsDaoTest.kt
@@ -61,6 +61,7 @@ class CouponsDaoTest {
         val newCoupon = coupon.copy(description = "Updated", usageLimit = 2)
         val newExpected = CouponWithEmails(newCoupon, listOf(email))
         couponsDao.insertOrUpdateCoupon(newCoupon)
+        couponsDao.insertOrUpdateCouponEmail(email)
         observedCoupon = couponsDao.observeCoupons(coupon.siteId).first()
 
         // then
@@ -92,6 +93,7 @@ class CouponsDaoTest {
         val newCoupon = coupon.copy(description = "Updated", usageLimit = 2)
         expected = CouponWithEmails(newCoupon, listOf(email))
         couponsDao.insertOrUpdateCoupon(newCoupon)
+        couponsDao.insertOrUpdateCouponEmail(email)
 
         // then
         assertThat(observedCoupon.first()).isEqualTo(expected)


### PR DESCRIPTION
#### This PR implements #2320 partially. The next PR to this branch will update the example app.

## 🎯  Summary
This PR adds support for product variations batch update. 

## 🛠  Implementation details
* Added `/products/<id>/variations/batch endpoint`
* Implemented POST call to batch update variations `ProductRestClient::batchUpdateVariations`. Also introduced `BatchProductVariationsUpdateApiResponse` class wich models backend response.
* Implemented `WCProductStore::batchUpdateVariations` method responsible for variations batch update on the backend. It updates variations locally after a successful backend response.
* Created `BatchUpdateVariationsPayload` class consumed by `::batchUpdateVariations` and introduced `BatchUpdateVariationsPayload.Builder` to simplify creating variations updates map required by the REST API.

## 🧪  Testing

For now, you can run `WCProductStoreTest`.  New test methods were added here. 

## 🧭  Roadmap

Next PR to this branch will add `example` app update allowing to test batch update operation on the device.