### PR TITLE
Quick Start: Expose Quick Start Status Set

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
@@ -52,7 +52,7 @@ class QuickStartSqlUtils
                 .asModel.firstOrNull()
     }
 
-    private fun getQuickStartStatus(siteId: Long): QuickStartStatusModel? {
+    fun getQuickStartStatus(siteId: Long): QuickStartStatusModel? {
         return WellSql.select(QuickStartStatusModel::class.java)
                 .where().beginGroup()
                 .equals(QuickStartStatusModelTable.SITE_ID, siteId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
@@ -149,6 +149,10 @@ class QuickStartStore @Inject constructor(
                 .sortedBy { it.order }
     }
 
+    fun isQuickStartStatusSet(siteId: Long): Boolean {
+        return quickStartSqlUtils.getQuickStartStatus(siteId) != null
+    }
+
     fun setQuickStartCompleted(siteId: Long, isCompleted: Boolean) {
         quickStartSqlUtils.setQuickStartCompleted(siteId, isCompleted)
     }


### PR DESCRIPTION
This PR adds a function to `QuickStartStore` to return if `Quick Start` status is set in DB.

## How to Test?

See instructions in https://github.com/wordpress-mobile/WordPress-Android/pull/16651
