### PR TITLE
Removes: Explore Plans from the quick start store

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/quickstart/QuickStartStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/quickstart/QuickStartStoreTest.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.C
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.CREATE_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.EDIT_HOMEPAGE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.ENABLE_POST_SHARING
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.EXPLORE_PLANS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.FOLLOW_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.PUBLISH_POST
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.REVIEW_PAGES
@@ -48,7 +47,6 @@ class QuickStartStoreTest {
     @Test
     fun orderOfDoneTasks() = test {
         // marking tasks as done in random order
-        quickStartStore.setDoneTask(testLocalSiteId, EXPLORE_PLANS, true)
         quickStartStore.setDoneTask(testLocalSiteId, VIEW_SITE, true)
         quickStartStore.setDoneTask(testLocalSiteId, FOLLOW_SITE, true)
         quickStartStore.setDoneTask(testLocalSiteId, CREATE_SITE, true)
@@ -60,9 +58,8 @@ class QuickStartStoreTest {
         assertEquals(VIEW_SITE, completedCustomizeTasks[1])
 
         val completedGrowTasks = quickStartStore.getCompletedTasksByType(testLocalSiteId, GROW)
-        assertEquals(2, completedGrowTasks.size)
+        assertEquals(1, completedGrowTasks.size)
         assertEquals(FOLLOW_SITE, completedGrowTasks[0])
-        assertEquals(EXPLORE_PLANS, completedGrowTasks[1])
 
         // making sure undone tasks are retrieved in a correct order
         val uncompletedCustomizeTasks = quickStartStore.getUncompletedTasksByType(testLocalSiteId, CUSTOMIZE)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
@@ -55,8 +55,7 @@ class QuickStartStore @Inject constructor(
         ENABLE_POST_SHARING(QUICK_START_ENABLE_POST_SHARING_LABEL, GROW, 7),
         PUBLISH_POST(QUICK_START_PUBLISH_POST_LABEL, GROW, 8),
         FOLLOW_SITE(QUICK_START_FOLLOW_SITE_LABEL, GROW, 9),
-        CHECK_STATS(QUICK_START_CHECK_STATS_LABEL, GROW, 10),
-        EXPLORE_PLANS(QUICK_START_EXPLORE_PLANS_LABEL, GROW, 11);
+        CHECK_STATS(QUICK_START_CHECK_STATS_LABEL, GROW, 10);
 
         override fun toString(): String {
             return string
@@ -178,7 +177,6 @@ class QuickStartStore @Inject constructor(
         const val QUICK_START_PUBLISH_POST_LABEL = "publish_post"
         const val QUICK_START_FOLLOW_SITE_LABEL = "follow_site"
         const val QUICK_START_CHECK_STATS_LABEL = "check_stats"
-        const val QUICK_START_EXPLORE_PLANS_LABEL = "explore_plans"
         const val QUICK_START_CHECK_NOTIFIATIONS_LABEL = "check_notifications"
         const val QUICK_START_UPLOAD_MEDIA_LABEL = "upload_media"
     }


### PR DESCRIPTION
Fixes Issue - https://github.com/wordpress-mobile/WordPress-Android/issues/16477

This PR removes Explore Plans Quick start from the FluxC Store

To Test - 
Visit Parent PR for the client app - https://github.com/wordpress-mobile/WordPress-Android/pull/16582

