### PR TITLE
[Woo] Some fixes for product categories fetching

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -72,12 +72,12 @@ object ProductSqlUtils {
             .flowOn(Dispatchers.IO)
     }
 
-    fun observeCategories(site: SiteModel): Flow<List<WCProductCategoryModel>> {
+    fun observeCategories(site: SiteModel, sortType: ProductCategorySorting): Flow<List<WCProductCategoryModel>> {
         return categoriesUpdatesTrigger
             .onStart { emit(Unit) }
             .debounce(DEBOUNCE_DELAY_FOR_OBSERVERS)
             .mapLatest {
-                getProductCategoriesForSite(site)
+                getProductCategoriesForSite(site, sortType)
             }
             .flowOn(Dispatchers.IO)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -911,8 +911,11 @@ class WCProductStore @Inject constructor(
     fun observeVariations(site: SiteModel, productId: Long): Flow<List<WCProductVariationModel>> =
         ProductSqlUtils.observeVariations(site, productId)
 
-    fun observeCategories(site: SiteModel): Flow<List<WCProductCategoryModel>> =
-        ProductSqlUtils.observeCategories(site)
+    fun observeCategories(
+        site: SiteModel,
+        sortType: ProductCategorySorting = DEFAULT_CATEGORY_SORTING
+    ): Flow<List<WCProductCategoryModel>> =
+        ProductSqlUtils.observeCategories(site, sortType)
 
     suspend fun submitProductAttributeChanges(
         site: SiteModel,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1294,6 +1294,9 @@ class WCProductStore @Inject constructor(
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
+                    if (offset == 0 && includedCategoryIds.isEmpty() && excludedCategoryIds.isEmpty()) {
+                        ProductSqlUtils.deleteAllProductCategories()
+                    }
                     ProductSqlUtils.insertOrUpdateProductCategories(response.result)
                     val canLoadMore = response.result.size == pageSize
                     WooResult(canLoadMore)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1332,6 +1332,14 @@ class WCProductStore @Inject constructor(
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
+                    if (offset == 0 &&
+                        includedProductIds.isEmpty() &&
+                        excludedProductIds.isEmpty() &&
+                        filterOptions.isEmpty()
+                    ) {
+                        ProductSqlUtils.deleteProductsForSite(site)
+                    }
+
                     ProductSqlUtils.insertOrUpdateProducts(response.result)
                     val canLoadMore = response.result.size == pageSize
                     WooResult(canLoadMore)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1397,6 +1397,13 @@ class WCProductStore @Inject constructor(
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
+                    if (offset == 0 &&
+                        includedVariationIds.isEmpty() &&
+                        excludedVariationIds.isEmpty()
+                    ) {
+                        ProductSqlUtils.deleteVariationsForProduct(site, productId)
+                    }
+
                     ProductSqlUtils.insertOrUpdateProductVariations(response.result)
                     val canLoadMore = response.result.size == pageSize
                     WooResult(canLoadMore)


### PR DESCRIPTION
This small PR just brings some small improvements to improve fetching and pagination of categories:
1. Using a debounce for the exposed Flow of DB changes to avoid emitting multiple events for successive changes.
2. Clear categories when fetching first page.
3. Add sort parameter to the `observeCategories` function.

### Testing
Check the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/6602.