### PR TITLE
[DO NOT MERGE] Encode email delimiter chars defined in RFC 3986

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -52,7 +52,7 @@ import org.wordpress.android.fluxc.store.AccountStore.SubscriptionError;
 import org.wordpress.android.fluxc.store.AccountStore.SubscriptionResponsePayload;
 import org.wordpress.android.fluxc.store.AccountStore.SubscriptionType;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateSubscriptionPayload.SubscriptionFrequency;
-import org.wordpress.android.fluxc.utils.WPUrlUtils;
+import org.wordpress.android.fluxc.utils.extensions.StringExtensionsKt;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.LanguageUtils;
@@ -928,9 +928,11 @@ public class AccountRestClient extends BaseWPComRestClient {
      * {@link FetchAuthOptionsResponsePayload#isError()} can be used to check the request result.
      */
     public void fetchAuthOptions(@NonNull String emailOrUsername) {
-        final String url =
-                WPCOMREST.users.emailOrUsername(WPUrlUtils.escapeUrlPathWithRFC3986(emailOrUsername)).auth_options
-                        .getUrlV1_1();
+        final String url = WPCOMREST
+                .users
+                .emailOrUsername(StringExtensionsKt.encodeRfc3986Delimiters(emailOrUsername))
+                .auth_options
+                .getUrlV1_1();
         addUnauthedRequest(WPComGsonRequest.buildGetRequest(url, null, AuthOptionsResponse.class,
                 new Listener<AuthOptionsResponse>() {
                     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -52,6 +52,7 @@ import org.wordpress.android.fluxc.store.AccountStore.SubscriptionError;
 import org.wordpress.android.fluxc.store.AccountStore.SubscriptionResponsePayload;
 import org.wordpress.android.fluxc.store.AccountStore.SubscriptionType;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateSubscriptionPayload.SubscriptionFrequency;
+import org.wordpress.android.fluxc.utils.WPUrlUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.LanguageUtils;
@@ -927,7 +928,9 @@ public class AccountRestClient extends BaseWPComRestClient {
      * {@link FetchAuthOptionsResponsePayload#isError()} can be used to check the request result.
      */
     public void fetchAuthOptions(@NonNull String emailOrUsername) {
-        final String url = WPCOMREST.users.emailOrUsername(emailOrUsername).auth_options.getUrlV1_1();
+        final String url =
+                WPCOMREST.users.emailOrUsername(WPUrlUtils.escapeUrlPathWithRFC3986(emailOrUsername)).auth_options
+                        .getUrlV1_1();
         addUnauthedRequest(WPComGsonRequest.buildGetRequest(url, null, AuthOptionsResponse.class,
                 new Listener<AuthOptionsResponse>() {
                     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -27,7 +27,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthEmailErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
-import org.wordpress.android.fluxc.utils.WPUrlUtils;
+import org.wordpress.android.fluxc.utils.extensions.StringExtensionsKt;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.LanguageUtils;
@@ -216,7 +216,7 @@ public class Authenticator {
                 : WPCOMREST.auth.send_login_email.getUrlV1_3();
 
         Map<String, Object> params = new HashMap<>();
-        params.put("email", WPUrlUtils.escapeUrlPathWithRFC3986(payload.emailOrUsername));
+        params.put("email", StringExtensionsKt.encodeRfc3986Delimiters(payload.emailOrUsername));
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthEmailErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
+import org.wordpress.android.fluxc.utils.WPUrlUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.LanguageUtils;
@@ -215,7 +216,7 @@ public class Authenticator {
                 : WPCOMREST.auth.send_login_email.getUrlV1_3();
 
         Map<String, Object> params = new HashMap<>();
-        params.put("email", payload.emailOrUsername);
+        params.put("email", WPUrlUtils.escapeUrlPathWithRFC3986(payload.emailOrUsername));
         params.put("client_id", mAppSecrets.getAppId());
         params.put("client_secret", mAppSecrets.getAppSecret());
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
@@ -79,9 +79,9 @@ public class WPUrlUtils {
 
     /**
      * Disallows delim characters as per RFC 3986
-     * https://datatracker.ietf.org/doc/html/rfc3986
+     * https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
      *
-     * Similar fix in iOS
+     * Similar fix in iOS:
      * https://github.com/wordpress-mobile/WordPressKit-iOS/pull/457
      */
     public static String escapeUrlPathWithRFC3986(String urlPath) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
@@ -76,4 +76,15 @@ public class WPUrlUtils {
             return null;
         }
     }
+
+    /**
+     * Disallows delim characters as per RFC 3986
+     * https://datatracker.ietf.org/doc/html/rfc3986
+     *
+     * Similar fix in iOS
+     * https://github.com/wordpress-mobile/WordPressKit-iOS/pull/457
+     */
+    public static String escapeUrlPathWithRFC3986(String urlPath) {
+        return urlPath.replaceAll("[!’()*]", "");
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
@@ -76,15 +76,4 @@ public class WPUrlUtils {
             return null;
         }
     }
-
-    /**
-     * Disallows delim characters as per RFC 3986
-     * https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
-     *
-     * Similar fix in iOS:
-     * https://github.com/wordpress-mobile/WordPressKit-iOS/pull/457
-     */
-    public static String escapeUrlPathWithRFC3986(String urlPath) {
-        return urlPath.replaceAll("[!'()*]", "");
-    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
@@ -85,6 +85,6 @@ public class WPUrlUtils {
      * https://github.com/wordpress-mobile/WordPressKit-iOS/pull/457
      */
     public static String escapeUrlPathWithRFC3986(String urlPath) {
-        return urlPath.replaceAll("[!’()*]", "");
+        return urlPath.replaceAll("[!'()*]", "");
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/extensions/StringExtensions.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/extensions/StringExtensions.kt
@@ -9,9 +9,9 @@ import java.net.URLEncoder
  * See [Similar fix in iOS](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/457)
  */
 fun String.encodeRfc3986Delimiters(): String {
-    val delimitersRegex = "[!'()*]".toRegex()
+    val rfc3986Delimiters = "!'()*"
 
-    return replace(delimitersRegex) {
+    return replace("[$rfc3986Delimiters]".toRegex()) {
         URLEncoder.encode(it.value, "UTF-8")
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/extensions/StringExtensions.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/extensions/StringExtensions.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.utils.extensions
+
+import java.net.URLEncoder
+
+/**
+ * Encodes delimiting characters as per
+ * [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2)
+ *
+ * See [Similar fix in iOS](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/457)
+ */
+fun String.encodeRfc3986Delimiters(): String {
+    val delimitersRegex = "[!'()*]".toRegex()
+
+    return replace(delimitersRegex) {
+        URLEncoder.encode(it.value, "UTF-8")
+    }
+}


### PR DESCRIPTION
Fixes #2170 

## Description

This PR encodes the delimiter characters based on the [RFC 3986 standard](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) because our backend code makes multiple references to RFC 3986.

**To Test:**
Follow the testing steps from the integrating PR: https://github.com/wordpress-mobile/WordPress-Android/pull/15526.

**Note:**
This PR was created to investigate why the CI checks don't succeed on the original one: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2171.