### PR TITLE
Add is editable api field

### DIFF
--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/15.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/15.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 15,
-    "identityHash": "c863efcff0193dc66c6a1915f5291d07",
+    "identityHash": "c1b4a5003f85e61f9427f4fa0edea3e1",
     "entities": [
       {
         "tableName": "AddonEntity",
@@ -527,7 +527,7 @@
       },
       {
         "tableName": "OrderEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `number` TEXT NOT NULL, `status` TEXT NOT NULL, `currency` TEXT NOT NULL, `orderKey` TEXT NOT NULL, `dateCreated` TEXT NOT NULL, `dateModified` TEXT NOT NULL, `total` TEXT NOT NULL, `totalTax` TEXT NOT NULL, `shippingTotal` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `paymentMethodTitle` TEXT NOT NULL, `datePaid` TEXT NOT NULL, `pricesIncludeTax` INTEGER NOT NULL, `customerNote` TEXT NOT NULL, `discountTotal` TEXT NOT NULL, `discountCodes` TEXT NOT NULL, `refundTotal` TEXT NOT NULL, `billingFirstName` TEXT NOT NULL, `billingLastName` TEXT NOT NULL, `billingCompany` TEXT NOT NULL, `billingAddress1` TEXT NOT NULL, `billingAddress2` TEXT NOT NULL, `billingCity` TEXT NOT NULL, `billingState` TEXT NOT NULL, `billingPostcode` TEXT NOT NULL, `billingCountry` TEXT NOT NULL, `billingEmail` TEXT NOT NULL, `billingPhone` TEXT NOT NULL, `shippingFirstName` TEXT NOT NULL, `shippingLastName` TEXT NOT NULL, `shippingCompany` TEXT NOT NULL, `shippingAddress1` TEXT NOT NULL, `shippingAddress2` TEXT NOT NULL, `shippingCity` TEXT NOT NULL, `shippingState` TEXT NOT NULL, `shippingPostcode` TEXT NOT NULL, `shippingCountry` TEXT NOT NULL, `shippingPhone` TEXT NOT NULL, `lineItems` TEXT NOT NULL, `shippingLines` TEXT NOT NULL, `feeLines` TEXT NOT NULL, `taxLines` TEXT NOT NULL, `metaData` TEXT NOT NULL, `paymentUrl` TEXT NOT NULL DEFAULT '', `isEditable` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`localSiteId`, `orderId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `number` TEXT NOT NULL, `status` TEXT NOT NULL, `currency` TEXT NOT NULL, `orderKey` TEXT NOT NULL, `dateCreated` TEXT NOT NULL, `dateModified` TEXT NOT NULL, `total` TEXT NOT NULL, `totalTax` TEXT NOT NULL, `shippingTotal` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `paymentMethodTitle` TEXT NOT NULL, `datePaid` TEXT NOT NULL, `pricesIncludeTax` INTEGER NOT NULL, `customerNote` TEXT NOT NULL, `discountTotal` TEXT NOT NULL, `discountCodes` TEXT NOT NULL, `refundTotal` TEXT NOT NULL, `billingFirstName` TEXT NOT NULL, `billingLastName` TEXT NOT NULL, `billingCompany` TEXT NOT NULL, `billingAddress1` TEXT NOT NULL, `billingAddress2` TEXT NOT NULL, `billingCity` TEXT NOT NULL, `billingState` TEXT NOT NULL, `billingPostcode` TEXT NOT NULL, `billingCountry` TEXT NOT NULL, `billingEmail` TEXT NOT NULL, `billingPhone` TEXT NOT NULL, `shippingFirstName` TEXT NOT NULL, `shippingLastName` TEXT NOT NULL, `shippingCompany` TEXT NOT NULL, `shippingAddress1` TEXT NOT NULL, `shippingAddress2` TEXT NOT NULL, `shippingCity` TEXT NOT NULL, `shippingState` TEXT NOT NULL, `shippingPostcode` TEXT NOT NULL, `shippingCountry` TEXT NOT NULL, `shippingPhone` TEXT NOT NULL, `lineItems` TEXT NOT NULL, `shippingLines` TEXT NOT NULL, `feeLines` TEXT NOT NULL, `taxLines` TEXT NOT NULL, `metaData` TEXT NOT NULL, `paymentUrl` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`localSiteId`, `orderId`))",
         "fields": [
           {
             "fieldPath": "localSiteId",
@@ -805,13 +805,6 @@
             "affinity": "TEXT",
             "notNull": true,
             "defaultValue": "''"
-          },
-          {
-            "fieldPath": "isEditable",
-            "columnName": "isEditable",
-            "affinity": "INTEGER",
-            "notNull": true,
-            "defaultValue": "false"
           }
         ],
         "primaryKey": {
@@ -1017,7 +1010,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c863efcff0193dc66c6a1915f5291d07')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c1b4a5003f85e61f9427f4fa0edea3e1')"
     ]
   }
 }

