### PR TITLE
[do-not-merge] MediaStore fetch media list by date range

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,6 +11,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
@@ -104,6 +105,7 @@ dependencies {
     implementation project(':fluxc')
     implementation project(':plugins:woocommerce')
 
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"

--- a/example/src/main/res/layout/fragment_media.xml
+++ b/example/src/main/res/layout/fragment_media.xml
@@ -14,6 +14,28 @@
         android:layout_height="wrap_content"
         android:text="Select Site" />
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/fetch_media_list_field_after"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:hint="From YYYY-MM-DD"
+            android:inputType="date" />
+
+        <EditText
+            android:id="@+id/fetch_media_list_field_before"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:hint="To YYYY-MM-DD"
+            android:inputType="date" />
+    </LinearLayout>
+
     <Button
         android:id="@+id/fetch_media_list"
         android:layout_width="match_parent"

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -81,6 +81,7 @@ public class MediaSqlUtilsTest {
         }
     }
 
+    // only testing date filtering
     @Test
     public void testGetMediaWithStatesDateFiltering() {
         final List<MediaModel> mediaList = generateRandomizedMediaList(3, TEST_LOCAL_SITE_ID);
@@ -100,21 +101,26 @@ public class MediaSqlUtilsTest {
                 uploadStates,
                 "2022-09-03",
                 null);
-        assertAfterNullDateRangeMedia(dates, results);
+        assertThat(results.size()).isEqualTo(2);
+        assertThat(results.get(0).getUploadDate()).isEqualTo(dates[1]);
+        assertThat(results.get(1).getUploadDate()).isEqualTo(dates[2]);
 
         // before is null
         results = MediaSqlUtils.getMediaWithStates(getTestSiteWithLocalId(TEST_LOCAL_SITE_ID),
                 uploadStates,
                 null,
                 "2022-09-02");
-        assertBeforeNullDateRange(dates, results);
+        assertThat(results.size()).isEqualTo(2);
+        assertThat(results.get(0).getUploadDate()).isEqualTo(dates[0]);
+        assertThat(results.get(1).getUploadDate()).isEqualTo(dates[1]);
 
         // after and before are not null
         results = MediaSqlUtils.getMediaWithStates(getTestSiteWithLocalId(TEST_LOCAL_SITE_ID),
                 uploadStates,
                 "2022-09-03",
                 "2022-09-02");
-        assertBeforeAfterDateRange(results, dates, 1, 1);
+        assertThat(results.size()).isEqualTo(1);
+        assertThat(results.get(0).getUploadDate()).isEqualTo(dates[1]);
     }
 
     // only testing date filtering
@@ -140,7 +146,9 @@ public class MediaSqlUtilsTest {
                 Type.IMAGE.getValue(),
                 "2022-09-03",
                 null);
