### PR TITLE
Adds: Vault press active on site reason

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/ScanStateModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/scan/ScanStateModel.kt
@@ -47,6 +47,7 @@ data class ScanStateModel(
 
     enum class Reason(val value: String?) {
         MULTISITE_NOT_SUPPORTED("multisite_not_supported"),
+        VP_ACTIVE_ON_SITE("vp_active_on_site"),
         NO_REASON(null),
         UNKNOWN("unknown");
 


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-Android/issues/14168

Parent https://github.com/wordpress-mobile/WordPress-Android/pull/16400

This PR adds a reason(VaultPress active). This will be used in the Use case to propagate the correct message to be shown to the user. 

**To test**
There's nothing to test in this PR as this change will be consumed in the Parent PR. Make sure that the reason has the same value as the response for a VP-powered site, which is
```
{
    "state": "unavailable",
    "threats": null,
    "has_cloud": true,
    "reason": "vp_active_on_site"
}
```

[Reference](https://github.com/wordpress-mobile/WordPress-iOS/issues/17146#issuecomment-1108787780)