### PR TITLE
[Detekt Baseline Warnings] Plugins Woo Commerce Module - Resolve/Suppress Style Warnings

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -209,7 +209,6 @@
     <ID>SwallowedException:WCProductModel.kt$WCProductModel$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ProductRestClient.kt$ProductRestClient$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:WCProductModel.kt$WCProductModel$ex: Exception</ID>
-    <ID>UnusedPrivateMember:WCStatsStore.kt$WCStatsStore$private val context: Context</ID>
     <ID>UseCheckOrError:ToDatabaseAddonsMapper.kt$ToDatabaseAddonsMapper$throw IllegalStateException("Addon has to be identified with a Group or a Product")</ID>
     <ID>UseCheckOrError:WCOrderStore.kt$WCOrderStore$throw IllegalStateException("Invalid action. Use suspendable updateOrderStatus(..) directly")</ID>
     <ID>VariableNaming:OrderDto.kt$OrderDto$// Same as shipping_lines, it's a list of objects val fee_lines: JsonElement? = null</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -160,7 +160,6 @@
     <ID>ComplexMethod:OrderDtoMapper.kt$OrderDtoMapper$fun toDatabaseEntity(orderDto: OrderDto, localSiteId: LocalId): Pair&lt;OrderEntity, List&lt;OrderMetaDataEntity>></ID>
     <ID>ComplexMethod:ProductApiResponse.kt$ProductApiResponse$fun asProductModel(): WCProductModel</ID>
     <ID>ComplexMethod:ProductRestClient.kt$ProductRestClient$private fun productModelToProductJsonBody( productModel: WCProductModel?, updatedProductModel: WCProductModel ): HashMap&lt;String, Any></ID>
-    <ID>ComplexMethod:ProductRestClient.kt$ProductRestClient$private fun variantModelToProductJsonBody( variationModel: WCProductVariationModel?, updatedVariationModel: WCProductVariationModel ): HashMap&lt;String, Any></ID>
     <ID>ComplexMethod:ProductVariationApiResponse.kt$ProductVariationApiResponse$fun asProductVariationModel()</ID>
     <ID>ComplexMethod:WCCustomerMapper.kt$WCCustomerMapper$fun mapToModel(site: SiteModel, dto: CustomerDTO): WCCustomerModel</ID>
     <ID>ComplexMethod:WCOrderStore.kt$WCOrderStore$@Subscribe(threadMode = ThreadMode.ASYNC) override fun onAction(action: Action&lt;*>)</ID>
@@ -175,12 +174,6 @@
     <ID>ConstructorParameterNaming:OrderDto.kt$OrderDto.Shipping$val last_name: String? = null</ID>
     <ID>ConstructorParameterNaming:WCPaymentChargeApiResult.kt$WCPaymentChargeApiResult.Refunds$@SerializedName("data") val `data`: List&lt;Any?>?</ID>
     <ID>EmptyFunctionBlock:WooCommerceStore.kt$WooCommerceStore${ }</ID>
-    <ID>ForbiddenComment:ProductRestClient.kt$ProductRestClient$// TODO: Once removal is supported, we can remove the extra isNotBlank() condition</ID>
-    <ID>ForbiddenComment:WCOrderFetcher.kt$WCOrderFetcher$// FIXME: Add error handling</ID>
-    <ID>ForbiddenComment:WCOrderFetcher.kt$WCOrderFetcher$// FIXME: Possible add new tracks event to track error fetching order list data "order_list_load_failed"</ID>
-    <ID>ForbiddenComment:WCOrderStore.kt$WCOrderStore$// TODO: Ideally we would have a separate process that prunes the following</ID>
-    <ID>ForbiddenComment:WCOrderStore.kt$WCOrderStore$// TODO: Use the actual error type</ID>
-    <ID>ForbiddenComment:WCProductStore.kt$WCProductStore$// TODO: 18/08/2021 @wzieba add tests</ID>
     <ID>ImplicitDefaultLocale:DateUtils.kt$DateUtils$String.format("%d-%02d-%02d", year, (month + 1), dayOfMonth)</ID>
     <ID>LargeClass:OrderRestClient.kt$OrderRestClient : BaseWPComRestClient</ID>
     <ID>LargeClass:ProductRestClient.kt$ProductRestClient : BaseWPComRestClient</ID>
@@ -192,7 +185,6 @@
     <ID>LongMethod:ProductApiResponse.kt$ProductApiResponse$fun asProductModel(): WCProductModel</ID>
     <ID>LongMethod:ProductRestClient.kt$ProductRestClient$fun fetchProducts( site: SiteModel, pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE, offset: Int = 0, sortType: ProductSorting = DEFAULT_PRODUCT_SORTING, searchQuery: String? = null, isSkuSearch: Boolean = false, includedProductIds: List&lt;Long>? = null, filterOptions: Map&lt;ProductFilterOption, String>? = null, excludedProductIds: List&lt;Long>? = null )</ID>
     <ID>LongMethod:ProductRestClient.kt$ProductRestClient$private fun productModelToProductJsonBody( productModel: WCProductModel?, updatedProductModel: WCProductModel ): HashMap&lt;String, Any></ID>
-    <ID>LongMethod:ProductRestClient.kt$ProductRestClient$private fun variantModelToProductJsonBody( variationModel: WCProductVariationModel?, updatedVariationModel: WCProductVariationModel ): HashMap&lt;String, Any></ID>
     <ID>LongMethod:ProvideAddonsIntegrationTests.kt$ProvideAddonsIntegrationTests$@Test fun `should map Checkbox add-on`()</ID>
     <ID>LongMethod:RemoteAddonMapper.kt$RemoteAddonMapper$fun toDomain(dto: RemoteAddonDto): Addon</ID>
     <ID>LongMethod:WCProductStore.kt$WCProductStore$@Subscribe(threadMode = ThreadMode.ASYNC) override fun onAction(action: Action&lt;*>)</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -162,7 +162,6 @@
     <ID>ComplexMethod:ProductRestClient.kt$ProductRestClient$private fun productModelToProductJsonBody( productModel: WCProductModel?, updatedProductModel: WCProductModel ): HashMap&lt;String, Any></ID>
     <ID>ComplexMethod:ProductVariationApiResponse.kt$ProductVariationApiResponse$fun asProductVariationModel()</ID>
     <ID>ComplexMethod:WCCustomerMapper.kt$WCCustomerMapper$fun mapToModel(site: SiteModel, dto: CustomerDTO): WCCustomerModel</ID>
