### PR TITLE
Woo/Allow displayValue to be null

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMetaDataHandler.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMetaDataHandler.kt
@@ -34,7 +34,7 @@ class OrderMetaDataHandler @Inject constructor(
                         key = it.key,
                         value = it.value.toString(),
                         displayKey = it.displayKey,
-                        displayValue = it.displayValue.toString()
+                        displayValue = it.displayValue?.toString()
                     )
                 }
         )


### PR DESCRIPTION
This tiny (one character!) PR fixes an issue with the `OrderMetaData` table that caused a null `displayValue` to be stored as the string "NULL".

**Before**
<img width="1103" alt="before" src="https://user-images.githubusercontent.com/3903757/178789971-1feee8a5-3a80-4a5f-ab5a-0f94187a888f.png">


**After**
<img width="1145" alt="after" src="https://user-images.githubusercontent.com/3903757/178789986-fa40ab0d-6450-4f58-ae92-4decc93f099d.png">

