### PR TITLE
[Detekt Baseline Warnings] FluxC Module - Resolve/Suppress Other Warnings

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -3,7 +3,6 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <!-- fluxc -->
-    <ID>EmptyFunctionBlock:QuickStartStore.kt$QuickStartStore${ }</ID>
     <ID>ImplicitDefaultLocale:SiteStore.kt$SiteStore.ConnectSiteInfoPayload$String.format( "url: %s, e: %b, wp: %b, jp: %b, wpcom: %b, urlAfterRedirects: %s", url, exists, isWordPress, hasJetpack, isWPCom, urlAfterRedirects )</ID>
     <ID>SpreadOperator:PlanOffersDao.kt$PlanOffersDao$(*it.planFeatures.toTypedArray())</ID>
     <ID>SpreadOperator:PlanOffersDao.kt$PlanOffersDao$(*it.planIds.toTypedArray())</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -4,10 +4,6 @@
   <CurrentIssues>
     <!-- fluxc -->
     <ID>ImplicitDefaultLocale:SiteStore.kt$SiteStore.ConnectSiteInfoPayload$String.format( "url: %s, e: %b, wp: %b, jp: %b, wpcom: %b, urlAfterRedirects: %s", url, exists, isWordPress, hasJetpack, isWPCom, urlAfterRedirects )</ID>
-    <ID>SpreadOperator:PlanOffersDao.kt$PlanOffersDao$(*it.planFeatures.toTypedArray())</ID>
-    <ID>SpreadOperator:PlanOffersDao.kt$PlanOffersDao$(*it.planIds.toTypedArray())</ID>
-    <ID>SpreadOperator:PlanOffersSqlUtils.kt$PlanOffersSqlUtils$( *(planOffers.mapIndexed { index, planOffersModel -> planOffersMapper.toDatabaseModel(index, planOffersModel) }).toTypedArray() )</ID>
-    <ID>SpreadOperator:WellSqlConfig.kt$WellSqlConfig$(*addOns)</ID>
     <!-- plugins:woocommerce -->
     <ID>ArrayPrimitive:CouponRestClient.kt$CouponRestClient$Array&lt;Long></ID>
     <ID>ArrayPrimitive:JsonObjectBuilder.kt$JsonObjectBuilder$Array&lt;Int></ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -8,8 +8,6 @@
     <ID>SpreadOperator:PlanOffersDao.kt$PlanOffersDao$(*it.planIds.toTypedArray())</ID>
     <ID>SpreadOperator:PlanOffersSqlUtils.kt$PlanOffersSqlUtils$( *(planOffers.mapIndexed { index, planOffersModel -> planOffersMapper.toDatabaseModel(index, planOffersModel) }).toTypedArray() )</ID>
     <ID>SpreadOperator:WellSqlConfig.kt$WellSqlConfig$(*addOns)</ID>
-    <ID>TooGenericExceptionThrown:ScanStore.kt$ScanStore$throw RuntimeException(msg)</ID>
-    <ID>TooGenericExceptionThrown:WPAPIEncodedBodyRequest.kt$WPAPIEncodedBodyRequest$throw RuntimeException("Encoding not supported: $paramsEncoding", uee)</ID>
     <!-- plugins:woocommerce -->
     <ID>ArrayPrimitive:CouponRestClient.kt$CouponRestClient$Array&lt;Long></ID>
     <ID>ArrayPrimitive:JsonObjectBuilder.kt$JsonObjectBuilder$Array&lt;Int></ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -8,14 +8,6 @@
     <ID>SpreadOperator:PlanOffersDao.kt$PlanOffersDao$(*it.planIds.toTypedArray())</ID>
     <ID>SpreadOperator:PlanOffersSqlUtils.kt$PlanOffersSqlUtils$( *(planOffers.mapIndexed { index, planOffersModel -> planOffersMapper.toDatabaseModel(index, planOffersModel) }).toTypedArray() )</ID>
     <ID>SpreadOperator:WellSqlConfig.kt$WellSqlConfig$(*addOns)</ID>
