### PR TITLE
Wc/2410 simple payment status

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -127,8 +127,8 @@ class OrderUpdateStore @Inject internal constructor(
     suspend fun createSimplePayment(
         site: SiteModel,
         amount: String,
-        status: WCOrderStatusModel,
-        isTaxable: Boolean
+        isTaxable: Boolean,
+        status: WCOrderStatusModel? = null
     ): WooResult<OrderEntity> {
         val createOrderRequest = UpdateOrderRequest(
             status = status,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -37,7 +37,7 @@ class OrderUpdateStore @Inject internal constructor(
     private val coroutineEngine: CoroutineEngine,
     private val wcOrderRestClient: OrderRestClient,
     private val ordersDao: OrdersDao,
-    private val siteSqlUtils: SiteSqlUtils,
+    private val siteSqlUtils: SiteSqlUtils
 ) {
     suspend fun updateCustomerOrderNote(
         orderId: Long,


### PR DESCRIPTION
Closes #2410 - adds support for setting the status of a simple payment, which is needed by [this WCAndroid issue](https://github.com/woocommerce/woocommerce-android/issues/6539). To test, simply run the included test and verify it passes.