-        assertAfterNullDateRangeMedia(dates, results);
+        assertThat(results.size()).isEqualTo(2);
+        assertThat(results.get(0).getUploadDate()).isEqualTo(dates[1]);
+        assertThat(results.get(1).getUploadDate()).isEqualTo(dates[2]);
 
         // before is null
         results = MediaSqlUtils.getMediaWithStatesAndMimeType(testSite,
@@ -148,7 +156,9 @@ public class MediaSqlUtilsTest {
                 Type.IMAGE.getValue(),
                 null,
                 "2022-09-02");
-        assertBeforeNullDateRange(dates, results);
+        assertThat(results.size()).isEqualTo(2);
+        assertThat(results.get(0).getUploadDate()).isEqualTo(dates[0]);
+        assertThat(results.get(1).getUploadDate()).isEqualTo(dates[1]);
 
         // after and before are not null
         results = MediaSqlUtils.getMediaWithStatesAndMimeType(testSite,
@@ -156,22 +166,8 @@ public class MediaSqlUtilsTest {
                 Type.IMAGE.getValue(),
                 "2022-09-03",
                 "2022-09-02");
-        assertBeforeAfterDateRange(results, dates, 1, 1);
-    }
-
-    private void assertBeforeNullDateRange(String[] dates, List<MediaModel> results) {
-        assertBeforeAfterDateRange(results, dates, 2, 0);
-        assertThat(results.get(1).getUploadDate()).isEqualTo(dates[1]);
-    }
-
-    private void assertBeforeAfterDateRange(List<MediaModel> results, String[] dates, int i, int i2) {
-        assertThat(results.size()).isEqualTo(i);
-        assertThat(results.get(0).getUploadDate()).isEqualTo(dates[i2]);
-    }
-
-    private void assertAfterNullDateRangeMedia(String[] dates, List<MediaModel> results) {
-        assertBeforeAfterDateRange(results, dates, 2, 1);
-        assertThat(results.get(1).getUploadDate()).isEqualTo(dates[2]);
+        assertThat(results.size()).isEqualTo(1);
+        assertThat(results.get(0).getUploadDate()).isEqualTo(dates[1]);
     }
 
     // Inserts a media item, verifies it's in the DB, deletes the item, verifies it's not in the DB

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.network.xmlrpc.media.MediaXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.MediaSqlUtils;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.MediaStore;
+import org.wordpress.android.fluxc.utils.DateTimeUtilsWrapper;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 
 import java.util.ArrayList;
@@ -44,7 +45,8 @@ public class MediaStoreTest {
     private MediaStore mMediaStore = new MediaStore(new Dispatcher(),
             Mockito.mock(MediaRestClient.class),
             Mockito.mock(MediaXMLRPCClient.class),
-            Mockito.mock(WPV2MediaRestClient.class));
+            Mockito.mock(WPV2MediaRestClient.class),
+            Mockito.mock(DateTimeUtilsWrapper.class));
 
     @Before
     public void setUp() {

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -49,17 +49,21 @@ import static org.wordpress.android.fluxc.media.MediaTestUtils.insertRandomMedia
 public class MediaStoreTest {
     public static final long AFTER_MILLIS = 2000000000;
     public static final long BEFORE_MILLIS = 2100000000;
-    private final MediaRestClient mMediaRestClient = mock(MediaRestClient.class);
-    private final WPV2MediaRestClient mWPV2MediaRestClient = mock(WPV2MediaRestClient.class);
-    private final DateTimeUtilsWrapper mDateTimeUtilsWrapper = mock(DateTimeUtilsWrapper.class);
-    private final MediaStore mMediaStore = new MediaStore(new Dispatcher(),
-            mMediaRestClient,
-            mock(MediaXMLRPCClient.class),
-            mWPV2MediaRestClient,
-            mDateTimeUtilsWrapper);
+    private MediaRestClient mMediaRestClient ;
+    private WPV2MediaRestClient mWPV2MediaRestClient;
+    private DateTimeUtilsWrapper mDateTimeUtilsWrapper;
+    private MediaStore mMediaStore;
 
     @Before
     public void setUp() {
+        mMediaRestClient = mock(MediaRestClient.class);
+        mWPV2MediaRestClient = mock(WPV2MediaRestClient.class);
+        mDateTimeUtilsWrapper = mock(DateTimeUtilsWrapper.class);
+        mMediaStore = new MediaStore(new Dispatcher(),
+                mMediaRestClient,
+                mock(MediaXMLRPCClient.class),
+                mWPV2MediaRestClient,
+                mDateTimeUtilsWrapper);
         Context context = RuntimeEnvironment.application.getApplicationContext();
         WellSqlConfig config = new SingleStoreWellSqlConfigForTests(context, MediaModel.class);
         WellSql.init(config);

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClientTest.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import org.wordpress.android.fluxc.utils.DateTimeUtilsWrapper
 import java.io.File
 import java.util.concurrent.CountDownLatch
 
@@ -54,7 +55,8 @@ class WPV2MediaRestClientTest {
                 okHttpClient = okHttpClient,
                 requestQueue = requestQueue,
                 accessToken = accessToken,
-                userAgent = userAgent
+                userAgent = userAgent,
+                dateTimeUtilsWrapper = DateTimeUtilsWrapper()
         )
         EventBus.getDefault().register(this)
     }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -11,6 +11,12 @@ android {
 
     compileSdkVersion 31
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
+    }
+
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
@@ -58,6 +64,8 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -345,7 +345,13 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         if (mediaList != null) {
                             AppLog.v(T.MEDIA, "Fetched media list for site with size: " + mediaList.size());
                             boolean canLoadMore = mediaList.size() == number;
-                            notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore, mimeType);
+                            notifyMediaListFetched(site,
+                                    mediaList,
+                                    offset > 0,
+                                    canLoadMore,
+                                    mimeType,
+                                    params.get("after"),
+                                    params.get("before"));
                         } else {
                             String errorMessage = "could not parse Fetch all media response: " + response;
                             AppLog.w(T.MEDIA, errorMessage);
@@ -606,9 +612,11 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                                         @NonNull List<MediaModel> media,
                                         boolean loadedMore,
                                         boolean canLoadMore,
-                                        MimeType.Type mimeType) {
+                                        MimeType.Type mimeType,
+                                        @Nullable String after,
+                                        @Nullable String before) {
         FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media,
-                loadedMore, canLoadMore, mimeType);
+                loadedMore, canLoadMore, mimeType, after, before);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -223,7 +223,15 @@ class WPV2MediaRestClient @Inject constructor(
                 val mediaList = response.data.map { it.toMediaModel(site.id) }
                 AppLog.v(MEDIA, "Fetched media list for site with size: " + mediaList.size)
                 val canLoadMore = mediaList.size == perPage
-                FetchMediaListResponsePayload(site, mediaList, offset > 0, canLoadMore, mimeType)
+                FetchMediaListResponsePayload(
+                        site,
+                        mediaList,
+                        offset > 0,
+                        canLoadMore,
+                        mimeType,
+                        params["after"],
+                        params["before"]
+                )
             }
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -202,7 +202,7 @@ class WPV2MediaRestClient @Inject constructor(
             params["before"] = dateTimeUtilsWrapper.iso8601UTCEndDateText(it)
         }
         after?.let {
-            params["after"] = dateTimeUtilsWrapper.iso8601UTCEndDateText(it)
+            params["after"] = dateTimeUtilsWrapper.iso8601UTCStartDateText(it)
         }
         val response = WPComGsonRequestBuilder().syncGetRequest(
                 this,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -31,8 +31,8 @@ public class MediaSqlUtils {
     }
     public static List<MediaModel> getMediaWithStates(SiteModel site,
                                                       List<String> uploadStates,
-                                                      String before,
-                                                      String after) {
+                                                      @Nullable String before,
+                                                      @Nullable String after) {
         return getMediaWithStatesQuery(site, uploadStates, before, after).getAsModel();
     }
 
@@ -40,7 +40,10 @@ public class MediaSqlUtils {
         return getMediaWithStatesQuery(site, uploadStates, null, null).getAsCursor();
     }
 
-    public static WellCursor<MediaModel> getMediaWithStatesAsCursor(SiteModel site, List<String> uploadStates, String before, String after) {
+    public static WellCursor<MediaModel> getMediaWithStatesAsCursor(SiteModel site,
+                                                                    List<String> uploadStates,
+                                                                    String before,
+                                                                    String after) {
         return getMediaWithStatesQuery(site, uploadStates, before, after).getAsCursor();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -624,24 +624,32 @@ public class MediaStore extends Store {
     public List<MediaModel> getAllSiteMedia(SiteModel siteModel) {
         return MediaSqlUtils.getAllSiteMedia(siteModel);
     }
+
     public List<MediaModel> getAllSiteMedia(SiteModel siteModel, @Nullable Long after, @Nullable Long before) {
-        String afterText = getDateSQLQueryText(after);
-        String beforeText = getDateSQLQueryText(before);
-        if (afterText != null || beforeText != null) {
+        if (after != null || before != null) {
             return MediaSqlUtils.getMediaWithStates(siteModel,
                     null,
-                    beforeText,
-                    afterText);
+                    getDateBeforeSQLQueryText(before),
+                    getDateAfterSQLQueryText(after));
         } else {
             return MediaSqlUtils.getAllSiteMedia(siteModel);
         }
     }
 
     @Nullable
-    private String getDateSQLQueryText(@Nullable Long after) {
+    private String getDateAfterSQLQueryText(@Nullable Long after) {
         String dateText = null;
         if (after != null) {
-            dateText = mDateTimeUtilsWrapper.iso8601UTCFromDate(new Date(after));
+            dateText = mDateTimeUtilsWrapper.iso8601UTCStartDateText(new Date(after));
+        }
+        return dateText;
+    }
+
+    @Nullable
+    private String getDateBeforeSQLQueryText(@Nullable Long before) {
+        String dateText = null;
+        if (before != null) {
+            dateText = mDateTimeUtilsWrapper.iso8601UTCEndDateText(new Date(before));
         }
         return dateText;
     }
@@ -681,14 +689,12 @@ public class MediaStore extends Store {
     }
 
     public List<MediaModel> getSiteImages(SiteModel siteModel, @Nullable Long after, @Nullable Long before) {
-        String afterText = getDateSQLQueryText(after);
-        String beforeText = getDateSQLQueryText(before);
-        if (afterText != null || beforeText != null) {
+        if (after != null || before != null) {
             return MediaSqlUtils.getMediaWithStatesAndMimeType(siteModel,
                     null,
                     MimeType.Type.IMAGE.getValue(),
-                    beforeText,
-                    afterText);
+                    getDateBeforeSQLQueryText(before),
+                    getDateAfterSQLQueryText(after));
         }
         return MediaSqlUtils.getSiteImages(siteModel);
     }
@@ -697,11 +703,44 @@ public class MediaStore extends Store {
         return MediaSqlUtils.getSiteVideos(siteModel);
     }
 
+    public List<MediaModel> getSiteVideos(SiteModel siteModel, @Nullable Long after, @Nullable Long before) {
+        if (after != null || before != null) {
+            return MediaSqlUtils.getMediaWithStatesAndMimeType(siteModel,
+                    null,
+                    MimeType.Type.VIDEO.getValue(),
+                    getDateBeforeSQLQueryText(before),
+                    getDateAfterSQLQueryText(after));
+        }
+        return MediaSqlUtils.getSiteVideos(siteModel);
+    }
+
     public List<MediaModel> getSiteAudio(SiteModel siteModel) {
         return MediaSqlUtils.getSiteAudio(siteModel);
     }
 
+    public List<MediaModel> getSiteAudio(SiteModel siteModel, @Nullable Long after, @Nullable Long before) {
+        if (after != null || before != null) {
+            return MediaSqlUtils.getMediaWithStatesAndMimeType(siteModel,
+                    null,
+                    MimeType.Type.AUDIO.getValue(),
+                    getDateBeforeSQLQueryText(before),
+                    getDateAfterSQLQueryText(after));
+        }
+        return MediaSqlUtils.getSiteAudio(siteModel);
+    }
+
     public List<MediaModel> getSiteDocuments(SiteModel siteModel) {
+        return MediaSqlUtils.getSiteDocuments(siteModel);
+    }
+
+    public List<MediaModel> getSiteDocuments(SiteModel siteModel, @Nullable Long after, @Nullable Long before) {
+        if (after != null || before != null) {
+            return MediaSqlUtils.getMediaWithStatesAndMimeType(siteModel,
+                    null,
+                    MimeType.Type.APPLICATION.getValue(),
+                    getDateBeforeSQLQueryText(before),
+                    getDateAfterSQLQueryText(after));
+        }
         return MediaSqlUtils.getSiteDocuments(siteModel);
     }
 
@@ -894,13 +933,13 @@ public class MediaStore extends Store {
         String beforeText = null;
         Date beforeDate = null;
         if (payload.before != null) {
-            beforeText = mDateTimeUtilsWrapper.iso8601UTCFromDate(new Date(payload.before));
+            beforeText = mDateTimeUtilsWrapper.iso8601UTCEndDateText(new Date(payload.before));
             beforeDate = new Date(payload.before);
         }
         String afterText = null;
         Date afterDate = null;
         if (payload.after != null) {
-            afterText = mDateTimeUtilsWrapper.iso8601UTCFromDate(new Date(payload.after));
+            afterText = mDateTimeUtilsWrapper.iso8601UTCStartDateText(new Date(payload.after));
             afterDate = new Date(payload.after);
         }
         if (payload.loadMore) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/DateTimeUtilsWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/DateTimeUtilsWrapper.kt
@@ -1,12 +1,37 @@
 package org.wordpress.android.fluxc.utils
 
 import dagger.Reusable
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
 import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
 import javax.inject.Inject
 
 @Reusable
 class DateTimeUtilsWrapper @Inject constructor() {
+    private val timeZone: TimeZone
+        get() = TimeZone.currentSystemDefault()
+
     fun timestampFromIso8601(strDate: String?) = DateTimeUtils.timestampFromIso8601(strDate)
     fun iso8601UTCFromDate(date: Date?): String? = DateTimeUtils.iso8601UTCFromDate(date)
+
+    fun iso8601UTCStartDateText(date: Date): String =
+        with(Instant.fromEpochMilliseconds(date.time)) {
+            LocalDateTime(
+                toLocalDateTime(timeZone).date,
+                LocalTime(0, 0, 0)
+            ).toInstant(timeZone).toString()
+        }
+
+    fun iso8601UTCEndDateText(date: Date) = with(Instant.fromEpochMilliseconds(date.time)) {
+        LocalDateTime(
+            toLocalDateTime(timeZone).date,
+            LocalTime(23, 59, 59)
+        ).toInstant(timeZone)
+            .toString()
+    }
 }


### PR DESCRIPTION
**WIP** - missing example app demo (tested on locally modified file) and unit tests. Some method signatures might also benefit from tweaks (e.g. `Date` to `String`/`Long` or the other way around).

This PR's work is a prerequisite for completing the WordPress Mobile Android task posted at https://github.com/wordpress-mobile/WordPress-Android/issues/13892

**Limitations**
*XML-RPC API does not support date range parameters
*REST client integration/API contract tests don't use Wiremock and don't have any existing way to verify that the request format is actually correct. It is possible to mock `OkHttpClient` using Mockito and verify the request URL passed to it. But the PR author is on a paid trial and has a limited number of hours to implement their task.

**The PR description will be updated later.**