### PR TITLE
Add ripgrep ignore file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ WordPress/src/main/res/values/com_crashlytics_export_strings.xml
 # Silver Searcher ignore file
 .agignore
 
+# ripgrep ignore file
+.rgignore
+
 # Monkey runner settings
 *.pyc
 


### PR DESCRIPTION
Adds [ripgrep's .rgignore file](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#automatic-filtering) to `.gitignore` so that developers can add custom ignore rules for `ripgrep`.

I'd like to be able to search `.circleci` & `.buildkite` folders, but these folders are ignored by `ripgrep` by default. I'd like to add `.rgignore` file with the contents below so that I can override this behavior. It's especially important for me because my file navigator `fzf` in my editor `neovim` depends on the results of `ripgrep`.

```.rgignore
!.buildkite
!.circleci
```

_P.S: I intend to make this change in other projects as well._