### PR TITLE
Removes: Explore Plans from the quick start from the DB with Migration 

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 173
+        return 174
     }
 
     override fun getDbName(): String {
@@ -1847,6 +1847,10 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 172 -> migrate(version) {
                     db.execSQL("ALTER TABLE EditorTheme ADD QUOTE_BLOCK_V2 BOOLEAN")
+                }
+                173 -> migrate(version) {
+                    db.execSQL("DELETE FROM QuickStartTaskModel WHERE TASK_NAME='explore_plans' " +
+                        "AND TASK_TYPE='grow';")
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/16477

This PR removes the Explore Plans quick start from the DB with Migration 

To test 
Visit Parent PR - https://github.com/wordpress-mobile/WordPress-Android/pull/16613