### PR TITLE
Use version catalog for configure & fetchstyle plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ plugins {
     alias(sharedLibs.plugins.kotlin.jvm).apply(false)
     alias(sharedLibs.plugins.kotlin.kapt).apply(false)
 
-    id "com.automattic.android.fetchstyle"
-    id "com.automattic.android.configure"
+    alias(sharedLibs.plugins.automattic.fetchstyle)
+    alias(sharedLibs.plugins.automattic.configure)
 }
 
 allprojects {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,26 +1,20 @@
 pluginManagement {
     repositories {
-        maven {
-            url 'https://a8c-libs.s3.amazonaws.com/android' 
-            content {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    url = uri("https://a8c-libs.s3.amazonaws.com/android")
+                }
+            }
+            filter {
                 includeGroup "com.automattic.android"
+                includeGroup "com.automattic.android.configure"
+                includeGroup "com.automattic.android.fetchstyle"
                 includeGroup "com.automattic.android.publish-to-s3"
             }
         }
         gradlePluginPortal()
         google()
-    }
-    resolutionStrategy {
-        eachPlugin {
-            // TODO: Remove this as soon as fetchstyle starts supporting Plugin Marker Artifacts
-            if (requested.id.id == "com.automattic.android.fetchstyle") {
-                useModule("com.automattic.android:fetchstyle:1.1")
-            }
-            // TODO: Remove this as soon as configure starts supporting Plugin Marker Artifacts
-            if (requested.id.id == "com.automattic.android.configure") {
-                useModule("com.automattic.android:configure:0.6.3")
-            }
-        }
     }
 }
 
@@ -29,7 +23,7 @@ plugins {
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.5'
 }
 
-def catalogVersion = "1.2.0"
+def catalogVersion = "1.3.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {


### PR DESCRIPTION
This PR updates our [dependency catalog](https://github.com/Automattic/android-dependency-catalog) to `1.3.0` which includes `0.6.5` version of `configure` & `1.1` version of `fetchstyle` plugins.

We started to publish the Plugin Marker Artifact for `configure`, so we don't need the extra resolution strategy for it anymore. This is actually the only difference between `0.6.3` and `0.6.5`, so no testing is necessary. For `fetchstyle`, I manually created the marker artifact 2 days ago and published it for `1.1` version, so we don't need the resolution rule for it either.

I also took this opportunity to update the plugin repositories using the more secure `exclusiveContent` syntax so that our plugins can't be fetched from any other repository. This is a standard improvement we are applying across the board whenever we get a chance.

**To test**

* Run `./gradlew` and open the build scan generated from it.
* In `Build dependencies` section, search for `configure` plugin and verify that its version is `0.6.5` (you can also check it from `Plugins` section)

Or just check the below screenshot where I did already did this 😅 

<img width="985" alt="Screen Shot 2022-08-03 at 4 28 06 PM" src="https://user-images.githubusercontent.com/662023/182705560-69c3e20c-0bd2-46b4-84b7-e66e73dce19c.png">