### PR TITLE
Add FOLLOWER_TYPES to InsightType

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -177,6 +177,7 @@ class StatsStore
         TOTAL_LIKES,
         TOTAL_COMMENTS,
         TOTAL_FOLLOWERS,
+        FOLLOWER_TYPES,
         FOLLOWER_TOTALS,
         TAGS_AND_CATEGORIES,
         ANNUAL_SITE_STATS,


### PR DESCRIPTION
New Insight type `FOLLOWER_TYPES` is added to `InsightType` to be used in Stats Revamp v2 project.