### PR TITLE
Add TOTAL_FOLLOWERS InsightType

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -176,6 +176,7 @@ class StatsStore
         ALL_TIME_STATS,
         TOTAL_LIKES,
         TOTAL_COMMENTS,
+        TOTAL_FOLLOWERS,
         FOLLOWER_TOTALS,
         TAGS_AND_CATEGORIES,
         ANNUAL_SITE_STATS,


### PR DESCRIPTION
This PR adds new `InsightType`, `TOTAL_FOLLOWERS` to be used in stats revamp v2.

To test:

This can be tested through https://github.com/wordpress-mobile/WordPress-Android/pull/16241