--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/16.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/16.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 16,
-    "identityHash": "2a60f35afe2b155a9eff772e66033583",
+    "identityHash": "152b7abad5ab1a500dc34a02e1e5a389",
     "entities": [
       {
         "tableName": "AddonEntity",
@@ -527,7 +527,7 @@
       },
       {
         "tableName": "OrderEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `number` TEXT NOT NULL, `status` TEXT NOT NULL, `currency` TEXT NOT NULL, `orderKey` TEXT NOT NULL, `dateCreated` TEXT NOT NULL, `dateModified` TEXT NOT NULL, `total` TEXT NOT NULL, `totalTax` TEXT NOT NULL, `shippingTotal` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `paymentMethodTitle` TEXT NOT NULL, `datePaid` TEXT NOT NULL, `pricesIncludeTax` INTEGER NOT NULL, `customerNote` TEXT NOT NULL, `discountTotal` TEXT NOT NULL, `discountCodes` TEXT NOT NULL, `refundTotal` TEXT NOT NULL, `billingFirstName` TEXT NOT NULL, `billingLastName` TEXT NOT NULL, `billingCompany` TEXT NOT NULL, `billingAddress1` TEXT NOT NULL, `billingAddress2` TEXT NOT NULL, `billingCity` TEXT NOT NULL, `billingState` TEXT NOT NULL, `billingPostcode` TEXT NOT NULL, `billingCountry` TEXT NOT NULL, `billingEmail` TEXT NOT NULL, `billingPhone` TEXT NOT NULL, `shippingFirstName` TEXT NOT NULL, `shippingLastName` TEXT NOT NULL, `shippingCompany` TEXT NOT NULL, `shippingAddress1` TEXT NOT NULL, `shippingAddress2` TEXT NOT NULL, `shippingCity` TEXT NOT NULL, `shippingState` TEXT NOT NULL, `shippingPostcode` TEXT NOT NULL, `shippingCountry` TEXT NOT NULL, `shippingPhone` TEXT NOT NULL, `lineItems` TEXT NOT NULL, `shippingLines` TEXT NOT NULL, `feeLines` TEXT NOT NULL, `taxLines` TEXT NOT NULL, `metaData` TEXT NOT NULL, `paymentUrl` TEXT NOT NULL DEFAULT '', `isEditable` INTEGER NOT NULL DEFAULT true, PRIMARY KEY(`localSiteId`, `orderId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `number` TEXT NOT NULL, `status` TEXT NOT NULL, `currency` TEXT NOT NULL, `orderKey` TEXT NOT NULL, `dateCreated` TEXT NOT NULL, `dateModified` TEXT NOT NULL, `total` TEXT NOT NULL, `totalTax` TEXT NOT NULL, `shippingTotal` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `paymentMethodTitle` TEXT NOT NULL, `datePaid` TEXT NOT NULL, `pricesIncludeTax` INTEGER NOT NULL, `customerNote` TEXT NOT NULL, `discountTotal` TEXT NOT NULL, `discountCodes` TEXT NOT NULL, `refundTotal` TEXT NOT NULL, `billingFirstName` TEXT NOT NULL, `billingLastName` TEXT NOT NULL, `billingCompany` TEXT NOT NULL, `billingAddress1` TEXT NOT NULL, `billingAddress2` TEXT NOT NULL, `billingCity` TEXT NOT NULL, `billingState` TEXT NOT NULL, `billingPostcode` TEXT NOT NULL, `billingCountry` TEXT NOT NULL, `billingEmail` TEXT NOT NULL, `billingPhone` TEXT NOT NULL, `shippingFirstName` TEXT NOT NULL, `shippingLastName` TEXT NOT NULL, `shippingCompany` TEXT NOT NULL, `shippingAddress1` TEXT NOT NULL, `shippingAddress2` TEXT NOT NULL, `shippingCity` TEXT NOT NULL, `shippingState` TEXT NOT NULL, `shippingPostcode` TEXT NOT NULL, `shippingCountry` TEXT NOT NULL, `shippingPhone` TEXT NOT NULL, `lineItems` TEXT NOT NULL, `shippingLines` TEXT NOT NULL, `feeLines` TEXT NOT NULL, `taxLines` TEXT NOT NULL, `metaData` TEXT NOT NULL, `paymentUrl` TEXT NOT NULL DEFAULT '', `isEditable` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`localSiteId`, `orderId`))",
         "fields": [
           {
             "fieldPath": "localSiteId",
@@ -811,7 +811,7 @@
             "columnName": "isEditable",
             "affinity": "INTEGER",
             "notNull": true,
-            "defaultValue": "true"
+            "defaultValue": "1"
           }
         ],
         "primaryKey": {
@@ -1017,7 +1017,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2a60f35afe2b155a9eff772e66033583')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '152b7abad5ab1a500dc34a02e1e5a389')"
     ]
   }
 }