-    <ID>ComplexMethod:WCOrderStore.kt$WCOrderStore$@Subscribe(threadMode = ThreadMode.ASYNC) override fun onAction(action: Action&lt;*>)</ID>
     <ID>ComplexMethod:WCProductStore.kt$WCProductStore$@Subscribe(threadMode = ThreadMode.ASYNC) override fun onAction(action: Action&lt;*>)</ID>
     <ID>ConstructorParameterNaming:OrderDto.kt$OrderDto.Billing$val address_1: String? = null</ID>
     <ID>ConstructorParameterNaming:OrderDto.kt$OrderDto.Billing$val address_2: String? = null</ID>
@@ -209,7 +208,6 @@
     <ID>SwallowedException:WCProductModel.kt$WCProductModel$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ProductRestClient.kt$ProductRestClient$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:WCProductModel.kt$WCProductModel$ex: Exception</ID>
-    <ID>UseCheckOrError:WCOrderStore.kt$WCOrderStore$throw IllegalStateException("Invalid action. Use suspendable updateOrderStatus(..) directly")</ID>
     <ID>VariableNaming:OrderDto.kt$OrderDto$// Same as shipping_lines, it's a list of objects val fee_lines: JsonElement? = null</ID>
     <ID>VariableNaming:OrderDto.kt$OrderDto$// This is actually a list of objects. We're storing this as JSON initially, and it will be deserialized on demand. // See OrderEntity.LineItem val line_items: JsonElement? = null</ID>
     <ID>VariableNaming:OrderDto.kt$OrderDto$// This is actually a list of objects. We're storing this as JSON initially, and it will be deserialized on demand. // See OrderEntity.ShippingLines val shipping_lines: JsonElement? = null</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -176,7 +176,6 @@
     <ID>ConstructorParameterNaming:WCPaymentChargeApiResult.kt$WCPaymentChargeApiResult.Refunds$@SerializedName("data") val `data`: List&lt;Any?>?</ID>
     <ID>DataClassShouldBeImmutable:LineItem.kt$LineItem$@SerializedName("product_id") var productId: Long? = null</ID>
     <ID>DataClassShouldBeImmutable:LineItem.kt$LineItem$var quantity: Float? = null</ID>
-    <ID>DataClassShouldBeImmutable:WCOrderStore.kt$WCOrderStore.OnQuickOrderResult$var order: OrderEntity? = null</ID>
     <ID>EmptyFunctionBlock:WooCommerceStore.kt$WooCommerceStore${ }</ID>
     <ID>ForbiddenComment:ProductRestClient.kt$ProductRestClient$// TODO: Once removal is supported, we can remove the extra isNotBlank() condition</ID>
     <ID>ForbiddenComment:WCOrderFetcher.kt$WCOrderFetcher$// FIXME: Add error handling</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -201,7 +201,6 @@
     <ID>NestedBlockDepth:WCProductModel.kt$WCProductModel$private fun getTriplets(jsonStr: String): ArrayList&lt;ProductTriplet></ID>
     <ID>NestedBlockDepth:WCProductModel.kt$WCProductModel$private fun parseJson(jsonString: String): List&lt;Long></ID>
     <ID>NestedBlockDepth:WCShippingLabelStore.kt$WCShippingLabelStore$private fun getActivePredefinedOptions(result: GetPackageTypesResponse): List&lt;PredefinedOption></ID>
-    <ID>SpacingBetweenPackageAndImports:WCPaymentChargeApiResult.kt$ </ID>
     <ID>SpreadOperator:WCInboxStore.kt$WCInboxStore$(siteId, *notesWithActions.toTypedArray())</ID>
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*it.result!!.toTypedArray())</ID>
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*payload.fetchedOrders.toTypedArray())</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -194,10 +194,6 @@
     <ID>LongParameterList:ShippingLabelRestClient.kt$ShippingLabelRestClient$( site: SiteModel, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, packagesData: List&lt;WCShippingLabelPackageData>, customsData: List&lt;WCShippingPackageCustoms>?, emailReceipts: Boolean = false )</ID>
     <ID>LongParameterList:WCShippingLabelStore.kt$WCShippingLabelStore$( site: SiteModel, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, packages: List&lt;ShippingLabelPackage>, customsData: List&lt;WCShippingPackageCustoms>? )</ID>
     <ID>LongParameterList:WCShippingLabelStore.kt$WCShippingLabelStore$( site: SiteModel, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, packagesData: List&lt;WCShippingLabelPackageData>, customsData: List&lt;WCShippingPackageCustoms>?, emailReceipts: Boolean = false )</ID>
-    <ID>MaxLineLength:LeaderboardProductItem.kt$LeaderboardProductItem$"display": "&lt;a href='https:\/\/mystagingwebsite.com\/wp-admin\/admin.php?page=wc-admin&amp;path=\/analytics\/products&amp;filter=single_product&amp;products=14'>Beanie&lt;\/a>",</ID>
-    <ID>MaxLineLength:LeaderboardProductItem.kt$LeaderboardProductItem$"display": "&lt;span class=\"woocommerce-Price-amount amount\">&lt;span class=\"woocommerce-Price-currencySymbol\">&amp;#82;&amp;#36;&lt;\/span>36.000,00&lt;\/span>",</ID>
-    <ID>MaxLineLength:LeaderboardProductItem.kt$LeaderboardProductItem$*</ID>
-    <ID>MaxLineLength:Migrations.kt$&lt;no name provided>$CREATE UNIQUE INDEX IF NOT EXISTS `index_InboxNotes_remoteId_siteId` ON `InboxNotes` (`remoteId`, `siteId`)</ID>
     <ID>MaxLineLength:OrderDtoMapper.kt$OrderDtoMapper$// Extract the discount codes from the coupon_lines list and store them as a comma-delimited String</ID>
     <ID>MaxLineLength:ProductRestClient.kt$ProductRestClient$*</ID>
     <ID>MaxLineLength:WCOrderStore.kt$WCOrderStore$// This is the simplest way of keeping our local orders in sync with remote orders (in case of deletions,</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -201,18 +201,11 @@
     <ID>NestedBlockDepth:WCProductModel.kt$WCProductModel$private fun getTriplets(jsonStr: String): ArrayList&lt;ProductTriplet></ID>
     <ID>NestedBlockDepth:WCProductModel.kt$WCProductModel$private fun parseJson(jsonString: String): List&lt;Long></ID>
     <ID>NestedBlockDepth:WCShippingLabelStore.kt$WCShippingLabelStore$private fun getActivePredefinedOptions(result: GetPackageTypesResponse): List&lt;PredefinedOption></ID>
