### PR TITLE
woo/wcdatastore-state-fix

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/data/WCDataStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/data/WCDataStoreTest.kt
@@ -106,6 +106,15 @@ class WCDataStoreTest {
         assertThat(states).isEqualTo(emptyList<WCLocationModel>())
     }
 
+    @Test
+    fun `when empty country code is passed, then empty list is returned when getting states`() = test {
+        fetchCountries()
+
+        val states = store.getStates("")
+
+        assertThat(states).isEqualTo(emptyList<WCLocationModel>())
+    }
+
     private suspend fun fetchCountries(): WooResult<List<WCLocationModel>> {
         val payload = WooPayload(sampleResponse.toTypedArray())
         whenever(restClient.fetchCountries(site)).thenReturn(payload)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCCountriesSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCCountriesSqlUtils.kt
@@ -14,11 +14,15 @@ object WCCountriesSqlUtils {
     }
 
     fun getStates(country: String): List<WCLocationModel> {
-        return WellSql.select(WCLocationModel::class.java)
+        return if (country.isNotEmpty()) {
+            WellSql.select(WCLocationModel::class.java)
                 .where()
                 .equals(WCLocationsTable.PARENT_CODE, country)
                 .endWhere()
                 .asModel
+        } else {
+            emptyList()
+        }
     }
 
     fun insertOrUpdateLocations(locations: List<WCLocationModel>): Int {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCDataStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCDataStore.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WCDataStore @Inject constructor(
+class x @Inject constructor(
     private val restClient: WCDataRestClient,
     private val coroutineEngine: CoroutineEngine,
     private val mapper: WCCountryMapper

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCDataStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCDataStore.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class x @Inject constructor(
+class WCDataStore @Inject constructor(
     private val restClient: WCDataRestClient,
     private val coroutineEngine: CoroutineEngine,
     private val mapper: WCCountryMapper


### PR DESCRIPTION
Fixes #2393 - this PR resolves the problem where asking for a list of states returns a list of countries if the country code is blank. This will fix [this related WCAndroid issue](https://github.com/woocommerce/woocommerce-android/issues/5816).

To test, simply run the test added in this PR.