--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/16.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/16.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 15,
-    "identityHash": "c863efcff0193dc66c6a1915f5291d07",
+    "version": 16,
+    "identityHash": "2a60f35afe2b155a9eff772e66033583",
     "entities": [
       {
         "tableName": "AddonEntity",
@@ -527,7 +527,7 @@
       },
       {
         "tableName": "OrderEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `number` TEXT NOT NULL, `status` TEXT NOT NULL, `currency` TEXT NOT NULL, `orderKey` TEXT NOT NULL, `dateCreated` TEXT NOT NULL, `dateModified` TEXT NOT NULL, `total` TEXT NOT NULL, `totalTax` TEXT NOT NULL, `shippingTotal` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `paymentMethodTitle` TEXT NOT NULL, `datePaid` TEXT NOT NULL, `pricesIncludeTax` INTEGER NOT NULL, `customerNote` TEXT NOT NULL, `discountTotal` TEXT NOT NULL, `discountCodes` TEXT NOT NULL, `refundTotal` TEXT NOT NULL, `billingFirstName` TEXT NOT NULL, `billingLastName` TEXT NOT NULL, `billingCompany` TEXT NOT NULL, `billingAddress1` TEXT NOT NULL, `billingAddress2` TEXT NOT NULL, `billingCity` TEXT NOT NULL, `billingState` TEXT NOT NULL, `billingPostcode` TEXT NOT NULL, `billingCountry` TEXT NOT NULL, `billingEmail` TEXT NOT NULL, `billingPhone` TEXT NOT NULL, `shippingFirstName` TEXT NOT NULL, `shippingLastName` TEXT NOT NULL, `shippingCompany` TEXT NOT NULL, `shippingAddress1` TEXT NOT NULL, `shippingAddress2` TEXT NOT NULL, `shippingCity` TEXT NOT NULL, `shippingState` TEXT NOT NULL, `shippingPostcode` TEXT NOT NULL, `shippingCountry` TEXT NOT NULL, `shippingPhone` TEXT NOT NULL, `lineItems` TEXT NOT NULL, `shippingLines` TEXT NOT NULL, `feeLines` TEXT NOT NULL, `taxLines` TEXT NOT NULL, `metaData` TEXT NOT NULL, `paymentUrl` TEXT NOT NULL DEFAULT '', `isEditable` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`localSiteId`, `orderId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `number` TEXT NOT NULL, `status` TEXT NOT NULL, `currency` TEXT NOT NULL, `orderKey` TEXT NOT NULL, `dateCreated` TEXT NOT NULL, `dateModified` TEXT NOT NULL, `total` TEXT NOT NULL, `totalTax` TEXT NOT NULL, `shippingTotal` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `paymentMethodTitle` TEXT NOT NULL, `datePaid` TEXT NOT NULL, `pricesIncludeTax` INTEGER NOT NULL, `customerNote` TEXT NOT NULL, `discountTotal` TEXT NOT NULL, `discountCodes` TEXT NOT NULL, `refundTotal` TEXT NOT NULL, `billingFirstName` TEXT NOT NULL, `billingLastName` TEXT NOT NULL, `billingCompany` TEXT NOT NULL, `billingAddress1` TEXT NOT NULL, `billingAddress2` TEXT NOT NULL, `billingCity` TEXT NOT NULL, `billingState` TEXT NOT NULL, `billingPostcode` TEXT NOT NULL, `billingCountry` TEXT NOT NULL, `billingEmail` TEXT NOT NULL, `billingPhone` TEXT NOT NULL, `shippingFirstName` TEXT NOT NULL, `shippingLastName` TEXT NOT NULL, `shippingCompany` TEXT NOT NULL, `shippingAddress1` TEXT NOT NULL, `shippingAddress2` TEXT NOT NULL, `shippingCity` TEXT NOT NULL, `shippingState` TEXT NOT NULL, `shippingPostcode` TEXT NOT NULL, `shippingCountry` TEXT NOT NULL, `shippingPhone` TEXT NOT NULL, `lineItems` TEXT NOT NULL, `shippingLines` TEXT NOT NULL, `feeLines` TEXT NOT NULL, `taxLines` TEXT NOT NULL, `metaData` TEXT NOT NULL, `paymentUrl` TEXT NOT NULL DEFAULT '', `isEditable` INTEGER NOT NULL DEFAULT true, PRIMARY KEY(`localSiteId`, `orderId`))",
         "fields": [
           {
             "fieldPath": "localSiteId",
@@ -811,7 +811,7 @@
             "columnName": "isEditable",
             "affinity": "INTEGER",
             "notNull": true,
-            "defaultValue": "false"
+            "defaultValue": "true"
           }
         ],
         "primaryKey": {
@@ -1017,7 +1017,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c863efcff0193dc66c6a1915f5291d07')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2a60f35afe2b155a9eff772e66033583')"
     ]
   }
 }