-    <ID>ReturnCount:ProductRestClient.kt$ProductRestClient$suspend fun fetchProductReviews( site: SiteModel, offset: Int, reviewIds: List&lt;Long>? = null, productIds: List&lt;Long>? = null, filterByStatus: List&lt;String>? = null ): FetchProductReviewsResponsePayload</ID>
-    <ID>ReturnCount:ProductRestClient.kt$ProductRestClient$suspend fun fetchSingleVariation( site: SiteModel, remoteProductId: Long, remoteVariationId: Long ): RemoteVariationPayload</ID>
-    <ID>ReturnCount:ProductSqlUtils.kt$ProductSqlUtils$fun deleteProductImage(site: SiteModel, remoteProductId: Long, remoteMediaId: Long): Boolean</ID>
     <ID>ReturnCount:WCProductModel.kt$WCProductModel$fun hasSameAttributes(otherProduct: WCProductModel): Boolean</ID>
     <ID>ReturnCount:WCProductModel.kt$WCProductModel$fun hasSameCategories(updatedProduct: WCProductModel): Boolean</ID>
     <ID>ReturnCount:WCProductModel.kt$WCProductModel$fun hasSameImages(updatedProduct: WCProductModel): Boolean</ID>
     <ID>ReturnCount:WCProductModel.kt$WCProductModel$fun hasSameTags(updatedProduct: WCProductModel): Boolean</ID>
     <ID>ReturnCount:WCProductVariationModel.kt$WCProductVariationModel$fun getImageModel(): WCProductImageModel?</ID>
-    <ID>ReturnCount:WCStatsStore.kt$WCStatsStore$@Suppress("UNCHECKED_CAST") private fun &lt;T> getStatsForField( site: SiteModel, field: OrderStatsField, granularity: StatsGranularity, quantity: String? = null, date: String? = null, isCustomField: Boolean = false ): Map&lt;String, T></ID>
-    <ID>ReturnCount:WCStatsStore.kt$WCStatsStore$fun getNewVisitorStats( site: SiteModel, granularity: StatsGranularity, quantity: String? = null, date: String? = null, isCustomField: Boolean = false ): Map&lt;String, Int></ID>
-    <ID>ReturnCount:WCStatsStore.kt$WCStatsStore$fun getStatsCurrencyForSite(site: SiteModel): String?</ID>
-    <ID>ReturnCount:WCStatsStore.kt$WCStatsStore$fun getVisitorStats( site: SiteModel, granularity: StatsGranularity, quantity: String? = null, date: String? = null, isCustomField: Boolean = false ): Map&lt;String, Int></ID>
     <ID>ReturnCount:WooCommerceStore.kt$WooCommerceStore$suspend fun fetchWooCommerceSite(site: SiteModel): WooResult&lt;SiteModel></ID>
     <ID>SpacingBetweenPackageAndImports:WCPaymentChargeApiResult.kt$ </ID>
     <ID>SpreadOperator:WCInboxStore.kt$WCInboxStore$(siteId, *notesWithActions.toTypedArray())</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -194,11 +194,6 @@
     <ID>LongParameterList:ShippingLabelRestClient.kt$ShippingLabelRestClient$( site: SiteModel, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, packagesData: List&lt;WCShippingLabelPackageData>, customsData: List&lt;WCShippingPackageCustoms>?, emailReceipts: Boolean = false )</ID>
     <ID>LongParameterList:WCShippingLabelStore.kt$WCShippingLabelStore$( site: SiteModel, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, packages: List&lt;ShippingLabelPackage>, customsData: List&lt;WCShippingPackageCustoms>? )</ID>
     <ID>LongParameterList:WCShippingLabelStore.kt$WCShippingLabelStore$( site: SiteModel, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, packagesData: List&lt;WCShippingLabelPackageData>, customsData: List&lt;WCShippingPackageCustoms>?, emailReceipts: Boolean = false )</ID>
-    <ID>MaxLineLength:OrderDtoMapper.kt$OrderDtoMapper$// Extract the discount codes from the coupon_lines list and store them as a comma-delimited String</ID>
-    <ID>MaxLineLength:ProductRestClient.kt$ProductRestClient$*</ID>
-    <ID>MaxLineLength:WCOrderStore.kt$WCOrderStore$// This is the simplest way of keeping our local orders in sync with remote orders (in case of deletions,</ID>
-    <ID>MaxLineLength:WCProductStore.kt$WCProductStore$*</ID>
-    <ID>MaxLineLength:WCStatsStore.kt$WCStatsStore$*</ID>
     <ID>MemberNameEqualsClassName:WCRevenueStatsModel.kt$WCRevenueStatsModel.Interval$val interval: String? = null</ID>
     <ID>NestedBlockDepth:OrderStatsRestClient.kt$OrderStatsRestClient$suspend fun fetchNewVisitorStats( site: SiteModel, unit: OrderStatsApiUnit, granularity: StatsGranularity, date: String, quantity: Int, force: Boolean = false, startDate: String? = null, endDate: String? = null ): FetchNewVisitorStatsResponsePayload</ID>
     <ID>NestedBlockDepth:WCOrderStore.kt$WCOrderStore$private fun handleFetchOrderStatusOptionsCompleted(payload: FetchOrderStatusOptionsResponsePayload)</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -209,8 +209,6 @@
     <ID>SwallowedException:WCProductModel.kt$WCProductModel$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ProductRestClient.kt$ProductRestClient$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:WCProductModel.kt$WCProductModel$ex: Exception</ID>
-    <ID>UnnecessaryAbstractClass:CouponsDao.kt$CouponsDao$CouponsDao</ID>
-    <ID>UnnecessaryAbstractClass:WCDatabaseModule.kt$WCDatabaseModule$WCDatabaseModule</ID>
     <ID>UnusedPrivateMember:WCStatsStore.kt$WCStatsStore$private val context: Context</ID>
     <ID>UseCheckOrError:ToDatabaseAddonsMapper.kt$ToDatabaseAddonsMapper$throw IllegalStateException("Addon has to be identified with a Group or a Product")</ID>
     <ID>UseCheckOrError:WCOrderStore.kt$WCOrderStore$throw IllegalStateException("Invalid action. Use suspendable updateOrderStatus(..) directly")</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -174,8 +174,6 @@
     <ID>ConstructorParameterNaming:OrderDto.kt$OrderDto.Shipping$val first_name: String? = null</ID>
     <ID>ConstructorParameterNaming:OrderDto.kt$OrderDto.Shipping$val last_name: String? = null</ID>
     <ID>ConstructorParameterNaming:WCPaymentChargeApiResult.kt$WCPaymentChargeApiResult.Refunds$@SerializedName("data") val `data`: List&lt;Any?>?</ID>
