### PR TITLE
Enable ignored Buildkite connected tests

### DIFF
--- a/.buildkite/connected-tests.sh
+++ b/.buildkite/connected-tests.sh
@@ -13,7 +13,7 @@ echo -e "\n--- :gcloud: Logging into Google Cloud"
 gcloud auth activate-service-account --key-file .configure-files/firebase.secrets.json
 
 echo -e "\n--- :hammer_and_wrench: Building Tests"
-./gradlew --stacktrace example:assembleDebug example:assembleDebugAndroidTest
+./gradlew example:assembleDebug example:assembleDebugAndroidTest
 
 echo -e "\n--- :firebase: Run Tests"
 mkdir -p build/test-results

--- a/.buildkite/connected-tests.sh
+++ b/.buildkite/connected-tests.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo "--- :closed_lock_with_key: Installing Secrets"
-cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
+cp gradle.properties-example gradle.properties
 ./gradlew applyConfiguration
 
 echo -e "\n--- :open_file_folder: Merge Properties Files"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,19 +44,19 @@ steps:
   - label: "checkstyle"
     command: |
       cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-      ./gradlew --stacktrace checkstyle
+      ./gradlew checkstyle
     artifact_paths: *artifact_paths
 
   - label: "ktlint"
     command: |
       cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-      ./gradlew --stacktrace ktlint
+      ./gradlew ktlint
     artifact_paths: *artifact_paths
 
   - label: "Lint"
     command: |
       cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-      ./gradlew --stacktrace lintRelease || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1);
+      ./gradlew lintRelease || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1);
       find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || exit 0;
     artifact_paths: *artifact_paths
 

--- a/.buildkite/unit-tests.sh
+++ b/.buildkite/unit-tests.sh
@@ -6,7 +6,7 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
 
 echo "--- :gradle: Run Tests"
-./gradlew --stacktrace example:testRelease plugins:woocommerce:testRelease || EXIT_CODE=$?
+./gradlew example:testRelease plugins:woocommerce:testRelease || EXIT_CODE=$?
 
 echo -e "\n--- :buildkite: Upload Test Results to Test Analytics"
 find example/build/test-results/testReleaseUnitTest -name "TEST-*.xml" -exec upload_buildkite_test_analytics_junit {} $BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS \;

--- a/.buildkite/woocommerce-tests.sh
+++ b/.buildkite/woocommerce-tests.sh
@@ -9,7 +9,7 @@ cp gradle.properties-example gradle.properties && cp -a example/properties-examp
 wget $API_TEST_SITE_URL
 
 echo -e "\n--- :gradle: Run Tests"
-./gradlew --stacktrace :tests:api:test  || EXIT_CODE=$?
+./gradlew :tests:api:test  || EXIT_CODE=$?
 
 echo -e "\n--- :buildkite: Upload Test Results to Test Analytics"
 find tests/api/build/test-results/test -name "TEST-*.xml" -exec upload_buildkite_test_analytics_junit {} $BUILDKITE_ANALYTICS_TOKEN_WOO_TESTS \;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -7,7 +7,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.fluxc.TestUtils
 import org.wordpress.android.fluxc.action.ActivityLogAction
@@ -75,7 +74,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         this.incomingActions.clear()
     }
 
-    @Ignore @Test
+    @Test
     fun testFetchActivities() {
         val site = authenticate(FreeJetpackSite)
 
@@ -92,7 +91,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         assertEquals(fetchActivities.rowsAffected, activityLogForSite.size)
     }
 
-    @Ignore @Test
+    @Test
     fun testFetchRewindableActivities() {
         val site = authenticate(FreeJetpackSite)
 
@@ -131,7 +130,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         assertTrue(userActivities != rewindActivities)
     }
 
-    @Ignore @Test
+    @Test
     fun testFetchRewindState() {
         val site = authenticate(FreeJetpackSite)
 
@@ -150,7 +149,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         }
     }
 
-    @Ignore @Test
+    @Test
     fun storeAndRetrieveActivityLogInOrderByDateFromDb() {
         val site = authenticate(FreeJetpackSite)
 
@@ -171,7 +170,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         assertEquals(activityLogForSite[2], firstActivity)
     }
 
