### PR TITLE
Fetch order summaries after adding a new order

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -239,6 +239,8 @@ class OrderUpdateStore @Inject internal constructor(
             } else {
                 val model = result.result!!
                 ordersDao.insertOrUpdateOrder(model)
+                // Emit a request to refresh the list of order summaries to make sure the added order is
+                // added to the list
                 dispatcher.dispatch(
                     WCOrderActionBuilder.newFetchOrderListAction(
                         FetchOrderListPayload(offset = 0, listDescriptor = WCOrderListDescriptor(site = site))

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScope
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
@@ -44,6 +45,7 @@ class OrderUpdateStoreTest {
     private val siteSqlUtils: SiteSqlUtils = mock {
         on { getSiteWithLocalId(any()) } doReturn site
     }
+    private val dispatcher: Dispatcher = mock()
 
     private val ordersDao: OrdersDao = mock {
         onBlocking { getOrder(TEST_REMOTE_ORDER_ID, TEST_LOCAL_SITE_ID) } doReturn initialOrder
@@ -52,6 +54,7 @@ class OrderUpdateStoreTest {
     fun setUp(setMocks: suspend () -> Unit) = runBlocking {
         setMocks.invoke()
         sut = OrderUpdateStore(
+                dispatcher = dispatcher,
                 coroutineEngine = CoroutineEngine(
                         TestCoroutineScope().coroutineContext,
                         mock()


### PR DESCRIPTION
This is needed to fix the issue https://github.com/woocommerce/woocommerce-android/issues/6693

Check the PR https://github.com/woocommerce/woocommerce-android/pull/6706 for details.