### PR TITLE
Fix blogging reminder db migration test

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/WPAndroidDatabaseMigrationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/WPAndroidDatabaseMigrationTest.kt
@@ -146,10 +146,8 @@ class WPAndroidDatabaseMigrationTest {
         assertThat(cursor.getInt(2)).isEqualTo(1)
         assertThat(cursor.getInt(4)).isEqualTo(0)
         assertThat(cursor.getInt(8)).isEqualTo(10)
-        assertThat(cursor.getInt(9)).isEqualTo(0)
-        assertThat(cursor.getInt(10)).isEqualTo(10)
-        assertThat(cursor.getInt(11)).isEqualTo(33)
-        assertThat(cursor.getInt(12)).isEqualTo(0)
+        assertThat(cursor.getInt(9)).isEqualTo(33)
+        assertThat(cursor.getInt(10)).isEqualTo(0)
         cursor.close()
         db.close()
     }


### PR DESCRIPTION
This PR fixes blogging reminder db migration test.

Looks like the test was broken initially, and for some reason was not picked up by CI.

To test is you can run the offending test locally and make sure it passes.