-    @Ignore @Test
+    @Test
     fun storeAndRetrieveRewindableActivityLogInOrderByDateFromDb() {
         val site = authenticate(FreeJetpackSite)
 
@@ -191,7 +190,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         assertEquals(activityLogForSite[1], firstActivity)
     }
 
-    @Ignore @Test
+    @Test
     fun updatesActivityWithTheSameActivityId() {
         val site = authenticate(FreeJetpackSite)
 
@@ -217,7 +216,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         assertEquals(updatedActivityLogForSite[0].name, updatedName)
     }
 
-    @Ignore @Test
+    @Test
     fun rewindOperationFailsOnNonexistentId() {
         val site = authenticate(FreeJetpackSite)
 
@@ -230,7 +229,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         assertEquals(rewindResult.error.type, RewindErrorType.GENERIC_ERROR)
     }
 
-    @Ignore @Test
+    @Test
     fun insertAndRetrieveRewindStatus() {
         val site = authenticate(FreeJetpackSite)
         this.mCountDownLatch = CountDownLatch(1)
@@ -256,7 +255,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
         }
     }
 
-    @Ignore @Test
+    @Test
     fun testFetchActivityTypes() {
         val site = authenticate(FreeJetpackSite)
         val payload = FetchActivityTypesPayload(site.siteId, null, null)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -476,8 +476,8 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     }
 
     private StockMediaModel newStockMedia(int id) {
-        String name = "pexels-photo-" + id;
-        String url = "https://images.pexels.com/photos/" + id + "/" + name + ".jpeg?w=320";
+        String name = "pexels-photo-" + id + ".jpeg";
+        String url = "https://images.pexels.com/photos/" + id + "/" + name + "?w=320";
 
         StockMediaModel stockMedia = new StockMediaModel();
         stockMedia.setName(name);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -229,14 +229,14 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         // Upload media attached to remotely saved post
         MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
         testMedia.setLocalPostId(5);
-        testMedia.setPostId(1);
+        testMedia.setPostId(4507);
         mNextEvent = TestEvents.UPLOADED_MEDIA;
         uploadMedia(testMedia);
 
         testMedia.setMediaId(mLastUploadedId);
         MediaModel uploadedMedia = mMediaStore.getSiteMediaWithId(sSite, testMedia.getMediaId());
         assertNotNull(uploadedMedia);
-        assertEquals(1, uploadedMedia.getPostId());
+        assertEquals(4507, uploadedMedia.getPostId());
         assertEquals(5, uploadedMedia.getLocalPostId());
 
         mNextEvent = TestEvents.DELETED_MEDIA;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.release;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
@@ -335,7 +334,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
     }
 
-    @Ignore @Test
+    @Test
     public void testFetchPages() throws InterruptedException {
         mNextEvent = TestEvents.PAGES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);
@@ -680,7 +679,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         testAutoSavePostOrPage(post, false, false);
     }
 
