### PR TITLE
[Add Detekt] Remove KtLint

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,12 +47,6 @@ steps:
       ./gradlew checkstyle
     artifact_paths: *artifact_paths
 
-  - label: "ktlint"
-    command: |
-      cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-      ./gradlew ktlint
-    artifact_paths: *artifact_paths
-
   - label: "detekt"
     command: |
       cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/

--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ Once installed, you can configure the plugin here:
 
 From there, add and enable the configuration file for FluxC, located at [config/checkstyle.xml](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/trunk/config/checkstyle.xml).
 
-## Using ktlint
-
-The FluxC project uses [ktlint](https://github.com/shyiko/ktlint) for Kotlin linting. You can run ktlint using `./gradlew ktlint`, and you can also run `./gradlew ktlintFormat` for auto-formatting. There is no IDEA plugin (like Checkstyle's) at this time.
-
 ## Using Detekt
 
 The FluxC project uses [detekt](https://github.com/detekt/detekt) for Kotlin linting and code style check.

--- a/build.gradle
+++ b/build.gradle
@@ -61,28 +61,6 @@ allprojects {
     }
 }
 
-subprojects {
-    configurations {
-        ktlint
-    }
-
-    dependencies {
-        ktlint 'com.github.shyiko:ktlint:0.31.0'
-    }
-
-    task ktlint(type: JavaExec) {
-        main = "com.github.shyiko.ktlint.Main"
-        classpath = configurations.ktlint
-        args "src/**/*.kt"
-    }
-
-    task ktlintFormat(type: JavaExec) {
-        main = "com.github.shyiko.ktlint.Main"
-        classpath = configurations.ktlint
-        args "-F", "src/**/*.kt"
-    }
-}
-
 ext {
     fluxcAnnotationsProjectDependency = project.hasProperty("fluxcAnnotationsVersion") ? "org.wordpress.fluxc:fluxc-annotations:${project.getProperty("fluxcAnnotationsVersion")}" : project(":fluxc-annotations")
     fluxcProcessorProjectDependency = project.hasProperty("fluxcProcessorVersion") ? "org.wordpress.fluxc:fluxc-processor:${project.getProperty("fluxcProcessorVersion")}" : project(":fluxc-processor")


### PR DESCRIPTION
Parent: #2476
Closes: #2478

This PR removes [KtLint](https://ktlint.github.io) from the repo, and includes the following:

- Removes build configuration for KtLint (01b38a9a863aa1d510a76fbe1c371a2b752f278d).
- Removes CI configuration for KtLint (edc3c490f1d3bb25bba52d077573cc0bed3457a4).
- Removes any KtLint documentation (2a7fdc75834273524d7d32a918f31e13cd406bfd).

As per the removal of KtLint from both, [WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/16828) and [WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/4149), this PR removes it from FluxC as well. [KtLint](https://ktlint.github.io) is being replaced with [Detekt](https://detekt.dev) (see [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2482)) and its [formatting rule set](https://detekt.dev/docs/rules/formatting), which provides wrappers for rules implemented by KtLint.

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough (and more specifically, that the ktlint check is gone).

-----

Merge Instructions:

- [x] Make sure that the PR is reviewed, tested and approved.
- [x] Remove the required `buildkite/wordpress-fluxc-android/ktlint` status check from the [branch protection rule](https://github.com/wordpress-mobile/WordPress-FluxC-Android/settings/branch_protection_rules/701984) page for `trunk`.