-    <ID>DataClassShouldBeImmutable:LineItem.kt$LineItem$@SerializedName("product_id") var productId: Long? = null</ID>
-    <ID>DataClassShouldBeImmutable:LineItem.kt$LineItem$var quantity: Float? = null</ID>
     <ID>EmptyFunctionBlock:WooCommerceStore.kt$WooCommerceStore${ }</ID>
     <ID>ForbiddenComment:ProductRestClient.kt$ProductRestClient$// TODO: Once removal is supported, we can remove the extra isNotBlank() condition</ID>
     <ID>ForbiddenComment:WCOrderFetcher.kt$WCOrderFetcher$// FIXME: Add error handling</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -201,12 +201,6 @@
     <ID>NestedBlockDepth:WCProductModel.kt$WCProductModel$private fun getTriplets(jsonStr: String): ArrayList&lt;ProductTriplet></ID>
     <ID>NestedBlockDepth:WCProductModel.kt$WCProductModel$private fun parseJson(jsonString: String): List&lt;Long></ID>
     <ID>NestedBlockDepth:WCShippingLabelStore.kt$WCShippingLabelStore$private fun getActivePredefinedOptions(result: GetPackageTypesResponse): List&lt;PredefinedOption></ID>
-    <ID>ReturnCount:WCProductModel.kt$WCProductModel$fun hasSameAttributes(otherProduct: WCProductModel): Boolean</ID>
-    <ID>ReturnCount:WCProductModel.kt$WCProductModel$fun hasSameCategories(updatedProduct: WCProductModel): Boolean</ID>
-    <ID>ReturnCount:WCProductModel.kt$WCProductModel$fun hasSameImages(updatedProduct: WCProductModel): Boolean</ID>
-    <ID>ReturnCount:WCProductModel.kt$WCProductModel$fun hasSameTags(updatedProduct: WCProductModel): Boolean</ID>
-    <ID>ReturnCount:WCProductVariationModel.kt$WCProductVariationModel$fun getImageModel(): WCProductImageModel?</ID>
-    <ID>ReturnCount:WooCommerceStore.kt$WooCommerceStore$suspend fun fetchWooCommerceSite(site: SiteModel): WooResult&lt;SiteModel></ID>
     <ID>SpacingBetweenPackageAndImports:WCPaymentChargeApiResult.kt$ </ID>
     <ID>SpreadOperator:WCInboxStore.kt$WCInboxStore$(siteId, *notesWithActions.toTypedArray())</ID>
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*it.result!!.toTypedArray())</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -194,21 +194,6 @@
     <ID>LongParameterList:ShippingLabelRestClient.kt$ShippingLabelRestClient$( site: SiteModel, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, packagesData: List&lt;WCShippingLabelPackageData>, customsData: List&lt;WCShippingPackageCustoms>?, emailReceipts: Boolean = false )</ID>
     <ID>LongParameterList:WCShippingLabelStore.kt$WCShippingLabelStore$( site: SiteModel, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, packages: List&lt;ShippingLabelPackage>, customsData: List&lt;WCShippingPackageCustoms>? )</ID>
     <ID>LongParameterList:WCShippingLabelStore.kt$WCShippingLabelStore$( site: SiteModel, orderId: Long, origin: ShippingLabelAddress, destination: ShippingLabelAddress, packagesData: List&lt;WCShippingLabelPackageData>, customsData: List&lt;WCShippingPackageCustoms>?, emailReceipts: Boolean = false )</ID>
-    <ID>MagicNumber:DateUtils.kt$DateUtils$1000</ID>
-    <ID>MagicNumber:DateUtils.kt$DateUtils$23</ID>
-    <ID>MagicNumber:DateUtils.kt$DateUtils$24</ID>
-    <ID>MagicNumber:DateUtils.kt$DateUtils$59</ID>
-    <ID>MagicNumber:DateUtils.kt$DateUtils$6</ID>
-    <ID>MagicNumber:DateUtils.kt$DateUtils$60</ID>
-    <ID>MagicNumber:DateUtils.kt$DateUtils$7</ID>
-    <ID>MagicNumber:DateUtils.kt$DateUtils$8</ID>
-    <ID>MagicNumber:WCProductReviewModel.kt$WCProductReviewModel.AvatarSize.Companion$24</ID>
-    <ID>MagicNumber:WCProductReviewModel.kt$WCProductReviewModel.AvatarSize.Companion$48</ID>
-    <ID>MagicNumber:WCProductReviewModel.kt$WCProductReviewModel.AvatarSize.Companion$96</ID>
-    <ID>MagicNumber:WCShippingLabelStore.kt$WCShippingLabelStore$2000</ID>
-    <ID>MagicNumber:WCStatsStore.kt$WCStatsStore$12</ID>
-    <ID>MagicNumber:WCStatsStore.kt$WCStatsStore$2011</ID>
-    <ID>MagicNumber:WCStatsStore.kt$WCStatsStore$7</ID>
     <ID>MaxLineLength:LeaderboardProductItem.kt$LeaderboardProductItem$"display": "&lt;a href='https:\/\/mystagingwebsite.com\/wp-admin\/admin.php?page=wc-admin&amp;path=\/analytics\/products&amp;filter=single_product&amp;products=14'>Beanie&lt;\/a>",</ID>
     <ID>MaxLineLength:LeaderboardProductItem.kt$LeaderboardProductItem$"display": "&lt;span class=\"woocommerce-Price-amount amount\">&lt;span class=\"woocommerce-Price-currencySymbol\">&amp;#82;&amp;#36;&lt;\/span>36.000,00&lt;\/span>",</ID>
     <ID>MaxLineLength:LeaderboardProductItem.kt$LeaderboardProductItem$*</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -209,7 +209,6 @@
     <ID>SwallowedException:WCProductModel.kt$WCProductModel$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ProductRestClient.kt$ProductRestClient$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:WCProductModel.kt$WCProductModel$ex: Exception</ID>