-    <ID>TooGenericExceptionCaught:BloggingPromptsStore.kt$BloggingPromptsStore$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:CardsStore.kt$CardsStore$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:EncryptedLogUploadRequest.kt$EncryptedLogUploadRequest$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:EncryptedLogUploadRequest.kt$EncryptedLogUploadRequest$jsonParsingError: Throwable</ID>
-    <ID>TooGenericExceptionCaught:PostWPComRestResponse.kt$PostWPComRestResponse.MetaDataAdapter$ex: Exception</ID>
-    <ID>TooGenericExceptionCaught:SiteStore.kt$SiteStore$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:ThreatContextDeserializer.kt$ThreatContextDeserializer$ex: IndexOutOfBoundsException</ID>
-    <ID>TooGenericExceptionCaught:WPV2MediaRestClient.kt$WPV2MediaRestClient.&lt;no name provided>$e: NullPointerException</ID>
     <ID>TooGenericExceptionThrown:ScanStore.kt$ScanStore$throw RuntimeException(msg)</ID>
     <ID>TooGenericExceptionThrown:WPAPIEncodedBodyRequest.kt$WPAPIEncodedBodyRequest$throw RuntimeException("Encoding not supported: $paramsEncoding", uee)</ID>
     <!-- plugins:woocommerce -->

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -8,29 +8,6 @@
     <ID>SpreadOperator:PlanOffersDao.kt$PlanOffersDao$(*it.planIds.toTypedArray())</ID>
     <ID>SpreadOperator:PlanOffersSqlUtils.kt$PlanOffersSqlUtils$( *(planOffers.mapIndexed { index, planOffersModel -> planOffersMapper.toDatabaseModel(index, planOffersModel) }).toTypedArray() )</ID>
     <ID>SpreadOperator:WellSqlConfig.kt$WellSqlConfig$(*addOns)</ID>
-    <ID>SwallowedException:ActivityTypesDeserializer.kt$ActivityTypesDeserializer$ex: ClassCastException</ID>
-    <ID>SwallowedException:ActivityTypesDeserializer.kt$ActivityTypesDeserializer$ex: IllegalStateException</ID>
-    <ID>SwallowedException:BloggingPromptsStore.kt$BloggingPromptsStore$e: Exception</ID>
-    <ID>SwallowedException:CardsStore.kt$CardsStore$e: Exception</ID>
-    <ID>SwallowedException:EditorTheme.kt$EditorThemeElementListSerializer$e: JsonSyntaxException</ID>
-    <ID>SwallowedException:EncryptedLogStore.kt$EncryptedLogStore$e: UnsatisfiedLinkError</ID>
-    <ID>SwallowedException:EncryptedLogUploadRequest.kt$EncryptedLogUploadRequest$e: Exception</ID>
-    <ID>SwallowedException:FixThreatsStatusDeserializer.kt$FixThreatsStatusDeserializer$ex: ClassCastException</ID>
-    <ID>SwallowedException:FixThreatsStatusDeserializer.kt$FixThreatsStatusDeserializer$ex: IllegalStateException</ID>
-    <ID>SwallowedException:FixableDeserializer.kt$FixableDeserializer$e: JsonSyntaxException</ID>
-    <ID>SwallowedException:RowsDeserializer.kt$RowsDeserializer$ex: ClassCastException</ID>
-    <ID>SwallowedException:RowsDeserializer.kt$RowsDeserializer$ex: IllegalStateException</ID>
-    <ID>SwallowedException:SiteRestClient.kt$SiteRestClient$e: IllegalArgumentException</ID>
-    <ID>SwallowedException:SiteRestClient.kt$SiteRestClient$e: JSONException</ID>
-    <ID>SwallowedException:SiteStore.kt$SiteStore$caughtException: DuplicateSiteException</ID>
-    <ID>SwallowedException:SiteStore.kt$SiteStore$e: DuplicateSiteException</ID>
-    <ID>SwallowedException:SiteStore.kt$SiteStore$e: Exception</ID>
-    <ID>SwallowedException:ThreatContextDeserializer.kt$ThreatContextDeserializer$ex: ClassCastException</ID>
-    <ID>SwallowedException:ThreatContextDeserializer.kt$ThreatContextDeserializer$ex: IllegalStateException</ID>
-    <ID>SwallowedException:ThreatContextDeserializer.kt$ThreatContextDeserializer$ex: IndexOutOfBoundsException</ID>
-    <ID>SwallowedException:WPV2MediaRestClient.kt$WPV2MediaRestClient$e: CancellationException</ID>
-    <ID>SwallowedException:WPV2MediaRestClient.kt$WPV2MediaRestClient.&lt;no name provided>$e: CancellationException</ID>
-    <ID>SwallowedException:XMLRPCRequestBuilder.kt$XMLRPCRequestBuilder$e: ClassCastException</ID>
     <ID>TooGenericExceptionCaught:BloggingPromptsStore.kt$BloggingPromptsStore$e: Exception</ID>
     <ID>TooGenericExceptionCaught:CardsStore.kt$CardsStore$e: Exception</ID>
     <ID>TooGenericExceptionCaught:EncryptedLogUploadRequest.kt$EncryptedLogUploadRequest$e: Exception</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -4,8 +4,6 @@
   <CurrentIssues>
     <!-- fluxc -->
     <ID>EmptyFunctionBlock:QuickStartStore.kt$QuickStartStore${ }</ID>
