### PR TITLE
[Issue-2320] Variations batch update: example app

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragme
 import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooAddonsTestFragment
+import org.wordpress.android.fluxc.example.ui.products.WooBatchUpdateVariationsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductAttributeFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductFiltersFragment
@@ -96,6 +97,9 @@ internal abstract class FragmentsModule {
 
     @ContributesAndroidInjector
     abstract fun provideWooUpdateVariationFragmentInjector(): WooUpdateVariationFragment
+
+    @ContributesAndroidInjector
+    abstract fun provideWooBatchUpdateVariationsFragmentInjector(): WooBatchUpdateVariationsFragment
 
     @ContributesAndroidInjector
     abstract fun provideWooProductFiltersFragmentInjector(): WooProductFiltersFragment

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
@@ -158,9 +158,6 @@ class WooBatchUpdateVariationsFragment : Fragment() {
             with(stock_quantity.getText()) {
                 if (isNotEmpty()) variationsUpdatePayloadBuilder.stockQuantity(this.toInt())
             }
-            with(stock_quantity.getText()) {
-                if (isNotEmpty()) variationsUpdatePayloadBuilder.stockQuantity(this.toInt())
-            }
             with(weight.getText()) {
                 if (isNotEmpty()) variationsUpdatePayloadBuilder.weight(this)
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
@@ -1,0 +1,252 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.app.DatePickerDialog
+import android.app.DatePickerDialog.OnDateSetListener
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_batch_update_variations.*
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.ListSelectorDialog
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsUpdateApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.BatchUpdateVariationsPayload
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.DateUtils
+import java.lang.NumberFormatException
+import java.util.Calendar
+import javax.inject.Inject
+
+class WooBatchUpdateVariationsFragment : Fragment() {
+    @Inject internal lateinit var wcProductStore: WCProductStore
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    private var selectedSitePosition: Int = -1
+
+    private lateinit var variationsUpdatePayloadBuilder: BatchUpdateVariationsPayload.Builder
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        arguments?.let {
+            selectedSitePosition = it.getInt(ARG_SELECTED_SITE_POS, 0)
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
+        inflater.inflate(layout.fragment_woo_batch_update_variations, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        update_product_info.setOnClickListener {
+            val site = getWCSite()
+            if (site == null) {
+                prependToLog("No valid site found...doing nothing")
+                return@setOnClickListener
+            }
+
+            val productId = getProductIdInput()
+            if (productId == null){
+                prependToLog("Product with id is empty or has wrong format...doing nothing")
+                return@setOnClickListener
+            }
+            val product = wcProductStore.getProductByRemoteId(site, productId)
+            if(product == null) {
+                prependToLog("Product with id: $productId not found in DB. Did you forget to fetch?...doing nothing")
+                return@setOnClickListener
+            }
+
+            val variationsIds: Collection<Long> = getVariationsIdsInput()
+            if (variationsIds.isEmpty()) {
+                prependToLog("Variations are empty or have wrong format...doing nothing")
+                return@setOnClickListener
+            }
+            variationsIds.forEach { variationId ->
+                val variation = wcProductStore.getVariationByRemoteId(site, productId, variationId)
+                if (variation == null) {
+                    prependToLog("Variation with id: $variationId not found in DB. Did you forget to fetch?...doing nothing")
+                    return@setOnClickListener
+                }
+            }
+
+            variationsUpdatePayloadBuilder = BatchUpdateVariationsPayload.Builder(
+                site,
+                productId,
+                variationsIds
+            )
+
+            status.text = "Selected product: $productId. Variation ids: ${variationsIds.joinToString("|")}"
+
+            enableVariationModificationInputs()
+        }
+
+        stock_status_button.setOnClickListener {
+            activity?.supportFragmentManager?.let { fm ->
+                val items = CoreProductStockStatus.values().map { it.value }
+                val dialog = ListSelectorDialog.newInstance(this, items, LIST_RESULT_CODE_STOCK_STATUS, null)
+                dialog.show(fm, "StockStatusDialog")
+            }
+        }
+
+        date_on_sale_from.setOnClickListener {
+            showDatePickerDialog(date_on_sale_from.text.toString()) { _, y, m, d ->
+                date_on_sale_from.text = DateUtils.getFormattedDateString(y, m, d)
+                variationsUpdatePayloadBuilder.startOfSale(date_on_sale_from.text.toString())
+            }
+        }
+
+        date_on_sale_to.setOnClickListener {
+            showDatePickerDialog(date_on_sale_to.text.toString()) { _, y, m, d ->
+                date_on_sale_to.text = DateUtils.getFormattedDateString(y, m, d)
+                variationsUpdatePayloadBuilder.startOfSale(date_on_sale_to.text.toString())
+            }
+        }
+
+        invoke_button.setOnClickListener {
+            val payload = buildPayload()
+            runBatchUpdate(payload)
+        }
+    }
+
+    private fun getProductIdInput() = try {
+        product_id.getText().toLong()
+    } catch (e: NumberFormatException) {
+        null
+    }
+
+    private fun getVariationsIdsInput() = try {
+        variations_ids.getText().split(",").map(String::toLong)
+    } catch (e: NumberFormatException) {
+        emptyList()
+    }
+
+    private fun buildPayload(): BatchUpdateVariationsPayload =
+        with(variationsUpdatePayloadBuilder) {
+            with(regular_price.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.regularPrice(this)
+            }
+            with(sale_price.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.salePrice(this)
+            }
+            with(date_on_sale_from_gmt.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.startOfSaleGmt(this)
+            }
+            with(date_on_sale_to_gmt.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.endOfSaleGmt(this)
+            }
+            with(stock_quantity.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.stockQuantity(this.toInt())
+            }
+            with(stock_quantity.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.stockQuantity(this.toInt())
+            }
+            with(weight.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.weight(this)
+            }
+            with(dimensions.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.dimensions(this)
+            }
+            with(shipping_class_id.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.shippingClassId(this)
+            }
+            with(shipping_class.getText()) {
+                if (isNotEmpty()) variationsUpdatePayloadBuilder.shippingClassSlug(this)
+            }
+            build()
+        }
+
+    private fun runBatchUpdate(payload: BatchUpdateVariationsPayload) {
+        lifecycleScope.launch(IO) {
+            val result: WooResult<BatchProductVariationsUpdateApiResponse> =
+                wcProductStore.batchUpdateVariations(payload)
+
+            withContext(Main) {
+                if (result.isError) {
+                    prependToLog("Error: ${result.error.message}")
+                } else {
+                    val count = result.model?.updatedVariations?.count() ?: 0
+                    prependToLog("Success: $count variations updated")
+                }
+            }
+        }
+    }
+
+    private fun enableVariationModificationInputs() {
+        arrayOf(
+            regular_price,
+            sale_price,
+            date_on_sale_from,
+            date_on_sale_to,
+            date_on_sale_from_gmt,
+            date_on_sale_to_gmt,
+            stock_quantity,
+            stock_status_button,
+            weight,
+            dimensions,
+            shipping_class_id,
+            shipping_class,
+            invoke_button,
+        ).forEach { it.isEnabled = true }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == ListSelectorDialog.LIST_SELECTOR_REQUEST_CODE) {
+            val selectedItem = data?.getStringExtra(ListSelectorDialog.ARG_LIST_SELECTED_ITEM)
+            when (resultCode) {
+                LIST_RESULT_CODE_STOCK_STATUS -> {
+                    selectedItem?.let { name ->
+                        stock_status_button.text = name
+                        variationsUpdatePayloadBuilder.stockStatus(CoreProductStockStatus.values().first { it.value == name })
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showDatePickerDialog(dateString: String?, listener: OnDateSetListener) {
+        val date = if (dateString.isNullOrEmpty()) DateUtils.getCurrentDateString() else dateString
+        val calendar = DateUtils.getCalendarInstance(date)
+        DatePickerDialog(
+            requireActivity(), listener, calendar.get(Calendar.YEAR),
+            calendar.get(Calendar.MONTH), calendar.get(Calendar.DATE)
+        )
+        .show()
+    }
+
+    private fun getWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(selectedSitePosition)
+
+    companion object {
+        const val ARG_SELECTED_SITE_POS = "ARG_SELECTED_SITE_POS"
+
+        const val LIST_RESULT_CODE_STOCK_STATUS = 101
+
+        fun newInstance(selectedSitePosition: Int): WooBatchUpdateVariationsFragment {
+            val fragment = WooBatchUpdateVariationsFragment()
+            val args = Bundle()
+            args.putInt(ARG_SELECTED_SITE_POS, selectedSitePosition)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
@@ -119,7 +119,7 @@ class WooBatchUpdateVariationsFragment : Fragment() {
         date_on_sale_to.setOnClickListener {
             showDatePickerDialog(date_on_sale_to.text.toString()) { _, y, m, d ->
                 date_on_sale_to.text = DateUtils.getFormattedDateString(y, m, d)
-                variationsUpdatePayloadBuilder.startOfSale(date_on_sale_to.text.toString())
+                variationsUpdatePayloadBuilder.endOfSale(date_on_sale_to.text.toString())
             }
         }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.BatchUpdateVariationsPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.DateUtils
-import java.lang.NumberFormatException
 import java.util.Calendar
 import javax.inject.Inject
 
@@ -149,12 +148,6 @@ class WooBatchUpdateVariationsFragment : Fragment() {
             with(sale_price.getText()) {
                 if (isNotEmpty()) variationsUpdatePayloadBuilder.salePrice(this)
             }
-            with(date_on_sale_from_gmt.getText()) {
-                if (isNotEmpty()) variationsUpdatePayloadBuilder.startOfSaleGmt(this)
-            }
-            with(date_on_sale_to_gmt.getText()) {
-                if (isNotEmpty()) variationsUpdatePayloadBuilder.endOfSaleGmt(this)
-            }
             with(stock_quantity.getText()) {
                 if (isNotEmpty()) variationsUpdatePayloadBuilder.stockQuantity(this.toInt())
             }
@@ -195,8 +188,6 @@ class WooBatchUpdateVariationsFragment : Fragment() {
             sale_price,
             date_on_sale_from,
             date_on_sale_to,
-            date_on_sale_from_gmt,
-            date_on_sale_to_gmt,
             stock_quantity,
             stock_status_button,
             weight,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
@@ -154,8 +154,11 @@ class WooBatchUpdateVariationsFragment : Fragment() {
             with(weight.getText()) {
                 if (isNotEmpty()) variationsUpdatePayloadBuilder.weight(this)
             }
-            with(dimensions.getText()) {
-                if (isNotEmpty()) variationsUpdatePayloadBuilder.dimensions(this)
+            val length = length.getText()
+            val width = width.getText()
+            val height = height.getText()
+            if (length.isNotEmpty() || width.isNotEmpty() || height.isNotEmpty()) {
+                variationsUpdatePayloadBuilder.dimensions(length = length, width = width, height = height)
             }
             with(shipping_class_id.getText()) {
                 if (isNotEmpty()) variationsUpdatePayloadBuilder.shippingClassId(this)
@@ -191,10 +194,12 @@ class WooBatchUpdateVariationsFragment : Fragment() {
             stock_quantity,
             stock_status_button,
             weight,
-            dimensions,
             shipping_class_id,
             shipping_class,
             invoke_button,
+            width,
+            height,
+            length,
         ).forEach { it.isEnabled = true }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -502,6 +502,10 @@ class WooProductsFragment : StoreSelectingFragment() {
                 }
             }
         }
+
+        batch_update_variations.setOnClickListener {
+            replaceFragment(WooBatchUpdateVariationsFragment.newInstance(selectedPos))
+        }
     }
 
     /**

--- a/example/src/main/res/layout/fragment_woo_batch_update_variations.xml
+++ b/example/src/main/res/layout/fragment_woo_batch_update_variations.xml
@@ -52,17 +52,6 @@
         app:layout_constraintTop_toBottomOf="@+id/update_product_info"
         tools:text="Selected product ID: 123456, Variations IDs: 1234, 1234, 4321" />
 
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/header"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:paddingTop="12dp"
-        android:paddingBottom="12dp"
-        android:textAppearance="@style/TextAppearance.AppCompat.Widget.ActionMode.Subtitle"
-        app:layout_constraintTop_toBottomOf="@+id/status"
-        tools:text="Variation properties available for batch update 👇" />
-
     <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
         android:id="@+id/regular_price"
         android:layout_width="0dp"
@@ -72,7 +61,7 @@
         android:lines="1"
         app:layout_constraintEnd_toStartOf="@+id/sale_price"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/header"
+        app:layout_constraintTop_toBottomOf="@+id/status"
         app:textHint="Regular price" />
 
     <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
@@ -84,7 +73,7 @@
         android:lines="1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/regular_price"
-        app:layout_constraintTop_toBottomOf="@+id/header"
+        app:layout_constraintTop_toBottomOf="@+id/status"
         app:textHint="Sale price" />
 
     <Button
@@ -165,7 +154,7 @@
         android:lines="1"
         app:layout_constraintEnd_toStartOf="@+id/date_on_sale_to"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/stock_status_button"
+        app:layout_constraintTop_toBottomOf="@+id/stock_quantity"
         app:textHint="Weight" />
 
     <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
@@ -177,7 +166,7 @@
         android:lines="1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/date_on_sale_from"
-        app:layout_constraintTop_toBottomOf="@+id/stock_status_button"
+        app:layout_constraintTop_toBottomOf="@+id/stock_quantity"
         app:textHint="Dimensions" />
 
     <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText

--- a/example/src/main/res/layout/fragment_woo_batch_update_variations.xml
+++ b/example/src/main/res/layout/fragment_woo_batch_update_variations.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="12dp"
+    tools:context="org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment"
+    tools:ignore="HardcodedText">
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/product_id"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="true"
+        android:inputType="textMultiLine"
+        android:lines="2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:textHint="Remote product ID" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/variations_ids"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="true"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/product_id"
+        app:textHint="Variations IDs comma-separated" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/update_product_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Set up product ID and variations IDs 💾"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/variations_ids" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:textColor="#00f"
+        app:layout_constraintTop_toBottomOf="@+id/update_product_info"
+        tools:text="Selected product ID: 123456, Variations IDs: 1234, 1234, 4321" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Widget.ActionMode.Subtitle"
+        app:layout_constraintTop_toBottomOf="@+id/status"
+        tools:text="Variation properties available for batch update 👇" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/regular_price"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toStartOf="@+id/sale_price"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/header"
+        app:textHint="Regular price" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/sale_price"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/regular_price"
+        app:layout_constraintTop_toBottomOf="@+id/header"
+        app:textHint="Sale price" />
+
+    <Button
+        android:id="@+id/date_on_sale_from"
+        style="?android:attr/spinnerStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:hint="Start of sale"
+        app:layout_constraintEnd_toStartOf="@+id/date_on_sale_to"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/sale_price" />
+
+    <Button
+        android:id="@+id/date_on_sale_to"
+        style="?android:attr/spinnerStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:hint="End of sale"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/date_on_sale_from"
+        app:layout_constraintTop_toBottomOf="@+id/sale_price" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/date_on_sale_from_gmt"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toStartOf="@+id/date_on_sale_to"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_from"
+        app:textHint="Start of sale GMT" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/date_on_sale_to_gmt"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/date_on_sale_from"
+        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_from"
+        app:textHint="End of sale GMT" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/stock_quantity"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toStartOf="@+id/date_on_sale_to"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_to_gmt"
+        app:textHint="Stock quantity" />
+
+    <Button
+        android:id="@+id/stock_status_button"
+        style="?android:attr/spinnerStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:text="Stock status 📊"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/date_on_sale_from"
+        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_to_gmt" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/weight"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toStartOf="@+id/date_on_sale_to"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/stock_status_button"
+        app:textHint="Weight" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/dimensions"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/date_on_sale_from"
+        app:layout_constraintTop_toBottomOf="@+id/stock_status_button"
+        app:textHint="Dimensions" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/shipping_class_id"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toStartOf="@+id/date_on_sale_to"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/dimensions"
+        app:textHint="Shipping class ID" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/shipping_class"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textMultiLine"
+        android:lines="1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/date_on_sale_from"
+        app:layout_constraintTop_toBottomOf="@+id/dimensions"
+        app:textHint="Shipping class slug" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/invoke_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:text="run batch update 🚀"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/shipping_class" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/layout/fragment_woo_batch_update_variations.xml
+++ b/example/src/main/res/layout/fragment_woo_batch_update_variations.xml
@@ -128,22 +128,50 @@
         android:enabled="false"
         android:inputType="textMultiLine"
         android:lines="1"
-        app:layout_constraintEnd_toStartOf="@+id/date_on_sale_to"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/stock_quantity"
         app:textHint="Weight" />
 
-    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+    <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/dimensions"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:enabled="false"
-        android:inputType="textMultiLine"
-        android:lines="1"
+        android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/date_on_sale_from"
-        app:layout_constraintTop_toBottomOf="@+id/stock_quantity"
-        app:textHint="Dimensions" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/weight">
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/width"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:enabled="false"
+            android:inputType="textMultiLine"
+            android:lines="1"
+            app:textHint="Width" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/height"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:enabled="false"
+            android:inputType="textMultiLine"
+            android:lines="1"
+            app:textHint="Height" />
+
+        <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+            android:id="@+id/length"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:enabled="false"
+            android:inputType="textMultiLine"
+            android:lines="1"
+            app:textHint="Length" />
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
     <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
         android:id="@+id/shipping_class_id"

--- a/example/src/main/res/layout/fragment_woo_batch_update_variations.xml
+++ b/example/src/main/res/layout/fragment_woo_batch_update_variations.xml
@@ -99,30 +99,6 @@
         app:layout_constraintTop_toBottomOf="@+id/sale_price" />
 
     <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
-        android:id="@+id/date_on_sale_from_gmt"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:enabled="false"
-        android:inputType="textMultiLine"
-        android:lines="1"
-        app:layout_constraintEnd_toStartOf="@+id/date_on_sale_to"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_from"
-        app:textHint="Start of sale GMT" />
-
-    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
-        android:id="@+id/date_on_sale_to_gmt"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:enabled="false"
-        android:inputType="textMultiLine"
-        android:lines="1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/date_on_sale_from"
-        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_from"
-        app:textHint="End of sale GMT" />
-
-    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
         android:id="@+id/stock_quantity"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -131,7 +107,7 @@
         android:lines="1"
         app:layout_constraintEnd_toStartOf="@+id/date_on_sale_to"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_to_gmt"
+        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_to"
         app:textHint="Stock quantity" />
 
     <Button
@@ -143,7 +119,7 @@
         android:text="Stock status 📊"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/date_on_sale_from"
-        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_to_gmt" />
+        app:layout_constraintTop_toBottomOf="@+id/date_on_sale_to" />
 
     <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
         android:id="@+id/weight"

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -201,5 +201,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Delete product"/>
+
+        <Button
+            android:id="@+id/batch_update_variations"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Batch update variations"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.wc.product
 
+import com.google.gson.JsonObject
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -458,12 +459,12 @@ class WCProductStoreTest {
         val modifiedSalePrice = "123,2.4"
         val modifiedStartOfSale = "tomorrow"
         val modifiedEndOfSale = "next week"
-        val modifiedStartOfSaleGmt = "tomorrow"
-        val modifiedEndOfSaleGmt = "next week"
         val modifiedStockQuantity = 1234
         val modifiedStockStatus = CoreProductStockStatus.IN_STOCK
         val modifiedWeight = "1234 kg"
-        val modifiedDimensions = "10x12x10 cm"
+        val modifiedWidth = "5"
+        val modifiedHeight = "10"
+        val modifiedLength = "15"
         val modifiedShippingClassId = "1234"
         val modifiedShippingClassSlug = "DHL"
 
@@ -475,7 +476,7 @@ class WCProductStoreTest {
             .stockQuantity(modifiedStockQuantity)
             .stockStatus(modifiedStockStatus)
             .weight(modifiedWeight)
-            .dimensions(modifiedDimensions)
+            .dimensions(length = modifiedLength, width = modifiedWidth, height = modifiedHeight)
             .shippingClassId(modifiedShippingClassId)
             .shippingClassSlug(modifiedShippingClassSlug)
         val payload = builder.build()
@@ -486,12 +487,14 @@ class WCProductStoreTest {
             assertThat(get("sale_price")).isEqualTo(modifiedSalePrice)
             assertThat(get("date_on_sale_from")).isEqualTo(modifiedStartOfSale)
             assertThat(get("date_on_sale_to")).isEqualTo(modifiedEndOfSale)
-            assertThat(get("date_on_sale_from_gmt")).isEqualTo(modifiedStartOfSaleGmt)
-            assertThat(get("date_on_sale_to_gmt")).isEqualTo(modifiedEndOfSaleGmt)
             assertThat(get("stock_quantity")).isEqualTo(modifiedStockQuantity)
             assertThat(get("stock_status")).isEqualTo(modifiedStockStatus)
             assertThat(get("weight")).isEqualTo(modifiedWeight)
-            assertThat(get("dimensions")).isEqualTo(modifiedDimensions)
+            with(get("dimensions") as JsonObject) {
+                assertThat(get("length").asString).isEqualTo(modifiedLength)
+                assertThat(get("height").asString).isEqualTo(modifiedHeight)
+                assertThat(get("width").asString).isEqualTo(modifiedWidth)
+            }
             assertThat(get("shipping_class_id")).isEqualTo(modifiedShippingClassId)
             assertThat(get("shipping_class")).isEqualTo(modifiedShippingClassSlug)
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -472,8 +472,6 @@ class WCProductStoreTest {
             .salePrice(modifiedSalePrice)
             .startOfSale(modifiedStartOfSale)
             .endOfSale(modifiedEndOfSale)
-            .startOfSaleGmt(modifiedStartOfSaleGmt)
-            .endOfSaleGmt(modifiedEndOfSaleGmt)
             .stockQuantity(modifiedStockQuantity)
             .stockStatus(modifiedStockStatus)
             .weight(modifiedWeight)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.store
 
 import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -223,7 +225,12 @@ class WCProductStore @Inject constructor(
                 variationsModifications["weight"] = weight
             }
 
-            fun dimensions(dimensions: String) = apply {
+            fun dimensions(length: String, width: String, height: String) = apply {
+                val dimensions = JsonObject().apply {
+                    add("length", JsonPrimitive(length))
+                    add("width", JsonPrimitive(width))
+                    add("height", JsonPrimitive(height))
+                }
                 variationsModifications["dimensions"] = dimensions
             }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -211,14 +211,6 @@ class WCProductStore @Inject constructor(
                 variationsModifications["date_on_sale_to"] = endOfSale
             }
 
-            fun startOfSaleGmt(startOfSale: String) = apply {
-                variationsModifications["date_on_sale_from_gmt"] = startOfSale
-            }
-
-            fun endOfSaleGmt(endOfSale: String) = apply {
-                variationsModifications["date_on_sale_to_gmt"] = endOfSale
-            }
-
             fun stockQuantity(stockQuantity: Int) = apply {
                 variationsModifications["stock_quantity"] = stockQuantity
             }


### PR DESCRIPTION
**This PR updates `example` to allow testing variations batch update. It's based on the other [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2367) which introduced batch variations update feature in `WcProductStore`. It is the last implementation part of the https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/2320 issue.** 

#### 🎯 Summary
This PR updates `example` app to allow testing variations batch update feature.

#### 🛠 Implementation details
* Added `WooBatchUpdateVariationsFragment`, accessible from `WooProductsFragment`.

#### 📱 Visual changes

<img src="https://user-images.githubusercontent.com/4527432/166104912-4a28e5eb-defb-4474-8801-5742c2fb975e.png" height="512"/> <img src="https://user-images.githubusercontent.com/4527432/166104917-0625fee8-e022-4717-b3b9-59a1d7c90fb1.png" height="512"/>

#### 🧪 Testing
Run the example app and:
1. Navigate to `Batch Update Variations` screen.  
2. Enter product id, and ids of variations (comma-separated).
3. Click `Set up product id and variations ids` button to validate ids and check if they exist in DB.
4. Fill in the form below with the data you want to batch update the variations.
5. Click the button at the bottom.

In-app logs should inform about the product/variations validation errors and the batch update operation result.

#### 🧭 Roadmap
Once this PR is merged, there will be an aggregate PR raised containing the previous [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2367) and closing the https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/2320 issue.