### PR TITLE
Use mapOf instead of toMap to fix failing test

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -630,9 +630,9 @@ class ProductRestClient @Inject constructor(
      */
     fun updateProductPassword(site: SiteModel, remoteProductId: Long, password: String) {
         val url = WPCOMREST.sites.site(site.siteId).posts.post(remoteProductId).urlV1_2
-        val body = listOfNotNull(
+        val body = mapOf(
                 "password" to password
-        ).toMap()
+        )
 
         val request = WPComGsonRequest.buildPostRequest(url,
                 body,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -34,7 +34,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
-import org.wordpress.android.fluxc.network.utils.toMap
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE
@@ -822,7 +821,6 @@ class ProductRestClient @Inject constructor(
             val variationsUpdates: List<Map<String, Any>> = variationsIds.map { variationId ->
                 modifiedProperties.toMutableMap()
                     .also { properties -> properties["id"] = variationId }
-                    .toMap()
             }
             jetpackTunnelGsonRequestBuilder.syncPostRequest(
                 this@ProductRestClient,


### PR DESCRIPTION
`testUpdateProductPassword` has been failing for the last several days with the following exception:

```
2022-05-17 19:30:28.936 26844-26941/? E/AndroidRuntime: FATAL EXCEPTION: pool-2-thread-1
    Process: org.wordpress.android.fluxc.example, PID: 26844
    org.greenrobot.eventbus.EventBusException: Invoking subscriber failed
        at org.greenrobot.eventbus.EventBus.handleSubscriberException(EventBus.java:537)
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:519)
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:511)
        at org.greenrobot.eventbus.AsyncPoster.run(AsyncPoster.java:46)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:920)
     Caused by: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 1 column 3 path $[0]
        at com.google.gson.Gson.fromJson(Gson.java:939)
        at com.google.gson.Gson.fromJson(Gson.java:892)
        at com.google.gson.Gson.fromJson(Gson.java:841)
        at org.wordpress.android.fluxc.network.utils.JsonExtKt.toMap(JsonExt.kt:20)
        at org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient.updateProductPassword(ProductRestClient.kt:635)
        at org.wordpress.android.fluxc.store.WCProductStore.updateProductPassword(WCProductStore.kt:1144)
        at org.wordpress.android.fluxc.store.WCProductStore.onAction(WCProductStore.kt:860)
        at java.lang.reflect.Method.invoke(Native Method)
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:517)
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:511) 
        at org.greenrobot.eventbus.AsyncPoster.run(AsyncPoster.java:46) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:920) 
     Caused by: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 1 column 3 path $[0]
        at com.google.gson.stream.JsonReader.beginArray(JsonReader.java:350)
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:172)
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:145)
        at com.google.gson.Gson.fromJson(Gson.java:927)
        at com.google.gson.Gson.fromJson(Gson.java:892) 
        at com.google.gson.Gson.fromJson(Gson.java:841) 
        at org.wordpress.android.fluxc.network.utils.JsonExtKt.toMap(JsonExt.kt:20) 
        at org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient.updateProductPassword(ProductRestClient.kt:635) 
        at org.wordpress.android.fluxc.store.WCProductStore.updateProductPassword(WCProductStore.kt:1144) 
        at org.wordpress.android.fluxc.store.WCProductStore.onAction(WCProductStore.kt:860) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:517) 
        at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:511) 
        at org.greenrobot.eventbus.AsyncPoster.run(AsyncPoster.java:46) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:920) 
```

I noticed it's not failing due to a server response as usual with this type of exception. It's failing when we attempt to create a body of the request. 

This PR fixing the failing tests. `However, it's still a draft since I plan to continue investigating what is the root cause of the issue and what change in our codebase caused the test to start failing.` @hichamboushaba Correctly pointed out that the issue was caused by a wrong import to our custom version of `toMap` function which doesn't work in certain cases. The PR is now ready for review - I've left a couple in code comments explaining my train of thoughts.

~@wzieba This issue slightly reminds me the investigation you did regarding lambdas in the new version of Kotlin. Pinging you in case you'd know from the top of your head what is causing this issue. If nothing comes to your mind I'll investigate it tomorrow. Thanks!~

To test:
1. Run `testUpdateProductPassword` and verify it succeeds