### PR TITLE
[Tooling/CI] Update CI pipeline to group steps + add missing step dependencies

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,61 @@ agents:
   queue: "android"
 
 steps:
+  ############################
+  # Linters
+  ############################
+  - group: "🕵️ Linters"
+    key: all-linters
+    steps:
+      - label: "🕵️ checkstyle"
+        command: |
+          cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
+          ./gradlew checkstyle
+        artifact_paths: *artifact_paths
+
+      - label: "🕵️ detekt"
+        command: |
+          cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
+          ./gradlew detekt
+        artifact_paths: *artifact_paths
+
+      - label: "🕵️ Lint"
+        command: |
+          cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
+          ./gradlew lintRelease || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1);
+          find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || exit 0;
+        artifact_paths: *artifact_paths
+
+  ############################
+  # Unit Tests
+  ############################
+  - group: 🔬 Unit Tests
+    key: all-unit-tests
+    steps:
+      - label: "🔬 Unit Test"
+        command: .buildkite/unit-tests.sh
+        artifact_paths: *artifact_paths
+        plugins: *common_plugins
+
+      - label: "🔬 WooCommerce Tests"
+        command: .buildkite/woocommerce-tests.sh
+        artifact_paths: *artifact_paths
+        plugins: *common_plugins
+
+  ############################
+  # Connected Tests
+  ############################
+  - label: "🔬 Connected Tests"
+    key: connected-tests
+    command: .buildkite/connected-tests.sh
+    artifact_paths: *artifact_paths
+    plugins: *common_plugins
+
+  ############################
+  # Publish artefacts to S3
+  ############################
   - group: 🚀 Publish to S3
+    key: publish-to-s3
     depends_on:
       - all-linters
       - all-unit-tests
@@ -47,44 +101,3 @@ steps:
           - "publish-fluxc"
         command: .buildkite/publish-plugins-woocommerce.sh
         plugins: *common_plugins
-
-  - group: "🕵️ Linters"
-    key: all-linters
-    steps:
-      - label: "🕵️ checkstyle"
-        command: |
-          cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-          ./gradlew checkstyle
-        artifact_paths: *artifact_paths
-
-      - label: "🕵️ detekt"
-        command: |
-          cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-          ./gradlew detekt
-        artifact_paths: *artifact_paths
-
-      - label: "🕵️ Lint"
-        command: |
-          cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-          ./gradlew lintRelease || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1);
-          find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || exit 0;
-        artifact_paths: *artifact_paths
-
-  - group: 🔬 Unit Tests
-    key: all-unit-tests
-    steps:
-      - label: "🔬 Unit Test"
-        command: .buildkite/unit-tests.sh
-        artifact_paths: *artifact_paths
-        plugins: *common_plugins
-
-      - label: "🔬 WooCommerce Tests"
-        command: .buildkite/woocommerce-tests.sh
-        artifact_paths: *artifact_paths
-        plugins: *common_plugins
-
-  - label: "🔬 Connected Tests"
-    key: connected-tests
-    command: .buildkite/connected-tests.sh
-    artifact_paths: *artifact_paths
-    plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,65 +12,79 @@ agents:
   queue: "android"
 
 steps:
-  - label: "Publish :fluxc-annotations"
-    key: "publish-fluxc-annotations"
-    command: .buildkite/publish-fluxc-annotations.sh
-    plugins: *common_plugins
-
-  - label: "Publish :fluxc-processor"
-    key: "publish-fluxc-processor"
+  - group: 🚀 Publish to S3
     depends_on:
-      - "publish-fluxc-annotations"
-    command: .buildkite/publish-fluxc-processor.sh
-    plugins: *common_plugins
+      - all-linters
+      - all-unit-tests
+      # Note: Dependency on `connected-tests` is disabled for now until they are more stable to not become a blocker
+      # - connected-tests
+    steps:
+      - label: "🚀 Publish :fluxc-annotations"
+        key: "publish-fluxc-annotations"
+        command: .buildkite/publish-fluxc-annotations.sh
+        plugins: *common_plugins
 
-  - label: "Publish :fluxc"
-    key: "publish-fluxc"
-    depends_on:
-      - "publish-fluxc-processor"
-      - "publish-fluxc-annotations"
-    command: .buildkite/publish-fluxc.sh
-    plugins: *common_plugins
+      - label: "🚀 Publish :fluxc-processor"
+        key: "publish-fluxc-processor"
+        depends_on:
+          - "publish-fluxc-annotations"
+        command: .buildkite/publish-fluxc-processor.sh
+        plugins: *common_plugins
 