-    @Ignore @Test
+    @Test
     public void testAutoSaveScheduledPost() throws InterruptedException {
         // Arrange
         PostModel post = createNewPost();
@@ -751,7 +750,7 @@ public class ReleaseStack_PostTestWPCom extends ReleaseStack_WPComBase {
         assertEquals(uploadedPost.getRemoteLastModified(), postAfterAutoSave.getRemoteLastModified());
     }
 
-    @Ignore @Test
+    @Test
     public void testAutoSaveModifiedDateIsDifferentThanPostModifiedDate() throws InterruptedException {
         // Arrange
         PostModel post = createNewPost();

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.release;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -348,7 +348,7 @@ public class ReleaseStack_PostTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(currentStoredPosts <= (PostStore.NUM_POSTS_PER_FETCH * 2));
     }
 
-    @Ignore @Test
+    @Test
     public void testFetchPages() throws InterruptedException {
         mNextEvent = TestEvents.PAGES_FETCHED;
         mCountDownLatch = new CountDownLatch(1);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -352,7 +352,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         // Get the first site
         SiteModel firstSite = mSiteStore.getSites().get(0);
         // Default quota for a wpcom site is 3Gb
-        assertEquals(firstSite.getSpaceAllowed(), 3L * 1024 * 1024 * 1024);
+        assertTrue(firstSite.getSpaceAllowed() > 3L * 1024 * 1024 * 1024);
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestWPCom.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TimeStatsTestWPCom.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.release
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
@@ -24,6 +25,9 @@ class ReleaseStack_TimeStatsTestWPCom : ReleaseStack_WPComBase() {
         init()
     }
 
+    @Ignore("File download stats are not available for Jetpack sites")
+    // Running the test will fail due to:
+    // {"error":"invalid_blog","message":"File download stats are not available for Jetpack sites"}
     @Test
     fun testFetchFileDownloads() {
         val selectedDate = Calendar.getInstance()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -74,7 +74,8 @@ public class CommentErrorUtils {
         if (error instanceof WPComGsonNetworkError) {
             WPComGsonNetworkError wpComGsonNetworkError = (WPComGsonNetworkError) error;
             // Duplicate comment on WPCom REST
-            if ("comment_duplicate".equals(wpComGsonNetworkError.apiError)) {
+            if ("comment_duplicate".equals(wpComGsonNetworkError.apiError)
+                || "duplicate_comment".equals(wpComGsonNetworkError.apiError)) {
                 errorType = CommentErrorType.DUPLICATE_COMMENT;
             }
             if ("unauthorized".equals(wpComGsonNetworkError.apiError)) {

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx6G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
 android.jetifier.ignorelist=bcprov


### PR DESCRIPTION
This is a "suggestions" PR for #2472. It enables the ignored tests as I am hoping that I addressed the failures by cleaning up our test sites. It also suggests the following changes:

* Remove `cp -a example/properties-example/ example/properties/` from connected tests since these files will be copied during `./gradlew applyConfiguration` in the next line
* Increases the memory in `gradle.properties-example` so we don't unnecessarily slow down Buildkite agents and risk "out of memory" errors. The reason we had such a low memory setting before was CircleCI which we can now remove.
* Removes `--stacktrace` flag from Buildkite commands. This flag is rarely useful and can make it harder to find the information we are looking for, so it makes sense to keep it disabled for CI. In the odd case that we need the stacktrace, we can run the command locally, or temporarily enable it in CI.
* It looks like the API error for duplicate comment changed from `comment_duplicate` to `duplicate_comment`. To be on the safe side, I just handled both `comment_duplicate` & `duplicate_comment` as a duplicate comment in 58c6a77067331cd23f82d9615f4be623f50de43f. This should fix the failing `testErrorDuplicatedComment` connected test.
* 4a304e5a0512cb2506551627ba97e1a27d230875 fixes upload stock media connected test by adding `.jpeg` suffix to the stock media name
* 65a3bfe2654c0c056ad94bb61e80916c64c8faa7 updates to post id used by `testUploadImageAttachedToPost`. This change was necessary as the original post that was used for this test was removed during cleanup.
* 4f2f7d1394c9f6df428f0ec1d99368a62e9318a1 updates the logic for `testActivateTheme` to use the installed themes instead of wp.com themes for activation. When I upgraded the plan for the test site to Business, it made it a "jetpack connected" site which historically meant self-hosted site, so activating a theme required it to be installed first. This doesn't seem to be the case anymore, but `ThemeStore` is not up to pace on these changes as WPAndroid seems to be using a browser for theme installation/activation. I decided to use the installed themes in this test to avoid changing the logic in `ThemeStore`. Not only would that be beyond the scope of this PR, but also, in my opinion, it'd be the wrong time to make that kind of change if our clients are not going to utilize it. I also [explained this situation in the line comments](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2473/commits/4f2f7d1394c9f6df428f0ec1d99368a62e9318a1#diff-9e2adeec4705757802f9bd8a75faf2c7f1cc42253318f6d3bf2917015b1e36f4R86), so hopefully the next person won't need to spend as much as I did.
* 01aae6d7f69a0160d05d7df7aea688ef49df66b7 changes the space allowed check for a site from matching exactly 3G to being larger than 3G. This is another issue caused by the business plan change. I don't think the exact number is very important here as the goal of the test is to verify that we get a non-zero (hopefully accurate) number from the API for the `spaceAllowed` value. So, checking that it's larger than the default 3G should be enough.
* 4b55efd234f30c5b6cfeb7e0e6ef530abd7110f9 ignores `testFetchFileDownloads` because it results in `{"error":"invalid_blog","message":"File download stats are not available for Jetpack sites"}` due to the business plan upgrade.

Note that CircleCI might fail because of the memory change. I assume we'll have a PR to remove CircleCI immediately after we merge Buildkite connected tests, so we can just ignore it.