### PR TITLE
Observe orders count

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -383,11 +383,6 @@ class WCOrderStoreTest {
 
             // Then COMPLETED orders count = 1
             assertThat(count).isEqualTo(1)
-
-            count = orderStore.observeOrderCountForSite(site).first()
-
-            // Then orders count = 4
-            assertThat(count).isEqualTo(4)
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -12,6 +12,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import com.yarolegovich.wellsql.WellSql
 import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import okhttp3.internal.toImmutableMap
@@ -345,6 +346,49 @@ class WCOrderStoreTest {
         assertThat(ordersDao.getOrder(orderModel.orderId, orderModel.localSiteId)?.status)
                 .isEqualTo(CoreOrderStatus.PROCESSING.value)
         Unit
+    }
+
+    @Test
+    fun testObserveOrdersCount() {
+        runBlocking {
+            val siteId = 5
+            val site = SiteModel().apply { id = siteId }
+            // When inserting 3 PROCESSING and 1 COMPLETED orders
+            for (i in 1L..3L) {
+                OrderTestUtils.generateSampleOrder(
+                    siteId = siteId,
+                    orderId = i,
+                    orderStatus = CoreOrderStatus.PROCESSING.value
+                ).saveToDb()
+            }
+
+            OrderTestUtils.generateSampleOrder(
+                siteId = siteId,
+                orderId = 4L,
+                orderStatus = CoreOrderStatus.COMPLETED.value
+            ).saveToDb()
+
+            // Then PROCESSING orders count = 3
+            var count = orderStore.observeOrderCountForSite(
+                site,
+                listOf(CoreOrderStatus.PROCESSING.value)
+            ).first()
+
+            assertThat(count).isEqualTo(3)
+
+            count = orderStore.observeOrderCountForSite(
+                site,
+                listOf(CoreOrderStatus.COMPLETED.value)
+            ).first()
+
+            // Then COMPLETED orders count = 1
+            assertThat(count).isEqualTo(1)
+
+            count = orderStore.observeOrderCountForSite(site).first()
+
+            // Then orders count = 4
+            assertThat(count).isEqualTo(4)
+        }
     }
 
     private fun setupMissingOrders(): MutableMap<WCOrderSummaryModel, OrderEntity?> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
@@ -58,9 +58,6 @@ abstract class OrdersDao {
     @Query("SELECT COUNT(*) FROM OrderEntity WHERE localSiteId = :localSiteId")
     abstract fun getOrderCountForSite(localSiteId: LocalId): Int
 
-    @Query("SELECT COUNT(*) FROM OrderEntity WHERE localSiteId = :localSiteId")
-    abstract fun observeOrderCountForSite(localSiteId: LocalId): Flow<Int>
-
     @Query("SELECT COUNT(*) FROM OrderEntity WHERE localSiteId = :localSiteId AND status IN (:status)")
     abstract fun observeOrderCountForSite(localSiteId: LocalId, status: List<String>): Flow<Int>
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
@@ -58,6 +58,12 @@ abstract class OrdersDao {
     @Query("SELECT COUNT(*) FROM OrderEntity WHERE localSiteId = :localSiteId")
     abstract fun getOrderCountForSite(localSiteId: LocalId): Int
 
+    @Query("SELECT COUNT(*) FROM OrderEntity WHERE localSiteId = :localSiteId")
+    abstract fun observeOrderCountForSite(localSiteId: LocalId): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM OrderEntity WHERE localSiteId = :localSiteId AND status IN (:status)")
+    abstract fun observeOrderCountForSite(localSiteId: LocalId, status: List<String>): Flow<Int>
+
     @Query("DELETE FROM OrderEntity WHERE localSiteId = :localSiteId AND orderId = :orderId")
     abstract suspend fun deleteOrder(localSiteId: LocalId, orderId: Long)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -351,7 +351,7 @@ class WCOrderStore @Inject constructor(
     }
 
     /**
-     * Observe the changes to number of orders for a given [SiteModel]
+     * Observe the changes to the number of orders for a given [SiteModel]
      *
      * @param site the current site
      * @param statuses an optional list of statuses to filter the list of orders, pass an empty list to include all

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -350,6 +350,21 @@ class WCOrderStore @Inject constructor(
         }
     }
 
+    /**
+     * Observe the changes to number of orders for a given [SiteModel]
+     *
+     * @param site the current site
+     * @param statuses an optional list of statuses to filter the list of orders, pass an empty list to include all
+     *                 orders
+     */
+    fun observeOrderCountForSite(site: SiteModel, statuses: List<String> = emptyList()): Flow<Int> {
+        return if (statuses.isEmpty()) {
+            ordersDao.observeOrderCountForSite(site.localId())
+        } else {
+            ordersDao.observeOrderCountForSite(site.localId(), statuses)
+        }
+    }
+
     fun getOrdersForDescriptor(
         orderListDescriptor: WCOrderListDescriptor,
         orderIds: List<Long>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -354,16 +354,12 @@ class WCOrderStore @Inject constructor(
      * Observe the changes to the number of orders for a given [SiteModel]
      *
      * @param site the current site
-     * @param statuses an optional list of statuses to filter the list of orders, pass an empty list to include all
-     *                 orders
+     * @param statuses a list of statuses to filter the list of orders
      */
-    fun observeOrderCountForSite(site: SiteModel, statuses: List<String> = emptyList()): Flow<Int> {
-        return if (statuses.isEmpty()) {
-            ordersDao.observeOrderCountForSite(site.localId())
-        } else {
-            ordersDao.observeOrderCountForSite(site.localId(), statuses)
-        }
-    }
+    fun observeOrderCountForSite(
+        site: SiteModel,
+        statuses: List<String>
+    ): Flow<Int> = ordersDao.observeOrderCountForSite(site.localId(), statuses)
 
     fun getOrdersForDescriptor(
         orderListDescriptor: WCOrderListDescriptor,


### PR DESCRIPTION
Closes: #2428

### Description
This PR adds a new function for counting the total number of orders in the DB. It does that by relying on an SQLite query using `COUNT` and Room for observing the changes.

### Testing
Run tests in WCOrderStoreTest
See corresponding Woo PR for tests https://github.com/woocommerce/woocommerce-android/pull/6659
