### PR TITLE
[Coupons] Fix product search empty result

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1367,7 +1367,11 @@ class WCProductStore @Inject constructor(
                 response.result != null -> {
                     ProductSqlUtils.insertOrUpdateProducts(response.result)
                     val productIds = response.result.map { it.remoteProductId }
-                    val products = ProductSqlUtils.getProductsByRemoteIds(site, productIds)
+                    val products = if (productIds.isNotEmpty()) {
+                        ProductSqlUtils.getProductsByRemoteIds(site, productIds)
+                    } else {
+                        emptyList()
+                    }
                     val canLoadMore = response.result.size == pageSize
                     WooResult(ProductSearchResult(products, canLoadMore))
                 }
@@ -1393,9 +1397,9 @@ class WCProductStore @Inject constructor(
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
                     ProductSqlUtils.insertOrUpdateProductCategories(response.result)
-                    val productIds = response.result.map { it.remoteCategoryId }
-                    val categories = if (productIds.isNotEmpty()) {
-                        ProductSqlUtils.getProductCategoriesByRemoteIds(site, productIds)
+                    val categoryIds = response.result.map { it.remoteCategoryId }
+                    val categories = if (categoryIds.isNotEmpty()) {
+                        ProductSqlUtils.getProductCategoriesByRemoteIds(site, categoryIds)
                     } else {
                         emptyList()
                     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1386,7 +1386,11 @@ class WCProductStore @Inject constructor(
         offset: Int = 0,
         pageSize: Int = DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE
     ): WooResult<ProductCategorySearchResult> {
-        return coroutineEngine.withDefaultContext(API, this, "searchProducts") {
+        return coroutineEngine.withDefaultContext(
+            API,
+            this,
+            "searchProductCategories"
+        ) {
             val response = wcProductRestClient.fetchProductsCategoriesWithSyncRequest(
                 site = site,
                 offset = offset,


### PR DESCRIPTION
This PR fixes a crash that that occurs if the search result is empty.

**To test:**
Run the app and test the product search in [WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/6735).