### PR TITLE
Add the variation ID list deserialization to WCProductModel

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -92,7 +92,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(product.getAttributeList().size, 2)
             assertEquals(product.getAttributeList().get(0).options.size, 3)
             assertEquals(product.getAttributeList().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
-            assertEquals(product.getNumVariations(), 2)
+            assertEquals(product.getVariationIdList().size, 2)
             assertEquals(product.getDownloadableFiles().size, 1)
             assertEquals(product.downloadExpiry, 10)
             assertEquals(product.downloadLimit, 123123124124)
@@ -113,7 +113,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals(product.getAttributeList().size, 2)
             assertEquals(product.getAttributeList().get(0).options.size, 3)
             assertEquals(product.getAttributeList().get(0).getCommaSeparatedOptions(), "Small, Medium, Large")
-            assertEquals(product.getNumVariations(), 2)
+            assertEquals(product.getVariationIdList().size, 2)
             assertEquals(product.getDownloadableFiles().size, 1)
             assertEquals(product.downloadExpiry, 10)
             assertEquals(product.downloadLimit, 123123124124)
@@ -189,19 +189,19 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
             assertEquals("10,11,12", products[0].getGroupedProductIdList().joinToString(","))
             assertEquals("10,11,12", products[0].getUpsellProductIdList().joinToString(","))
             assertEquals("10,11,12", products[0].getCrossSellProductIdList().joinToString(","))
-            assertEquals(3, products[0].getNumVariations())
+            assertEquals(3, products[0].getVariationIdList().size)
 
             // verify that response as json object in product response is handled correctly
             assertEquals("10,11,12", products[1].getGroupedProductIdList().joinToString(","))
             assertEquals("10,11,12", products[1].getUpsellProductIdList().joinToString(","))
             assertEquals("10,11,12", products[1].getCrossSellProductIdList().joinToString(","))
-            assertEquals(3, products[1].getNumVariations())
+            assertEquals(3, products[1].getVariationIdList().size)
 
             // verify that response as null in product response is handled correctly
             assertEquals(0, products[2].getGroupedProductIdList().size)
             assertEquals(0, products[2].getUpsellProductIdList().size)
             assertEquals(0, products[2].getCrossSellProductIdList().size)
-            assertEquals(0, products[2].getNumVariations())
+            assertEquals(0, products[2].getVariationIdList().size)
             assertEquals(0, products[2].getCategoryList().size)
         }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -97,7 +97,7 @@ class WooProductsFragment : StoreSelectingFragment() {
 
                             val product = wcProductStore.getProductByRemoteId(site, result.remoteProductId)
                             product?.let {
-                                val numVariations = it.getNumVariations()
+                                val numVariations = it.getVariationIdList().size
                                 if (numVariations > 0) {
                                     prependToLog("Single product with $numVariations variations fetched! ${it.name}")
                                 } else {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -409,6 +409,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return productIds
     }
 
+    fun getNumVariations() = getVariationIdList().size
+
     fun getVariationIdList() = parseJson(variations)
 
     fun getGroupedProductIdList() = parseJson(groupedProductIds)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -409,25 +409,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return productIds
     }
 
-    fun getNumVariations(): Int {
-        return try {
-            if (variations.isNotEmpty()) {
-                val jsonElement = Gson().fromJson(variations, JsonElement::class.java)
-                when {
-                    jsonElement.isJsonArray -> {
-                        jsonElement.asJsonArray.size()
-                    }
-                    jsonElement.isJsonObject -> {
-                        jsonElement.asJsonObject.entrySet().size
-                    }
-                    else -> 0
-                }
-            } else 0
-        } catch (e: JsonParseException) {
-            AppLog.e(T.API, e)
-            0
-        }
-    }
+    fun getVariationIdList() = parseJson(variations)
 
     fun getGroupedProductIdList() = parseJson(groupedProductIds)
 


### PR DESCRIPTION
This PR adds the remote variation ID list deserialization. The list is being fetched but only the count has been available to the client.

**To test:**
1. Make sure the unit tests pass