### PR TITLE
WCSettingsModel Crash Fix

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1874,7 +1874,7 @@ open class WellSqlConfig : DefaultWellConfig {
                         "AND TASK_TYPE='customize';")
                 }
                 177 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("ALTER TABLE WCSettingsModel ADD COUPONS_ENABLED BOOLEAN")
+                    db.execSQL("ALTER TABLE WCSettingsModel ADD COUPONS_ENABLED INTEGER")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1874,7 +1874,7 @@ open class WellSqlConfig : DefaultWellConfig {
                         "AND TASK_TYPE='customize';")
                 }
                 177 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("ALTER TABLE WCSettingsModel ADD COUPONS_ENABLED INTEGER")
+                    db.execSQL("ALTER TABLE WCSettingsModel ADD COUPONS_ENABLED BOOLEAN NOT NULL DEFAULT 0")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1874,7 +1874,7 @@ open class WellSqlConfig : DefaultWellConfig {
                         "AND TASK_TYPE='customize';")
                 }
                 177 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("ALTER TABLE WCSettingsModel ADD COUPONS_ENABLED BOOLEAN NOT NULL")
+                    db.execSQL("ALTER TABLE WCSettingsModel ADD COUPONS_ENABLED BOOLEAN")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSettingsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCSettingsModel.kt
@@ -15,7 +15,7 @@ data class WCSettingsModel(
     val city: String = "",
     val postalCode: String = "",
     val stateCode: String = "", // The state code for the site in 2-letter format i.e. NY
-    val couponsEnabled: Boolean
+    val couponsEnabled: Boolean = false
 ) {
     enum class CurrencyPosition {
         LEFT, RIGHT, LEFT_SPACE, RIGHT_SPACE;


### PR DESCRIPTION
⚠️  **Please do not merge yet:** this needs a companion [WC Android PR](https://github.com/woocommerce/woocommerce-android/pull/6897) to be merged together

---

This fixes the previous crash situation where the migration script has:

`ALTER TABLE WCSettingsModel ADD COUPONS_ENABLED BOOLEAN NOT NULL`

Yet the `WCSettingsModel` had `val couponsEnabled: Boolean` with no default value.

### Testing Instruction
Please follow the testing instruction in https://github.com/woocommerce/woocommerce-android/pull/6897 


---

Reported error message:

```
2022-07-05 17:49:43.468 15763-15763/com.woocommerce.android.dev E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.woocommerce.android.dev, PID: 15763
    java.lang.RuntimeException: Unable to create application com.woocommerce.android.WooCommerceDebug: android.database.sqlite.SQLiteException: Cannot add a NOT NULL column with default value NULL (code 1 SQLITE_ERROR)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6710)
        at android.app.ActivityThread.access$1500(ActivityThread.java:249)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2060)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7813)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
     Caused by: android.database.sqlite.SQLiteException: Cannot add a NOT NULL column with default value NULL (code 1 SQLITE_ERROR)
        at android.database.sqlite.SQLiteConnection.nativeExecuteForChangedRowCount(Native Method)
        at android.database.sqlite.SQLiteConnection.executeForChangedRowCount(SQLiteConnection.java:892)
        at android.database.sqlite.SQLiteSession.executeForChangedRowCount(SQLiteSession.java:756)
        at android.database.sqlite.SQLiteStatement.executeUpdateDelete(SQLiteStatement.java:67)
        at android.database.sqlite.SQLiteDatabase.executeSql(SQLiteDatabase.java:1921)
        at android.database.sqlite.SQLiteDatabase.execSQL(SQLiteDatabase.java:1842)
        at org.wordpress.android.fluxc.persistence.WellSqlConfig$onUpgrade$179.invoke(WellSqlConfig.kt:1877)
        at org.wordpress.android.fluxc.persistence.WellSqlConfig$onUpgrade$179.invoke(WellSqlConfig.kt:1876)
        at org.wordpress.android.fluxc.persistence.WellSqlConfig.migrateAddOn(WellSqlConfig.kt:1960)
        at org.wordpress.android.fluxc.persistence.WellSqlConfig.onUpgrade(WellSqlConfig.kt:1876)
        at com.yarolegovich.wellsql.WellSql.onUpgrade(WellSql.java:44)
        at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:416)
        at android.database.sqlite.SQLiteOpenHelper.getReadableDatabase(SQLiteOpenHelper.java:340)
        at com.yarolegovich.wellsql.WellSql.select(WellSql.java:69)
        at org.wordpress.android.fluxc.persistence.AccountSqlUtils.getAccountByLocalId(AccountSqlUtils.java:120)
        at org.wordpress.android.fluxc.persistence.AccountSqlUtils.getDefaultAccount(AccountSqlUtils.java:111)
        at org.wordpress.android.fluxc.store.AccountStore.loadAccount(AccountStore.java:1251)
        at org.wordpress.android.fluxc.store.AccountStore.<init>(AccountStore.java:820)
        at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get0(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:5509)
        at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:5894)
        at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
        at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl.wCCrashLoggingDataProvider(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:5120)
        at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl.access$18000(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:4766)
        at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get0(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:5506)
        at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:5894)
        at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
        at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl.injectAppInitializer(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:5446)
2022-07-05 17:49:43.468 15763-15763/com.woocommerce.android.dev E/AndroidRuntime:     at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl.access$17900(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:4766)
        at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get0(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:5503)
        at com.woocommerce.android.DaggerWooCommerceDebug_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get(DaggerWooCommerceDebug_HiltComponents_SingletonC.java:5894)
        at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
        at com.woocommerce.android.WooCommerce.onCreate(WooCommerce.kt:29)
        at com.woocommerce.android.Hilt_WooCommerceDebug.onCreate(Hilt_WooCommerceDebug.java:43)
        at com.woocommerce.android.WooCommerceDebug.onCreate(WooCommerceDebug.kt:33)
        at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1223)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6705)
        	... 9 more
```