### PR TITLE
Wc/reuse build parameters map

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -611,12 +611,13 @@ class ProductRestClient @Inject constructor(
         filterOptions?.let { options ->
             params.putAll(options.map { it.key.toString() to it.value })
         }
-        searchQuery?.let { query ->
+
+        if (searchQuery.isNullOrEmpty().not()) {
             if (isSkuSearch) {
-                params["sku"] = query // full SKU match
-                params["search_sku"] = query // partial SKU match, added in core v6.6
+                params["sku"] = searchQuery!! // full SKU match
+                params["search_sku"] = searchQuery // partial SKU match, added in core v6.6
             } else {
-                params.putIfNotEmpty("search" to query)
+                params["search"] = searchQuery!!
             }
         }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -612,7 +612,6 @@ class ProductRestClient @Inject constructor(
             params.putAll(options.map { it.key.toString() to it.value })
         }
 
-
         if (isSkuSearch) {
             params.putIfNotEmpty("sku" to searchQuery) // full SKU match
             params.putIfNotEmpty("search_sku" to searchQuery) // partial SKU match, added in core v6.6

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -611,12 +611,13 @@ class ProductRestClient @Inject constructor(
         filterOptions?.let { options ->
             params.putAll(options.map { it.key.toString() to it.value })
         }
-
-        if (isSkuSearch) {
-            params.putIfNotEmpty("sku" to searchQuery) // full SKU match
-            params.putIfNotEmpty("search_sku" to searchQuery) // partial SKU match, added in core v6.6
-        } else {
-            params.putIfNotEmpty("search" to searchQuery)
+        searchQuery?.let { query ->
+            if (isSkuSearch) {
+                params["sku"] = query // full SKU match
+                params["search_sku"] = query // partial SKU match, added in core v6.6
+            } else {
+                params.putIfNotEmpty("search" to query)
+            }
         }
 
         return params

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1054,8 +1054,11 @@ class WCProductStore @Inject constructor(
     private fun fetchProducts(payload: FetchProductsPayload) {
         with(payload) {
             wcProductRestClient.fetchProducts(
-                    site, pageSize, offset, sorting,
-                    remoteProductIds = remoteProductIds,
+                    site = site,
+                    pageSize = pageSize,
+                    offset = offset,
+                    sortType = sorting,
+                    includedProductIds = remoteProductIds,
                     filterOptions = filterOptions,
                     excludedProductIds = excludedProductIds
             )


### PR DESCRIPTION
This PR updates `ProductRestClient` to reuse `buildProductParametersMap` in `fetchProducts` rather than have two places where the parameters are created.