### PR TITLE
Nick/metadata test

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
@@ -32,6 +32,8 @@ abstract class WCDatabaseModule {
 
         @Provides fun provideOrderNotesDao(database: WCAndroidDatabase) = database.orderNotesDao
 
+        @Provides fun provideOrderMetaDataDao(database: WCAndroidDatabase) = database.orderMetaDataDao
+
         @Provides fun provideInboxNotesDao(database: WCAndroidDatabase) = database.inboxNotesDao
     }
     @Binds abstract fun bindTransactionExecutor(database: WCAndroidDatabase): TransactionExecutor

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.fluxc.model
+
+import androidx.room.Entity
+import androidx.room.Index
+import com.google.gson.annotations.SerializedName
+
+@Entity(
+    tableName = "OrderEntity",
+    indices = [Index(
+        value = ["localSiteId", "orderId"]
+    )],
+    primaryKeys = ["localSiteId", "orderId", "id"]
+)
+data class OrderMetaDataEntity(
+    @SerializedName("id") val id: Long,
+    @SerializedName("localSiteId") val localSiteId: Long,
+    @SerializedName("orderId") val orderId: Long,
+    @SerializedName("key") val key: String,
+    @SerializedName("value") val value: Any,
+    @SerializedName("display_key") val displayKey: String?,
+    @SerializedName("display_value") val displayValue: Any?
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
@@ -5,6 +5,9 @@ import androidx.room.Index
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isInternalAttribute
 
+/**
+ * The OrderMetaDataEntity table is used to store viewable order meta data separately from the order
+ */
 @Entity(
     tableName = "OrderMetaDataEntity",
     indices = [Index(
@@ -22,7 +25,11 @@ data class OrderMetaDataEntity(
     @SerializedName("display_value") val displayValue: String?
 )
 
-fun List<Metadata>.fromFatOrder(fatModel: OrderEntity): List<OrderMetaDataEntity> {
+/**
+ * Creates a list of OrderMetaDataEntity from a "fat" order model, which is the order before
+ * calling [StripOrder] to remove most of the metadata
+ */
+fun fromFatOrder(fatModel: OrderEntity): List<OrderMetaDataEntity> {
     val metaData = fatModel.getMetaDataList()
         .filter {
             it.isInternalAttribute.not()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
@@ -16,7 +16,7 @@ data class OrderMetaDataEntity(
     @SerializedName("localSiteId") val localSiteId: Long,
     @SerializedName("orderId") val orderId: Long,
     @SerializedName("key") val key: String,
-    @SerializedName("value") val value: Any,
+    @SerializedName("value") val value: String,
     @SerializedName("display_key") val displayKey: String?,
-    @SerializedName("display_value") val displayValue: Any?
+    @SerializedName("display_value") val displayValue: String?
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.model
 import androidx.room.Entity
 import androidx.room.Index
 import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isInternalAttribute
 
 @Entity(
     tableName = "OrderMetaDataEntity",
@@ -13,10 +14,32 @@ import com.google.gson.annotations.SerializedName
 )
 data class OrderMetaDataEntity(
     @SerializedName("id") val id: Long,
-    @SerializedName("localSiteId") val localSiteId: Long,
+    @SerializedName("localSiteId") val localSiteId: LocalOrRemoteId,
     @SerializedName("orderId") val orderId: Long,
     @SerializedName("key") val key: String,
     @SerializedName("value") val value: String,
     @SerializedName("display_key") val displayKey: String?,
     @SerializedName("display_value") val displayValue: String?
 )
+
+fun List<Metadata>.fromFatOrder(fatModel: OrderEntity): List<OrderMetaDataEntity> {
+    val metaData = fatModel.getMetaDataList()
+        .filter {
+            it.isInternalAttribute.not()
+        }
+    return ArrayList<OrderMetaDataEntity>().also { list ->
+        metaData.forEach { meta ->
+            list.add(
+                OrderMetaDataEntity(
+                    id = meta.id,
+                    localSiteId = fatModel.localSiteId,
+                    orderId = fatModel.orderId,
+                    key = meta.key,
+                    value = meta.value.toString(),
+                    displayKey = meta.displayKey,
+                    displayValue = meta.displayKey
+                )
+            )
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderMetaDataEntity.kt
@@ -5,7 +5,7 @@ import androidx.room.Index
 import com.google.gson.annotations.SerializedName
 
 @Entity(
-    tableName = "OrderEntity",
+    tableName = "OrderMetaDataEntity",
     indices = [Index(
         value = ["localSiteId", "orderId"]
     )],

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -101,7 +101,7 @@ class OrderRestClient @Inject constructor(
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderDto>? ->
                     val orderModels = response?.map { orderDto ->
-                        orderMetaDataDao.insertOrUpdateOrderMetaData(orderDto, site.localId())
+                        orderMetaDataDao.updateOrderMetaData(orderDto, site.localId())
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
 
@@ -202,7 +202,7 @@ class OrderRestClient @Inject constructor(
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderDto>? ->
                     val orderModels = response?.map { orderDto ->
-                        orderMetaDataDao.insertOrUpdateOrderMetaData(orderDto, site.localId())
+                        orderMetaDataDao.updateOrderMetaData(orderDto, site.localId())
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
 
@@ -273,7 +273,7 @@ class OrderRestClient @Inject constructor(
         val request = JetpackTunnelGsonRequest.buildGetRequest(url, site.siteId, params, responseType,
                 { response: List<OrderDto>? ->
                     val orderModels = response?.map { orderDto ->
-                        orderMetaDataDao.insertOrUpdateOrderMetaData(orderDto, site.localId())
+                        orderMetaDataDao.updateOrderMetaData(orderDto, site.localId())
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
 
@@ -311,7 +311,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 response.data?.let { orderDto ->
-                    orderMetaDataDao.insertOrUpdateOrderMetaData(orderDto, site.localId())
+                    orderMetaDataDao.updateOrderMetaData(orderDto, site.localId())
                     val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     RemoteOrderPayload(newModel, site)
                 } ?: RemoteOrderPayload(
@@ -441,7 +441,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 response.data?.let { orderDto ->
-                    orderMetaDataDao.insertOrUpdateOrderMetaData(orderDto, site.localId())
+                    orderMetaDataDao.updateOrderMetaData(orderDto, site.localId())
                     val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId()).copy(
                             orderId = orderToUpdate.orderId
                     )
@@ -772,7 +772,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackError -> WooPayload(response.error.toWooError())
             is JetpackSuccess -> response.data?.let { orderDto ->
-                orderMetaDataDao.insertOrUpdateOrderMetaData(orderDto, site.localId())
+                orderMetaDataDao.updateOrderMetaData(orderDto, site.localId())
                 WooPayload(orderDtoMapper.toDatabaseEntity(orderDto, site.localId()))
             } ?: WooPayload(
                     error = WooError(
@@ -803,7 +803,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackError -> WooPayload(response.error.toWooError())
             is JetpackSuccess -> response.data?.let { orderDto ->
-                orderMetaDataDao.insertOrUpdateOrderMetaData(orderDto, site.localId())
+                orderMetaDataDao.updateOrderMetaData(orderDto, site.localId())
                 WooPayload(orderDtoMapper.toDatabaseEntity(orderDto, site.localId()))
             } ?: WooPayload(
                     error = WooError(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -306,6 +306,7 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is JetpackSuccess -> {
                 response.data?.let { orderDto ->
+                    saveOrderMetaData(orderDto, site)
                     val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     RemoteOrderPayload(newModel, site)
                 } ?: RemoteOrderPayload(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -22,9 +22,7 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                 metaData = gson.toJson(
                         fatModel.getMetaDataList()
                                 .filter {
-                                    it.key == CHARGE_ID_KEY ||
-                                        it.key == SHIPPING_PHONE_KEY ||
-                                        it.isInternalAttribute.not()
+                                    it.key == CHARGE_ID_KEY || it.key == SHIPPING_PHONE_KEY
                                 }
                 )
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -22,7 +22,8 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                 metaData = gson.toJson(
                         fatModel.getMetaDataList()
                                 .filter {
-                                            it.key == CHARGE_ID_KEY || it.key == SHIPPING_PHONE_KEY
+                                            // it.key == CHARGE_ID_KEY || it.key == SHIPPING_PHONE_KEY
+                                    !it.key.startsWith("_")
                                 }
                 )
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -22,8 +22,9 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                 metaData = gson.toJson(
                         fatModel.getMetaDataList()
                                 .filter {
-                                            // it.key == CHARGE_ID_KEY || it.key == SHIPPING_PHONE_KEY
-                                    !it.key.startsWith("_")
+                                    it.key == CHARGE_ID_KEY ||
+                                        it.key == SHIPPING_PHONE_KEY ||
+                                        it.key.startsWith("_").not()
                                 }
                 )
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -24,7 +24,7 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                                 .filter {
                                     it.key == CHARGE_ID_KEY ||
                                         it.key == SHIPPING_PHONE_KEY ||
-                                        it.key.startsWith("_").not()
+                                        it.isInternalAttribute.not()
                                 }
                 )
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -8,6 +8,7 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.room.withTransaction
 import org.wordpress.android.fluxc.model.OrderEntity
+import org.wordpress.android.fluxc.model.OrderMetaDataEntity
 import org.wordpress.android.fluxc.persistence.converters.BigDecimalConverter
 import org.wordpress.android.fluxc.persistence.converters.LocalIdConverter
 import org.wordpress.android.fluxc.persistence.converters.LongListConverter
@@ -49,6 +50,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
             GlobalAddonGroupEntity::class,
             OrderNoteEntity::class,
             OrderEntity::class,
+            OrderMetaDataEntity::class,
             InboxNoteEntity::class,
             InboxNoteActionEntity::class
         ],

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -8,16 +8,15 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.room.withTransaction
 import org.wordpress.android.fluxc.model.OrderEntity
-import org.wordpress.android.fluxc.model.OrderMetaDataEntity
 import org.wordpress.android.fluxc.persistence.converters.BigDecimalConverter
 import org.wordpress.android.fluxc.persistence.converters.LocalIdConverter
 import org.wordpress.android.fluxc.persistence.converters.LongListConverter
 import org.wordpress.android.fluxc.persistence.converters.RemoteIdConverter
 import org.wordpress.android.fluxc.persistence.dao.AddonsDao
-import org.wordpress.android.fluxc.persistence.dao.OrderNotesDao
 import org.wordpress.android.fluxc.persistence.dao.CouponsDao
 import org.wordpress.android.fluxc.persistence.dao.InboxNotesDao
 import org.wordpress.android.fluxc.persistence.dao.OrderMetaDataDao
+import org.wordpress.android.fluxc.persistence.dao.OrderNotesDao
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import org.wordpress.android.fluxc.persistence.entity.AddonEntity
 import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
@@ -26,6 +25,7 @@ import org.wordpress.android.fluxc.persistence.entity.CouponEntity
 import org.wordpress.android.fluxc.persistence.entity.GlobalAddonGroupEntity
 import org.wordpress.android.fluxc.persistence.entity.InboxNoteActionEntity
 import org.wordpress.android.fluxc.persistence.entity.InboxNoteEntity
+import org.wordpress.android.fluxc.persistence.entity.OrderMetaDataEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration13to14
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration14to15

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.persistence.dao.AddonsDao
 import org.wordpress.android.fluxc.persistence.dao.OrderNotesDao
 import org.wordpress.android.fluxc.persistence.dao.CouponsDao
 import org.wordpress.android.fluxc.persistence.dao.InboxNotesDao
+import org.wordpress.android.fluxc.persistence.dao.OrderMetaDataDao
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import org.wordpress.android.fluxc.persistence.entity.AddonEntity
 import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
@@ -73,6 +74,7 @@ abstract class WCAndroidDatabase : RoomDatabase(), TransactionExecutor {
     abstract val addonsDao: AddonsDao
     abstract val ordersDao: OrdersDao
     abstract val orderNotesDao: OrderNotesDao
+    abstract val orderMetaDataDao: OrderMetaDataDao
     abstract val couponsDao: CouponsDao
     abstract val inboxNotesDao: InboxNotesDao
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.persistence.entity.InboxNoteEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration13to14
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration14to15
+import org.wordpress.android.fluxc.persistence.migrations.AutoMigration16to17
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_10_11
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_11_12
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_15_16
@@ -39,7 +40,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_8_9
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
 
 @Database(
-        version = 16,
+        version = 17,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,
@@ -54,7 +55,8 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
         autoMigrations = [
             AutoMigration(from = 12, to = 13),
             AutoMigration(from = 13, to = 14, spec = AutoMigration13to14::class),
-            AutoMigration(from = 14, to = 15, spec = AutoMigration14to15::class)
+            AutoMigration(from = 14, to = 15, spec = AutoMigration14to15::class),
+            AutoMigration(from = 16, to = 17, spec = AutoMigration16to17::class)
         ]
 )
 @TypeConverters(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
@@ -21,12 +21,14 @@ abstract class OrderMetaDataDao {
     @Query("DELETE FROM OrderMetaDataEntity WHERE localSiteId = :localSiteId AND orderId = :orderId")
     abstract fun deleteOrderMetaData(localSiteId: LocalId, orderId: Long)
 
-    open fun insertOrUpdateOrderMetaData(
+    @Transaction
+    open fun updateOrderMetaData(
         orderDto: OrderDto,
         localSiteId: LocalId
     ) {
         val orderId = orderDto.id ?: 0
         deleteOrderMetaData(localSiteId, orderId)
+
         val responseType = object : TypeToken<List<WCMetaData>>() {}.type
         val metaData = Gson().fromJson(orderDto.meta_data, responseType) as? List<WCMetaData>
             ?: emptyList()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
@@ -10,6 +10,7 @@ import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.WCMetaData
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isInternalAttribute
 import org.wordpress.android.fluxc.persistence.entity.OrderMetaDataEntity
 
 @Dao
@@ -32,7 +33,7 @@ abstract class OrderMetaDataDao {
         val responseType = object : TypeToken<List<WCMetaData>>() {}.type
         val metaData = Gson().fromJson(orderDto.meta_data, responseType) as? List<WCMetaData>
             ?: emptyList()
-        metaData.filter { it.key.startsWith("_").not() }
+        metaData.filter { it.isInternalAttribute.not() }
             .map {
                 insertOrUpdateMetaData(
                     OrderMetaDataEntity(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
@@ -32,18 +32,20 @@ abstract class OrderMetaDataDao {
         val responseType = object : TypeToken<List<WCMetaData>>() {}.type
         val metaData = Gson().fromJson(orderDto.meta_data, responseType) as? List<WCMetaData>
             ?: emptyList()
-        metaData.forEach { meta ->
-            insertOrUpdateMetaData(
-                OrderMetaDataEntity(
-                    id = meta.id,
-                    localSiteId = localSiteId,
-                    orderId = orderId,
-                    key = meta.key,
-                    value = meta.value.toString(),
-                    displayKey = meta.displayKey,
-                    displayValue = meta.displayValue.toString()
+        metaData.filter { it.key.startsWith("_").not() }
+            .map {
+                insertOrUpdateMetaData(
+                    OrderMetaDataEntity(
+                        id = it.id,
+                        localSiteId = localSiteId,
+                        orderId = orderId,
+                        key = it.key,
+                        value = it.value.toString(),
+                        displayKey = it.displayKey,
+                        displayValue = it.displayValue.toString()
+                    )
                 )
-            )
-        }
+            }
     }
 }
+

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Transaction
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.WCMetaData
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isInternalAttribute
@@ -17,6 +18,9 @@ import org.wordpress.android.fluxc.persistence.entity.OrderMetaDataEntity
 abstract class OrderMetaDataDao {
     @Insert(onConflict = REPLACE)
     abstract fun insertOrUpdateMetaData(metaDataEntity: OrderMetaDataEntity)
+
+    @Query("SELECT * FROM OrderMetaDataEntity WHERE orderId = :orderId AND localSiteId = :localSiteId")
+    abstract suspend fun getOrderMetaData(orderId: Long, localSiteId: LocalId): List<OrderMetaDataEntity>
 
     @Transaction
     @Query("DELETE FROM OrderMetaDataEntity WHERE localSiteId = :localSiteId AND orderId = :orderId")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
@@ -19,9 +19,9 @@ abstract class OrderMetaDataDao {
 
     @Transaction
     @Query("DELETE FROM OrderMetaDataEntity WHERE localSiteId = :localSiteId AND orderId = :orderId")
-    abstract suspend fun deleteOrderMetaData(localSiteId: LocalId, orderId: Long)
+    abstract fun deleteOrderMetaData(localSiteId: LocalId, orderId: Long)
 
-    open suspend fun insertOrUpdateOrderMetaData(
+    open fun insertOrUpdateOrderMetaData(
         orderDto: OrderDto,
         localSiteId: LocalId
     ) {
@@ -39,7 +39,7 @@ abstract class OrderMetaDataDao {
                     key = meta.key,
                     value = meta.value.toString(),
                     displayKey = meta.displayKey,
-                    displayValue = meta.displayKey
+                    displayValue = meta.displayValue.toString()
                 )
             )
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.persistence.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy.REPLACE
+import androidx.room.Query
+import androidx.room.Transaction
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.WCMetaData
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto
+import org.wordpress.android.fluxc.persistence.entity.OrderMetaDataEntity
+
+@Dao
+abstract class OrderMetaDataDao {
+    @Insert(onConflict = REPLACE)
+    abstract fun insertOrUpdateMetaData(metaDataEntity: OrderMetaDataEntity)
+
+    @Transaction
+    @Query("DELETE FROM OrderMetaDataEntity WHERE localSiteId = :localSiteId AND orderId = :orderId")
+    abstract suspend fun deleteOrderMetaData(localSiteId: LocalId, orderId: Long)
+
+    open suspend fun insertOrUpdateOrderMetaData(
+        orderDto: OrderDto,
+        localSiteId: LocalId
+    ) {
+        val orderId = orderDto.id ?: 0
+        deleteOrderMetaData(localSiteId, orderId)
+        val responseType = object : TypeToken<List<WCMetaData>>() {}.type
+        val metaData = Gson().fromJson(orderDto.meta_data, responseType) as? List<WCMetaData>
+            ?: emptyList()
+        metaData.forEach { meta ->
+            insertOrUpdateMetaData(
+                OrderMetaDataEntity(
+                    id = meta.id,
+                    localSiteId = localSiteId,
+                    orderId = orderId,
+                    key = meta.key,
+                    value = meta.value.toString(),
+                    displayKey = meta.displayKey,
+                    displayValue = meta.displayKey
+                )
+            )
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderMetaDataEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderMetaDataEntity.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.persistence.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
-import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 
 /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderMetaDataEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderMetaDataEntity.kt
@@ -1,9 +1,10 @@
 package org.wordpress.android.fluxc.persistence.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
-import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 
 /**
  * The OrderMetaDataEntity table is used to store viewable order meta data separately from the order
@@ -16,11 +17,12 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId
     primaryKeys = ["localSiteId", "orderId", "id"]
 )
 data class OrderMetaDataEntity(
-    @SerializedName("id") val id: Long,
-    @SerializedName("localSiteId") val localSiteId: LocalOrRemoteId,
-    @SerializedName("orderId") val orderId: Long,
-    @SerializedName("key") val key: String,
-    @SerializedName("value") val value: String,
-    @SerializedName("display_key") val displayKey: String?,
-    @SerializedName("display_value") val displayValue: String?
+    @ColumnInfo(name = "localSiteId")
+    val localSiteId: LocalId,
+    val id: Long,
+    val orderId: Long,
+    val key: String,
+    val value: String,
+    val displayKey: String?,
+    val displayValue: String?
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderMetaDataEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderMetaDataEntity.kt
@@ -2,13 +2,8 @@ package org.wordpress.android.fluxc.persistence.entity
 
 import androidx.room.Entity
 import androidx.room.Index
-import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
-import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
-import org.wordpress.android.fluxc.model.WCMetaData
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto
 
 /**
  * The OrderMetaDataEntity table is used to store viewable order meta data separately from the order
@@ -29,23 +24,3 @@ data class OrderMetaDataEntity(
     @SerializedName("display_key") val displayKey: String?,
     @SerializedName("display_value") val displayValue: String?
 )
-
-fun fromOrderDto(orderDto: OrderDto, localSiteId: LocalId): List<OrderMetaDataEntity> {
-    val responseType = object : TypeToken<List<WCMetaData>>() {}.type
-    val metaData = Gson().fromJson(orderDto.meta_data, responseType) as? List<WCMetaData> ?: emptyList()
-    return ArrayList<OrderMetaDataEntity>().also { list ->
-        metaData.forEach { meta ->
-            list.add(
-                OrderMetaDataEntity(
-                    id = meta.id,
-                    localSiteId = localSiteId,
-                    orderId = orderDto.id ?: 0,
-                    key = meta.key,
-                    value = meta.value.toString(),
-                    displayKey = meta.displayKey,
-                    displayValue = meta.displayKey
-                )
-            )
-        }
-    }
-}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderMetaDataEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderMetaDataEntity.kt
@@ -1,9 +1,14 @@
-package org.wordpress.android.fluxc.model
+package org.wordpress.android.fluxc.persistence.entity
 
 import androidx.room.Entity
 import androidx.room.Index
+import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isInternalAttribute
+import com.google.gson.reflect.TypeToken
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.WCMetaData
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto
 
 /**
  * The OrderMetaDataEntity table is used to store viewable order meta data separately from the order
@@ -25,22 +30,16 @@ data class OrderMetaDataEntity(
     @SerializedName("display_value") val displayValue: String?
 )
 
-/**
- * Creates a list of OrderMetaDataEntity from a "fat" order model, which is the order before
- * calling [StripOrder] to remove most of the metadata
- */
-fun fromFatOrder(fatModel: OrderEntity): List<OrderMetaDataEntity> {
-    val metaData = fatModel.getMetaDataList()
-        .filter {
-            it.isInternalAttribute.not()
-        }
+fun fromOrderDto(orderDto: OrderDto, localSiteId: LocalId): List<OrderMetaDataEntity> {
+    val responseType = object : TypeToken<List<WCMetaData>>() {}.type
+    val metaData = Gson().fromJson(orderDto.meta_data, responseType) as? List<WCMetaData> ?: emptyList()
     return ArrayList<OrderMetaDataEntity>().also { list ->
         metaData.forEach { meta ->
             list.add(
                 OrderMetaDataEntity(
                     id = meta.id,
-                    localSiteId = fatModel.localSiteId,
-                    orderId = fatModel.orderId,
+                    localSiteId = localSiteId,
+                    orderId = orderDto.id ?: 0,
                     key = meta.key,
                     value = meta.value.toString(),
                     displayKey = meta.displayKey,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -515,6 +515,8 @@ internal class AutoMigration13to14 : AutoMigrationSpec
 @DeleteTable(tableName = "ProductCategories")
 internal class AutoMigration14to15 : AutoMigrationSpec
 
+internal class AutoMigration16to17 : AutoMigrationSpec
+
 internal val MIGRATION_15_16 = object : Migration(15, 16) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.apply {


### PR DESCRIPTION
This is a test PR to experiment with storing order metadata in a separate table. Right now when an order is fetched we strip most of the metadata before storing it. We do this in several places:

* `fetchSingleOrder`
* `fetchOrders`
* `fetchOrdersByIds`
* `updateOrder`

The approach taken here is to create a function that's used in all these places to store the metadata before its stripped. Another option would be to fetch the metadata separately when needed, but I didn't like the idea of adding another network request to order detail.