### PR TITLE
Fixed canGetOrderStatusOptions test

### DIFF
--- a/tests/api/src/test/java/APITesting_WCOrder.java
+++ b/tests/api/src/test/java/APITesting_WCOrder.java
@@ -86,7 +86,7 @@ public class APITesting_WCOrder {
             get().
         then().
             statusCode(200).
-            body("data", hasSize(7));
+            body("data", hasSize(8));
     }
 
     @Test


### PR DESCRIPTION
The PR fixes `canGetOrderStatusOptions`. Apparently the response has changed

https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-FluxC-Android/7459/workflows/b4eeac6b-dae6-4898-b7af-7be28411cc6d/jobs/19041