### PR TITLE
[Issue/2320] Product variations batch update

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
@@ -66,12 +66,12 @@ class WooBatchUpdateVariationsFragment : Fragment() {
             }
 
             val productId = getProductIdInput()
-            if (productId == null){
+            if (productId == null) {
                 prependToLog("Product with id is empty or has wrong format...doing nothing")
                 return@setOnClickListener
             }
             val product = wcProductStore.getProductByRemoteId(site, productId)
-            if(product == null) {
+            if (product == null) {
                 prependToLog("Product with id: $productId not found in DB. Did you forget to fetch?...doing nothing")
                 return@setOnClickListener
             }
@@ -84,7 +84,9 @@ class WooBatchUpdateVariationsFragment : Fragment() {
             variationsIds.forEach { variationId ->
                 val variation = wcProductStore.getVariationByRemoteId(site, productId, variationId)
                 if (variation == null) {
-                    prependToLog("Variation with id: $variationId not found in DB. Did you forget to fetch?...doing nothing")
+                    val msg = "Variation with id: $variationId not found in DB. " +
+                        "Did you forget to fetch?...doing nothing"
+                    prependToLog(msg)
                     return@setOnClickListener
                 }
             }
@@ -199,7 +201,7 @@ class WooBatchUpdateVariationsFragment : Fragment() {
             invoke_button,
             width,
             height,
-            length,
+            length
         ).forEach { it.isEnabled = true }
     }
 
@@ -210,7 +212,9 @@ class WooBatchUpdateVariationsFragment : Fragment() {
                 LIST_RESULT_CODE_STOCK_STATUS -> {
                     selectedItem?.let { name ->
                         stock_status_button.text = name
-                        variationsUpdatePayloadBuilder.stockStatus(CoreProductStockStatus.values().first { it.value == name })
+                        variationsUpdatePayloadBuilder.stockStatus(
+                            CoreProductStockStatus.values().first { it.value == name }
+                        )
                     }
                 }
             }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -327,9 +327,22 @@ class WCProductStoreTest {
 
             // when
             val variationsIds = variations.map { it.remoteVariationId }
-            val variationsUpdatePayload = BatchUpdateVariationsPayload.Builder(site, product.remoteProductId, variationsIds).build()
-            val response = BatchProductVariationsUpdateApiResponse().apply { updatedVariations = emptyList() }
-            whenever(productRestClient.batchUpdateVariations(any(), any(), any(), any())) doReturn WooPayload(response)
+            val variationsUpdatePayload = BatchUpdateVariationsPayload.Builder(
+                site,
+                product.remoteProductId,
+                variationsIds
+            ).build()
+            val response = BatchProductVariationsUpdateApiResponse().apply {
+                updatedVariations = emptyList()
+            }
+            whenever(
+                productRestClient.batchUpdateVariations(
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            ) doReturn WooPayload(response)
             val result = productStore.batchUpdateVariations(variationsUpdatePayload)
 
             // then
@@ -339,28 +352,37 @@ class WCProductStoreTest {
         }
 
     @Test
-    fun `batch variations update should return negative result on failed backend request`() = runBlocking {
-        // given
-        val product = ProductTestUtils.generateSampleProduct(Random.nextLong())
-        val site = SiteModel().apply { id = product.localSiteId }
-        val variations = generateSampleVariations(
-            number = 64,
-            productId = product.remoteProductId,
-            siteId = site.id
-        )
+    fun `batch variations update should return negative result on failed backend request`() =
+        runBlocking {
+            // given
+            val product = ProductTestUtils.generateSampleProduct(Random.nextLong())
+            val site = SiteModel().apply { id = product.localSiteId }
+            val variations = generateSampleVariations(
+                number = 64,
+                productId = product.remoteProductId,
+                siteId = site.id
+            )
 
-        // when
-        val variationsIds = variations.map { it.remoteVariationId }
-        val variationsUpdatePayload =
-            BatchUpdateVariationsPayload.Builder(site, product.remoteProductId, variationsIds).build()
-        val errorResponse = WooError(GENERIC_ERROR, NETWORK_ERROR, "🔴")
-        whenever(productRestClient.batchUpdateVariations(any(), any(), any(), any())) doReturn WooPayload(errorResponse)
-        val result = productStore.batchUpdateVariations(variationsUpdatePayload)
+            // when
+            val variationsIds = variations.map { it.remoteVariationId }
+            val variationsUpdatePayload =
+                BatchUpdateVariationsPayload.Builder(site, product.remoteProductId, variationsIds)
+                    .build()
+            val errorResponse = WooError(GENERIC_ERROR, NETWORK_ERROR, "🔴")
+            whenever(
+                productRestClient.batchUpdateVariations(
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            ) doReturn WooPayload(errorResponse)
+            val result = productStore.batchUpdateVariations(variationsUpdatePayload)
 
-        // then
-        assertThat(result.isError).isTrue
-        Unit
-    }
+            // then
+            assertThat(result.isError).isTrue
+            Unit
+        }
 
     @Test
     fun `batch variations update should update variations locally after successful backend request`() =
@@ -393,8 +415,17 @@ class WCProductStoreTest {
                     sale_price = newSalePrice
                 }
             }
-            val response = BatchProductVariationsUpdateApiResponse().apply { updatedVariations = variationsReturnedFromBackend }
-            whenever(productRestClient.batchUpdateVariations(any(), any(), any(), any())) doReturn WooPayload(response)
+            val response = BatchProductVariationsUpdateApiResponse().apply {
+                updatedVariations = variationsReturnedFromBackend
+            }
+            whenever(
+                productRestClient.batchUpdateVariations(
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            ) doReturn WooPayload(response)
             val result = productStore.batchUpdateVariations(variationsUpdatePayload)
 
             // then
@@ -433,7 +464,14 @@ class WCProductStoreTest {
                     .salePrice(newSalePrice)
                     .build()
             val errorResponse = WooError(GENERIC_ERROR, NETWORK_ERROR, "🔴")
-            whenever(productRestClient.batchUpdateVariations(any(), any(), any(), any())) doReturn WooPayload(errorResponse)
+            whenever(
+                productRestClient.batchUpdateVariations(
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            ) doReturn WooPayload(errorResponse)
             val result = productStore.batchUpdateVariations(variationsUpdatePayload)
 
             // then
@@ -452,8 +490,16 @@ class WCProductStoreTest {
         // given
         val product = ProductTestUtils.generateSampleProduct(Random.nextLong())
         val site = SiteModel().apply { id = 23 }
-        val variations = generateSampleVariations(number = 64, productId = product.remoteProductId, siteId = site.id)
-        val builder = BatchUpdateVariationsPayload.Builder(site, product.remoteProductId, variations.map { it.remoteVariationId })
+        val variations = generateSampleVariations(
+            number = 64,
+            productId = product.remoteProductId,
+            siteId = site.id
+        )
+        val builder = BatchUpdateVariationsPayload.Builder(
+            site,
+            product.remoteProductId,
+            variations.map { it.remoteVariationId }
+        )
 
         val modifiedRegularPrice = "11234.234"
         val modifiedSalePrice = "123,2.4"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -816,7 +816,7 @@ class ProductRestClient @Inject constructor(
         site: SiteModel,
         productId: Long,
         variationsIds: Collection<Long>,
-        modifiedProperties: Map<String, Any>,
+        modifiedProperties: Map<String, Any>
     ): WooPayload<BatchProductVariationsUpdateApiResponse> = WOOCOMMERCE.products.id(productId).variations.batch.pathV3
         .let { url ->
             val variationsUpdates: List<Map<String, Any>> = variationsIds.map { variationId ->
@@ -832,7 +832,6 @@ class ProductRestClient @Inject constructor(
                 BatchProductVariationsUpdateApiResponse::class.java
             ).handleResult()
         }
-
 
     /**
      * Makes a POST request to `/wp-json/wc/v3/products` to create

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -193,7 +193,7 @@ class WCProductStore @Inject constructor(
         class Builder(
             private val site: SiteModel,
             private val remoteProductId: Long,
-            private val variationsIds: Collection<Long>,
+            private val variationsIds: Collection<Long>
         ) {
             private val variationsModifications = mutableMapOf<String, Any>()
 
@@ -1231,7 +1231,8 @@ class WCProductStore @Inject constructor(
      *
      * @param payload Instance of [BatchUpdateVariationsPayload]. It can be produced using [BatchUpdateVariationsPayload.Builder] class.
      */
-    suspend fun batchUpdateVariations(payload: BatchUpdateVariationsPayload): WooResult<BatchProductVariationsUpdateApiResponse> =
+    suspend fun batchUpdateVariations(payload: BatchUpdateVariationsPayload):
+        WooResult<BatchProductVariationsUpdateApiResponse> =
         coroutineEngine.withDefaultContext(API, this, "batchUpdateVariations") {
             with(payload) {
                 val result: WooPayload<BatchProductVariationsUpdateApiResponse> =


### PR DESCRIPTION
**This PR closes #2320 issue. It consists of 2 already reviewed PRs: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2367 and https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2374 which are merged to this feature branch.**

### 🎯 Summary
This PR adds support for product variations batch update, and updates `example` app.

### 🛠 Implementation details
1. Added `/products/<id>/variations/batch endpoint`
2. Implemented POST call to batch update variations `ProductRestClient::batchUpdateVariations`, and introduced `BatchProductVariationsUpdateApiResponse` class wich models backend response.
3. Implemented `WCProductStore::batchUpdateVariations` method responsible for variations batch update on the backend. It updates variations locally after a successful backend response.
4. Created `BatchUpdateVariationsPayload` class consumed by `::batchUpdateVariations` and introduced `BatchUpdateVariationsPayload.Builder` to simplify creating variations updates map required by the REST API.
5. Updated `example` app. Added `WooBatchUpdateVariationsFragment`, accessible from `WooProductsFragment`.

### 📱 Visual changes

<img src="https://user-images.githubusercontent.com/4527432/166924004-34eec8e6-5659-4049-8119-eb1aafcf2935.png" height="512"/> <img src="https://user-images.githubusercontent.com/4527432/166924020-2f4ef1c0-a59f-41d3-990f-aac3235581f9.png" height="512"/>

### 🧪 Testing
* Run WCProductStoreTest. Unit test methods were added here.
* Test with the example app:
    1. Navigate to Batch Update Variations screen.
    2. Enter product id, and ids of variations (comma-separated).
    3. Click Set up product id and variations ids button to validate ids and check if they exist in DB.
    4. Fill in the form below with the data you want to batch update the variations.
    5. Click the button at the bottom.
    
In-app logs inform about the product/variations validation errors and the batch update operation result.