-    <ID>GlobalCoroutineUsage:WhatsNewStore.kt$WhatsNewStore$GlobalScope.launch(coroutineContext) { emitChange( fetchRemoteAnnouncements( versionName, appId ) ) }</ID>
-    <ID>GlobalCoroutineUsage:WhatsNewStore.kt$WhatsNewStore$GlobalScope.launch(coroutineContext) { emitChange(fetchCachedAnnouncements()) }</ID>
     <ID>ImplicitDefaultLocale:SiteStore.kt$SiteStore.ConnectSiteInfoPayload$String.format( "url: %s, e: %b, wp: %b, jp: %b, wpcom: %b, urlAfterRedirects: %s", url, exists, isWordPress, hasJetpack, isWPCom, urlAfterRedirects )</ID>
     <ID>SpreadOperator:PlanOffersDao.kt$PlanOffersDao$(*it.planFeatures.toTypedArray())</ID>
     <ID>SpreadOperator:PlanOffersDao.kt$PlanOffersDao$(*it.planIds.toTypedArray())</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -2,8 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <!-- fluxc -->
-    <ID>ImplicitDefaultLocale:SiteStore.kt$SiteStore.ConnectSiteInfoPayload$String.format( "url: %s, e: %b, wp: %b, jp: %b, wpcom: %b, urlAfterRedirects: %s", url, exists, isWordPress, hasJetpack, isWPCom, urlAfterRedirects )</ID>
     <!-- plugins:woocommerce -->
     <ID>ArrayPrimitive:CouponRestClient.kt$CouponRestClient$Array&lt;Long></ID>
     <ID>ArrayPrimitive:JsonObjectBuilder.kt$JsonObjectBuilder$Array&lt;Int></ID>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -154,6 +154,7 @@ data class EditorThemeElement(
 }
 
 class EditorThemeElementListSerializer : JsonDeserializer<List<EditorThemeElement>> {
+    @Suppress("SwallowedException")
     override fun deserialize(
         json: JsonElement?,
         typeOfT: Type?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/EncryptedLogUploadRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/EncryptedLogUploadRequest.kt
@@ -36,6 +36,7 @@ class EncryptedLogUploadRequest(
         return contents.toByteArray()
     }
 
+    @Suppress("SwallowedException")
     override fun parseNetworkResponse(response: NetworkResponse?): Response<NetworkResponse> {
         return try {
             Response.success(response, HttpHeaderParser.parseCacheHeaders(response))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/EncryptedLogUploadRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/EncryptedLogUploadRequest.kt
@@ -36,7 +36,7 @@ class EncryptedLogUploadRequest(
         return contents.toByteArray()
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override fun parseNetworkResponse(response: NetworkResponse?): Response<NetworkResponse> {
         return try {
             Response.success(response, HttpHeaderParser.parseCacheHeaders(response))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIEncodedBodyRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIEncodedBodyRequest.kt
@@ -48,6 +48,7 @@ class WPAPIEncodedBodyRequest(
      * @param params parameters that are converted
      * @return an application/x-www-form-urlencoded encoded string
      */
+    @Suppress("TooGenericExceptionThrown")
     private fun encodeParameters(params: Map<String, String>): ByteArray {
         val encodedParams = StringBuilder()
         return try {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityTypesDeserializer.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityTypesDeserializer.kt
@@ -46,6 +46,7 @@ class ActivityTypesDeserializer : JsonDeserializer<Groups?> {
         }
     }
 
+    @Suppress("SwallowedException")
     private fun getActivityType(
         key: String,
         groups: JsonObject

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -96,7 +96,7 @@ class WPV2MediaRestClient @Inject constructor(
         }
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun syncUploadMedia(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
         fun ProducerScope<ProgressPayload>.handleFailure(media: MediaModel, error: MediaError) {
             media.setUploadState(FAILED)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPV2MediaRestClient.kt
@@ -96,6 +96,7 @@ class WPV2MediaRestClient @Inject constructor(
         }
     }
 
+    @Suppress("SwallowedException")
     private fun syncUploadMedia(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
         fun ProducerScope<ProgressPayload>.handleFailure(media: MediaModel, error: MediaError) {
             media.setUploadState(FAILED)
@@ -104,7 +105,7 @@ class WPV2MediaRestClient @Inject constructor(
                 sendBlocking(payload)
                 close()
             } catch (e: CancellationException) {
-                // the flow has been cancelled
+                // Do nothing (the flow has been cancelled)
             }
         }
 
@@ -116,7 +117,7 @@ class WPV2MediaRestClient @Inject constructor(
                     try {
                         offer(payload)
                     } catch (e: CancellationException) {
-                        // the flow has been cancelled
+                        // Do nothing (the flow has been cancelled)
                     }
                 }
             }
@@ -152,7 +153,7 @@ class WPV2MediaRestClient @Inject constructor(
                                 sendBlocking(payload)
                                 close()
                             } catch (e: CancellationException) {
-                                // the flow has been cancelled
+                                // Do nothing (the flow has been cancelled)
                             }
                         } catch (e: JsonSyntaxException) {
                             AppLog.e(MEDIA, e)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -143,7 +143,6 @@ data class PostWPComRestResponse(
             return metaDataList
         }
 
-        override fun write(out: JsonWriter?, value: List<PostMetaData>) { // Do Nothing
-        }
+        override fun write(out: JsonWriter?, value: List<PostMetaData>) = Unit // Do Nothing (ignore)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostWPComRestResponse.kt
@@ -103,7 +103,7 @@ data class PostWPComRestResponse(
 
     class MetaDataAdapter(private val gson: Gson) : TypeAdapter<List<PostMetaData>>() {
         @Throws(IOException::class)
-        @Suppress("NestedBlockDepth")
+        @Suppress("NestedBlockDepth", "TooGenericExceptionCaught")
         override fun read(jsonReader: JsonReader): List<PostMetaData> {
             val metaDataList = arrayListOf<PostMetaData>()
 
@@ -128,6 +128,7 @@ data class PostWPComRestResponse(
                                         AppLog.w(POSTS, "Error in post metadata json conversion: " + ex.message)
                                         jsonReader.skipValue()
                                     }
+                                    else -> Unit // Do nothing (ignore)
                                 }
                             }
                         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsStatusDeserializer.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixThreatsStatusDeserializer.kt
@@ -29,6 +29,7 @@ class FixThreatsStatusDeserializer : JsonDeserializer<List<FixThreatStatus>?> {
         }
     }.toList()
 
+    @Suppress("SwallowedException")
     private fun getFixThreatStatus(key: String, inputJsonObject: JsonObject) =
         inputJsonObject.get(key)?.takeIf { it.isJsonObject }?.asJsonObject?.let { threat ->
             try {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixableDeserializer.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/FixableDeserializer.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.scan.threat.Threat.Fixable
 import java.lang.reflect.Type
 
 class FixableDeserializer : JsonDeserializer<Fixable?> {
+    @Suppress("SwallowedException")
     override fun deserialize(
         json: JsonElement?,
         typeOfT: Type?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/RowsDeserializer.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/RowsDeserializer.kt
@@ -47,6 +47,7 @@ class RowsDeserializer : JsonDeserializer<List<Row>?> {
         }
     }
 
+    @Suppress("SwallowedException")
     private fun getRow(
         key: String,
         rowJsonObject: JsonObject

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/ThreatContextDeserializer.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/ThreatContextDeserializer.kt
@@ -118,7 +118,7 @@ class ThreatContextDeserializer : JsonDeserializer<ThreatContext?> {
         return highlights
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun getSelectionRange(rangeArrayJsonElement: JsonElement): Pair<Int, Int>? {
         return try {
             val startIndex = rangeArrayJsonElement.asJsonArray.get(0).asInt

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/ThreatContextDeserializer.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/threat/ThreatContextDeserializer.kt
@@ -118,6 +118,7 @@ class ThreatContextDeserializer : JsonDeserializer<ThreatContext?> {
         return highlights
     }
 
+    @Suppress("SwallowedException")
     private fun getSelectionRange(rangeArrayJsonElement: JsonElement): Pair<Int, Int>? {
         return try {
             val startIndex = rangeArrayJsonElement.asJsonArray.get(0).asInt

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -586,9 +586,8 @@ class SiteRestClient @Inject constructor(
         add(request)
     }
 
-    //
     // Unauthenticated network calls
-    //
+    @Suppress("SwallowedException")
     fun fetchConnectSiteInfo(siteUrl: String) {
         // Get a proper URI to reliably retrieve the scheme.
         val uri: URI = try {
@@ -618,6 +617,7 @@ class SiteRestClient @Inject constructor(
         addUnauthedRequest(request)
     }
 
+    @Suppress("SwallowedException")
     fun fetchWPComSiteByUrl(siteUrl: String) {
         val sanitizedUrl: String
         try {
@@ -1087,6 +1087,7 @@ class SiteRestClient @Inject constructor(
         return site
     }
 
+    @Suppress("SwallowedException")
     private fun volleyErrorToAccountResponsePayload(
         error: VolleyError,
         dryRun: Boolean = false

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequestBuilder.kt
@@ -23,7 +23,7 @@ class XMLRPCRequestBuilder @Inject constructor() {
      * @param listener the success listener
      * @param errorListener the error listener
      */
-    @Suppress("LongParameterList")
+    @Suppress("LongParameterList", "SwallowedException")
     fun <T> buildGetRequest(
         url: String,
         method: XMLRPC,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersDao.kt
@@ -16,6 +16,7 @@ import androidx.room.Transaction
 @Dao
 abstract class PlanOffersDao {
     @Transaction
+    @Suppress("SpreadOperator")
     open fun insertPlanOfferWithDetails(vararg planOfferWithDetails: PlanOfferWithDetails) {
         planOfferWithDetails.forEach {
             this.insertPlanOffer(it.planOffer)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersSqlUtils.kt
@@ -10,6 +10,7 @@ class PlanOffersSqlUtils @Inject constructor(
     private val planOffersDao: PlanOffersDao,
     private val planOffersMapper: PlanOffersMapper
 ) {
+    @Suppress("SpreadOperator")
     fun storePlanOffers(planOffers: List<PlanOffersModel>) {
         planOffersDao.clearPlanOffers()
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ScanSqlUtils.kt
@@ -127,8 +127,7 @@ class ScanSqlUtils @Inject constructor() {
                         isInitial = initial
                     )
                 }
-                else -> { // Do nothing
-                }
+                else -> Unit // Do nothing (ignore)
             }
 
             return ScanStateModel(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThreatSqlUtils.kt
@@ -86,8 +86,7 @@ class ThreatSqlUtils @Inject constructor(private val gson: Gson, private val thr
                 fileName = this.fileName
                 context = gson.toJson(this.context)
             }
-            else -> { // Do Nothing
-            }
+            else -> Unit // Do Nothing (ignore)
         }
         return ThreatBuilder(
             threatId = baseThreatModel.id,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -27,6 +27,8 @@ open class WellSqlConfig : DefaultWellConfig {
     }
 
     constructor(context: Context) : super(context)
+
+    @Suppress("SpreadOperator")
     constructor(context: Context, @AddOn vararg addOns: String) : super(context, mutableSetOf(*addOns))
 
     @Retention(SOURCE)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -140,6 +140,7 @@ class EncryptedLogStore @Inject constructor(
         }
     }
 
+    @Suppress("SwallowedException")
     private suspend fun uploadEncryptedLog(encryptedLog: EncryptedLog) {
         // If the log file doesn't exist, fail immediately and try the next log file
         if (!isValidFile(encryptedLog.file)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/QuickStartStore.kt
@@ -114,8 +114,7 @@ class QuickStartStore @Inject constructor(
     }
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
-    override fun onAction(action: Action<*>) {
-    }
+    override fun onAction(action: Action<*>) = Unit // Do nothing (ignore)
 
     override fun onRegister() {
         AppLog.d(AppLog.T.API, QuickStartStore::class.java.simpleName + " onRegister")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ScanStore.kt
@@ -198,6 +198,7 @@ class ScanStore @Inject constructor(
         return emitFetchScanHistoryResult(resultPayload)
     }
 
+    @Suppress("TooGenericExceptionThrown")
     private fun storeThreatsWithStatuses(
         action: ScanAction,
         site: SiteModel,
@@ -210,9 +211,7 @@ class ScanStore @Inject constructor(
                     if (it.size != threats.size) {
                         val msg = "$action action returned a Threat with ThreatState not in ${statuses.joinToString()}"
                         appLogWrapper.e(AppLog.T.API, msg)
-                        if (buildConfigWrapper.isDebug()) {
-                            throw RuntimeException(msg)
-                        }
+                        if (buildConfigWrapper.isDebug()) throw RuntimeException(msg)
                     }
                 }
                 ?.run { threatSqlUtils.insertThreats(site, this) }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1333,7 +1333,7 @@ open class SiteStore @Inject constructor(
         return updateSites(siteXMLRPCClient.fetchSites(payload.url, payload.username, payload.password))
     }
 
-    @Suppress("ForbiddenComment")
+    @Suppress("ForbiddenComment", "SwallowedException")
     private fun updateSiteProfile(siteModel: SiteModel) {
         val event = OnProfileFetched(siteModel)
         if (siteModel.isError) {
@@ -1349,7 +1349,7 @@ open class SiteStore @Inject constructor(
         emitChange(event)
     }
 
-    @Suppress("ForbiddenComment")
+    @Suppress("ForbiddenComment", "SwallowedException")
     private fun updateSite(siteModel: SiteModel): OnSiteChanged {
         return if (siteModel.isError) {
             // TODO: what kind of error could we get here?
@@ -1404,6 +1404,7 @@ open class SiteStore @Inject constructor(
         }
     }
 
+    @Suppress("SwallowedException")
     private fun createOrUpdateSites(sites: SitesModel): UpdateSitesResult {
         var rowsAffected = 0
         var duplicateSiteFound = false
@@ -1553,6 +1554,7 @@ open class SiteStore @Inject constructor(
         }
     }
 
+    @Suppress("SwallowedException")
     private fun designateMobileEditor(payload: DesignateMobileEditorPayload) {
         // wpcom sites sync the new value with the backend
         if (payload.site.isUsingWpComRestApi) {
@@ -1570,6 +1572,7 @@ open class SiteStore @Inject constructor(
         emitChange(event)
     }
 
+    @Suppress("SwallowedException")
     private fun designateMobileEditorForAllSites(payload: DesignateMobileEditorForAllSitesPayload) {
         var rowsAffected = 0
         var wpcomPostRequestRequired = false
@@ -1595,6 +1598,7 @@ open class SiteStore @Inject constructor(
         emitChange(OnAllSitesMobileEditorChanged(rowsAffected, isNetworkResponse, error))
     }
 
+    @Suppress("SwallowedException")
     private fun updateSiteEditors(payload: FetchedEditorsPayload) {
         val site = payload.site
         val event = if (payload.isError) {
@@ -1620,6 +1624,7 @@ open class SiteStore @Inject constructor(
         emitChange(event)
     }
 
+    @Suppress("SwallowedException")
     private fun onAllSitesMobileEditorChanged(
         payload: DesignateMobileEditorForAllSitesResponsePayload
     ): OnAllSitesMobileEditorChanged {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1554,7 +1554,7 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun designateMobileEditor(payload: DesignateMobileEditorPayload) {
         // wpcom sites sync the new value with the backend
         if (payload.site.isUsingWpComRestApi) {
@@ -1572,7 +1572,7 @@ open class SiteStore @Inject constructor(
         emitChange(event)
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun designateMobileEditorForAllSites(payload: DesignateMobileEditorForAllSitesPayload) {
         var rowsAffected = 0
         var wpcomPostRequestRequired = false
@@ -1598,7 +1598,7 @@ open class SiteStore @Inject constructor(
         emitChange(OnAllSitesMobileEditorChanged(rowsAffected, isNetworkResponse, error))
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun updateSiteEditors(payload: FetchedEditorsPayload) {
         val site = payload.site
         val event = if (payload.isError) {
@@ -1624,7 +1624,7 @@ open class SiteStore @Inject constructor(
         emitChange(event)
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun onAllSitesMobileEditorChanged(
         payload: DesignateMobileEditorForAllSitesResponsePayload
     ): OnAllSitesMobileEditorChanged {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -109,7 +109,6 @@ import org.wordpress.android.fluxc.utils.SiteErrorUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.AppLog.T.API
-import java.util.ArrayList
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -355,8 +354,9 @@ open class SiteStore @Inject constructor(
 
         fun description(): String {
             return String.format(
-                    "url: %s, e: %b, wp: %b, jp: %b, wpcom: %b, urlAfterRedirects: %s",
-                    url, exists, isWordPress, hasJetpack, isWPCom, urlAfterRedirects
+                Locale.US,
+                "url: %s, e: %b, wp: %b, jp: %b, wpcom: %b, urlAfterRedirects: %s",
+                url, exists, isWordPress, hasJetpack, isWPCom, urlAfterRedirects
             )
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/WhatsNewStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/WhatsNewStore.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.store
 
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -21,13 +19,11 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.AppLog.T.API
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 @Singleton
 class WhatsNewStore @Inject constructor(
     private val whatsNewRestClient: WhatsNewRestClient,
     private val whatsNewSqlUtils: WhatsNewSqlUtils,
-    private val coroutineContext: CoroutineContext,
     private val coroutineEngine: CoroutineEngine,
     dispatcher: Dispatcher
 ) : Store(dispatcher) {
@@ -38,17 +34,12 @@ class WhatsNewStore @Inject constructor(
             FETCH_REMOTE_ANNOUNCEMENT -> {
                 val versionName = (action.payload as WhatsNewFetchPayload).versionName
                 val appId = (action.payload as WhatsNewFetchPayload).appId
-                GlobalScope.launch(coroutineContext) {
-                    emitChange(
-                            fetchRemoteAnnouncements(
-                                    versionName,
-                                    appId
-                            )
-                    )
+                coroutineEngine.launch(AppLog.T.API, this, "FETCH_REMOTE_ANNOUNCEMENT") {
+                    emitChange(fetchRemoteAnnouncements(versionName, appId))
                 }
             }
             FETCH_CACHED_ANNOUNCEMENT -> {
-                GlobalScope.launch(coroutineContext) {
+                coroutineEngine.launch(AppLog.T.API, this, "FETCH_CACHED_ANNOUNCEMENT") {
                     emitChange(fetchCachedAnnouncements())
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStore.kt
@@ -79,6 +79,7 @@ class BloggingPromptsStore @Inject constructor(
         }
     }
 
+    @Suppress("SwallowedException")
     private suspend fun handlePayloadResponse(
         site: SiteModel,
         response: BloggingPromptsListResponse

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStore.kt
@@ -79,7 +79,7 @@ class BloggingPromptsStore @Inject constructor(
         }
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private suspend fun handlePayloadResponse(
         site: SiteModel,
         response: BloggingPromptsListResponse

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
@@ -47,7 +47,7 @@ class CardsStore @Inject constructor(
         else -> CardsResult(error)
     }
 
-    @Suppress("SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private suspend fun handlePayloadResponse(
         site: SiteModel,
         response: CardsResponse

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
@@ -47,6 +47,7 @@ class CardsStore @Inject constructor(
         else -> CardsResult(error)
     }
 
+    @Suppress("SwallowedException")
     private suspend fun handlePayloadResponse(
         site: SiteModel,
         response: CardsResponse


### PR DESCRIPTION
Parent #2479
Partially Closes: #2485

This PR resolves/suppresses all `coroutines`, `empty-blocks`, `exceptions`, `performance` and `potential-bugs` related warnings for the `fluxc` module:

- `2` x coroutines
    1. `2` x GlobalCoroutineUsage (Resolve: 85c983879f40b3d0661da2a8e257820f4ffb6359 + Question [❓]: [see comment](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1605#issuecomment-1210609730) @khaykov @develric)
- `1` x empty-blocks
    1. `1` x EmptyFunctionBlock (Resolve: 0a1267f22a2a25d3f7e47d2173ef873bbd7155b0 + c61e17519f3f613eed922bb0688cc58e4b558fe3)
- `33` x exceptions
    1. `23` x SwallowedException (Suppress: 395e8de0dbd396561434235431a1c4229a1b3db9)
    2. `8` x TooGenericExceptionCaught (Suppress: 3cfaee1a4662cddb68a5a23773361412669c2f52)
    3. `2` x TooGenericExceptionThrown (Suppress: a9264d2939e365dbfab435309026df10d3dd995b)
- `4` x performance
    1. `4` x SpreadOperator (Suppress: a9207ef0110a891d252d61cbe4684b229157abcd)
- `1` x potential-bugs
    1. `1` x ImplicitDefaultLocale (Resolve: 9f50893044336efd2f318af97458f523b6bc8c7a)

PS.1: I am randomly adding one engineer from the WPAndroid team and one from the WCAndroid team as the main reviewers, that is, in addition to the @wordpress-mobile/owl-team team itself, since I just want someone from these teams to sign-off on that change as well (or additionally to the 🦉 team).

PS.2: I recommend reviewing this PR commit-by-commit.

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough (especially the `detekt` check).
- However, if you really want to be thorough, you could smoke test the `example` and/or the `WPAndroid/WCAndroid` apps to verify that everything works as expected.

PS: Please ignore the failing `connected-tests` check as they are unrelated to this PR. This check has been failing consistency for some time now due to tests being flaky or needing to be updated/fixed.

Merge instructions:

- [x] Wait for #2491 to be approved and merged to `trunk`.
- [x] Make sure this PR's base is automatically updated to `trunk`.
- [x] Update PR with latest `trunk`.
- [x] Remove `[Status] Not Ready for Merge` label.
- [ ] Merge PR to `trunk`.