### PR TITLE
Add updatePaymentGateway function to WCGatewayStore.kt

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGatewayStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGatewayStore.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways.GatewayRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways.GatewayRestClient.GatewayId
 import org.wordpress.android.fluxc.persistence.WCGatewaySqlUtils
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
@@ -36,6 +37,27 @@ class WCGatewayStore @Inject constructor(
             }
         }
     }
+
+    suspend fun updatePaymentGateway(
+        site: SiteModel,
+        gatewayId: GatewayId,
+        enabled: Boolean? = null,
+        title: String? = null
+    ): WooResult<WCGatewayModel> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "updatePaymentGateway") {
+            val response = restClient.updatePaymentGateway(site, gatewayId, enabled, title)
+            return@withDefaultContext when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+                response.result != null -> {
+                    WCGatewaySqlUtils.insertOrUpdate(site, response.result)
+                    WooResult(mapper.map(response.result))
+                }
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+    }
+}
 
     fun getAllGateways(site: SiteModel): List<WCGatewayModel> =
             WCGatewaySqlUtils.selectAllGateways(site).map { mapper.map(it) }


### PR DESCRIPTION
Still related to https://github.com/woocommerce/woocommerce-android/issues/7141 and https://github.com/woocommerce/woocommerce-android/issues/7144 and continuing the work started on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2492 this PR adds the updatePaymentGateway function to WCGatewayStore.kt

Please note: we considered adding a release test here but decided not to. 
cc: @malinajirka 

ps: The mock tests for the GatwaysRestClient methods will be added on a separate PR