### PR TITLE
Stats Revamp v2: New Insight Types for Comments Details Screen

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -181,6 +181,8 @@ class StatsStore
         TAGS_AND_CATEGORIES,
         ANNUAL_SITE_STATS,
         COMMENTS,
+        AUTHORS_COMMENTS,
+        POSTS_COMMENTS,
         FOLLOWERS,
         TODAY_STATS,
         POSTING_ACTIVITY,


### PR DESCRIPTION
This PR adds new InsightTypes, AUTHORS_COMMENTS and POSTS_COMMENTS

Fixes [#16508](https://github.com/wordpress-mobile/WordPress-Android/issues/16508)

To test:

This can be tested through https://github.com/wordpress-mobile/WordPress-Android/pull/16519