### PR TITLE
Add support for crash logger

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLogger.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLogger.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.logging
+
+interface FluxCCrashLogger {
+    fun recordEvent(message: String, category: String?)
+
+    fun recordException(exception: Throwable, category: String?)
+
+    fun sendReport(exception: Throwable?, tags: Map<String, String>, message: String?)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLoggerProvider.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLoggerProvider.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.fluxc.logging
+
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+
+object FluxCCrashLoggerProvider {
+    var crashLogger: FluxCCrashLogger? = null
+        get() {
+            if (field == null) {
+                AppLog.w(T.MAIN, "FluxCCrashLogger is not initialized.")
+            }
+            return field
+        }
+        private set
+
+    fun initLogger(logger: FluxCCrashLogger) {
+        crashLogger = logger
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLoggerProvider.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLoggerProvider.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 
 object FluxCCrashLoggerProvider {
+    @Volatile
     var crashLogger: FluxCCrashLogger? = null
         get() {
             if (field == null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLoggerProvider.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLoggerProvider.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.logging
 
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.AppLog.T.MAIN
 
 object FluxCCrashLoggerProvider {
     @Volatile
@@ -15,7 +16,20 @@ object FluxCCrashLoggerProvider {
         private set
 
     fun initLogger(logger: FluxCCrashLogger) {
-        if (crashLogger != null) throw IllegalStateException("FLuxCCrashLogger is already initialized")
-        crashLogger = logger
+        if (crashLogger == null) {
+            synchronized(FluxCCrashLoggerProvider.javaClass) {
+                if (crashLogger == null) {
+                    crashLogger = logger
+                } else {
+                    logAlreadyInitialized()
+                }
+            }
+        } else {
+            logAlreadyInitialized()
+        }
+    }
+
+    private fun logAlreadyInitialized() {
+        AppLog.w(MAIN, "FluxCCrashLoggerProvider already initialized.")
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLoggerProvider.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/logging/FluxCCrashLoggerProvider.kt
@@ -15,6 +15,7 @@ object FluxCCrashLoggerProvider {
         private set
 
     fun initLogger(logger: FluxCCrashLogger) {
+        if (crashLogger != null) throw IllegalStateException("FLuxCCrashLogger is already initialized")
         crashLogger = logger
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -94,10 +94,7 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
                 res = mGson.fromJson(json, mClass);
             }
             return Response.success(res, createCacheEntry(response));
-        } catch (UnsupportedEncodingException e) {
-            logRequestPath();
-            return Response.error(new ParseError(e));
-        } catch (JsonSyntaxException e) {
+        } catch (UnsupportedEncodingException | JsonSyntaxException e) {
             logRequestPath();
             return Response.error(new ParseError(e));
         }


### PR DESCRIPTION
This PR 
- Introduces Crash Logger into FluxC
- Records "Request path" when an error occurs while parsing a server response

This is a pretty native but imo a good enough implementation of Crash Logger. The client apps need to initialize the logger using the `FluxCCrashLoggerProvider.initLogger()` method.

This PR also records `request path` when an error occurs while parsing a server response. If the app is using JetpackTunnel, the actual path of the endpoint is stored in `path` parameter. Otherwise, the actual uri path is used. The client apps can for example add a breadcrumb into Sentry so the logs in Sentry contain information about the endpoint which resulted in the parsing error.

To test:
1. Add `AppLog.e(AppLog.T.API, "Testing: path is " + getPath());` above [this line](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/f132e83b5d8d9fb6872ecfec65179b3141ed6f89/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java#L96).
2. Start the example app.
3. Try running different queries - ideally some used by WPAndroid (not using jetpack tunnel) and some used by WCAndroid (using jetpack tunnel).
4. Check the logs and notice the correct path is recorded.

<img width="1861" alt="Screenshot 2022-05-24 at 10 07 27" src="https://user-images.githubusercontent.com/2261188/169981909-f19610c7-df22-4e38-bd31-b4016c696f93.png">

The actual CrashLogging will be tested in a PR in WCAndroid.