### PR TITLE
[Woo] add support for searching product categories

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -507,6 +507,7 @@ class ProductRestClient @Inject constructor(
         site: SiteModel,
         includedCategoryIds: List<Long> = emptyList(),
         excludedCategoryIds: List<Long> = emptyList(),
+        searchQuery: String? = null,
         pageSize: Int = DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE,
         productCategorySorting: ProductCategorySorting = DEFAULT_CATEGORY_SORTING,
         offset: Int = 0
@@ -521,7 +522,7 @@ class ProductRestClient @Inject constructor(
             "offset" to offset.toString(),
             "order" to sortOrder,
             "orderby" to "name"
-        )
+        ).putIfNotEmpty("search" to searchQuery)
         if (includedCategoryIds.isNotEmpty()) {
             params["include"] = includedCategoryIds.map { it }.joinToString()
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -596,6 +596,19 @@ object ProductSqlUtils {
                 .asModel.firstOrNull()
     }
 
+    fun getProductCategoriesByRemoteIds(
+        site: SiteModel,
+        categoryIds: List<Long>
+    ): List<WCProductCategoryModel> {
+        return WellSql.select(WCProductCategoryModel::class.java)
+            .where()
+            .beginGroup()
+            .isIn(WCProductCategoryModelTable.REMOTE_CATEGORY_ID, categoryIds)
+            .equals(WCProductCategoryModelTable.LOCAL_SITE_ID, site.id)
+            .endGroup().endWhere()
+            .asModel
+    }
+
     fun getProductCategoryByNameAndParentId(
         localSiteId: Int,
         categoryName: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1394,7 +1394,11 @@ class WCProductStore @Inject constructor(
                 response.result != null -> {
                     ProductSqlUtils.insertOrUpdateProductCategories(response.result)
                     val productIds = response.result.map { it.remoteCategoryId }
-                    val categories = ProductSqlUtils.getProductCategoriesByRemoteIds(site, productIds)
+                    val categories = if (productIds.isNotEmpty()) {
+                        ProductSqlUtils.getProductCategoriesByRemoteIds(site, productIds)
+                    } else {
+                        emptyList()
+                    }
                     val canLoadMore = response.result.size == pageSize
                     WooResult(ProductCategorySearchResult(categories, canLoadMore))
                 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1376,6 +1376,33 @@ class WCProductStore @Inject constructor(
         }
     }
 
+    suspend fun searchProductCategories(
+        site: SiteModel,
+        searchString: String,
+        offset: Int = 0,
+        pageSize: Int = DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE
+    ): WooResult<ProductCategorySearchResult> {
+        return coroutineEngine.withDefaultContext(API, this, "searchProducts") {
+            val response = wcProductRestClient.fetchProductsCategoriesWithSyncRequest(
+                site = site,
+                offset = offset,
+                pageSize = pageSize,
+                searchQuery = searchString
+            )
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> {
+                    ProductSqlUtils.insertOrUpdateProductCategories(response.result)
+                    val productIds = response.result.map { it.remoteCategoryId }
+                    val categories = ProductSqlUtils.getProductCategoriesByRemoteIds(site, productIds)
+                    val canLoadMore = response.result.size == pageSize
+                    WooResult(ProductCategorySearchResult(categories, canLoadMore))
+                }
+                else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+
     // Returns a boolean indicating whether more coupons can be fetched
     suspend fun fetchProductVariations(
         site: SiteModel,
@@ -1705,6 +1732,11 @@ class WCProductStore @Inject constructor(
 
     data class ProductSearchResult(
         val products: List<WCProductModel>,
+        val canLoadMore: Boolean
+    )
+
+    data class ProductCategorySearchResult(
+        val categories: List<WCProductCategoryModel>,
         val canLoadMore: Boolean
     )
 }


### PR DESCRIPTION
This simply adds an additional function to search for product categories, it reuses the same network implementation with just an additional parameter for the search query.

Check https://github.com/woocommerce/woocommerce-android/pull/6722 for testing instructions.