### PR TITLE
Stats revamp v2 summary url

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClientTest.kt
@@ -1,0 +1,107 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.insights
+
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.SummaryRestClient.SummaryResponse
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.test
+
+@RunWith(MockitoJUnitRunner::class)
+class SummaryRestClientTest {
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var restClient: SummaryRestClient
+    private val siteId: Long = 12
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        restClient = SummaryRestClient(
+            dispatcher,
+            wpComGsonRequestBuilder,
+            null,
+            requestQueue,
+            accessToken,
+            userAgent
+        )
+    }
+
+    @Test
+    fun `returns summary success response`() = test {
+        val response = mock<SummaryResponse>()
+        initSummaryResponse(response)
+
+        val responseModel = restClient.fetchSummary(site, false)
+
+        assertThat(responseModel.response).isNotNull
+        assertThat(responseModel.response).isEqualTo(response)
+        assertThat(urlCaptor.lastValue).isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12/stats/summary/")
+        assertThat(paramsCaptor.lastValue).isEmpty()
+    }
+
+    @Test
+    fun `returns summary error response`() = test {
+        val errorMessage = "message"
+        initSummaryResponse(
+            error = WPComGsonNetworkError(
+                BaseNetworkError(NETWORK_ERROR, errorMessage, VolleyError(errorMessage))
+            )
+        )
+
+        val responseModel = restClient.fetchSummary(site, false)
+
+        assertThat(responseModel.error).isNotNull
+        assertThat(responseModel.error.type).isEqualTo(API_ERROR)
+        assertThat(responseModel.error.message).isEqualTo(errorMessage)
+    }
+
+    private suspend fun initSummaryResponse(
+        data: SummaryResponse? = null,
+        error: WPComGsonNetworkError? = null
+    ): Response<SummaryResponse> {
+        val response = if (error != null) Error(error) else Success(data ?: mock())
+        whenever(
+            wpComGsonRequestBuilder.syncGetRequest(
+                any(),
+                urlCaptor.capture(),
+                paramsCaptor.capture(),
+                eq(SummaryResponse::class.java),
+                eq(false),
+                any(),
+                eq(false)
+            )
+        ).thenReturn(response)
+        whenever(site.siteId).thenReturn(siteId)
+        return response
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsFixtures.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActi
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse.Streaks
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRestClient.PublicizeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRestClient.PublicizeResponse.Service
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.SummaryRestClient.SummaryResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse.TagsGroup
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse.TagsGroup.TagResponse
@@ -139,6 +140,7 @@ val TOP_COMMENTS_RESPONSE = CommentsResponse(
         listOf(AUTHOR),
         listOf(POST)
 )
+val SUMMARY_RESPONSE = SummaryResponse(100)
 val SERVICE_RESPONSE = Service("facebook", 100)
 val PUBLICIZE_RESPONSE = PublicizeResponse(listOf(SERVICE_RESPONSE))
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsFixtures.kt
@@ -140,7 +140,7 @@ val TOP_COMMENTS_RESPONSE = CommentsResponse(
         listOf(AUTHOR),
         listOf(POST)
 )
-val SUMMARY_RESPONSE = SummaryResponse(100)
+val SUMMARY_RESPONSE = SummaryResponse(LIKE_COUNT, COMMENT_COUNT, 100)
 val SERVICE_RESPONSE = Service("facebook", 100)
 val PUBLICIZE_RESPONSE = PublicizeResponse(listOf(SERVICE_RESPONSE))
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/insights/SummaryStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/insights/SummaryStoreTest.kt
@@ -1,0 +1,80 @@
+package org.wordpress.android.fluxc.store.stats.insights
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.InsightsMapper
+import org.wordpress.android.fluxc.model.stats.SummaryModel
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.SummaryRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.SummaryRestClient.SummaryResponse
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.SummarySqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.API_ERROR
+import org.wordpress.android.fluxc.store.stats.SUMMARY_RESPONSE
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunWith(MockitoJUnitRunner::class)
+class SummaryStoreTest {
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var restClient: SummaryRestClient
+    @Mock lateinit var sqlUtils: SummarySqlUtils
+    @Mock lateinit var mapper: InsightsMapper
+    private lateinit var store: SummaryStore
+
+    @Before
+    fun setUp() {
+        store = SummaryStore(restClient, sqlUtils, mapper, initCoroutineEngine())
+    }
+
+    @Test
+    fun `returns summary per site`() = test {
+        val fetchSummaryPayload = FetchStatsPayload(SUMMARY_RESPONSE)
+        val forced = true
+        whenever(restClient.fetchSummary(site, forced)).thenReturn(fetchSummaryPayload)
+        val model = mock<SummaryModel>()
+        whenever(mapper.map(SUMMARY_RESPONSE)).thenReturn(model)
+
+        val responseModel = store.fetchSummary(site, forced)
+
+        Assertions.assertThat(responseModel.model).isEqualTo(model)
+        verify(sqlUtils).insert(site, SUMMARY_RESPONSE)
+    }
+
+    @Test
+    fun `returns error when summary call fail`() = test {
+        val type = API_ERROR
+        val message = "message"
+        val errorPayload = FetchStatsPayload<SummaryResponse>(StatsError(type, message))
+        val forced = true
+        whenever(restClient.fetchSummary(site, forced)).thenReturn(errorPayload)
+
+        val responseModel = store.fetchSummary(site, forced)
+
+        assertNotNull(responseModel.error)
+        val error = responseModel.error!!
+        assertEquals(type, error.type)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `returns summary from db`() {
+        whenever(sqlUtils.select(site)).thenReturn(SUMMARY_RESPONSE)
+        val model = mock<SummaryModel>()
+        whenever(mapper.map(SUMMARY_RESPONSE)).thenReturn(model)
+
+        val result = store.getSummary(site)
+
+        Assertions.assertThat(result).isEqualTo(model)
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostI
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.MostPopularRestClient.MostPopularResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRestClient.PublicizeResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.SummaryRestClient.SummaryResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse.TagsGroup.TagResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TodayInsightsRestClient.VisitResponse
@@ -211,6 +212,8 @@ class InsightsMapper
         val hasMorePosts = (response.posts != null && cacheMode is Top && response.posts.size > cacheMode.limit)
         return CommentsModel(posts ?: listOf(), authors ?: listOf(), hasMorePosts, hasMoreAuthors)
     }
+
+    fun map(response: SummaryResponse) = SummaryModel(response.followers ?: 0)
 
     fun map(response: TagsResponse, cacheMode: LimitMode): TagsModel {
         return TagsModel(response.tags.let {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -213,7 +213,11 @@ class InsightsMapper
         return CommentsModel(posts ?: listOf(), authors ?: listOf(), hasMorePosts, hasMoreAuthors)
     }
 
-    fun map(response: SummaryResponse) = SummaryModel(response.followers ?: 0)
+    fun map(response: SummaryResponse) = SummaryModel(
+        response.likes ?: 0,
+        response.comments ?: 0,
+        response.followers ?: 0
+    )
 
     fun map(response: TagsResponse, cacheMode: LimitMode): TagsModel {
         return TagsModel(response.tags.let {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/SummaryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/SummaryModel.kt
@@ -1,3 +1,3 @@
 package org.wordpress.android.fluxc.model.stats
 
-data class SummaryModel(val followers: Int)
+data class SummaryModel(val likes: Int, val comments: Int, val followers: Int)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/SummaryModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/SummaryModel.kt
@@ -1,0 +1,3 @@
+package org.wordpress.android.fluxc.model.stats
+
+data class SummaryModel(val followers: Int)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClient.kt
@@ -44,5 +44,9 @@ class SummaryRestClient @Inject constructor(
         }
     }
 
-    data class SummaryResponse(@SerializedName("followers") val followers: Int?)
+    data class SummaryResponse(
+        @SerializedName("likes") val likes: Int?,
+        @SerializedName("comments") val comments: Int?,
+        @SerializedName("followers") val followers: Int?
+    )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClient.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.insights
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.toStatsError
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class SummaryRestClient @Inject constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchSummary(site: SiteModel, forced: Boolean): FetchStatsPayload<SummaryResponse> {
+        val url = WPCOMREST.sites.site(site.siteId).stats.summary.urlV1_1
+
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+            this,
+            url,
+            mapOf(),
+            SummaryResponse::class.java,
+            enableCaching = false,
+            forced = forced
+        )
+        return when (response) {
+            is Success -> FetchStatsPayload(response.data)
+            is Error -> FetchStatsPayload(response.error.toStatsError())
+        }
+    }
+
+    data class SummaryResponse(@SerializedName("followers") val followers: Int?)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.LatestPostI
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.MostPopularRestClient.MostPopularResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PostingActivityRestClient.PostingActivityResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRestClient.PublicizeResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.SummaryRestClient.SummaryResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TodayInsightsRestClient.VisitResponse
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType
@@ -20,6 +21,7 @@ import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.LATEST_PO
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.MOST_POPULAR_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTING_ACTIVITY
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.PUBLICIZE_INSIGHTS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.SUMMARY
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.TAGS_AND_CATEGORIES_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.TODAYS_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.WP_COM_FOLLOWERS
@@ -128,6 +130,17 @@ constructor(
             statsRequestSqlUtils,
             COMMENTS_INSIGHTS,
             CommentsResponse::class.java
+    )
+
+    class SummarySqlUtils
+    @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<SummaryResponse>(
+        statsSqlUtils,
+        statsRequestSqlUtils,
+        SUMMARY,
+        SummaryResponse::class.java
     )
 
     class WpComFollowersSqlUtils

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -156,6 +156,7 @@ class StatsSqlUtils
         WP_COM_FOLLOWERS,
         EMAIL_FOLLOWERS,
         COMMENTS_INSIGHTS,
+        SUMMARY,
         TAGS_AND_CATEGORIES_INSIGHTS,
         POSTS_AND_PAGES_VIEWS,
         REFERRERS,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -174,6 +174,8 @@ class StatsStore
         LATEST_POST_SUMMARY,
         MOST_POPULAR_DAY_AND_HOUR,
         ALL_TIME_STATS,
+        TOTAL_LIKES,
+        TOTAL_COMMENTS,
         FOLLOWER_TOTALS,
         TAGS_AND_CATEGORIES,
         ANNUAL_SITE_STATS,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/SummaryStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/SummaryStore.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.fluxc.store.stats.insights
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.InsightsMapper
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.SummaryRestClient
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.SummarySqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SummaryStore @Inject constructor(
+    private val restClient: SummaryRestClient,
+    private val sqlUtils: SummarySqlUtils,
+    private val insightsMapper: InsightsMapper,
+    private val coroutineEngine: CoroutineEngine
+) {
+    suspend fun fetchSummary(site: SiteModel, forced: Boolean = false) =
+        coroutineEngine.withDefaultContext(AppLog.T.STATS, this, "fetchSummary") {
+            if (!forced && sqlUtils.hasFreshRequest(site)) {
+                return@withDefaultContext OnStatsFetched(getSummary(site), cached = true)
+            }
+            val payload = restClient.fetchSummary(site, forced)
+            return@withDefaultContext when {
+                payload.isError -> OnStatsFetched(payload.error)
+                payload.response != null -> {
+                    sqlUtils.insert(site, payload.response)
+                    OnStatsFetched(insightsMapper.map(payload.response))
+                }
+                else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
+            }
+        }
+
+    fun getSummary(site: SiteModel) = coroutineEngine.run(AppLog.T.STATS, this, "getSummary") {
+        sqlUtils.select(site)?.let { insightsMapper.map(it) }
+    }
+}


### PR DESCRIPTION
This PR adds `SummaryStore` to use [summary url](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/summary/) of stats.

To test:

This can be tested through [corresponding WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16241)