### PR TITLE
Fixes XML RPC non-latin filename upload issue

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.BaseUploadRequestBody;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import okhttp3.MediaType;
@@ -76,7 +77,9 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
     @Override
     public long contentLength() throws IOException {
         if (mContentSize == -1) {
-            mContentSize = getMediaBase64EncodedSize() + mPrependString.length() + APPEND_XML.length();
+            mContentSize = getMediaBase64EncodedSize()
+                           + mPrependString.getBytes(StandardCharsets.UTF_8).length
+                           + APPEND_XML.length();
         }
         return mContentSize;
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/16130

`WordPress-Android` PR: https://github.com/wordpress-mobile/WordPress-Android/pull/16421

# Description
Fixes XML RPC non-latin filename upload issue by using UTF-8 for calculating the length of the filename used for the XML RPC content-length header.

# To test
follow the instructions at https://github.com/wordpress-mobile/WordPress-Android/pull/16421