### PR TITLE
Stats Revamp v2: Update insights to new set of defaults

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -47,8 +47,7 @@ val DEFAULT_INSIGHTS = listOf(
         MOST_POPULAR_DAY_AND_HOUR,
         ALL_TIME_STATS,
         TODAY_STATS,
-        FOLLOWERS,
-        COMMENTS
+        FOLLOWERS
 )
 
 val JETPACK_DEFAULT_INSIGHTS = listOf(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -22,7 +22,6 @@ import org.wordpress.android.fluxc.store.StatsStore.InsightType.ACTION_GROW
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.ACTION_REMINDER
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.ACTION_SCHEDULE
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.ALL_TIME_STATS
-import org.wordpress.android.fluxc.store.StatsStore.InsightType.COMMENTS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.FOLLOWERS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.LATEST_POST_SUMMARY
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.MOST_POPULAR_DAY_AND_HOUR

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -44,9 +44,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 val DEFAULT_INSIGHTS = listOf(
-        VIEWS_AND_VISITORS,
-        TOTAL_LIKES,
-        TOTAL_COMMENTS,
         TOTAL_FOLLOWERS,
         MOST_POPULAR_DAY_AND_HOUR,
         LATEST_POST_SUMMARY,
@@ -55,6 +52,14 @@ val DEFAULT_INSIGHTS = listOf(
         FOLLOWERS,
         COMMENTS
 )
+
+val JETPACK_DEFAULT_INSIGHTS = listOf(
+        VIEWS_AND_VISITORS,
+        TOTAL_LIKES,
+        TOTAL_COMMENTS,
+        TOTAL_FOLLOWERS
+)
+
 val STATS_UNAVAILABLE_WITH_JETPACK = listOf(FILE_DOWNLOADS)
 const val INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN = "INSIGHTS_MANAGEMENT_NEWS_CARD_SHOWN"
 
@@ -225,12 +230,12 @@ class StatsStore
 
     enum class InsightType : StatsType {
         VIEWS_AND_VISITORS,
-        LATEST_POST_SUMMARY,
-        MOST_POPULAR_DAY_AND_HOUR,
-        ALL_TIME_STATS,
         TOTAL_LIKES,
         TOTAL_COMMENTS,
         TOTAL_FOLLOWERS,
+        LATEST_POST_SUMMARY,
+        MOST_POPULAR_DAY_AND_HOUR,
+        ALL_TIME_STATS,
         FOLLOWER_TYPES,
         FOLLOWER_TOTALS,
         TAGS_AND_CATEGORIES,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -44,9 +44,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 val DEFAULT_INSIGHTS = listOf(
-        TOTAL_FOLLOWERS,
         MOST_POPULAR_DAY_AND_HOUR,
-        LATEST_POST_SUMMARY,
         ALL_TIME_STATS,
         TODAY_STATS,
         FOLLOWERS,
@@ -57,7 +55,9 @@ val JETPACK_DEFAULT_INSIGHTS = listOf(
         VIEWS_AND_VISITORS,
         TOTAL_LIKES,
         TOTAL_COMMENTS,
-        TOTAL_FOLLOWERS
+        TOTAL_FOLLOWERS,
+        MOST_POPULAR_DAY_AND_HOUR,
+        LATEST_POST_SUMMARY
 )
 
 val STATS_UNAVAILABLE_WITH_JETPACK = listOf(FILE_DOWNLOADS)


### PR DESCRIPTION
This PR separates insights into old and new and updates to new through feature announcement try it now action.

This can be tested through [corresponding WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16822).