-    <ID>UseCheckOrError:ToDatabaseAddonsMapper.kt$ToDatabaseAddonsMapper$throw IllegalStateException("Addon has to be identified with a Group or a Product")</ID>
     <ID>UseCheckOrError:WCOrderStore.kt$WCOrderStore$throw IllegalStateException("Invalid action. Use suspendable updateOrderStatus(..) directly")</ID>
     <ID>VariableNaming:OrderDto.kt$OrderDto$// Same as shipping_lines, it's a list of objects val fee_lines: JsonElement? = null</ID>
     <ID>VariableNaming:OrderDto.kt$OrderDto$// This is actually a list of objects. We're storing this as JSON initially, and it will be deserialized on demand. // See OrderEntity.LineItem val line_items: JsonElement? = null</ID>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -55,7 +55,7 @@ import org.hamcrest.CoreMatchers.`is` as isEqual
 class WCStatsStoreTest {
     private val mockOrderStatsRestClient = mock<OrderStatsRestClient>()
     private val appContext = RuntimeEnvironment.application.applicationContext
-    private val wcStatsStore = WCStatsStore(Dispatcher(), appContext, mockOrderStatsRestClient, initCoroutineEngine())
+    private val wcStatsStore = WCStatsStore(Dispatcher(), mockOrderStatsRestClient, initCoroutineEngine())
 
     @Before
     fun setUp() {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import javax.inject.Singleton
 
 @Module
-abstract class WCDatabaseModule {
+interface WCDatabaseModule {
     companion object {
         @Singleton @Provides fun provideDatabase(context: Context): WCAndroidDatabase {
             return WCAndroidDatabase.buildDb(context)
@@ -36,5 +36,5 @@ abstract class WCDatabaseModule {
 
         @Provides fun provideInboxNotesDao(database: WCAndroidDatabase) = database.inboxNotesDao
     }
-    @Binds abstract fun bindTransactionExecutor(database: WCAndroidDatabase): TransactionExecutor
+    @Binds fun bindTransactionExecutor(database: WCAndroidDatabase): TransactionExecutor
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -238,6 +238,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     /**
      * Returns true if this product has the same attributes as the passed product
      */
+    @Suppress("ReturnCount")
     fun hasSameAttributes(otherProduct: WCProductModel): Boolean {
         // do a quick string comparison first so we can avoid parsing the attributes when possible
         if (this.attributes == otherProduct.attributes) {
@@ -479,6 +480,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * Compares this product's images with the passed product's images, returns true only if both
      * lists contain the same images in the same order
      */
+    @Suppress("ReturnCount")
     fun hasSameImages(updatedProduct: WCProductModel): Boolean {
         val updatedImages = updatedProduct.getImageList()
         val thisImages = getImageList()
@@ -497,6 +499,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * Compares this product's categories with the passed product's categories, returns true only if both
      * lists contain the same categories in the same order
      */
+    @Suppress("ReturnCount")
     fun hasSameCategories(updatedProduct: WCProductModel): Boolean {
         val updatedCategories = updatedProduct.getCategoryList()
         val storedCategories = getCategoryList()
@@ -515,6 +518,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
      * Compares this product's tags with the passed product's tags, returns true only if both
      * lists contain the same tags in the same order
      */
+    @Suppress("ReturnCount")
     fun hasSameTags(updatedProduct: WCProductModel): Boolean {
         val updatedTags = updatedProduct.getTagList()
         val storedTags = getTagList()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductReviewModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductReviewModel.kt
@@ -101,9 +101,9 @@ data class WCProductReviewModel(@PrimaryKey @Column private var id: Int = 0) : I
         companion object {
             fun getAvatarSizeForValue(size: Int): AvatarSize {
                 return when (size) {
-                    24 -> SMALL
-                    48 -> MEDIUM
-                    96 -> LARGE
+                    SMALL.size -> SMALL
+                    MEDIUM.size -> MEDIUM
+                    LARGE.size -> LARGE
                     else -> MEDIUM
                 }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -114,6 +114,7 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     /**
      * Parses the images json array into a list of product images
      */
+    @Suppress("ReturnCount")
     fun getImageModel(): WCProductImageModel? {
         if (image.isNotBlank()) {
             try {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -9,10 +9,10 @@ data class LineItem(
     @SerializedName("parent_name")
     val parentName: String? = null,
     @SerializedName("product_id")
-    var productId: Long? = null,
+    val productId: Long? = null,
     @SerializedName("variation_id")
     val variationId: Long? = null,
-    var quantity: Float? = null,
+    val quantity: Float? = null,
     val subtotal: String? = null,
     val total: String? = null, // Price x quantity
     @SerializedName("total_tax")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCPaymentChargeApiResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCPaymentChargeApiResult.kt
@@ -1,4 +1,5 @@
 package org.wordpress.android.fluxc.model.payments.inperson
+
 import com.google.gson.annotations.SerializedName
 
 data class WCPaymentChargeApiResult(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.Leaderboar
 
  This class represents one Single Top Performer item response as a Product type one
  */
+@Suppress("MaxLineLength")
 class LeaderboardProductItem(
     private val itemRows: Array<LeaderboardItemRow>? = null
 ) {
@@ -78,7 +79,7 @@ class LeaderboardProductItem(
      *  fromHtmlWithSafeApiCall
      *      Output: R$
      */
-    val currency by lazy {
+    @Suppress("MaxLineLength") val currency by lazy {
         priceAmountHtmlTag
                 ?.split(">")
                 ?.firstOrNull { it.contains("&#") }
@@ -105,7 +106,7 @@ class LeaderboardProductItem(
      *  regex filter with replace
      *      Output: DKK
      */
-    private val plainTextCurrency by lazy {
+    @Suppress("MaxLineLength") private val plainTextCurrency by lazy {
         fromHtmlWithSafeApiCall(priceAmountHtmlTag)
                 .toString()
                 .replace(Regex("[0-9.,]"), "")
@@ -137,8 +138,7 @@ class LeaderboardProductItem(
      *  try to convert to long
      *      Output: 14 as Long
      */
-
-    val productId by lazy {
+    @Suppress("MaxLineLength") val productId by lazy {
         link
                 ?.split("&")
                 ?.firstOrNull { it.contains("${PRODUCTS.value}=", true) }
@@ -151,7 +151,6 @@ class LeaderboardProductItem(
      * This property will operate and transform a HTML tag in order to retrieve the inner URL out of the <a href/> tag
      * using the [SpannableStringBuilder] implementation in order to parse it
      */
-
     private val link by lazy {
         fromHtmlWithSafeApiCall(itemHtmlTag)
                 .run { this as? SpannableStringBuilder }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -36,13 +36,15 @@ class OrderDtoMapper @Inject internal constructor(
                     customerNote = this.customer_note ?: "",
                     discountTotal = this.discount_total ?: "",
                     discountCodes = this.coupon_lines?.let { couponLines ->
-                        // Extract the discount codes from the coupon_lines list and store them as a comma-delimited String
+                        // Extract the discount codes from the coupon lines list and
+                        // store them as a comma-delimited 'String'.
                         couponLines
                                 .filter { !it.code.isNullOrEmpty() }
                                 .joinToString { it.code!! }
                     }.orEmpty(),
                     refundTotal = this.refunds?.let { refunds ->
-                        // Extract the individual refund totals from the refunds list and store their sum as a Double,
+                        // Extract the individual refund totals from the refunds list and
+                        // store their sum as a 'Double'.
                         refunds.sumOf { it.total?.toBigDecimalOrNull() ?: BigDecimal.ZERO }
                     } ?: BigDecimal.ZERO,
                     billingFirstName = this.billing?.first_name ?: "",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -786,8 +786,9 @@ class ProductRestClient @Inject constructor(
     }
 
     /**
-     * Makes a GET call to `/wp-json/wc/v3/products/[productId]/variations` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * retrieving a list of variations for the given WooCommerce [SiteModel] and product.
+     * Makes a GET call to `/wp-json/wc/v3/products/[productId]/variations` via the Jetpack tunnel
+     * (see [JetpackTunnelGsonRequest]), retrieving a list of variations for the given WooCommerce [SiteModel]
+     * and product.
      *
      * @param [productId] Unique server id of the product
      *
@@ -1095,8 +1096,8 @@ class ProductRestClient @Inject constructor(
      * Makes a GET call to `/wc/v3/products/categories` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * retrieving a list of product categories for a given WooCommerce [SiteModel].
      *
-     * The number of categories to fetch is defined in [WCProductStore.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE], and retrieving older
-     * categories is done by passing an [offset].
+     * The number of categories to fetch is defined in [WCProductStore.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE],
+     * and retrieving older categories is done by passing an [offset].
      *
      * Dispatches a [WCProductAction.FETCHED_PRODUCT_CATEGORIES]
      *
@@ -1607,7 +1608,8 @@ class ProductRestClient @Inject constructor(
      * This method checks if there is a cached version of the product stored locally.
      * If not, it generates a new product model for the same product ID, with default fields
      * and verifies that the [updatedVariationModel] has fields that are different from the default
-     * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any changes
+     * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any
+     * changes.
      */
     @Suppress("ForbiddenComment", "LongMethod", "ComplexMethod")
     private fun variantModelToProductJsonBody(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1609,6 +1609,7 @@ class ProductRestClient @Inject constructor(
      * and verifies that the [updatedVariationModel] has fields that are different from the default
      * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any changes
      */
+    @Suppress("ForbiddenComment", "LongMethod", "ComplexMethod")
     private fun variantModelToProductJsonBody(
         variationModel: WCProductVariationModel?,
         updatedVariationModel: WCProductVariationModel

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -466,11 +466,11 @@ object ProductSqlUtils {
                 imageList.add(image)
             }
         }
-        if (imageList.size == product.getImageList().size) {
-            return false
+        return if (imageList.size == product.getImageList().size) {
+            false
+        } else {
+            updateProductImages(product, imageList) > 0
         }
-
-        return updateProductImages(product, imageList) > 0
     }
 
     fun deleteProduct(site: SiteModel, remoteProductId: Long): Int {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
@@ -11,36 +11,36 @@ import org.wordpress.android.fluxc.persistence.entity.CouponEntity
 import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
 
 @Dao
-abstract class CouponsDao {
+interface CouponsDao {
     @Transaction
     @Query("SELECT * FROM Coupons WHERE siteId = :siteId ORDER BY dateCreated DESC")
-    abstract fun observeCoupons(siteId: Long): Flow<List<CouponWithEmails>>
+    fun observeCoupons(siteId: Long): Flow<List<CouponWithEmails>>
 
     @Transaction
     @Query("SELECT * FROM Coupons " +
         "WHERE siteId = :siteId AND id IN (:couponIds) ORDER BY dateCreated DESC")
-    abstract suspend fun getCoupons(siteId: Long, couponIds: List<Long>): List<CouponWithEmails>
+    suspend fun getCoupons(siteId: Long, couponIds: List<Long>): List<CouponWithEmails>
 
     @Transaction
     @Query("SELECT * FROM Coupons WHERE siteId = :siteId AND id = :couponId")
-    abstract fun observeCoupon(siteId: Long, couponId: Long): Flow<CouponWithEmails?>
+    fun observeCoupon(siteId: Long, couponId: Long): Flow<CouponWithEmails?>
 
     @Transaction
     @Query("SELECT * FROM Coupons WHERE siteId = :siteId AND id = :couponId")
-    abstract suspend fun getCoupon(siteId: Long, couponId: Long): CouponWithEmails?
+    suspend fun getCoupon(siteId: Long, couponId: Long): CouponWithEmails?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insertOrUpdateCoupon(entity: CouponEntity): Long
+    suspend fun insertOrUpdateCoupon(entity: CouponEntity): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insertOrUpdateCouponEmail(entity: CouponEmailEntity): Long
+    suspend fun insertOrUpdateCouponEmail(entity: CouponEmailEntity): Long
 
     @Query("DELETE FROM Coupons WHERE siteId = :siteId AND id = :couponId")
-    abstract suspend fun deleteCoupon(siteId: Long, couponId: Long)
+    suspend fun deleteCoupon(siteId: Long, couponId: Long)
 
     @Query("DELETE FROM Coupons WHERE siteId = :siteId")
-    abstract suspend fun deleteAllCoupons(siteId: Long)
+    suspend fun deleteAllCoupons(siteId: Long)
 
     @Query("SELECT COUNT(*) FROM CouponEmails WHERE siteId = :siteId AND couponId = :couponId")
-    abstract suspend fun getEmailCount(siteId: Long, couponId: Long): Int
+    suspend fun getEmailCount(siteId: Long, couponId: Long): Int
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/mappers/ToDatabaseAddonsMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/mappers/ToDatabaseAddonsMapper.kt
@@ -16,8 +16,8 @@ object ToDatabaseAddonsMapper {
         globalGroupLocalId: Long? = null,
         productBasedIdentification: ProductBasedIdentification? = null
     ): AddonEntity {
-        if (globalGroupLocalId == null && productBasedIdentification == null) {
-            throw IllegalStateException("Addon has to be identified with a Group or a Product")
+        check(globalGroupLocalId != null || productBasedIdentification != null) {
+            "Addon has to be identified with a Group or a Product"
         }
 
         val range = domain.mapRange()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -461,6 +461,7 @@ internal val MIGRATION_10_11 = object : Migration(10, 11) {
 }
 
 internal val MIGRATION_11_12 = object : Migration(11, 12) {
+    @Suppress("MaxLineLength")
     override fun migrate(database: SupportSQLiteDatabase) {
         database.apply {
             execSQL(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderFetcher.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderFetcher.kt
@@ -58,7 +58,7 @@ class WCOrderFetcher @Inject constructor(private val dispatcher: Dispatcher) {
         }
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "ForbiddenComment")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onOrdersFetchedById(event: OnOrdersFetchedByIds) {
         if (event.isError) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -322,11 +322,6 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    // TODO nbradbury this and related code can be removed
-    data class OnQuickOrderResult(
-        var order: OrderEntity? = null
-    ) : OnChanged<OrderError>()
-
     /**
      * Emitted after fetching a list of Order summaries from the network.
      */

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -722,8 +722,8 @@ class WCOrderStore @Inject constructor(
                 OnOrderChanged(orderError = payload.error)
             } else {
                 // Clear existing uploading orders if this is a fresh fetch (loadMore = false in the original request)
-                // This is the simplest way of keeping our local orders in sync with remote orders (in case of deletions,
-                // or if the user manual changed some order IDs)
+                // This is the simplest way of keeping our local orders in sync with remote orders
+                // (in case of deletions, or if the user manual changed some order IDs).
                 if (!payload.loadedMore) {
                     ordersDao.deleteOrdersForSite(payload.site.localId())
                     orderNotesDao.deleteOrderNotesForSite(payload.site.remoteId())

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -739,6 +739,7 @@ class WCOrderStore @Inject constructor(
         }
     }
 
+    @Suppress("ForbiddenComment")
     private fun handleFetchOrderListCompleted(payload: FetchOrderListResponsePayload) {
         // TODO: Ideally we would have a separate process that prunes the following
         // tables of defunct records:

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -460,6 +460,7 @@ class WCOrderStore @Inject constructor(
     fun getShipmentProvidersForSite(site: SiteModel): List<WCOrderShipmentProviderModel> =
         OrderSqlUtils.getOrderShipmentProvidersForSite(site)
 
+    @Suppress("ComplexMethod", "UseCheckOrError")
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? WCOrderAction ?: return

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1265,7 +1265,8 @@ class WCProductStore @Inject constructor(
     /**
      * Batch updates variations on the backend and updates variations locally after successful request.
      *
-     * @param payload Instance of [BatchUpdateVariationsPayload]. It can be produced using [BatchUpdateVariationsPayload.Builder] class.
+     * @param payload Instance of [BatchUpdateVariationsPayload]. It can be produced using
+     * [BatchUpdateVariationsPayload.Builder] class.
      */
     suspend fun batchUpdateVariations(payload: BatchUpdateVariationsPayload):
         WooResult<BatchProductVariationsUpdateApiResponse> =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -993,6 +993,7 @@ class WCProductStore @Inject constructor(
 
     override fun onRegister() = AppLog.d(API, "WCProductStore onRegister")
 
+    @Suppress("ForbiddenComment")
     suspend fun fetchSingleProduct(payload: FetchSingleProductPayload): OnProductChanged {
         return coroutineEngine.withDefaultContext(API, this, "fetchSingleProduct") {
             val result = with(payload) { wcProductRestClient.fetchSingleProduct(site, remoteProductId) }
@@ -1504,6 +1505,7 @@ class WCProductStore @Inject constructor(
         emitChange(onProductSkuAvailabilityChanged)
     }
 
+    @Suppress("ForbiddenComment")
     private fun handleFetchProductsCompleted(payload: RemoteProductListPayload) {
         coroutineEngine.launch(T.DB, this, "handleFetchProductsCompleted") {
             val onProductChanged: OnProductChanged

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -42,6 +42,8 @@ import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private const val PURCHASE_SHIPPING_LABELS_DELAY = 2000L
+
 @Singleton
 class WCShippingLabelStore @Inject constructor(
     private val restClient: ShippingLabelRestClient,
@@ -429,7 +431,7 @@ class WCShippingLabelStore @Inject constructor(
             return@withDefaultContext when {
                 response.isError -> WooResult(response.error)
                 response.result?.labels != null -> {
-                    delay(2000)
+                    delay(PURCHASE_SHIPPING_LABELS_DELAY)
                     val labelsStatusResponse = pollShippingLabelsForPurchase(
                             site,
                             orderId,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.store
 
-import android.content.Context
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -35,7 +34,6 @@ import javax.inject.Singleton
 @Singleton
 class WCStatsStore @Inject constructor(
     dispatcher: Dispatcher,
-    private val context: Context,
     private val wcOrderStatsClient: OrderStatsRestClient,
     private val coroutineEngine: CoroutineEngine
 ) : Store(dispatcher) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -40,9 +40,14 @@ class WCStatsStore @Inject constructor(
     private val coroutineEngine: CoroutineEngine
 ) : Store(dispatcher) {
     companion object {
+        const val WOO_COMMERCE_INITIAL_RELEASE = 2011
+
         const val STATS_QUANTITY_DAYS = 30
         const val STATS_QUANTITY_WEEKS = 17
         const val STATS_QUANTITY_MONTHS = 12
+
+        const val STATS_GRANULARITY_DAYS = 1
+        const val STATS_GRANULARITY_YEARS = 12
 
         private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
         private const val DATE_FORMAT_WEEK = "yyyy-'W'ww"
@@ -411,7 +416,7 @@ class WCStatsStore @Inject constructor(
             OrderStatsApiUnit.MONTH -> STATS_QUANTITY_MONTHS
             OrderStatsApiUnit.YEAR -> {
                 // Years since 2011 (WooCommerce initial release), inclusive
-                SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_YEAR).toInt() - 2011 + 1
+                SiteUtils.getCurrentDateTimeForSite(site, DATE_FORMAT_YEAR).toInt() - WOO_COMMERCE_INITIAL_RELEASE + 1
             }
             else -> STATS_QUANTITY_DAYS
         }
@@ -710,10 +715,10 @@ class WCStatsStore @Inject constructor(
     private fun getPerPageQuantityForRevenueStatsGranularity(
         granularity: StatsGranularity
     ) = when (granularity) {
-        StatsGranularity.DAYS -> 1
-        StatsGranularity.WEEKS -> 7
+        StatsGranularity.DAYS -> STATS_GRANULARITY_DAYS
+        StatsGranularity.WEEKS -> Calendar.getInstance().getActualMaximum(Calendar.DAY_OF_WEEK)
         StatsGranularity.MONTHS -> Calendar.getInstance().getActualMaximum(Calendar.DAY_OF_MONTH)
-        StatsGranularity.YEARS -> 12
+        StatsGranularity.YEARS -> STATS_GRANULARITY_YEARS
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -287,7 +287,8 @@ class WCStatsStore @Inject constructor(
      * [StatsGranularity.MONTHS]: the last 12 months, in increments of a month
      * [StatsGranularity.YEARS]: all data since 2011, in increments on a year
      *
-     * The start date is the current day/week/month/year, relative to the site's own timezone (not the current device's).
+     * The start date is the current day/week/month/year, relative to the site's own timezone
+     * (not the current device's).
      *
      * The format of the date key in the returned map depends on the [granularity]:
      * [StatsGranularity.DAYS]: "2018-05-01"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -96,6 +96,7 @@ open class WooCommerceStore @Inject constructor(
         return WooResult(getWooCommerceSites())
     }
 
+    @Suppress("ReturnCount")
     suspend fun fetchWooCommerceSite(site: SiteModel): WooResult<SiteModel> {
         if (!site.isJetpackCPConnected) {
             siteStore.fetchSite(site).let {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -12,6 +12,14 @@ object DateUtils {
     private const val DATE_TIME_FORMAT_START = "yyyy-MM-dd'T'00:00:00"
     private const val DATE_TIME_FORMAT_END = "yyyy-MM-dd'T'23:59:59"
 
+    private const val ONE_WEEK_IN_DAYS = 7
+    private const val ONE_DAY_IN_HOURS = 24
+    private const val ONE_HOUR_IN_MINUTES = 60
+    private const val ONE_MINUTE_IN_SECONDS = 60
+    private const val ONE_SECOND_IN_MILLISECONDS = 1000
+    private const val ONE_DAY_IN_MILLIS =
+        ONE_DAY_IN_HOURS * ONE_HOUR_IN_MINUTES * ONE_MINUTE_IN_SECONDS * ONE_SECOND_IN_MILLISECONDS
+
     /**
      * Given a [SiteModel] and a [String] compatible with [SimpleDateFormat]
      * and a {@param dateString}
@@ -98,9 +106,9 @@ object DateUtils {
     fun getEndDateCalendar(endDate: Date, locale: Locale = Locale.getDefault()): Calendar {
         val cal2 = Calendar.getInstance(locale)
         cal2.time = endDate
-        cal2.set(Calendar.HOUR_OF_DAY, 23)
-        cal2.set(Calendar.MINUTE, 59)
-        cal2.set(Calendar.SECOND, 59)
+        cal2.set(Calendar.HOUR_OF_DAY, ONE_DAY_IN_HOURS - 1)
+        cal2.set(Calendar.MINUTE, ONE_HOUR_IN_MINUTES - 1)
+        cal2.set(Calendar.SECOND, ONE_MINUTE_IN_SECONDS - 1)
         cal2.set(Calendar.MILLISECOND, 59) // TODO: (@anitaa) Why '59' instead of '999'?
         return cal2
     }
@@ -117,7 +125,7 @@ object DateUtils {
         val millis2 = endDateCalendar.timeInMillis
 
         val diff = Math.abs(millis2 - millis1)
-        return Math.ceil(diff / (24 * 60 * 60 * 1000).toDouble()).toLong()
+        return Math.ceil(diff / ONE_DAY_IN_MILLIS.toDouble()).toLong()
     }
 
     /**
@@ -145,7 +153,7 @@ object DateUtils {
         }
 
         val diffInDays = getQuantityInDays(startDateCalendar, endDateCalendar).toDouble()
-        return Math.ceil(diffInDays / 7).toLong()
+        return Math.ceil(diffInDays / ONE_WEEK_IN_DAYS).toLong()
     }
 
     /**
@@ -339,9 +347,9 @@ object DateUtils {
      * Returns (#Calendar.DAY_OF_WEEK) constant for last day of week.
      */
     fun getConstantForLastDayOfWeek(calendar: Calendar): Int {
-        val lastDay = calendar.firstDayOfWeek + 6
-        return if (lastDay > 7) {
-            lastDay % 8 + 1
+        val lastDay = calendar.firstDayOfWeek + (ONE_WEEK_IN_DAYS - 1)
+        return if (lastDay > ONE_WEEK_IN_DAYS) {
+            lastDay % (ONE_WEEK_IN_DAYS + 1) + 1
         } else {
             lastDay
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -94,13 +94,14 @@ object DateUtils {
      * The end date time is set to 23:59:59
      *
      */
+    @Suppress("MagicNumber", "ForbiddenComment")
     fun getEndDateCalendar(endDate: Date, locale: Locale = Locale.getDefault()): Calendar {
         val cal2 = Calendar.getInstance(locale)
         cal2.time = endDate
         cal2.set(Calendar.HOUR_OF_DAY, 23)
         cal2.set(Calendar.MINUTE, 59)
         cal2.set(Calendar.SECOND, 59)
-        cal2.set(Calendar.MILLISECOND, 59)
+        cal2.set(Calendar.MILLISECOND, 59) // TODO: (@anitaa) Why '59' instead of '999'?
         return cal2
     }
 


### PR DESCRIPTION
Parent #2479
Partially Closes: #2486

This PR resolves/suppresses all `style` related warnings for the `plugins:woocommerce` module:

1. `3` x DataClassShouldBeImmutable (Resolve: 8a526d4ab273cdaf9dcc5cc8e3b1383e8375de5a + 44788816a8ce9d79b2dc4b7768662dd8bae8141f)
2. `6` x ForbiddenComment (Suppress: b7466eee836f7cb2ec1d4cdce174a8c490614cd8)
3. `15` x MagicNumber (Resolve: f55ad6e65a38b9eea888b3b91ee9a02a86e5ba01 + Suppress: c33859f36ade917667213484c86b8e255d777b64 + Question [❓]: [see comment](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1103#issuecomment-1211868401) @anitaa1990 @AmandaRiu)
4. `9` x MaxLineLength (Resolve: 5d6b66222333d6410317cfc0c8b04c32c3db7044 + Suppress: 7097dc2af36808c427132075a85486990d3248a4)
5. `13` x ReturnCount (Resolve: c700ef6f7945ff6b739346e259b490412fc03d33 + Suppress: 2e9394667112549e535a3cb165d510f9fab5bf09)
6. `1` x SpacingBetweenPackageAndImports (Resolve: 6dcca837a736ada45008ad8f9dc22b931a8a126d)
7. `2` x UnnecessaryAbstractClass (Resolve: 377e3ca9ff7d9208a81b05d88bbde0fe13ddf9ca)
8. `1` x UnusedPrivateMember (Resolve: 6871985de7f76ba4f137fc6a3dd55c23c5c4135a)
9. `2` x UseCheckOrError (Resolve: 1594872df7959dab2af33114b5ff253ce9934e9c + Suppress: 5236ee56acb95d259a0027c4eef47a074de04e02)

PS.1: I am randomly adding an engineer from the WCAndroid team as the main reviewers, that is, in addition to the @wordpress-mobile/owl-team team itself, since I just want someone from that team to sign-off on that change as well (or additionally to the 🦉 team).

PS.2: I recommend reviewing this PR commit-by-commit.

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough (especially the `detekt` check).
- However, if you really want to be thorough, you could smoke test the `example` and/or the `WCAndroid` apps to verify that everything works as expected.

PS: Please ignore the failing `connected-tests` check as they are unrelated to this PR. This check has been failing consistency for some time now due to tests being flaky or needing to be updated/fixed.