-  - label: "Publish :plugins:woocommerce"
-    key: "publish-plugins-woocommerce"
-    depends_on:
-      - "publish-fluxc-processor"
-      - "publish-fluxc-annotations"
-      - "publish-fluxc"
-    command: .buildkite/publish-plugins-woocommerce.sh
-    plugins: *common_plugins
+      - label: "🚀 Publish :fluxc"
+        key: "publish-fluxc"
+        depends_on:
+          - "publish-fluxc-processor"
+          - "publish-fluxc-annotations"
+        command: .buildkite/publish-fluxc.sh
+        plugins: *common_plugins
 
-  - label: "checkstyle"
-    command: |
-      cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-      ./gradlew checkstyle
-    artifact_paths: *artifact_paths
+      - label: "🚀 Publish :plugins:woocommerce"
+        key: "publish-plugins-woocommerce"
+        depends_on:
+          - "publish-fluxc-processor"
+          - "publish-fluxc-annotations"
+          - "publish-fluxc"
+        command: .buildkite/publish-plugins-woocommerce.sh
+        plugins: *common_plugins
 
-  - label: "detekt"
-    command: |
-      cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-      ./gradlew detekt
-    artifact_paths: *artifact_paths
+  - group: "🕵️ Linters"
+    key: all-linters
+    steps:
+      - label: "🕵️ checkstyle"
+        command: |
+          cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
+          ./gradlew checkstyle
+        artifact_paths: *artifact_paths
 
-  - label: "Lint"
-    command: |
-      cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
-      ./gradlew lintRelease || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1);
-      find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || exit 0;
-    artifact_paths: *artifact_paths
+      - label: "🕵️ detekt"
+        command: |
+          cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
+          ./gradlew detekt
+        artifact_paths: *artifact_paths
 
-  - label: "Unit Test"
-    command: .buildkite/unit-tests.sh
-    artifact_paths: *artifact_paths
-    plugins: *common_plugins
+      - label: "🕵️ Lint"
+        command: |
+          cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
+          ./gradlew lintRelease || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1);
+          find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || exit 0;
+        artifact_paths: *artifact_paths
 
-  - label: "WooCommerce Tests"
-    command: .buildkite/woocommerce-tests.sh
-    artifact_paths: *artifact_paths
-    plugins: *common_plugins
+  - group: 🔬 Unit Tests
+    key: all-unit-tests
+    steps:
+      - label: "🔬 Unit Test"
+        command: .buildkite/unit-tests.sh
+        artifact_paths: *artifact_paths
+        plugins: *common_plugins
 
-  - label: "Connected Tests"
+      - label: "🔬 WooCommerce Tests"
+        command: .buildkite/woocommerce-tests.sh
+        artifact_paths: *artifact_paths
+        plugins: *common_plugins
+
+  - label: "🔬 Connected Tests"
+    key: connected-tests
     command: .buildkite/connected-tests.sh
     artifact_paths: *artifact_paths
     plugins: *common_plugins


### PR DESCRIPTION
Up until now, the various Lint and Unit Test steps that [have been recently added to the pipeline](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2472) were not set up as prerequisites for the various PublishToS3 steps. Which means that nothing prevented us to publish a version to S3 before realizing that the lint found violations or the Unit Tests failed.

This PR:
 - Groups the steps per topic, using [Buildkite's Group steps](https://buildkite.com/docs/pipelines/group-step), both to improve the way those are presented in the Buildkite dashboard and summary header, and to make the dependency logic easier to write
 - Add step dependencies between the `Publish to S3` group and all the linters and unit test steps/groups
 - Move the "Publish to S3" group / steps at the end of the pipeline, so that they appear at the end of the list in the Buildkite UI / dashboard too for consistency (since they'll run last, after Lint and Tests)

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/216089/183451799-80902066-a7e3-41b8-ab1a-c227f2a40344.png">

> **Note**: We deliberately decided not to make the Publish to S3 group depend on the Connected Tests step for now, because:
> - Those Connected Tests as still a bit flaky and prone to randomly fail, and preventing the publication to S3 because of this flakiness would be quite impractical.
> - Those Connected Tests take ≈40mn to run, which would delay the publication of new versions of FluxC by quite a lot compared to the speed we have now between creating a new tag or commit and having it published.


<details><summary>As you can see, the four <em>Publish</em> steps don't start while the Lint and Unit tests are still running and haven't passed yet.</summary>
<img width="1161" alt="image" src="https://user-images.githubusercontent.com/216089/183452160-23413fb5-2560-4077-8c14-c0a9e248b851.png">
</details>

<details><summary>And a bit later, you can see that the Publish steps start once the Lint and Unit Test steps have finished — even if the Connected Tests step is still running (because we decided not to depend on that one, see above)</summary>
<img width="1154" alt="image" src="https://user-images.githubusercontent.com/216089/183455114-48a1942b-91f3-4a5b-9bf4-7cc2f36dced8.png">
</details>

> **Note**: This PR might be easier to review with "Ignore Whitespace" turned on, since a large portion of the diff is change in indentation to move existing-and-unmodified-steps under a `group:` parent step.