### PR TITLE
Quick Start: Delete "Explore Plan" task rows from "QuickStartTaskModel" table in DB

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 173
+        return 174
     }
 
     override fun getDbName(): String {
@@ -1847,6 +1847,10 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 172 -> migrate(version) {
                     db.execSQL("ALTER TABLE EditorTheme ADD QUOTE_BLOCK_V2 BOOLEAN")
+                }
+                173 -> migrate(version) {
+                    db.execSQL("DELETE FROM QuickStartTaskModel WHERE TASK_NAME='explore_plans' " +
+                        "AND TASK_TYPE='grow';")
                 }
             }
         }


### PR DESCRIPTION
- This PR is a cherry-pick of commit 09296d1 from PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2415. 
- PR #2415 was created to fix a regression issue [Internal Ref: p1653032561125799/1651587009.445519-slack-C011BKNU1V5]. We informed not to release next `WPAndroid` beta pointing to `1.42.1` tag till it included this fix.
- PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2415 was merged to `release/1.42.1` but got stuck as [`1.42.1` tag was already published to S3.](https://buildkite.com/automattic/wordpress-fluxc-android/builds/1243#11282141-9a05-4eb2-bd78-eb734d0015ec/159-191) 
- To resolve the issue, this PR targets `release/1.42.2` which includes all changes from `release/1.42.1` before we merged https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2415.
- `1.42.1` can be ignored now in favor of `release/1.42.2` as `WPAndroid` beta pointing to `1.42.1` was never released.

Note that CI is failing on [release/1.42.1](https://github.com/wordpress-mobile/WordPress-FluxC-Android/tree/release/1.42.1) branch.