### PR TITLE
Prevent NPE with site.wpApiRestUrl

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -113,13 +113,18 @@ class ReactNativeStore
         params: Map<String, String>,
         enableCaching: Boolean
     ): ReactNativeFetchResponse {
-        val usingSavedRestUrl = site.wpApiRestUrl != null
+        // Storing this in a variable to avoid a NPE that can occur if the site object is mutated
+        // from another thread: https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1579
+        var wpApiRestUrl = site.wpApiRestUrl
+
+        val usingSavedRestUrl = wpApiRestUrl != null
         if (!usingSavedRestUrl) {
-            site.wpApiRestUrl = discoveryWPAPIRestClient.discoverWPAPIBaseURL(site.url) // discover rest api endpoint
+            wpApiRestUrl = discoveryWPAPIRestClient.discoverWPAPIBaseURL(site.url) // discover rest api endpoint
                     ?: slashJoin(site.url, "wp-json/") // fallback to ".../wp-json/" default if discovery fails
+            site.wpApiRestUrl = wpApiRestUrl
             persistSiteSafely(site)
         }
-        val fullRestUrl = slashJoin(site.wpApiRestUrl, path)
+        val fullRestUrl = slashJoin(wpApiRestUrl, path)
 
         var nonce = nonceRestClient.getNonce(site)
         val usingSavedNonce = nonce is Available


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1579

This seems like a really tricky bug since it seems like the NPE is occurring because site object is getting mutated by another thread while this method is running (more info in the issue discussion). This avoids the issue by instead capturing the `wpApiRestUrl` in a local variable. That way we won't have the NPE even if `site.wpApiRestUrl` gets modified to be `null` from another thread while this method runs. 

I don't love this fix, but I don't have a better idea that doesn't involve significant architectural changes to remove our usage of mutable `SiteModel` objects. **Definitely let me know if you have other ideas for how to address this.**

This avoids the NPE if `site.wpApiRestUrl` gets modified to be `null` from another thread, but it obviously doesn't prevent `site.wpApiRestUrl` from being modified to be `null` by another thread. I don't think there would be any harm from this because it would just mean that the next time we make an API call we will make another call to the discovery API to get the `wpApiRestUrl`.

### Testing

I can't reproduce this NPE directly, so I tested this by running the first 5 tests in [ReactNativeStoreWPAPITest](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/trunk/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt#L79-L215), and using a debug breakpoint to set `site.wpApiRestUrl` to `null` on line 127. In order to get those tests to pass with me manually updating `site.wpApiRestUrl` to be `null` I obviously had to comment out that specific check from those tests (note that the end `fetchUrl` verifications are still there and should still pass).

<details><summary>Removing site.wpApiRestUrl from the tests</summary>

``` diff
diff --git a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
index 952ed0817..eb42e3f04 100644
--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
@@ -99,7 +99,7 @@ class ReactNativeStoreWPAPITest {
 
         val actualResponse = store.executeRequest(site, restPathWithParams)
         assertEquals(callWithSuccess, actualResponse)
-        assertEquals(restUrl, site.wpApiRestUrl, "site should be updated with rest endpoint used for successful call")
+//        assertEquals(restUrl, site.wpApiRestUrl, "site should be updated with rest endpoint used for successful call")
         inOrder(discoveryWPAPIRestClient, sitePersistenceMock, wpApiRestClient, nonceRestClient) {
             verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL(site.url)
             verify(sitePersistenceMock)(site) // persist site after discovering wpApiRestUrl
@@ -142,7 +142,7 @@ class ReactNativeStoreWPAPITest {
 
         val actualResponse = store.executeRequest(site, restPathWithParams)
         assertEquals(initialResponseWithSuccess, actualResponse)
-        assertEquals(restUrl, site.wpApiRestUrl, "site should be updated with rest endpoint used for successful call")
+//        assertEquals(restUrl, site.wpApiRestUrl, "site should be updated with rest endpoint used for successful call")
         inOrder(discoveryWPAPIRestClient, sitePersistenceMock, wpApiRestClient) {
             verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL(site.url)
             verify(sitePersistenceMock)(site) // persist site after discovering wpApiRestUrl
@@ -168,10 +168,10 @@ class ReactNativeStoreWPAPITest {
 
         val actualResponse = store.executeRequest(site, "$restPath?$queryKey=$queryValue")
         assertEquals(successfulResponse, actualResponse)
-        assertEquals(
-                fallbackRestUrl, site.wpApiRestUrl,
-                "site should be updated with rest endpoint used for successful call"
-        )
+//        assertEquals(
+//                fallbackRestUrl, site.wpApiRestUrl,
+//                "site should be updated with rest endpoint used for successful call"
+//        )
         inOrder(discoveryWPAPIRestClient, sitePersistenceMock, wpApiRestClient) {
             verify(discoveryWPAPIRestClient).discoverWPAPIBaseURL(site.url)
             verify(sitePersistenceMock)(site) // persist default endpoint after failed discovery
@@ -204,7 +204,7 @@ class ReactNativeStoreWPAPITest {
 
         val actualResponse = store.executeRequest(site, restPathWithParams)
         assertEquals(secondResponseWithSuccess, actualResponse)
-        assertEquals(restUrl, site.wpApiRestUrl, "should save rest endpoint used for successful call")
+//        assertEquals(restUrl, site.wpApiRestUrl, "should save rest endpoint used for successful call")
         inOrder(discoveryWPAPIRestClient, sitePersistenceMock, wpApiRestClient) {
             verify(wpApiRestClient).fetch(incorrectUrl)
             verify(sitePersistenceMock)(site) // persist site after clearing wpApiRestUrl that resulted in 404 failure

```

</details>

I also tested this by building WPAndroid with this version of fluxc and verifying that the Gutenberg editor still worked fine.