--- a/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
+++ b/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
@@ -4,11 +4,13 @@ import androidx.room.migration.AutoMigrationSpec
 import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_10_11
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_11_12
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_15_16
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
@@ -56,8 +58,8 @@ class MigrationTests {
         helper.apply {
             createDatabase(TEST_DB, 6).apply {
                 execSQL(
-                        // language=RoomSql
-                        """
+                    // language=RoomSql
+                    """
                             INSERT INTO OrderEntity VALUES(1, 2, 3, '123', 'processing', '$', 'key', 'date of creation', 'date of modification', '123', '456', '789', 'card', 'by card', 'date paid', 1, 'sample customer note', '213', 'CODE', 123, 'billing first name', 'billing last name', 'billing company', 'billing address1', 'billing address2', 'billing city', 'billing state', 'billing postcode', 'billing country', 'billing email', 'billing phone', 'shipping first name', 'shipping last name', 'shipping company', 'shipping address1', 'shipping address2', 'shipping city', 'shipping state', 'shipping postcode', 'shipping country', 'shipping phone', 'line items', 'shipping lines', 'fee lines', 'meta data')
                         """.trimIndent()
                 )
@@ -66,8 +68,8 @@ class MigrationTests {
             val migratedDb = runMigrationsAndValidate(TEST_DB, 7, true, MIGRATION_6_7)
 
             migratedDb.query(
-                    // language=RoomSql
-                    """
+                // language=RoomSql
+                """
                         SELECT * FROM OrderEntity
                     """.trimIndent()
             )
@@ -119,6 +121,31 @@ class MigrationTests {
         helper.apply {
             createDatabase(TEST_DB, 12).close()
             runMigrationsAndValidate(TEST_DB, 13, true)
+        }
+    }
+
+    @Test
+    fun testMigrate15to16() {
+        helper.apply {
+            createDatabase(TEST_DB, 15).apply {
+                execSQL(
+                    // language=RoomSql
+                    """
+                    INSERT INTO OrderEntity VALUES(1, 2, 3, '123', 'processing', '$', 'key', 'date of creation', 'date of modification', '123', '456', '789', 'card', 'by card', 'date paid', 1, 'sample customer note', '213', 'CODE', 123, 'billing first name', 'billing last name', 'billing company', 'billing address1', 'billing address2', 'billing city', 'billing state', 'billing postcode', 'billing country', 'billing email', 'billing phone', 'shipping first name', 'shipping last name', 'shipping company', 'shipping address1', 'shipping address2', 'shipping city', 'shipping state', 'shipping postcode', 'shipping country', 'shipping phone', 'line items', 'shipping lines', 'fee lines', 'meta data', 'payment url')
+                    """.trimIndent()
+                )
+            }.close()
+
+            val migratedDb = runMigrationsAndValidate(TEST_DB, 16, true, MIGRATION_15_16)
+            val cursor = migratedDb.query(
+                // language=RoomSql
+                """
+                        SELECT * FROM OrderEntity
+                    """.trimIndent()
+            )
+            // Ensure we delete all saved OrderEntities and use the API as the source of true
+            assertThat(cursor.count).isEqualTo(0)
+            cursor.close()
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderEntity.kt
@@ -69,7 +69,7 @@ data class OrderEntity(
     val metaData: String = "",
     @ColumnInfo(name = "paymentUrl", defaultValue = "")
     val paymentUrl: String = "",
-    @ColumnInfo(name = "isEditable", defaultValue = "true")
+    @ColumnInfo(name = "isEditable", defaultValue = "1")
     val isEditable: Boolean = true
 ) {
     companion object {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderEntity.kt
@@ -70,7 +70,7 @@ data class OrderEntity(
     @ColumnInfo(name = "paymentUrl", defaultValue = "")
     val paymentUrl: String = "",
     @ColumnInfo(name = "isEditable", defaultValue = "true")
-    val isEditable: Boolean = false
+    val isEditable: Boolean = true
 ) {
     companion object {
         private val gson by lazy { Gson() }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderEntity.kt
@@ -68,7 +68,9 @@ data class OrderEntity(
     val taxLines: String = "",
     val metaData: String = "",
     @ColumnInfo(name = "paymentUrl", defaultValue = "")
-    val paymentUrl: String = ""
+    val paymentUrl: String = "",
+    @ColumnInfo(name = "isEditable", defaultValue = "true")
+    val isEditable: Boolean = false
 ) {
     companion object {
         private val gson by lazy { Gson() }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
@@ -71,4 +71,5 @@ class OrderDto : Response {
     val meta_data: JsonElement? = null
     val tax_lines: JsonElement? = null
     val payment_url: String? = null
+    val is_editable: Boolean? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -69,7 +69,7 @@ class OrderDtoMapper @Inject internal constructor(
                     taxLines = this.tax_lines.toString(),
                     metaData = this.meta_data.toString(),
                     paymentUrl = this.payment_url ?: "",
-                    isEditable = this.is_editable ?: ( this.status in EDITABLE_STATUSES )
+                    isEditable = this.is_editable ?: (this.status in EDITABLE_STATUSES)
             )
         }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -69,7 +69,7 @@ class OrderDtoMapper @Inject internal constructor(
                     taxLines = this.tax_lines.toString(),
                     metaData = this.meta_data.toString(),
                     paymentUrl = this.payment_url ?: "",
-                    isEditable = this.is_editable ?: this.status in EDITABLE_STATUSES
+                    isEditable = this.is_editable ?: ( this.status in EDITABLE_STATUSES )
             )
         }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -68,7 +68,8 @@ class OrderDtoMapper @Inject internal constructor(
                     feeLines = this.fee_lines.toString(),
                     taxLines = this.tax_lines.toString(),
                     metaData = this.meta_data.toString(),
-                    paymentUrl = this.payment_url ?: ""
+                    paymentUrl = this.payment_url ?: "",
+                    isEditable = this.is_editable ?: this.status in EDITABLE_STATUSES
             )
         }
 
@@ -76,6 +77,7 @@ class OrderDtoMapper @Inject internal constructor(
     }
 
     companion object {
+        val EDITABLE_STATUSES = listOf("pending", "on-hold", "auto-draft")
         fun OrderAddress.Billing.toDto() = OrderDto.Billing(
                 first_name = this.firstName,
                 last_name = this.lastName,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -934,7 +934,8 @@ class OrderRestClient @Inject constructor(
                 "total",
                 "total_tax",
                 "meta_data",
-                "payment_url"
+                "payment_url",
+                "is_editable"
         ).joinToString(separator = ",")
 
         private val TRACKING_FIELDS = arrayOf(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.persistence.entity.InboxNoteEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration13to14
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration14to15
+import org.wordpress.android.fluxc.persistence.migrations.AutoMigration15to16
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_10_11
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_11_12
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
@@ -54,7 +55,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
             AutoMigration(from = 12, to = 13),
             AutoMigration(from = 13, to = 14, spec = AutoMigration13to14::class),
             AutoMigration(from = 14, to = 15, spec = AutoMigration14to15::class),
-            AutoMigration(from = 15, to = 16, spec = AutoMigration14to15::class)
+            AutoMigration(from = 15, to = 16, spec = AutoMigration15to16::class)
         ]
 )
 @TypeConverters(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -53,7 +53,8 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
         autoMigrations = [
             AutoMigration(from = 12, to = 13),
             AutoMigration(from = 13, to = 14, spec = AutoMigration13to14::class),
-            AutoMigration(from = 14, to = 15, spec = AutoMigration14to15::class)
+            AutoMigration(from = 14, to = 15, spec = AutoMigration14to15::class),
+            AutoMigration(from = 15, to = 16, spec = AutoMigration14to15::class)
         ]
 )
 @TypeConverters(
@@ -78,7 +79,7 @@ abstract class WCAndroidDatabase : RoomDatabase(), TransactionExecutor {
                 "wc-android-database"
         ).allowMainThreadQueries()
                 .fallbackToDestructiveMigrationOnDowngrade()
-                .fallbackToDestructiveMigrationFrom(1, 2, 15)
+                .fallbackToDestructiveMigrationFrom(1, 2)
                 .addMigrations(MIGRATION_3_4)
                 .addMigrations(MIGRATION_4_5)
                 .addMigrations(MIGRATION_5_6)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -78,7 +78,7 @@ abstract class WCAndroidDatabase : RoomDatabase(), TransactionExecutor {
                 "wc-android-database"
         ).allowMainThreadQueries()
                 .fallbackToDestructiveMigrationOnDowngrade()
-                .fallbackToDestructiveMigrationFrom(1, 2)
+                .fallbackToDestructiveMigrationFrom(1, 2, 15)
                 .addMigrations(MIGRATION_3_4)
                 .addMigrations(MIGRATION_4_5)
                 .addMigrations(MIGRATION_5_6)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -27,9 +27,9 @@ import org.wordpress.android.fluxc.persistence.entity.InboxNoteEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration13to14
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration14to15
-import org.wordpress.android.fluxc.persistence.migrations.AutoMigration15to16
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_10_11
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_11_12
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_15_16
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
@@ -54,8 +54,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
         autoMigrations = [
             AutoMigration(from = 12, to = 13),
             AutoMigration(from = 13, to = 14, spec = AutoMigration13to14::class),
-            AutoMigration(from = 14, to = 15, spec = AutoMigration14to15::class),
-            AutoMigration(from = 15, to = 16, spec = AutoMigration15to16::class)
+            AutoMigration(from = 14, to = 15, spec = AutoMigration14to15::class)
         ]
 )
 @TypeConverters(
@@ -90,6 +89,7 @@ abstract class WCAndroidDatabase : RoomDatabase(), TransactionExecutor {
                 .addMigrations(MIGRATION_9_10)
                 .addMigrations(MIGRATION_10_11)
                 .addMigrations(MIGRATION_11_12)
+                .addMigrations(MIGRATION_15_16)
                 .build()
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -38,7 +38,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_8_9
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
 
 @Database(
-        version = 15,
+        version = 16,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -83,7 +83,7 @@ internal val MIGRATION_5_6 = object : Migration(5, 6) {
             execSQL("DROP TABLE OrderEntity")
             execSQL(
                 // language=RoomSql
-                """ CREATE TABLE IF NOT EXISTS OrderEntity (
+                """CREATE TABLE IF NOT EXISTS OrderEntity (
                         `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                         `localSiteId` INTEGER NOT NULL,
                         `remoteOrderId` INTEGER NOT NULL,
@@ -522,7 +522,7 @@ internal val MIGRATION_15_16 = object : Migration(15, 16) {
             // language=RoomSql
             execSQL(
                 """
-                CREATE TABLE `OrderEntity` (
+                CREATE TABLE IF NOT EXISTS  `OrderEntity` (
                   `localSiteId` INTEGER NOT NULL,
                   `orderId` INTEGER NOT NULL,
                   `number` TEXT NOT NULL,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -10,7 +10,7 @@ internal val MIGRATION_3_4 = object : Migration(3, 4) {
         database.apply {
             // language=RoomSql
             execSQL(
-                    """
+                """
                               CREATE TABLE IF NOT EXISTS `OrderEntity` (
                                 `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                                 `localSiteId` INTEGER NOT NULL,
@@ -62,7 +62,7 @@ internal val MIGRATION_3_4 = object : Migration(3, 4) {
             )
             // language=RoomSql
             execSQL(
-                    """
+                """
                             CREATE UNIQUE INDEX IF NOT EXISTS `index_OrderEntity_localSiteId_remoteOrderId` 
                             ON `OrderEntity` (`localSiteId`, `remoteOrderId`);
                     """.trimIndent()
@@ -82,8 +82,8 @@ internal val MIGRATION_5_6 = object : Migration(5, 6) {
         database.apply {
             execSQL("DROP TABLE OrderEntity")
             execSQL(
-                    // language=RoomSql
-                    """ CREATE TABLE IF NOT EXISTS OrderEntity (
+                // language=RoomSql
+                """ CREATE TABLE IF NOT EXISTS OrderEntity (
                         `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
                         `localSiteId` INTEGER NOT NULL,
                         `remoteOrderId` INTEGER NOT NULL,
@@ -132,8 +132,8 @@ internal val MIGRATION_5_6 = object : Migration(5, 6) {
                     """.trimIndent()
             )
             execSQL(
-                    // language=RoomSql
-                    """
+                // language=RoomSql
+                """
                             CREATE UNIQUE INDEX IF NOT EXISTS `index_OrderEntity_localSiteId_remoteOrderId` 
                             ON `OrderEntity` (`localSiteId`, `remoteOrderId`);
                     """.trimIndent()
@@ -150,7 +150,8 @@ internal val MIGRATION_6_7 = object : Migration(6, 7) {
 
 internal val MIGRATION_7_8 = object : Migration(7, 8) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("""
+        database.execSQL(
+            """
             CREATE TABLE IF NOT EXISTS OrderNotes (
                 siteId INTEGER NOT NULL,
                 noteId INTEGER NOT NULL,
@@ -161,7 +162,8 @@ internal val MIGRATION_7_8 = object : Migration(7, 8) {
                 isSystemNote INTEGER NOT NULL,
                 isCustomerNote INTEGER NOT NULL,
                 PRIMARY KEY(`siteId`, `noteId`))
-        """.trimIndent())
+        """.trimIndent()
+        )
     }
 }
 
@@ -354,8 +356,8 @@ internal val MIGRATION_9_10 = object : Migration(9, 10) {
         database.apply {
             execSQL("DROP TABLE OrderEntity")
             execSQL(
-                    // language=RoomSql
-                    """ 
+                // language=RoomSql
+                """ 
                         CREATE TABLE IF NOT EXISTS OrderEntity (
                         `localSiteId` INTEGER NOT NULL,
                         `orderId` INTEGER NOT NULL,
@@ -407,8 +409,8 @@ internal val MIGRATION_9_10 = object : Migration(9, 10) {
                     """.trimIndent()
             )
             execSQL(
-                    // language=RoomSql
-                    """
+                // language=RoomSql
+                """
                         CREATE INDEX IF NOT EXISTS `index_OrderEntity_localSiteId_orderId` 
                         ON `OrderEntity` (`localSiteId`, `orderId`);
                     """.trimIndent()
@@ -513,5 +515,72 @@ internal class AutoMigration13to14 : AutoMigrationSpec
 @DeleteTable(tableName = "ProductCategories")
 internal class AutoMigration14to15 : AutoMigrationSpec
 
-@DeleteTable(tableName = "OrderEntity")
-internal class AutoMigration15to16 : AutoMigrationSpec
+internal val MIGRATION_15_16 = object : Migration(15, 16) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.apply {
+            execSQL("DROP TABLE OrderEntity")
+            // language=RoomSql
+            execSQL(
+                """
+                CREATE TABLE `OrderEntity` (
+                  `localSiteId` INTEGER NOT NULL,
+                  `orderId` INTEGER NOT NULL,
+                  `number` TEXT NOT NULL,
+                  `status` TEXT NOT NULL,
+                  `currency` TEXT NOT NULL,
+                  `orderKey` TEXT NOT NULL,
+                  `dateCreated` TEXT NOT NULL,
+                  `dateModified` TEXT NOT NULL,
+                  `total` TEXT NOT NULL,
+                  `totalTax` TEXT NOT NULL,
+                  `shippingTotal` TEXT NOT NULL,
+                  `paymentMethod` TEXT NOT NULL,
+                  `paymentMethodTitle` TEXT NOT NULL,
+                  `datePaid` TEXT NOT NULL,
+                  `pricesIncludeTax` INTEGER NOT NULL,
+                  `customerNote` TEXT NOT NULL,
+                  `discountTotal` TEXT NOT NULL,
+                  `discountCodes` TEXT NOT NULL,
+                  `refundTotal` TEXT NOT NULL,
+                  `billingFirstName` TEXT NOT NULL,
+                  `billingLastName` TEXT NOT NULL,
+                  `billingCompany` TEXT NOT NULL,
+                  `billingAddress1` TEXT NOT NULL,
+                  `billingAddress2` TEXT NOT NULL,
+                  `billingCity` TEXT NOT NULL,
+                  `billingState` TEXT NOT NULL,
+                  `billingPostcode` TEXT NOT NULL,
+                  `billingCountry` TEXT NOT NULL,
+                  `billingEmail` TEXT NOT NULL,
+                  `billingPhone` TEXT NOT NULL,
+                  `shippingFirstName` TEXT NOT NULL,
+                  `shippingLastName` TEXT NOT NULL,
+                  `shippingCompany` TEXT NOT NULL,
+                  `shippingAddress1` TEXT NOT NULL,
+                  `shippingAddress2` TEXT NOT NULL,
+                  `shippingCity` TEXT NOT NULL,
+                  `shippingState` TEXT NOT NULL,
+                  `shippingPostcode` TEXT NOT NULL,
+                  `shippingCountry` TEXT NOT NULL,
+                  `shippingPhone` TEXT NOT NULL,
+                  `lineItems` TEXT NOT NULL,
+                  `shippingLines` TEXT NOT NULL,
+                  `feeLines` TEXT NOT NULL,
+                  `taxLines` TEXT NOT NULL,
+                  `metaData` TEXT NOT NULL,
+                  `paymentUrl` TEXT NOT NULL DEFAULT '',
+                  `isEditable` INTEGER NOT NULL DEFAULT 1,
+                  PRIMARY KEY(`localSiteId`, `orderId`)
+                )
+            """.trimIndent()
+            )
+            execSQL(
+                // language=RoomSql
+                """
+                    CREATE INDEX IF NOT EXISTS `index_OrderEntity_localSiteId_orderId` 
+                    ON `OrderEntity` (`localSiteId`, `orderId`);
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -512,3 +512,6 @@ internal class AutoMigration13to14 : AutoMigrationSpec
 @DeleteTable(tableName = "Products")
 @DeleteTable(tableName = "ProductCategories")
 internal class AutoMigration14to15 : AutoMigrationSpec
+
+@DeleteTable(tableName = "OrderEntity")
+internal class AutoMigration15to16 : AutoMigrationSpec

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapperTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapperTest.kt
@@ -1,0 +1,66 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.AdditionalAnswers
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.model.OrderEntity
+
+internal class OrderDtoMapperTest {
+    private val stripOrder: StripOrder = mock {
+        on { invoke(any()) }.then(AdditionalAnswers.returnsFirstArg<OrderEntity>())
+    }
+    val localSiteId = LocalOrRemoteId.LocalId(0)
+    val sut = OrderDtoMapper(stripOrder)
+
+    @Test
+    fun `when is_editable is NULL and the status is an editable status the order in Editable`() {
+        for (status in OrderDtoMapper.EDITABLE_STATUSES) {
+            val oldOrderDTO = getEditableOrder(
+                isEditable = null,
+                status = status
+            )
+            val orderEntity = sut.toDatabaseEntity(oldOrderDTO, localSiteId)
+            assertThat(orderEntity.isEditable).isEqualTo(true)
+        }
+    }
+
+    @Test
+    fun `when is_editable is NULL and the status is not an editable status the order is not Editable`() {
+        val oldOrderDTO = getEditableOrder(isEditable = null, status = "")
+        val orderEntity = sut.toDatabaseEntity(oldOrderDTO, localSiteId)
+        assertThat(orderEntity.isEditable).isEqualTo(false)
+    }
+
+    @Test
+    fun `when is_editable field is true the order is Editable`() {
+        val oldOrderDTO = getEditableOrder(isEditable = true, status = "")
+        val orderEntity = sut.toDatabaseEntity(oldOrderDTO, localSiteId)
+        assertThat(orderEntity.isEditable).isEqualTo(true)
+    }
+
+    @Test
+    fun `when is_editable field is false the order is not Editable`() {
+        // We only check for editable statuses if the is_editable field is null
+        for (status in OrderDtoMapper.EDITABLE_STATUSES) {
+            val oldOrderDTO = getEditableOrder(isEditable = false, status = status)
+            val orderEntity = sut.toDatabaseEntity(oldOrderDTO, localSiteId)
+            assertThat(orderEntity.isEditable).isEqualTo(false)
+        }
+    }
+
+    private fun getEditableOrder(
+        isEditable: Boolean?,
+        status: String = "auto-draft"
+    ): OrderDto {
+        val json = JsonObject().apply {
+            addProperty("status", status)
+            isEditable?.let { value -> addProperty("is_editable", value) }
+        }
+        return Gson().fromJson(json, OrderDto::class.java)
+    }
+}


### PR DESCRIPTION
### Description
This PR adds the is_editable field to the database and uses a fallback strategy for older stores.

### Testing instructions
run testMigrate15to16
run OrderDtoMapperTest
For a full set of tests check the [Woo PR](https://github.com/woocommerce/woocommerce-android/pull/6684)