### PR TITLE
Merge 1.42.3 to trunk

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/QuickStartSqlUtils.kt
@@ -52,7 +52,7 @@ class QuickStartSqlUtils
                 .asModel.firstOrNull()
     }
 
-    private fun getQuickStartStatus(siteId: Long): QuickStartStatusModel? {
+    fun getQuickStartStatus(siteId: Long): QuickStartStatusModel? {
         return WellSql.select(QuickStartStatusModel::class.java)
                 .where().beginGroup()
                 .equals(QuickStartStatusModelTable.SITE_ID, siteId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
@@ -149,6 +149,10 @@ class QuickStartStore @Inject constructor(
                 .sortedBy { it.order }
     }
 
+    fun isQuickStartStatusSet(siteId: Long): Boolean {
+        return quickStartSqlUtils.getQuickStartStatus(siteId) != null
+    }
+
     fun setQuickStartCompleted(siteId: Long, isCompleted: Boolean) {
         quickStartSqlUtils.setQuickStartCompleted(siteId, isCompleted)
     }


### PR DESCRIPTION
This change has been reviewed in #2426 and merged to WPAndroid's `release/19.9` branch in https://github.com/wordpress-mobile/WordPress-Android/pull/16651, but hasn't been merged to FluxC's `trunk` yet. The fix is also not included in WPAndroid's current `trunk` which is about to be frozen.

Note that I'll need to admin merge this to continue with WCAndroid code freeze on a Sunday.