### PR TITLE
Add heic, heif image format support

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/MimeTypesTest.kt
@@ -52,6 +52,8 @@ class MimeTypesTest {
                         "image/png",
                         "image/gif",
                         "image/webp",
+                        "image/heic",
+                        "image/heif",
                         "application/pdf",
                         "application/msword",
                         "application/doc",
@@ -91,7 +93,9 @@ class MimeTypesTest {
                         "image/jpeg",
                         "image/png",
                         "image/gif",
-                        "image/webp"
+                        "image/webp",
+                        "image/heic",
+                        "image/heif"
                 )
         )
     }
@@ -105,7 +109,9 @@ class MimeTypesTest {
                         "image/jpeg",
                         "image/png",
                         "image/gif",
-                        "image/webp"
+                        "image/webp",
+                        "image/heic",
+                        "image/heif"
                 )
         )
     }
@@ -184,6 +190,8 @@ class MimeTypesTest {
             "image/png",
             "image/gif",
             "image/webp",
+            "image/heic",
+            "image/heif",
             "application/pdf",
             "application/msword",
             "application/doc",

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeType.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeType.kt
@@ -29,6 +29,8 @@ data class MimeType(val type: Type, val subtypes: List<Subtype>, val extensions:
         PNG("png"),
         GIF("gif"),
         WEBP("webp"),
+        HEIC("heic"),
+        HEIF("heif"),
         PDF("pdf"),
         DOC("doc"),
         MSDOC("ms-doc"),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -68,12 +68,16 @@ class MimeTypes {
      * .png - "image/png"
      * .gif - "image/gif"
      * .webp - "image/webp"
+     * .heic - "image/heic"
+     * .heif - "image/heif"
      */
     private val imageTypes = listOf(
             MimeType(IMAGE, Subtype.JPEG, listOf("jpg", "jpeg")),
             MimeType(IMAGE, Subtype.PNG, listOf("png")),
             MimeType(IMAGE, Subtype.GIF, listOf("gif")),
-            MimeType(IMAGE, Subtype.WEBP, listOf("webp"))
+            MimeType(IMAGE, Subtype.WEBP, listOf("webp")),
+            MimeType(IMAGE, Subtype.HEIC, listOf("heic")),
+            MimeType(IMAGE, Subtype.HEIF, listOf("heif"))
     )
 
     /*


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/16367

This PR adds support for `heic`, `heif` image formats.

### How to Test?

See corresponding WPAndroid PR:

https://github.com/wordpress-mobile/WordPress-Android/pull/16773