### PR TITLE
Issue/add prompt metadata to post

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -96,6 +96,8 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Column private boolean mHasCapabilityEditPost;
     @Column private boolean mHasCapabilityDeletePost;
 
+    @Column private int mAnsweredPromptId;
+
     public PostModel() {}
 
     @Override
@@ -518,6 +520,14 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
 
     public void setDateLocallyChanged(String dateLocallyChanged) {
         mDateLocallyChanged = dateLocallyChanged;
+    }
+
+    public int getAnsweredPromptId() {
+        return mAnsweredPromptId;
+    }
+
+    public void setAnsweredPromptId(int answeredPromptId) {
+        mAnsweredPromptId = answeredPromptId;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -538,8 +538,8 @@ public class PostRestClient extends BaseWPComRestClient {
 
                     if (key.equals("_jetpack_blogging_prompt_key")) {
                         Object metaDataValue = metaData.getValue();
-                        if (metaDataValue instanceof Integer) {
-                            post.setAnsweredPromptId((int) metaDataValue);
+                        if (metaDataValue instanceof String) {
+                            post.setAnsweredPromptId(Integer.parseInt(metaDataValue.toString()));
                         }
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 174
+        return 175
     }
 
     override fun getDbName(): String {
@@ -1861,6 +1861,9 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE SiteModel ADD IS_BLOGGING_REMINDER_ON_SUNDAY BOOLEAN")
                     db.execSQL("ALTER TABLE SiteModel ADD BLOGGING_REMINDER_HOUR INTEGER")
                     db.execSQL("ALTER TABLE SiteModel ADD BLOGGING_REMINDER_MINUTE INTEGER")
+                }
+                174 -> migrate(version) {
+                    db.execSQL("ALTER TABLE PostModel ADD ANSWERED_PROMPT_ID INTEGER")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -30,7 +30,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 175
+        return 176
     }
 
     override fun getDbName(): String {
@@ -1866,7 +1866,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE SiteModel ADD BLOGGING_REMINDER_HOUR INTEGER")
                     db.execSQL("ALTER TABLE SiteModel ADD BLOGGING_REMINDER_MINUTE INTEGER")
                 }
-                174 -> migrate(version) {
+                175 -> migrate(version) {
                     db.execSQL("ALTER TABLE PostModel ADD ANSWERED_PROMPT_ID INTEGER")
                 }
             }


### PR DESCRIPTION
This PR adds answered prompt ID to the post model and supports storing it as a metadata when retrieving or submitting posts.

Before that we only used metadata for geolocation information (not missing in the apps, and left for backward-compatibility reasons) and I added additional handling for blogging prompt metadata when submitting and retrieving post. Metadata is converted into blogging prompt ID which is stored in DB.

Companion WP Android PR is [here](https://github.com/wordpress-mobile/WordPress-Android/pull/16676).