### PR TITLE
Extract AndroidX Test Core Dependency Version Declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,14 +77,14 @@ ext {
     arch_lifecycle_version = '1.1.1'
     arch_core_version = '2.0.1'
     appcompat_version = '1.0.2'
-    mockitoVersion = '3.3.3'
-    assertJVersion = '3.19.0'
     kotlinCoroutinesVersion = '1.3.9'
     roomVersion = "2.4.2"
     wordPressUtilsVersion = "develop-eebc5d8e91a1d90190919f900f924b39c861a528"
 
     // Testing
     androidxTestCoreVersion = '1.4.0'
+    assertJVersion = '3.19.0'
+    mockitoVersion = '3.3.3'
 
     fluxcAnnotationsProjectDependency = project.hasProperty("fluxcAnnotationsVersion") ? "org.wordpress.fluxc:fluxc-annotations:${project.getProperty("fluxcAnnotationsVersion")}" : project(":fluxc-annotations")
     fluxcProcessorProjectDependency = project.hasProperty("fluxcProcessorVersion") ? "org.wordpress.fluxc:fluxc-processor:${project.getProperty("fluxcProcessorVersion")}" : project(":fluxc-processor")

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,9 @@ ext {
     roomVersion = "2.4.2"
     wordPressUtilsVersion = "develop-eebc5d8e91a1d90190919f900f924b39c861a528"
 
+    // Testing
+    androidxTestCoreVersion = '1.4.0'
+
     fluxcAnnotationsProjectDependency = project.hasProperty("fluxcAnnotationsVersion") ? "org.wordpress.fluxc:fluxc-annotations:${project.getProperty("fluxcAnnotationsVersion")}" : project(":fluxc-annotations")
     fluxcProcessorProjectDependency = project.hasProperty("fluxcProcessorVersion") ? "org.wordpress.fluxc:fluxc-processor:${project.getProperty("fluxcProcessorVersion")}" : project(":fluxc-processor")
     fluxcProjectDependency = project.hasProperty("fluxcVersion") ? "org.wordpress:fluxc:${project.getProperty("fluxcVersion")}" : project(":fluxc")

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$gradle.ext.kotlinVersion"
     testImplementation 'org.robolectric:robolectric:4.7.3'
-    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation "org.assertj:assertj-core:$assertJVersion"
@@ -151,7 +151,7 @@ dependencies {
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
     androidTestCompileOnly 'org.glassfish:javax.annotation:10.0-b28'
     // Test orchestrator
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation "androidx.test:runner:$androidxTestCoreVersion"
     androidTestUtil 'androidx.test:orchestrator:1.2.0'
 
     androidTestImplementation "com.goterl:lazysodium-android:5.0.2@aar"

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -84,14 +84,14 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.7.3'
-    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
 
     androidTestImplementation "androidx.room:room-testing:$roomVersion"
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation "androidx.test:runner:$androidxTestCoreVersion"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation "org.assertj:assertj-core:$assertJVersion"
 }


### PR DESCRIPTION
As per the documentation and the table list of all the artifacts in the `androidx.test` group, all the below individual test dependencies should be pointing to the same version:
- `androidx.test:core`
- `androidx.test:runner`

Doing that will make it more consistent and easier to update the `android.text` related to core dependencies.

PS: Additionally, as part of this PR all `testing` related dependency version declarations were move to the newly added `Testing` section for grouping purposes.

## Testing instructions

- CI running both the Unit and UI tests with successfully should be enough.
- Additionally, feel free to run both, the Unit and UI tests, locally to verify success.