### PR TITLE
Update Dagger to 2.42

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ subprojects {
 }
 
 ext {
-    daggerVersion = '2.29.1'
+    daggerVersion = '2.42'
     wellSqlVersion = '1.7.0'
     supportLibraryVersion = '27.1.1'
     arch_paging_version = '1.0.1'

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooAddonsTestFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooAddonsTestFragment.kt
@@ -62,7 +62,7 @@ class WooAddonsTestFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val selectedSiteRemoteId = arguments!!.getLong(SELECTED_SITE_REMOTE_ID)
+        val selectedSiteRemoteId = requireArguments().getLong(SELECTED_SITE_REMOTE_ID)
         val selectedSite = siteStore.getSiteBySiteId(selectedSiteRemoteId)!!
 
         addons_product_remote_id_apply.setOnClickListener {

--- a/example/src/main/res/layout/activity_example.xml
+++ b/example/src/main/res/layout/activity_example.xml
@@ -22,7 +22,8 @@
         <LinearLayout
             android:id="@+id/fragment_container"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
     </ScrollView>
 
     <TextView

--- a/example/src/main/res/layout/activity_example.xml
+++ b/example/src/main/res/layout/activity_example.xml
@@ -15,10 +15,15 @@
         app:title="@string/app_name" />
 
     <ScrollView
-        android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_weight="1" />
+        android:layout_weight="1" >
+
+        <LinearLayout
+            android:id="@+id/fragment_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </ScrollView>
 
     <TextView
         android:id="@+id/log"


### PR DESCRIPTION
AGP `7.2.1` update results in a crash during lint due to a bug in Dagger which is addressed in `2.42`. This PR updates Dagger to `2.42` and targets the AGP update branch, so they can be shipped together.