### PR TITLE
Woo: Coupons: Allow empty values on restriction fields when updating Coupons.

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
@@ -220,12 +220,15 @@ class CouponRestClient @Inject constructor(
             isShippingFree?.let { put("free_shipping", it) }
             productCategoryIds?.let { put("product_categories", it) }
             excludedProductCategoryIds?.let { put("excluded_product_categories", it) }
-            usageLimit?.let { put("usage_limit", it) }
-            usageLimitPerUser?.let { put("usage_limit_per_user", it) }
-            limitUsageToXItems?.let { put("limit_usage_to_x_items", it) }
             restrictedEmails?.let { put("email_restrictions", it) }
             isForIndividualUse?.let { put("individual_use", it) }
             areSaleItemsExcluded?.let { put("exclude_sale_items", it) }
+
+            // The following fields are allowed to be empty. When updating their values to be empty,
+            // the REST API accepts and treats `0` as empty.
+            put("usage_limit", usageLimit ?: 0)
+            put("usage_limit_per_user", usageLimitPerUser ?: 0)
+            put("limit_usage_to_x_items", limitUsageToXItems ?: 0)
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
@@ -224,8 +224,8 @@ class CouponRestClient @Inject constructor(
             isForIndividualUse?.let { put("individual_use", it) }
             areSaleItemsExcluded?.let { put("exclude_sale_items", it) }
 
-            // The following fields are allowed to be empty. When updating their values to be empty,
-            // the REST API accepts and treats `0` as empty.
+            // The following fields can have empty value. When updating a Coupon,
+            // the REST API accepts and treats `0` as empty for these fields.
             put("usage_limit", usageLimit ?: 0)
             put("usage_limit_per_user", usageLimitPerUser ?: 0)
             put("limit_usage_to_x_items", limitUsageToXItems ?: 0)


### PR DESCRIPTION
Fixes: #2431 

### Description:
This PR allows the update Coupons REST API call to have `0` value for these fields:
- `usage_limit`
- `usage_limit_per_user`
- `limit_usage_to_x_items`

The purpose of the `0` value is to allow merchants to set those optional fields as empty from the app.

**Note:** It's undocumented in the API but it seems to only accept `0` as empty, not empty string or other stuff I've tried.

### To test:
1. Go to Example app > Woo > Coupons,
2. Select a site that contains a Coupon,
3. Find a Coupon ID for testing, either using Fetch Coupons button or via wp-admin,
4. Click "Update Coupon",
5. Clik "Enter Coupon ID", and enter a Coupon ID from step 3. Wait until the data loads,
6. Scroll down to "Usage limit", "Usage limit per user", "Limit usage to X items" fields,
7. Set all of those values as empty,
8. Scroll up and find the check mark on top right to save.
9. Make sure Coupon is saved properly. Check the Coupon in wp-admin and make sure the values for those are empty.

Optional: back in Example app, try entering some value for those fields, save, check, then try emptying it out again. Make sure the data is shown the same in wp-admin.
