### PR TITLE
Recover from metadata null key

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class WCMetaData(
     @SerializedName("id") val id: Long,
-    @SerializedName("key") val key: String,
+    @SerializedName("key") val key: String?,
     @SerializedName("value") val value: Any,
     @SerializedName("display_key") val displayKey: String?,
     @SerializedName("display_value") val displayValue: Any?

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
@@ -6,5 +6,5 @@ object OrderMappingConst {
     const val CHARGE_ID_KEY = "_charge_id"
     const val SHIPPING_PHONE_KEY = "_shipping_phone"
     internal val WCMetaData.isInternalAttribute
-        get() = key.startsWith('_')
+        get() = key?.startsWith('_')
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
@@ -5,13 +5,11 @@ import org.wordpress.android.fluxc.model.WCMetaData
 object OrderMappingConst {
     const val CHARGE_ID_KEY = "_charge_id"
     const val SHIPPING_PHONE_KEY = "_shipping_phone"
-
     /**
-     * Verify if the Metadata key is a internal store attribute
-     * true if the `key` starts with the `_` character
-     * null if the key is null and it's not possible to verify if it's internal or not
-     * false otherwise
+     * Verify if the Metadata key is not null or a internal store attribute
+     * @return false if the `key` is null or starts with the `_` character
+     * @return true otherwise
      */
-    internal val WCMetaData.isInternalAttribute
-        get() = key?.startsWith('_')
+    internal val WCMetaData.isDisplayableAttribute
+        get() = key?.startsWith('_') ?: false
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
@@ -11,5 +11,5 @@ object OrderMappingConst {
      * @return true otherwise
      */
     internal val WCMetaData.isDisplayableAttribute
-        get() = key?.startsWith('_') ?: false
+        get() = key?.startsWith('_')?.not() ?: false
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
@@ -5,6 +5,13 @@ import org.wordpress.android.fluxc.model.WCMetaData
 object OrderMappingConst {
     const val CHARGE_ID_KEY = "_charge_id"
     const val SHIPPING_PHONE_KEY = "_shipping_phone"
+
+    /**
+     * Verify if the Metadata key is a internal store attribute
+     * true if the `key` starts with the `_` character
+     * null if the key is null and it's not possible to verify if it's internal or not
+     * false otherwise
+     */
     internal val WCMetaData.isInternalAttribute
         get() = key?.startsWith('_')
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isInternalAttribute
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isDisplayableAttribute
 import javax.inject.Inject
 
 internal class StripOrder @Inject constructor(private val gson: Gson) {
@@ -14,7 +14,7 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                 lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItem ->
                     lineItemDto.copy(
                         metaData = lineItemDto.metaData
-                            ?.filter { it.isInternalAttribute?.not() ?: false }
+                            ?.filter { it.isDisplayableAttribute }
                     )
                 }),
                 shippingLines = gson.toJson(fatModel.getShippingLineList()),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -13,7 +13,8 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
         return fatModel.copy(
                 lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItem ->
                     lineItemDto.copy(
-                        metaData = lineItemDto.metaData?.filter { it.isInternalAttribute.not() }
+                        metaData = lineItemDto.metaData
+                            ?.filter { it.isInternalAttribute?.not() ?: false }
                     )
                 }),
                 shippingLines = gson.toJson(fatModel.getShippingLineList()),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
@@ -5,7 +5,7 @@ import com.google.gson.JsonElement
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.WCMetaData
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isInternalAttribute
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isDisplayableAttribute
 import org.wordpress.android.fluxc.persistence.entity.OrderMetaDataEntity
 import javax.inject.Inject
 
@@ -27,7 +27,7 @@ class StripOrderMetaData @Inject internal constructor(private val gson: Gson) {
 
         return parseMetaDataJSON(orderDto.meta_data)
             ?.asSequence()
-            ?.filter { it.isInternalAttribute?.not() ?: false }
+            ?.filter { it.isDisplayableAttribute }
             ?.map { it.asOrderMetaDataEntity(orderDto.id, localSiteId) }
             ?.filter { it.value.isNotEmpty() && it.value.matches(jsonRegex).not() }
             ?.toList()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
@@ -27,7 +27,7 @@ class StripOrderMetaData @Inject internal constructor(private val gson: Gson) {
 
         return parseMetaDataJSON(orderDto.meta_data)
             ?.asSequence()
-            ?.filter { it.isInternalAttribute.not() }
+            ?.filter { it.isInternalAttribute?.not() ?: false }
             ?.map { it.asOrderMetaDataEntity(orderDto.id, localSiteId) }
             ?.filter { it.value.isNotEmpty() && it.value.matches(jsonRegex).not() }
             ?.toList()
@@ -47,7 +47,7 @@ class StripOrderMetaData @Inject internal constructor(private val gson: Gson) {
             id = id,
             localSiteId = localSiteId,
             orderId = orderId,
-            key = key,
+            key = key.orEmpty(),
             value = value.toString().replace(htmlRegex, "")
         )
 }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaDataTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaDataTest.kt
@@ -238,7 +238,7 @@ class StripOrderMetaDataTest {
     }
 
     @Test
-    fun `when Metadata key is null, then remove it from the list`() {
+    fun `when Metadata key is invalid, then remove it from the list`() {
         // Given
         val rawMetadata = listOf(
             WCMetaData(
@@ -249,7 +249,14 @@ class StripOrderMetaDataTest {
                 displayValue = null
             ),
             WCMetaData(
-                id = 2,
+                id = 2L,
+                key = "_internal key",
+                value = "valid value",
+                displayKey = null,
+                displayValue = null
+            ),
+            WCMetaData(
+                id = 3L,
                 key = "valid key",
                 value = "valid value",
                 displayKey = null,
@@ -271,7 +278,7 @@ class StripOrderMetaDataTest {
         assertThat(result).isEqualTo(
             listOf(
                 OrderMetaDataEntity(
-                    id = 2L,
+                    id = 3L,
                     orderId = 1,
                     localSiteId = LocalId(1),
                     key = "valid key",

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaDataTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaDataTest.kt
@@ -236,4 +236,48 @@ class StripOrderMetaDataTest {
             )
         )
     }
+
+    @Test
+    fun `when Metadata key is null, then remove it from the list`() {
+        // Given
+        val rawMetadata = listOf(
+            WCMetaData(
+                id = 1L,
+                key = null,
+                value = "valid value",
+                displayKey = null,
+                displayValue = null
+            ),
+            WCMetaData(
+                id = 2,
+                key = "valid key",
+                value = "valid value",
+                displayKey = null,
+                displayValue = null
+            )
+        )
+        gsonMock = mock {
+            val responseType = object : TypeToken<List<WCMetaData>>() {}.type
+            on { fromJson<List<WCMetaData>?>(jsonObjectMock, responseType) }.thenReturn(
+                rawMetadata
+            )
+        }
+        sut = StripOrderMetaData(gsonMock)
+
+        // When
+        val result = sut(orderDtoMock, LocalId(1))
+
+        // Then
+        assertThat(result).isEqualTo(
+            listOf(
+                OrderMetaDataEntity(
+                    id = 2L,
+                    orderId = 1,
+                    localSiteId = LocalId(1),
+                    key = "valid key",
+                    value = "valid value"
+                )
+            )
+        )
+    }
 }


### PR DESCRIPTION
Summary
==========
Fix the issue https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/2499 by allowing the WCMetaData.key field to be nullable. Since Metadata is a data that can be modified at will-be store plugins, we're seeing Gson ignoring Kotlin constraints about nullability and setting a null value within the WCMetaData model.

How to Test
==========
1. Simply ensure that the new test covering the null key scenario is working as expected, or forcefully inject a metadata with a null key inside the `StripOrderMetaData.invoke` call through the orderDto.meta_data parameter and verify it will be removed with success from the function output.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.