### PR TITLE
[Coupons] Set the missing remote product ID to WCProductVariation table

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -552,13 +552,19 @@ class ProductRestClient @Inject constructor(
         }
 
     @JvmName("handleResultFromProductVariationApiResponse")
-    private fun JetpackResponse<Array<ProductVariationApiResponse>>.handleResultFrom(site: SiteModel) =
+    private fun JetpackResponse<Array<ProductVariationApiResponse>>.handleResultFrom(
+        site: SiteModel,
+        productId: Long
+    ) =
         when (this) {
             is JetpackSuccess -> {
                 data
                     ?.map {
                         it.asProductVariationModel()
-                            .apply { localSiteId = site.id }
+                            .apply {
+                                localSiteId = site.id
+                                remoteProductId = productId
+                            }
                     }
                     .orEmpty()
                     .let { WooPayload(it.toList()) }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -727,7 +727,6 @@ class ProductRestClient @Inject constructor(
         offset: Int = 0
     ): RemoteProductVariationsPayload {
         val url = WOOCOMMERCE.products.id(productId).variations.pathV3
-        val responseType = object : TypeToken<List<ProductVariationApiResponse>>() {}.type
         val params = mutableMapOf(
                 "per_page" to pageSize.toString(),
                 "offset" to offset.toString(),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -797,7 +797,7 @@ class ProductRestClient @Inject constructor(
 
         return WOOCOMMERCE.products.id(productId).variations.pathV3
             .requestProductVariationTo(site, params)
-            .handleResultFrom(site)
+            .handleResultFrom(site, productId)
     }
 
     private suspend fun String.requestProductVariationTo(


### PR DESCRIPTION
This PR fixes an issue where the `remoteProductId` value was not being set after fetching variations. This resulted in variations not being loaded from the DB. 

I also added a test to verify that the variations are being fetched and stored properly now.

**To test:**
Make sure all unit tests pass.