### PR TITLE
[Detekt Baseline Warnings] Example Module - Resolve/Suppress Style Warnings

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -222,8 +222,6 @@
     <ID>LongMethod:WooUpdateCouponFragment.kt$WooUpdateCouponFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:WooUpdateProductFragment.kt$WooUpdateProductFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:WooUpdateVariationFragment.kt$WooUpdateVariationFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
-    <ID>MaxLineLength:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$ &lt;member>&lt;name>date_created_gmt&lt;/name>&lt;value>&lt;dateTime.iso8601>20210727T20:33:41&lt;/dateTime.iso8601>&lt;/value>&lt;/member></ID>
-    <ID>MaxLineLength:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$ &lt;member>&lt;name>link&lt;/name>&lt;value>&lt;string>http://test-debug.org/index.php/2021/04/01/no-jp/#comment-34&lt;/string>&lt;/value>&lt;/member></ID>
     <ID>NestedBlockDepth:WooProductsFragment.kt$WooProductsFragment$@Suppress("unused") @Subscribe(threadMode = ThreadMode.MAIN) fun onProductShippingClassesChanged(event: OnProductShippingClassesChanged)</ID>
     <ID>NestedBlockDepth:WooShippingLabelFragment.kt$WooShippingLabelFragment$private fun downloadUrl(url: String): File?</ID>
     <ID>PrintStackTrace:WooShippingLabelFragment.kt$WooShippingLabelFragment$e</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -222,7 +222,6 @@
     <ID>LongMethod:WooUpdateCouponFragment.kt$WooUpdateCouponFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:WooUpdateProductFragment.kt$WooUpdateProductFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:WooUpdateVariationFragment.kt$WooUpdateVariationFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
-    <ID>MaxLineLength:CommentSqlUtilsTest.kt$CommentSqlUtilsTest$// from 65 comments in DB we expect to have only 22 remote comments (remove first 3, 3 from the middle and all the comments that go after last comment in remoteComments</ID>
     <ID>MaxLineLength:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$ &lt;member>&lt;name>date_created_gmt&lt;/name>&lt;value>&lt;dateTime.iso8601>20210727T20:33:41&lt;/dateTime.iso8601>&lt;/value>&lt;/member></ID>
     <ID>MaxLineLength:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$ &lt;member>&lt;name>link&lt;/name>&lt;value>&lt;string>http://test-debug.org/index.php/2021/04/01/no-jp/#comment-34&lt;/string>&lt;/value>&lt;/member></ID>
     <ID>NestedBlockDepth:WooProductsFragment.kt$WooProductsFragment$@Suppress("unused") @Subscribe(threadMode = ThreadMode.MAIN) fun onProductShippingClassesChanged(event: OnProductShippingClassesChanged)</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -239,9 +239,6 @@
     <ID>TooGenericExceptionCaught:WooTaxFragment.kt$WooTaxFragment$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WooUpdateProductFragment.kt$WooUpdateProductFragment$ex: Exception</ID>
     <ID>TopLevelPropertyNaming:JsonObjectExtensionsTests.kt$private const val sampleJson = """ { "string": "Some string", "escaped_string": "\\ \" '", "number": 37, "nullstring": null, "object": { "name": "Object name" } } """</ID>
-    <ID>UnnecessaryAbstractClass:FragmentsModule.kt$FragmentsModule$FragmentsModule</ID>
-    <ID>UnnecessaryAbstractClass:MainActivityModule.kt$MainActivityModule$MainActivityModule</ID>
-    <ID>UnnecessaryAbstractClass:WCOrderListActivityModule.kt$WCOrderListActivityModule$WCOrderListActivityModule</ID>
     <ID>UnusedPrivateMember:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$private lateinit var accessToken: AccessToken</ID>
     <ID>UnusedPrivateMember:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder</ID>
     <ID>UnusedPrivateMember:InsightsRestClientTest.kt$InsightsRestClientTest$val date = Date()</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -239,7 +239,6 @@
     <ID>TooGenericExceptionCaught:WooTaxFragment.kt$WooTaxFragment$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WooUpdateProductFragment.kt$WooUpdateProductFragment$ex: Exception</ID>
     <ID>TopLevelPropertyNaming:JsonObjectExtensionsTests.kt$private const val sampleJson = """ { "string": "Some string", "escaped_string": "\\ \" '", "number": 37, "nullstring": null, "object": { "name": "Object name" } } """</ID>
-    <ID>UseArrayLiteralsInAnnotations:MainActivityModule.kt$MainActivityModule$modules = arrayOf(FragmentsModule::class)</ID>
     <ID>UseCheckOrError:ListSelectorDialog.kt$ListSelectorDialog$throw IllegalStateException("Activity cannot be null")</ID>
     <ID>UseCheckOrError:OrderListAdapter.kt$OrderListAdapter$throw IllegalStateException("The view type '$viewType' needs to be handled")</ID>
     <ID>UseCheckOrError:SiteSelectorDialog.kt$SiteSelectorDialog$throw IllegalStateException("Activity cannot be null")</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -222,12 +222,7 @@
     <ID>LongMethod:WooUpdateCouponFragment.kt$WooUpdateCouponFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:WooUpdateProductFragment.kt$WooUpdateProductFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:WooUpdateVariationFragment.kt$WooUpdateVariationFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
-    <ID>MagicNumber:CustomStatsDialog.kt$CustomStatsDialog.Companion$100</ID>
-    <ID>MagicNumber:WCAddOrderShipmentTrackingDialog.kt$WCAddOrderShipmentTrackingDialog.Companion$200</ID>
     <ID>MagicNumber:WCOrderListActivity.kt$TimeGroup.Companion$2</ID>
-    <ID>MagicNumber:WooOrdersFragment.kt$WooOrdersFragment$5</ID>
-    <ID>MagicNumber:WooShippingLabelFragment.kt$WooShippingLabelFragment$5000</ID>
-    <ID>MagicNumber:WooStatsFragment.kt$WooStatsFragment$10</ID>
     <ID>MaxLineLength:CommentSqlUtilsTest.kt$CommentSqlUtilsTest$// from 65 comments in DB we expect to have only 22 remote comments (remove first 3, 3 from the middle and all the comments that go after last comment in remoteComments</ID>
     <ID>MaxLineLength:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$ &lt;member>&lt;name>date_created_gmt&lt;/name>&lt;value>&lt;dateTime.iso8601>20210727T20:33:41&lt;/dateTime.iso8601>&lt;/value>&lt;/member></ID>
     <ID>MaxLineLength:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$ &lt;member>&lt;name>link&lt;/name>&lt;value>&lt;string>http://test-debug.org/index.php/2021/04/01/no-jp/#comment-34&lt;/string>&lt;/value>&lt;/member></ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -226,8 +226,6 @@
     <ID>NestedBlockDepth:WooShippingLabelFragment.kt$WooShippingLabelFragment$private fun downloadUrl(url: String): File?</ID>
     <ID>PrintStackTrace:WooShippingLabelFragment.kt$WooShippingLabelFragment$e</ID>
     <ID>PrintStackTrace:WooShippingLabelFragment.kt$WooShippingLabelFragment$ex</ID>
-    <ID>ReturnCount:OrderListAdapter.kt$&lt;no name provided>$override fun areContentsTheSame(oldItem: WCOrderListItemUIType, newItem: WCOrderListItemUIType): Boolean</ID>
-    <ID>ReturnCount:OrderListAdapter.kt$&lt;no name provided>$override fun areItemsTheSame(oldItem: WCOrderListItemUIType, newItem: WCOrderListItemUIType): Boolean</ID>
     <ID>SpreadOperator:WooOrdersFragment.kt$WooOrdersFragment$(site, *filter.toTypedArray())</ID>
     <ID>SwallowedException:WooCustomersSearchBuilderFragment.kt$WooCustomersSearchBuilderFragment$e: Exception</ID>
     <ID>SwallowedException:WooShippingLabelFragment.kt$WooShippingLabelFragment$e: Exception</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -239,11 +239,7 @@
     <ID>TooGenericExceptionCaught:WooTaxFragment.kt$WooTaxFragment$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WooUpdateProductFragment.kt$WooUpdateProductFragment$ex: Exception</ID>
     <ID>TopLevelPropertyNaming:JsonObjectExtensionsTests.kt$private const val sampleJson = """ { "string": "Some string", "escaped_string": "\\ \" '", "number": 37, "nullstring": null, "object": { "name": "Object name" } } """</ID>
-    <ID>UseCheckOrError:ListSelectorDialog.kt$ListSelectorDialog$throw IllegalStateException("Activity cannot be null")</ID>
     <ID>UseCheckOrError:OrderListAdapter.kt$OrderListAdapter$throw IllegalStateException("The view type '$viewType' needs to be handled")</ID>
-    <ID>UseCheckOrError:SiteSelectorDialog.kt$SiteSelectorDialog$throw IllegalStateException("Activity cannot be null")</ID>
-    <ID>UseCheckOrError:StoreSelectorDialog.kt$StoreSelectorDialog$throw IllegalStateException("Activity cannot be null")</ID>
-    <ID>UseCheckOrError:ThreeEditTextDialog.kt$ThreeEditTextDialog$throw IllegalStateException("Not attached to an activity!")</ID>
     <ID>UseCheckOrError:WooCustomersSearchAdapter.kt$WooCustomersSearchAdapter$throw IllegalStateException("View type $viewType is not supported")</ID>
     <ID>UtilityClassWithPublicConstructor:ReactNativeStoreWPAPITest.kt$ReactNativeStoreWPAPITest$StatusCode</ID>
     <ID>WildcardImport:AccountFragment.kt$import kotlinx.android.synthetic.main.fragment_account.*</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -239,7 +239,6 @@
     <ID>TooGenericExceptionCaught:WooTaxFragment.kt$WooTaxFragment$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WooUpdateProductFragment.kt$WooUpdateProductFragment$ex: Exception</ID>
     <ID>TopLevelPropertyNaming:JsonObjectExtensionsTests.kt$private const val sampleJson = """ { "string": "Some string", "escaped_string": "\\ \" '", "number": 37, "nullstring": null, "object": { "name": "Object name" } } """</ID>
-    <ID>UtilityClassWithPublicConstructor:ReactNativeStoreWPAPITest.kt$ReactNativeStoreWPAPITest$StatusCode</ID>
     <ID>WildcardImport:AccountFragment.kt$import kotlinx.android.synthetic.main.fragment_account.*</ID>
     <ID>WildcardImport:AddressEditDialogFragment.kt$import kotlinx.android.synthetic.main.fragment_address_edit_dialog.*</ID>
     <ID>WildcardImport:CustomStatsDialog.kt$import kotlinx.android.synthetic.main.dialog_custom_stats.*</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -239,8 +239,6 @@
     <ID>TooGenericExceptionCaught:WooTaxFragment.kt$WooTaxFragment$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WooUpdateProductFragment.kt$WooUpdateProductFragment$ex: Exception</ID>
     <ID>TopLevelPropertyNaming:JsonObjectExtensionsTests.kt$private const val sampleJson = """ { "string": "Some string", "escaped_string": "\\ \" '", "number": 37, "nullstring": null, "object": { "name": "Object name" } } """</ID>
-    <ID>UseCheckOrError:OrderListAdapter.kt$OrderListAdapter$throw IllegalStateException("The view type '$viewType' needs to be handled")</ID>
-    <ID>UseCheckOrError:WooCustomersSearchAdapter.kt$WooCustomersSearchAdapter$throw IllegalStateException("View type $viewType is not supported")</ID>
     <ID>UtilityClassWithPublicConstructor:ReactNativeStoreWPAPITest.kt$ReactNativeStoreWPAPITest$StatusCode</ID>
     <ID>WildcardImport:AccountFragment.kt$import kotlinx.android.synthetic.main.fragment_account.*</ID>
     <ID>WildcardImport:AddressEditDialogFragment.kt$import kotlinx.android.synthetic.main.fragment_address_edit_dialog.*</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -222,7 +222,6 @@
     <ID>LongMethod:WooUpdateCouponFragment.kt$WooUpdateCouponFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:WooUpdateProductFragment.kt$WooUpdateProductFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:WooUpdateVariationFragment.kt$WooUpdateVariationFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
-    <ID>MagicNumber:WCOrderListActivity.kt$TimeGroup.Companion$2</ID>
     <ID>MaxLineLength:CommentSqlUtilsTest.kt$CommentSqlUtilsTest$// from 65 comments in DB we expect to have only 22 remote comments (remove first 3, 3 from the middle and all the comments that go after last comment in remoteComments</ID>
     <ID>MaxLineLength:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$ &lt;member>&lt;name>date_created_gmt&lt;/name>&lt;value>&lt;dateTime.iso8601>20210727T20:33:41&lt;/dateTime.iso8601>&lt;/value>&lt;/member></ID>
     <ID>MaxLineLength:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$ &lt;member>&lt;name>link&lt;/name>&lt;value>&lt;string>http://test-debug.org/index.php/2021/04/01/no-jp/#comment-34&lt;/string>&lt;/value>&lt;/member></ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -167,10 +167,6 @@
     <ID>ComplexMethod:WooUpdateProductFragment.kt$WooUpdateProductFragment$override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?)</ID>
     <ID>ComplexMethod:WooUpdateProductFragment.kt$WooUpdateProductFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>ComplexMethod:WooUpdateVariationFragment.kt$WooUpdateVariationFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
-    <ID>DataClassShouldBeImmutable:WooProductCategoriesAdapter.kt$WooProductCategoriesAdapter.ProductCategoryViewHolderModel$var isSelected: Boolean = false</ID>
-    <ID>DataClassShouldBeImmutable:WooProductDownloadsFragment.kt$WooProductDownloadsFragment.ProductFile$var name: String</ID>
-    <ID>DataClassShouldBeImmutable:WooProductDownloadsFragment.kt$WooProductDownloadsFragment.ProductFile$var url: String</ID>
-    <ID>DataClassShouldBeImmutable:WooProductTagsAdapter.kt$WooProductTagsAdapter.ProductTagViewHolderModel$var isSelected: Boolean = false</ID>
     <ID>EmptyFunctionBlock:EditTextExt.kt$&lt;no name provided>${}</ID>
     <ID>EmptyFunctionBlock:ExperimentsFragment.kt$ExperimentsFragment.&lt;no name provided>${}</ID>
     <ID>EmptyFunctionBlock:RetryOnRedirectBasicNetworkTest.kt$RetryOnRedirectBasicNetworkTest.MockedRequest${}</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -239,54 +239,5 @@
     <ID>TooGenericExceptionCaught:WooTaxFragment.kt$WooTaxFragment$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WooUpdateProductFragment.kt$WooUpdateProductFragment$ex: Exception</ID>
     <ID>TopLevelPropertyNaming:JsonObjectExtensionsTests.kt$private const val sampleJson = """ { "string": "Some string", "escaped_string": "\\ \" '", "number": 37, "nullstring": null, "object": { "name": "Object name" } } """</ID>
-    <ID>WildcardImport:AccountFragment.kt$import kotlinx.android.synthetic.main.fragment_account.*</ID>
-    <ID>WildcardImport:AddressEditDialogFragment.kt$import kotlinx.android.synthetic.main.fragment_address_edit_dialog.*</ID>
-    <ID>WildcardImport:CustomStatsDialog.kt$import kotlinx.android.synthetic.main.dialog_custom_stats.*</ID>
-    <ID>WildcardImport:EditorThemeFragment.kt$import kotlinx.android.synthetic.main.fragment_editor_theme.*</ID>
-    <ID>WildcardImport:ExperimentsFragment.kt$import kotlinx.android.synthetic.main.fragment_experiments.*</ID>
-    <ID>WildcardImport:FloatingLabelEditText.kt$import kotlinx.android.synthetic.main.view_floating_edittext.view.*</ID>
-    <ID>WildcardImport:MainExampleActivity.kt$import kotlinx.android.synthetic.main.activity_example.*</ID>
-    <ID>WildcardImport:MainFragment.kt$import kotlinx.android.synthetic.main.fragment_main.*</ID>
-    <ID>WildcardImport:NotificationTypeSubtypeDialog.kt$import kotlinx.android.synthetic.main.dialog_notification_type_subtype.*</ID>
-    <ID>WildcardImport:NotificationsFragment.kt$import kotlinx.android.synthetic.main.fragment_notifications.*</ID>
-    <ID>WildcardImport:PluginsFragment.kt$import kotlinx.android.synthetic.main.fragment_notifications.*</ID>
-    <ID>WildcardImport:PluginsFragment.kt$import kotlinx.android.synthetic.main.fragment_plugins.*</ID>
-    <ID>WildcardImport:PostsFragment.kt$import kotlinx.android.synthetic.main.fragment_posts.*</ID>
-    <ID>WildcardImport:ReactNativeFragment.kt$import kotlinx.android.synthetic.main.fragment_reactnative.*</ID>
-    <ID>WildcardImport:StoreSelectingFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_products.*</ID>
-    <ID>WildcardImport:ThemeFragment.kt$import kotlinx.android.synthetic.main.fragment_themes.*</ID>
-    <ID>WildcardImport:WCAddOrderShipmentTrackingDialog.kt$import kotlinx.android.synthetic.main.dialog_wc_add_order_shipment_tracking.*</ID>
-    <ID>WildcardImport:WCOrderListActivity.kt$import kotlinx.android.synthetic.main.activity_wc_order_list.*</ID>
-    <ID>WildcardImport:WooAddonsTestFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_addons.*</ID>
-    <ID>WildcardImport:WooBatchUpdateVariationsFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_batch_update_variations.*</ID>
-    <ID>WildcardImport:WooCommerceFragment.kt$import kotlinx.android.synthetic.main.fragment_woocommerce.*</ID>
-    <ID>WildcardImport:WooCouponsFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_coupons.*</ID>
-    <ID>WildcardImport:WooCustomerCreationFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_customer_creation.*</ID>
-    <ID>WildcardImport:WooCustomersFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_customer.*</ID>
-    <ID>WildcardImport:WooCustomersSearchAdapter.kt$import kotlinx.android.synthetic.main.list_item_woo_customer.view.*</ID>
-    <ID>WildcardImport:WooCustomersSearchBuilderFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_customers_search_builder.*</ID>
-    <ID>WildcardImport:WooCustomersSearchFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_customers_search.*</ID>
-    <ID>WildcardImport:WooGatewaysFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_gateways.*</ID>
-    <ID>WildcardImport:WooHelpSupportFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_help_support.*</ID>
-    <ID>WildcardImport:WooLeaderboardsFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_leaderboards.*</ID>
-    <ID>WildcardImport:WooOrdersFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_orders.*</ID>
-    <ID>WildcardImport:WooProductAttributeFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_product_attribute.*</ID>
-    <ID>WildcardImport:WooProductCategoriesAdapter.kt$import kotlinx.android.synthetic.main.product_category_list_item.view.*</ID>
-    <ID>WildcardImport:WooProductCategoriesFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_product_categories.*</ID>
-    <ID>WildcardImport:WooProductDownloadsAdapter.kt$import kotlinx.android.synthetic.main.product_downloadable_file_list_item.view.*</ID>
-    <ID>WildcardImport:WooProductDownloadsFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_product_downloads.*</ID>
-    <ID>WildcardImport:WooProductFiltersFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_product_filters.*</ID>
-    <ID>WildcardImport:WooProductTagsAdapter.kt$import kotlinx.android.synthetic.main.product_category_list_item.view.*</ID>
-    <ID>WildcardImport:WooProductTagsFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_product_categories.*</ID>
-    <ID>WildcardImport:WooProductsFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_products.*</ID>
-    <ID>WildcardImport:WooRefundsFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_refunds.*</ID>
-    <ID>WildcardImport:WooRevenueStatsFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_revenue_stats.*</ID>
-    <ID>WildcardImport:WooShippingLabelFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_shippinglabels.*</ID>
-    <ID>WildcardImport:WooStatsFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_stats.*</ID>
-    <ID>WildcardImport:WooTaxFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_taxes.*</ID>
-    <ID>WildcardImport:WooUpdateCouponFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_update_coupon.*</ID>
-    <ID>WildcardImport:WooUpdateProductFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_update_product.*</ID>
-    <ID>WildcardImport:WooUpdateVariationFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_update_variation.*</ID>
-    <ID>WildcardImport:WooVerifyAddressFragment.kt$import kotlinx.android.synthetic.main.fragment_woo_verify_address.*</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -239,17 +239,6 @@
     <ID>TooGenericExceptionCaught:WooTaxFragment.kt$WooTaxFragment$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WooUpdateProductFragment.kt$WooUpdateProductFragment$ex: Exception</ID>
     <ID>TopLevelPropertyNaming:JsonObjectExtensionsTests.kt$private const val sampleJson = """ { "string": "Some string", "escaped_string": "\\ \" '", "number": 37, "nullstring": null, "object": { "name": "Object name" } } """</ID>
-    <ID>UnusedPrivateMember:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$private lateinit var accessToken: AccessToken</ID>
-    <ID>UnusedPrivateMember:CommentsXMLRPCClientTest.kt$CommentsXMLRPCClientTest$private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder</ID>
-    <ID>UnusedPrivateMember:InsightsRestClientTest.kt$InsightsRestClientTest$val date = Date()</ID>
-    <ID>UnusedPrivateMember:PageStoreTest.kt$PageStoreTest$private fun assertPage(map: Map&lt;PageStatus, List&lt;PageModel>>, position: Int, status: PageStatus)</ID>
-    <ID>UnusedPrivateMember:SiteHomepageRestClientTest.kt$SiteHomepageRestClientTest$@Mock private lateinit var siteHomepageSettingsMapper: SiteHomepageSettingsMapper</ID>
-    <ID>UnusedPrivateMember:WCProductStoreTest.kt$WCProductStoreTest$val modifications = variationsUpdatePayload.modifiedProperties</ID>
-    <ID>UnusedPrivateMember:WCShippingLabelStoreTest.kt$WCShippingLabelStoreTest$private val sampleListOfTwoIdenticalPredefinedPackages = listOf( PredefinedOption( title = "USPS Priority Mail Flat Rate Boxes", carrier = "usps", predefinedPackages = listOf( PredefinedPackage( id = "small_flat_box", title = "Small Flat Box", isLetter = false, dimensions = "10 x 10 x 10", boxWeight = 1.0f ), PredefinedPackage( id = "small_flat_box", title = "Small Flat Box", isLetter = false, dimensions = "10 x 10 x 10", boxWeight = 1.0f ) ) ) )</ID>
-    <ID>UnusedPrivateMember:WCStatsStoreTest.kt$WCStatsStoreTest$val missingDataPayload = FetchRevenueStatsResponsePayload(site, StatsGranularity.YEARS, null)</ID>
-    <ID>UnusedPrivateMember:WCUserTestUtils.kt$WCUserTestUtils$private fun generateSampleUser( firstName: String = "", lastName: String = "", username: String = "", email: String = "", roles: String = "", siteId: Int = 6 ): WCUserModel</ID>
-    <ID>UnusedPrivateMember:WooProductAttributeFragment.kt$WooProductAttributeFragment$view: View</ID>
-    <ID>UnusedPrivateMember:WooUpdateProductFragment.kt$WooUpdateProductFragment$view: View</ID>
     <ID>UseArrayLiteralsInAnnotations:MainActivityModule.kt$MainActivityModule$modules = arrayOf(FragmentsModule::class)</ID>
     <ID>UseCheckOrError:ListSelectorDialog.kt$ListSelectorDialog$throw IllegalStateException("Activity cannot be null")</ID>
     <ID>UseCheckOrError:OrderListAdapter.kt$OrderListAdapter$throw IllegalStateException("The view type '$viewType' needs to be handled")</ID>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -32,7 +32,8 @@ style:
     active: true
   WildcardImport:
     active: true
-    excludeImports: []
+    excludeImports:
+      - 'kotlinx.android.synthetic.*' # For the 'example' module.
   ForbiddenSuppress:
     active: true
     rules: ['MaximumLineLength']

--- a/example/src/main/java/org/wordpress/android/fluxc/example/CustomStatsDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/CustomStatsDialog.kt
@@ -26,6 +26,8 @@ class CustomStatsDialog : DialogFragment() {
     }
 
     companion object {
+        private const val CUSTOM_STATS_REQUEST_CODE = 100
+
         @JvmStatic
         fun newInstance(
             fragment: Fragment,
@@ -34,7 +36,7 @@ class CustomStatsDialog : DialogFragment() {
             unit: String?,
             wcOrderStatsAction: WCOrderStatsAction
         ) = CustomStatsDialog().apply {
-            setTargetFragment(fragment, 100)
+            setTargetFragment(fragment, CUSTOM_STATS_REQUEST_CODE)
             this.startDate = startDate
             this.endDate = endDate
             this.granularity = unit

--- a/example/src/main/java/org/wordpress/android/fluxc/example/OrderListAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/OrderListAdapter.kt
@@ -71,33 +71,23 @@ class OrderListAdapter : PagedListAdapter<WCOrderListItemUIType, ViewHolder>(Ord
 
 private val OrderListDiffItemCallback = object : DiffUtil.ItemCallback<WCOrderListItemUIType>() {
     override fun areItemsTheSame(oldItem: WCOrderListItemUIType, newItem: WCOrderListItemUIType): Boolean {
-        if (oldItem is SectionHeader && newItem is SectionHeader) {
-            return oldItem.title == newItem.title
+        return when {
+            oldItem is SectionHeader && newItem is SectionHeader -> oldItem.title == newItem.title
+            oldItem is LoadingItem && newItem is LoadingItem -> oldItem.orderId == newItem.orderId
+            oldItem is WCOrderListUIItem && newItem is WCOrderListUIItem -> oldItem.orderId == newItem.orderId
+            oldItem is LoadingItem && newItem is WCOrderListUIItem -> oldItem.orderId == newItem.orderId
+            else -> false
         }
-        if (oldItem is LoadingItem && newItem is LoadingItem) {
-            return oldItem.orderId == newItem.orderId
-        }
-        if (oldItem is WCOrderListUIItem && newItem is WCOrderListUIItem) {
-            return oldItem.orderId == newItem.orderId
-        }
-        if (oldItem is LoadingItem && newItem is WCOrderListUIItem) {
-            return oldItem.orderId == newItem.orderId
-        }
-        return false
     }
 
     override fun areContentsTheSame(oldItem: WCOrderListItemUIType, newItem: WCOrderListItemUIType): Boolean {
-        if (oldItem is SectionHeader && newItem is SectionHeader) {
-            return oldItem.title == newItem.title
-        }
-        if (oldItem is LoadingItem && newItem is LoadingItem) {
-            return oldItem.orderId == newItem.orderId
-        }
-        if (oldItem is WCOrderListUIItem && newItem is WCOrderListUIItem) {
+        return when {
+            oldItem is SectionHeader && newItem is SectionHeader -> oldItem.title == newItem.title
+            oldItem is LoadingItem && newItem is LoadingItem -> oldItem.orderId == newItem.orderId
             // AS is lying, it's not actually smart casting, so we have to do it :sigh:
-            return oldItem == newItem
+            oldItem is WCOrderListUIItem && newItem is WCOrderListUIItem -> oldItem == newItem
+            else -> false
         }
-        return false
     }
 }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/OrderListAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/OrderListAdapter.kt
@@ -31,6 +31,7 @@ class OrderListAdapter : PagedListAdapter<WCOrderListItemUIType, ViewHolder>(Ord
         }
     }
 
+    @Suppress("UseCheckOrError")
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return when (viewType) {
             VIEW_TYPE_ORDER_ITEM -> WCOrderItemUIViewHolder(R.layout.list_item_woo_order, parent)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SiteSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SiteSelectorDialog.kt
@@ -67,25 +67,23 @@ class SiteSelectorDialog : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        return activity?.let {
-            val adapter = SiteAdapter(it, siteStore.sites)
+        val adapter = SiteAdapter(requireActivity(), siteStore.sites)
 
-            // Use the Builder class for convenient dialog construction
-            val builder = AlertDialog.Builder(it)
-            builder.setTitle("Select a site")
-                    .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
-                        val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
-                        val site = adapter.getItem(which)
-                        if (site != null) {
-                            listener?.onSiteSelected(site, which)
-                        } else {
-                            prependToLog("SiteChanged error: site at position $which was null.")
-                        }
-                        dialog.dismiss()
+        // Use the Builder class for convenient dialog construction
+        val builder = AlertDialog.Builder(requireActivity())
+        builder.setTitle("Select a site")
+                .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
+                    val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
+                    val site = adapter.getItem(which)
+                    if (site != null) {
+                        listener?.onSiteSelected(site, which)
+                    } else {
+                        prependToLog("SiteChanged error: site at position $which was null.")
                     }
-            // Create the AlertDialog object and return it
-            builder.create()
-        } ?: throw IllegalStateException("Activity cannot be null")
+                    dialog.dismiss()
+                }
+        // Create the AlertDialog object and return it
+        return builder.create()
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThreeEditTextDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThreeEditTextDialog.kt
@@ -27,34 +27,32 @@ class ThreeEditTextDialog : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        activity?.let {
-            val builder = AlertDialog.Builder(it)
-            val inflater = it.layoutInflater
-            val view = inflater.inflate(R.layout.signin_dialog, null)
-            editText1 = view.findViewById(R.id.text1) as EditText
-            editText2 = view.findViewById(R.id.text2) as EditText
-            editText3 = view.findViewById(R.id.text3) as EditText
+        val builder = AlertDialog.Builder(requireActivity())
+        val inflater = requireActivity().layoutInflater
+        val view = inflater.inflate(R.layout.signin_dialog, null)
+        editText1 = view.findViewById(R.id.text1) as EditText
+        editText2 = view.findViewById(R.id.text2) as EditText
+        editText3 = view.findViewById(R.id.text3) as EditText
 
-            editText1.hint = hint1
-            editText2.hint = hint2
-            editText3.hint = hint3
-            if (TextUtils.isEmpty(hint1)) {
-                editText1.visibility = View.GONE
-            }
-            if (TextUtils.isEmpty(hint2)) {
-                editText2.visibility = View.GONE
-            }
-            if (TextUtils.isEmpty(hint3)) {
-                editText3.visibility = View.GONE
-            }
-            builder.setView(view)
-                    .setPositiveButton(android.R.string.ok) { dialog, id ->
-                        listener?.onClick(editText1.text.toString(), editText2.text.toString(),
-                                editText3.text.toString())
-                    }
-                    .setNegativeButton(android.R.string.cancel, null)
-            return builder.create()
-        } ?: throw IllegalStateException("Not attached to an activity!")
+        editText1.hint = hint1
+        editText2.hint = hint2
+        editText3.hint = hint3
+        if (TextUtils.isEmpty(hint1)) {
+            editText1.visibility = View.GONE
+        }
+        if (TextUtils.isEmpty(hint2)) {
+            editText2.visibility = View.GONE
+        }
+        if (TextUtils.isEmpty(hint3)) {
+            editText3.visibility = View.GONE
+        }
+        builder.setView(view)
+                .setPositiveButton(android.R.string.ok) { dialog, id ->
+                    listener?.onClick(editText1.text.toString(), editText2.text.toString(),
+                            editText3.text.toString())
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+        return builder.create()
     }
 
     companion object {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WCAddOrderShipmentTrackingDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WCAddOrderShipmentTrackingDialog.kt
@@ -22,6 +22,8 @@ import java.util.Date
 
 class WCAddOrderShipmentTrackingDialog : DialogFragment() {
     companion object {
+        private const val WC_ADD_ORDER_SHIPMENT_TRACKING_REQUEST_CODE = 200
+
         @JvmStatic
         fun newInstance(
             fragment: Fragment,
@@ -29,7 +31,7 @@ class WCAddOrderShipmentTrackingDialog : DialogFragment() {
             order: OrderEntity,
             providers: List<String>
         ) = WCAddOrderShipmentTrackingDialog().apply {
-            setTargetFragment(fragment, 200)
+            setTargetFragment(fragment, WC_ADD_ORDER_SHIPMENT_TRACKING_REQUEST_CODE)
             this.site = site
             this.order = order
             this.providers = providers

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WCOrderListActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WCOrderListActivity.kt
@@ -214,6 +214,7 @@ enum class TimeGroup {
     GROUP_OLDER_MONTH;
 
     companion object {
+        @Suppress("MagicNumber")
         fun getTimeGroupForDate(date: Date): TimeGroup {
             val dateToday = Date()
             return when {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -47,133 +47,133 @@ import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
 
 @Module
-internal abstract class FragmentsModule {
+internal interface FragmentsModule {
     @ContributesAndroidInjector
-    abstract fun provideMainFragmentInjector(): MainFragment
+    fun provideMainFragmentInjector(): MainFragment
 
     @ContributesAndroidInjector
-    abstract fun provideAccountFragmentInjector(): AccountFragment
+    fun provideAccountFragmentInjector(): AccountFragment
 
     @ContributesAndroidInjector
-    abstract fun provideCommentsFragmentInjector(): CommentsFragment
+    fun provideCommentsFragmentInjector(): CommentsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideMediaFragmentInjector(): MediaFragment
+    fun provideMediaFragmentInjector(): MediaFragment
 
     @ContributesAndroidInjector
-    abstract fun providePostsFragmentInjector(): PostsFragment
+    fun providePostsFragmentInjector(): PostsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideSignedOutActionsFragmentInjector(): SignedOutActionsFragment
+    fun provideSignedOutActionsFragmentInjector(): SignedOutActionsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideSitesFragmentInjector(): SitesFragment
+    fun provideSitesFragmentInjector(): SitesFragment
 
     @ContributesAndroidInjector
-    abstract fun provideTaxonomiesFragmentInjector(): TaxonomiesFragment
+    fun provideTaxonomiesFragmentInjector(): TaxonomiesFragment
 
     @ContributesAndroidInjector
-    abstract fun provideThemeFragmentInjector(): ThemeFragment
+    fun provideThemeFragmentInjector(): ThemeFragment
 
     @ContributesAndroidInjector
-    abstract fun provideUploadsFragmentInjector(): UploadsFragment
+    fun provideUploadsFragmentInjector(): UploadsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooCommerceFragmentInjector(): WooCommerceFragment
+    fun provideWooCommerceFragmentInjector(): WooCommerceFragment
 
     @ContributesAndroidInjector
-    abstract fun provideNotificationsFragmentInjector(): NotificationsFragment
+    fun provideNotificationsFragmentInjector(): NotificationsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooStatsFragmentInjector(): WooStatsFragment
+    fun provideWooStatsFragmentInjector(): WooStatsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooRevenueStatsFragmentInjector(): WooRevenueStatsFragment
+    fun provideWooRevenueStatsFragmentInjector(): WooRevenueStatsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooProductsFragmentInjector(): WooProductsFragment
+    fun provideWooProductsFragmentInjector(): WooProductsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooUpdateProductFragmentInjector(): WooUpdateProductFragment
+    fun provideWooUpdateProductFragmentInjector(): WooUpdateProductFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooUpdateCouponFragmentInjector(): WooUpdateCouponFragment
+    fun provideWooUpdateCouponFragmentInjector(): WooUpdateCouponFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooUpdateVariationFragmentInjector(): WooUpdateVariationFragment
+    fun provideWooUpdateVariationFragmentInjector(): WooUpdateVariationFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooBatchUpdateVariationsFragmentInjector(): WooBatchUpdateVariationsFragment
+    fun provideWooBatchUpdateVariationsFragmentInjector(): WooBatchUpdateVariationsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooProductFiltersFragmentInjector(): WooProductFiltersFragment
+    fun provideWooProductFiltersFragmentInjector(): WooProductFiltersFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooProductCategoriesFragmentInjector(): WooProductCategoriesFragment
+    fun provideWooProductCategoriesFragmentInjector(): WooProductCategoriesFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooProductTagsFragmentInjector(): WooProductTagsFragment
+    fun provideWooProductTagsFragmentInjector(): WooProductTagsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooOrdersFragmentInjector(): WooOrdersFragment
+    fun provideWooOrdersFragmentInjector(): WooOrdersFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooRefundsFragmentInjector(): WooRefundsFragment
+    fun provideWooRefundsFragmentInjector(): WooRefundsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooGatewaysFragmentInjector(): WooGatewaysFragment
+    fun provideWooGatewaysFragmentInjector(): WooGatewaysFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooTaxFragmentInjector(): WooTaxFragment
+    fun provideWooTaxFragmentInjector(): WooTaxFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooShippingLabelFragmentInjector(): WooShippingLabelFragment
+    fun provideWooShippingLabelFragmentInjector(): WooShippingLabelFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooVerifyAddressFragment(): WooVerifyAddressFragment
+    fun provideWooVerifyAddressFragment(): WooVerifyAddressFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooLeaderboardsFragmentInjector(): WooLeaderboardsFragment
+    fun provideWooLeaderboardsFragmentInjector(): WooLeaderboardsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideSiteSelectorDialogInjector(): SiteSelectorDialog
+    fun provideSiteSelectorDialogInjector(): SiteSelectorDialog
 
     @ContributesAndroidInjector
-    abstract fun provideStoreSelectorDialogInjector(): StoreSelectorDialog
+    fun provideStoreSelectorDialogInjector(): StoreSelectorDialog
 
     @ContributesAndroidInjector
-    abstract fun provideReactNativeFragmentInjector(): ReactNativeFragment
+    fun provideReactNativeFragmentInjector(): ReactNativeFragment
 
     @ContributesAndroidInjector
-    abstract fun provideEditorThemeFragmentInjector(): EditorThemeFragment
+    fun provideEditorThemeFragmentInjector(): EditorThemeFragment
 
     @ContributesAndroidInjector
-    abstract fun provideExperimentsFragmentInjector(): ExperimentsFragment
+    fun provideExperimentsFragmentInjector(): ExperimentsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooProductAttributeFragmentInjector(): WooProductAttributeFragment
+    fun provideWooProductAttributeFragmentInjector(): WooProductAttributeFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooCustomersFragmentInjector(): WooCustomersFragment
+    fun provideWooCustomersFragmentInjector(): WooCustomersFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooCouponsFragmentInjector(): WooCouponsFragment
+    fun provideWooCouponsFragmentInjector(): WooCouponsFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooCustomersSearchInjector(): WooCustomersSearchFragment
+    fun provideWooCustomersSearchInjector(): WooCustomersSearchFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooCustomerCreationFragment(): WooCustomerCreationFragment
+    fun provideWooCustomerCreationFragment(): WooCustomerCreationFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooAddonsTestFragment(): WooAddonsTestFragment
+    fun provideWooAddonsTestFragment(): WooAddonsTestFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooHelpSupportFragment(): WooHelpSupportFragment
+    fun provideWooHelpSupportFragment(): WooHelpSupportFragment
 
     @ContributesAndroidInjector
-    abstract fun provideWooAddressEditDialogFragment(): AddressEditDialogFragment
+    fun provideWooAddressEditDialogFragment(): AddressEditDialogFragment
 
     @ContributesAndroidInjector
-    abstract fun providePluginsFragment(): PluginsFragment
+    fun providePluginsFragment(): PluginsFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/MainActivityModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/MainActivityModule.kt
@@ -6,6 +6,6 @@ import org.wordpress.android.fluxc.example.MainExampleActivity
 
 @Module
 internal interface MainActivityModule {
-    @ContributesAndroidInjector(modules = arrayOf(FragmentsModule::class))
+    @ContributesAndroidInjector(modules = [FragmentsModule::class])
     fun provideMainActivityInjector(): MainExampleActivity
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/MainActivityModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/MainActivityModule.kt
@@ -5,7 +5,7 @@ import dagger.android.ContributesAndroidInjector
 import org.wordpress.android.fluxc.example.MainExampleActivity
 
 @Module
-internal abstract class MainActivityModule {
+internal interface MainActivityModule {
     @ContributesAndroidInjector(modules = arrayOf(FragmentsModule::class))
-    abstract fun provideMainActivityInjector(): MainExampleActivity
+    fun provideMainActivityInjector(): MainExampleActivity
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/WCOrderListActivityModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/WCOrderListActivityModule.kt
@@ -5,7 +5,7 @@ import dagger.android.ContributesAndroidInjector
 import org.wordpress.android.fluxc.example.WCOrderListActivity
 
 @Module
-internal abstract class WCOrderListActivityModule {
+internal interface WCOrderListActivityModule {
     @ContributesAndroidInjector
-    abstract fun provideWCOrderListActivityInjector(): WCOrderListActivity
+    fun provideWCOrderListActivityInjector(): WCOrderListActivity
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/ListSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/ListSelectorDialog.kt
@@ -60,37 +60,35 @@ class ListSelectorDialog : DialogFragment() {
             selectedListItem = it.getString(ARG_LIST_SELECTED_ITEM)
         }
 
-        return activity?.let { fragmentActivity ->
-            val builder = AlertDialog.Builder(fragmentActivity)
+        val builder = AlertDialog.Builder(requireActivity())
 
-            if (isSingleChoice) {
-                builder.setTitle("Select a list item")
-                    .setSingleChoiceItems(listItems?.toTypedArray(), getListIndex()) { dialog, which ->
-                        val intent = activity?.intent
-                        intent?.putExtra(ARG_LIST_SELECTED_ITEM, listItems?.get(which))
-                        targetFragment?.onActivityResult(LIST_SELECTOR_REQUEST_CODE, resultCode, intent)
-                        dialog.dismiss()
-                    }
-            } else {
-                val checked = items.map { item -> item.isSelected }.toBooleanArray()
-                builder.setTitle("Select multiple items")
-                    .setMultiChoiceItems(items.map { it.title }.toTypedArray(), checked) { _, which, isChecked ->
-                        items[which] = items[which].copy(isSelected = isChecked)
-                    }
-                    .setPositiveButton("OK") { dialog, _ ->
-                        val intent = activity?.intent
-                        val selectedIds = items.filter { it.isSelected }.map { it.id }.toLongArray()
-                        intent?.putExtra(ARG_LIST_SELECTED_ITEMS, selectedIds)
-                        targetFragment?.onActivityResult(LIST_MULTI_SELECTOR_REQUEST_CODE, resultCode, intent)
-                        dialog.dismiss()
-                    }
-                    .setNegativeButton("Cancel") { dialog, _ ->
-                        dialog.dismiss()
-                    }
-            }
+        if (isSingleChoice) {
+            builder.setTitle("Select a list item")
+                .setSingleChoiceItems(listItems?.toTypedArray(), getListIndex()) { dialog, which ->
+                    val intent = activity?.intent
+                    intent?.putExtra(ARG_LIST_SELECTED_ITEM, listItems?.get(which))
+                    targetFragment?.onActivityResult(LIST_SELECTOR_REQUEST_CODE, resultCode, intent)
+                    dialog.dismiss()
+                }
+        } else {
+            val checked = items.map { item -> item.isSelected }.toBooleanArray()
+            builder.setTitle("Select multiple items")
+                .setMultiChoiceItems(items.map { it.title }.toTypedArray(), checked) { _, which, isChecked ->
+                    items[which] = items[which].copy(isSelected = isChecked)
+                }
+                .setPositiveButton("OK") { dialog, _ ->
+                    val intent = activity?.intent
+                    val selectedIds = items.filter { it.isSelected }.map { it.id }.toLongArray()
+                    intent?.putExtra(ARG_LIST_SELECTED_ITEMS, selectedIds)
+                    targetFragment?.onActivityResult(LIST_MULTI_SELECTOR_REQUEST_CODE, resultCode, intent)
+                    dialog.dismiss()
+                }
+                .setNegativeButton("Cancel") { dialog, _ ->
+                    dialog.dismiss()
+                }
+        }
 
-            builder.create()
-        } ?: throw IllegalStateException("Activity cannot be null")
+        return builder.create()
     }
 
     private fun getListIndex(): Int {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectorDialog.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectorDialog.kt
@@ -42,25 +42,23 @@ class StoreSelectorDialog : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        return activity?.let {
-            val adapter = SiteAdapter(it, wooCommerceStore.getWooCommerceSites())
+        val adapter = SiteAdapter(requireActivity(), wooCommerceStore.getWooCommerceSites())
 
-            // Use the Builder class for convenient dialog construction
-            val builder = AlertDialog.Builder(it)
-            builder.setTitle("Select a site")
-                    .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
-                        val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
-                        val site = adapter.getItem(which)
-                        if (site != null) {
-                            listener?.onSiteSelected(site, which)
-                        } else {
-                            prependToLog("SiteChanged error: site at position $which was null.")
-                        }
-                        dialog.dismiss()
+        // Use the Builder class for convenient dialog construction
+        val builder = AlertDialog.Builder(requireActivity())
+        builder.setTitle("Select a site")
+                .setSingleChoiceItems(adapter, selectedPos) { dialog, which ->
+                    val adapter = (dialog as AlertDialog).listView.adapter as SiteAdapter
+                    val site = adapter.getItem(which)
+                    if (site != null) {
+                        listener?.onSiteSelected(site, which)
+                    } else {
+                        prependToLog("SiteChanged error: site at position $which was null.")
                     }
-            // Create the AlertDialog object and return it
-            builder.create()
-        } ?: throw IllegalStateException("Activity cannot be null")
+                    dialog.dismiss()
+                }
+        // Create the AlertDialog object and return it
+        return builder.create()
     }
 
     class SiteAdapter(

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/customer/search/WooCustomersSearchAdapter.kt
@@ -19,10 +19,12 @@ import javax.inject.Inject
 private const val VIEW_TYPE_ITEM = 0
 private const val VIEW_TYPE_LOADING = 1
 
-class WooCustomersSearchAdapter @Inject constructor(context: MainExampleActivity) :
-        PagedListAdapter<CustomerListItemType, ViewHolder>(customerListDiffItemCallback) {
+class WooCustomersSearchAdapter @Inject constructor(
+    context: MainExampleActivity
+) : PagedListAdapter<CustomerListItemType, ViewHolder>(customerListDiffItemCallback) {
     private val layoutInflater = LayoutInflater.from(context)
 
+    @Suppress("UseCheckOrError")
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return when (viewType) {
             VIEW_TYPE_ITEM -> CustomerItemViewHolder(inflateView(R.layout.list_item_woo_customer, parent))

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -59,6 +59,8 @@ import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
+private const val NUMBER_OF_FIRST_ORDERS_TO_PRINT = 5
+
 class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDialog.Listener {
     @Inject lateinit var dispatcher: Dispatcher
     @Inject lateinit var wcOrderStore: WCOrderStore
@@ -671,9 +673,13 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                                 val completedOrders = wcOrderStore.getOrdersForSite(site, "completed")
                                 prependToLog("Fetched ${completedOrders.size} completed orders from ${site.name}")
                             } else {
-                                prependToLog("printing the first 5 remoteOrderId's from result:")
+                                prependToLog(
+                                    "printing the first $NUMBER_OF_FIRST_ORDERS_TO_PRINT remoteOrderId's from result:"
+                                )
                                 val orders = wcOrderStore.getOrdersForSite(site)
-                                orders.take(5).forEach { prependToLog("- remoteOrderId [${it.orderId}]") }
+                                orders.take(NUMBER_OF_FIRST_ORDERS_TO_PRINT).forEach {
+                                    prependToLog("- remoteOrderId [${it.orderId}]")
+                                }
                             }
                         }
                         FETCH_ORDERS_COUNT -> {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductAttributeFragment.kt
@@ -30,17 +30,17 @@ class WooProductAttributeFragment : StoreSelectingFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        fetch_product_attributes.setOnClickListener(::onFetchAttributesListClicked)
-        fetch_product_attributes_from_db.setOnClickListener(::onFetchCachedAttributesListClicked)
-        create_product_attributes.setOnClickListener(::onCreateAttributeButtonClicked)
-        delete_product_attributes.setOnClickListener(::onDeleteAttributeButtonClicked)
-        update_product_attributes.setOnClickListener(::onUpdateAttributeButtonClicked)
-        fetch_product_single_attribute.setOnClickListener(::onFetchAttributeButtonClicked)
-        fetch_term_for_attribute.setOnClickListener(::onFetchAttributeTermsButtonClicked)
-        create_term_for_attribute.setOnClickListener(::onCreateAttributeTermButtonClicked)
+        fetch_product_attributes.setOnClickListener { onFetchAttributesListClicked() }
+        fetch_product_attributes_from_db.setOnClickListener { onFetchCachedAttributesListClicked() }
+        create_product_attributes.setOnClickListener { onCreateAttributeButtonClicked() }
+        delete_product_attributes.setOnClickListener { onDeleteAttributeButtonClicked() }
+        update_product_attributes.setOnClickListener { onUpdateAttributeButtonClicked() }
+        fetch_product_single_attribute.setOnClickListener { onFetchAttributeButtonClicked() }
+        fetch_term_for_attribute.setOnClickListener { onFetchAttributeTermsButtonClicked() }
+        create_term_for_attribute.setOnClickListener { onCreateAttributeTermButtonClicked() }
     }
 
-    private fun onCreateAttributeButtonClicked(view: View) {
+    private fun onCreateAttributeButtonClicked() {
         try {
             showSingleLineDialog(
                     activity,
@@ -63,7 +63,7 @@ class WooProductAttributeFragment : StoreSelectingFragment() {
         }
     }
 
-    private fun onDeleteAttributeButtonClicked(view: View) {
+    private fun onDeleteAttributeButtonClicked() {
         try {
             showSingleLineDialog(
                     activity,
@@ -89,7 +89,7 @@ class WooProductAttributeFragment : StoreSelectingFragment() {
         }
     }
 
-    private fun onUpdateAttributeButtonClicked(view: View) {
+    private fun onUpdateAttributeButtonClicked() {
         try {
             showSingleLineDialog(
                     activity,
@@ -121,7 +121,7 @@ class WooProductAttributeFragment : StoreSelectingFragment() {
         }
     }
 
-    private fun onFetchAttributeButtonClicked(view: View) {
+    private fun onFetchAttributeButtonClicked() {
         try {
             showSingleLineDialog(
                     activity,
@@ -147,7 +147,7 @@ class WooProductAttributeFragment : StoreSelectingFragment() {
         }
     }
 
-    private fun onFetchAttributeTermsButtonClicked(view: View) {
+    private fun onFetchAttributeTermsButtonClicked() {
         try {
             showSingleLineDialog(
                     activity,
@@ -174,7 +174,7 @@ class WooProductAttributeFragment : StoreSelectingFragment() {
         }
     }
 
-    private fun onCreateAttributeTermButtonClicked(view: View) {
+    private fun onCreateAttributeTermButtonClicked() {
         try {
             showSingleLineDialog(
                     activity,
@@ -206,7 +206,7 @@ class WooProductAttributeFragment : StoreSelectingFragment() {
         }
     }
 
-    private fun onFetchAttributesListClicked(view: View) = coroutineScope.launch {
+    private fun onFetchAttributesListClicked() = coroutineScope.launch {
         try {
             takeAsyncRequestWithValidSite {
                     wcAttributesStore.fetchStoreAttributes(it)
@@ -218,7 +218,7 @@ class WooProductAttributeFragment : StoreSelectingFragment() {
         }
     }
 
-    private fun onFetchCachedAttributesListClicked(view: View) = coroutineScope.launch {
+    private fun onFetchCachedAttributesListClicked() = coroutineScope.launch {
         try {
             takeAsyncRequestWithValidSite {
                 wcAttributesStore.loadCachedStoreAttributes(it)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesAdapter.kt
@@ -23,7 +23,11 @@ class WooProductCategoriesAdapter(
         fun onProductCategoryClick(productCategoryViewHolderModel: ProductCategoryViewHolderModel)
     }
 
-    data class ProductCategoryViewHolderModel(val category: ProductCategory, var isSelected: Boolean = false)
+    @Suppress("DataClassShouldBeImmutable")
+    data class ProductCategoryViewHolderModel(
+        val category: ProductCategory,
+        var isSelected: Boolean = false
+    )
 
     override fun getItemCount() = productCategoryList.size
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductDownloadsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductDownloadsFragment.kt
@@ -72,6 +72,7 @@ class WooProductDownloadsFragment : Fragment() {
     }
 
     @Parcelize
+    @Suppress("DataClassShouldBeImmutable")
     data class ProductFile(
         val id: String?,
         var name: String,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductTagsAdapter.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductTagsAdapter.kt
@@ -23,7 +23,11 @@ class WooProductTagsAdapter(
         fun onProductTagClick(productTagViewHolderModel: ProductTagViewHolderModel)
     }
 
-    data class ProductTagViewHolderModel(val tag: ProductTag, var isSelected: Boolean = false)
+    @Suppress("DataClassShouldBeImmutable")
+    data class ProductTagViewHolderModel(
+        val tag: ProductTag,
+        var isSelected: Boolean = false
+    )
 
     override fun getItemCount() = productTagList.size
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -405,10 +405,10 @@ class WooUpdateProductFragment : Fragment() {
             selectedProductModel?.virtual = isChecked
         }
 
-        attach_attribute.setOnClickListener(::onAttachAttributeToProductButtonClicked)
-        detach_attribute.setOnClickListener(::onDetachAttributeFromProductButtonClicked)
-        generate_variation.setOnClickListener(::onGenerateVariationButtonClicked)
-        delete_variation.setOnClickListener(::onDeleteVariationButtonClicked)
+        attach_attribute.setOnClickListener { onAttachAttributeToProductButtonClicked() }
+        detach_attribute.setOnClickListener { onDetachAttributeFromProductButtonClicked() }
+        generate_variation.setOnClickListener { onGenerateVariationButtonClicked() }
+        delete_variation.setOnClickListener { onDeleteVariationButtonClicked() }
 
         product_purchase_note.onTextChanged { selectedProductModel?.purchaseNote = it }
 
@@ -539,7 +539,7 @@ class WooUpdateProductFragment : Fragment() {
         } ?: prependToLog("No valid site found...doing nothing")
     }
 
-    private fun onAttachAttributeToProductButtonClicked(view: View) {
+    private fun onAttachAttributeToProductButtonClicked() {
         try {
             showSingleLineDialog(
                     activity,
@@ -567,7 +567,7 @@ class WooUpdateProductFragment : Fragment() {
         }
     }
 
-    private fun onDetachAttributeFromProductButtonClicked(view: View) {
+    private fun onDetachAttributeFromProductButtonClicked() {
         try {
             showSingleLineDialog(
                     activity,
@@ -593,7 +593,7 @@ class WooUpdateProductFragment : Fragment() {
         }
     }
 
-    private fun onGenerateVariationButtonClicked(view: View) {
+    private fun onGenerateVariationButtonClicked() {
         try {
             coroutineScope.launch {
                 takeAsyncRequestWithValidSite { site ->
@@ -606,7 +606,7 @@ class WooUpdateProductFragment : Fragment() {
         }
     }
 
-    private fun onDeleteVariationButtonClicked(view: View) {
+    private fun onDeleteVariationButtonClicked() {
         try {
             showSingleLineDialog(
                     activity,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/shippinglabels/WooShippingLabelFragment.kt
@@ -58,6 +58,8 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.ceil
 
+private const val LOAD_DATA_DELAY = 5000L // 5 seconds
+
 class WooShippingLabelFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
@@ -738,7 +740,7 @@ class WooShippingLabelFragment : StoreSelectingFragment() {
         val payload = FetchOrdersByIdsPayload(site, listOf(orderId))
         dispatcher.dispatch(WCOrderActionBuilder.newFetchOrdersByIdsAction(payload))
 
-        delay(5000)
+        delay(LOAD_DATA_DELAY)
 
         val origin = wooCommerceStore.fetchSiteGeneralSettings(site).model?.let {
             ShippingLabelAddress(

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooStatsFragment.kt
@@ -32,6 +32,8 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
+private const val TOP_EARNERS_STATS_PAYLOAD_LIMIT = 10
+
 class WooStatsFragment : Fragment(), CustomStatsDialog.Listener {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var wcStatsStore: WCStatsStore
@@ -136,14 +138,24 @@ class WooStatsFragment : Fragment(), CustomStatsDialog.Listener {
 
         fetch_top_earners_stats.setOnClickListener {
             getFirstWCSite()?.let {
-                val payload = FetchTopEarnersStatsPayload(it, StatsGranularity.DAYS, 10, false)
+                val payload = FetchTopEarnersStatsPayload(
+                    it,
+                    StatsGranularity.DAYS,
+                    TOP_EARNERS_STATS_PAYLOAD_LIMIT,
+                    false
+                )
                 dispatcher.dispatch(WCStatsActionBuilder.newFetchTopEarnersStatsAction(payload))
             }
         }
 
         fetch_top_earners_stats_forced.setOnClickListener {
             getFirstWCSite()?.let {
-                val payload = FetchTopEarnersStatsPayload(it, StatsGranularity.DAYS, 10, true)
+                val payload = FetchTopEarnersStatsPayload(
+                    it,
+                    StatsGranularity.DAYS,
+                    TOP_EARNERS_STATS_PAYLOAD_LIMIT,
+                    true
+                )
                 dispatcher.dispatch(WCStatsActionBuilder.newFetchTopEarnersStatsAction(payload))
             }
         }

--- a/example/src/test/java/org/wordpress/android/fluxc/comment/CommentSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comment/CommentSqlUtilsTest.kt
@@ -162,7 +162,8 @@ class CommentSqlUtilsTest {
                 APPROVED,
                 UNAPPROVED
         )
-        // from 65 comments in DB we expect to have only 22 remote comments (remove first 3, 3 from the middle and all the comments that go after last comment in remoteComments
+        // from 65 comments in DB we expect to have only 22 remote comments (remove first 3, 3 from the middle and all
+        // the comments that go after last comment in remoteComments
         Assertions.assertThat(numCommentsDeleted).isEqualTo(43)
         Assertions.assertThat(cleanedComments.size).isEqualTo(22)
         remoteComments.forEach {

--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
@@ -19,8 +19,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.comments.CommentsMapper
 import org.wordpress.android.fluxc.network.HTTPAuthManager
 import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequestBuilder
 import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentsXMLRPCClient
@@ -36,11 +34,9 @@ import java.util.concurrent.CountDownLatch
 class CommentsXMLRPCClientTest {
     private lateinit var dispatcher: Dispatcher
     private lateinit var requestQueue: RequestQueue
-    private lateinit var accessToken: AccessToken
     private lateinit var userAgent: UserAgent
     private lateinit var httpAuthManager: HTTPAuthManager
     private lateinit var commentsMapper: CommentsMapper
-    private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
     private lateinit var commentErrorUtilsWrapper: CommentErrorUtilsWrapper
     private lateinit var site: SiteModel
 

--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
@@ -206,6 +206,7 @@ class CommentsXMLRPCClientTest {
     }
 
     @Test
+    @Suppress("MaxLineLength")
     fun `fetchComment returns fetched comment`() = test {
         mockedResponse = """
             <?xml version="1.0" encoding="UTF-8"?>

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteHomepageRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteHomepageRestClientTest.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteHomepageSettings
 import org.wordpress.android.fluxc.model.SiteHomepageSettings.Posts
 import org.wordpress.android.fluxc.model.SiteHomepageSettings.StaticPage
-import org.wordpress.android.fluxc.model.SiteHomepageSettingsMapper
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
@@ -37,7 +36,6 @@ import org.wordpress.android.fluxc.test
 class SiteHomepageRestClientTest {
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
-    @Mock private lateinit var siteHomepageSettingsMapper: SiteHomepageSettingsMapper
     @Mock private lateinit var site: SiteModel
     @Mock private lateinit var requestQueue: RequestQueue
     @Mock private lateinit var accessToken: AccessToken

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -53,7 +53,6 @@ import org.wordpress.android.fluxc.store.stats.TAGS_RESPONSE
 import org.wordpress.android.fluxc.store.stats.TOP_COMMENTS_RESPONSE
 import org.wordpress.android.fluxc.store.stats.VISITS_RESPONSE
 import org.wordpress.android.fluxc.test
-import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 class InsightsRestClientTest {
@@ -284,7 +283,6 @@ class InsightsRestClientTest {
                 )
         )
 
-        val date = Date()
         val responseModel = todayInsightsRestClient.fetchTimePeriodStats(site, DAYS, false)
 
         assertThat(responseModel.error).isNotNull

--- a/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/page/PageStoreTest.kt
@@ -99,12 +99,6 @@ class PageStoreTest {
         assertThat(result[0].title).isEqualTo(pageWithQuery.title)
     }
 
-    private fun assertPage(map: Map<PageStatus, List<PageModel>>, position: Int, status: PageStatus) {
-        val page = map[status]?.get(position)
-        assertThat(page).isNotNull()
-        assertThat(page!!.status).isEqualTo(status)
-    }
-
     @Test
     fun emptySearchResultWhenNothingContainsQuery() {
         val result = runBlocking { store.search(site, "foo") }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
@@ -460,11 +460,9 @@ class ReactNativeStoreWPAPITest {
         error.volleyError = VolleyError(NetworkResponse(statusCode, null, false, 0L, null))
     }
 
-    private class StatusCode {
-        companion object {
-            const val UNAUTHORIZED_401 = 401
-            const val NOT_FOUND_404 = 404
-            const val UNKNOWN = 99999
-        }
+    private object StatusCode {
+        const val UNAUTHORIZED_401 = 401
+        const val NOT_FOUND_404 = 404
+        const val UNKNOWN = 99999
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -451,7 +451,6 @@ class WCProductStoreTest {
                     .regularPrice(newRegularPrice)
                     .salePrice(newSalePrice)
                     .build()
-            val modifications = variationsUpdatePayload.modifiedProperties
             val variationsReturnedFromBackend = variations.map {
                 ProductVariationApiResponse().apply {
                     id = it.remoteVariationId

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -181,29 +181,6 @@ class WCShippingLabelStoreTest {
             )
     )
 
-    private val sampleListOfTwoIdenticalPredefinedPackages = listOf(
-            PredefinedOption(
-                    title = "USPS Priority Mail Flat Rate Boxes",
-                    carrier = "usps",
-                    predefinedPackages = listOf(
-                            PredefinedPackage(
-                                    id = "small_flat_box",
-                                    title = "Small Flat Box",
-                                    isLetter = false,
-                                    dimensions = "10 x 10 x 10",
-                                    boxWeight = 1.0f
-                            ),
-                            PredefinedPackage(
-                                    id = "small_flat_box",
-                                    title = "Small Flat Box",
-                                    isLetter = false,
-                                    dimensions = "10 x 10 x 10",
-                                    boxWeight = 1.0f
-                            )
-                    )
-            )
-    )
-
     @Before
     fun setUp() {
         val appContext = RuntimeEnvironment.application.applicationContext

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -1456,7 +1456,6 @@ class WCStatsStoreTest {
         assertTrue(nonExistentOrderStats.isEmpty())
 
         // missing data
-        val missingDataPayload = FetchRevenueStatsResponsePayload(site, StatsGranularity.YEARS, null)
         whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
                 .thenReturn(nonExistentPayload)
         wcStatsStore.fetchRevenueStats(

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/user/WCUserTestUtils.kt
@@ -29,22 +29,4 @@ object WCUserTestUtils {
             localSiteId = siteModel.id
         }
     }
-
-    private fun generateSampleUser(
-        firstName: String = "",
-        lastName: String = "",
-        username: String = "",
-        email: String = "",
-        roles: String = "",
-        siteId: Int = 6
-    ): WCUserModel {
-        return WCUserModel().apply {
-            localSiteId = siteId
-            this.firstName = firstName
-            this.lastName = lastName
-            this.username = username
-            this.email = email
-            this.roles = roles
-        }
-    }
 }


### PR DESCRIPTION
Parent #2479
Partially Closes: #2487

This PR resolves/suppresses all `style` related warnings for the `example` module:

1. `4` x DataClassShouldBeImmutable (Suppress: a362503f65ae13b55bb13b00f8b21cfc4cf30b4a)
2. `6` x MagicNumber (Resolve: 348ac72aa19f3570610ee9560ddb1a0a9b411431 + Suppress: 43fe9c9aad683162a06725ac1d45001684f6eefe)
3. `3` x MaxLineLength (Resolve: 6c6d0a58678d1e32187f19da101728135edca0e5 + Suppress: 7b608916e7902502da4368d1a818c2947f2ffc31)
4. `2` x ReturnCount (Resolve: eacf465a721ebbf0585092a1132f6b9942384dca)
5. `3` x UnnecessaryAbstractClass (Resolve: 39b2be6aa5226888acffaca57e48761da217f6f5)
6. `11` x UnusedPrivateMember (Resolve: 907cc4da1e3b4df55fc57e57ccc2f8c1ed52f5fd)
7. `1` x UseArrayLiteralsInAnnotations (Resolve: 120f92fbe6bcd7b9551f3684754dfae52744e1d3)
8. `6` x UseCheckOrError (Resolve: d3c74f4888758633e2f48404c5ddf4a2c9a7ca4d + Suppress: a4b32f7207d2fecede1b39bf857e1c94efef735e)
9. `1` x UtilityClassWithPublicConstructor (Resolve: 585b153d919f676906ed4570956d209a83340d99)
10. `49` x WildcardImport (Config: d05702ea57c96d3d8350c7c38e77385126b0e736)

PS.1: I am randomly adding an engineer from either the WPAndroid or WCAndroid team as the main reviewer, that is, in addition to the @wordpress-mobile/owl-team team itself, since I just want someone from these teams to sign-off on that change as well (or additionally to the 🦉 team).

PS.2: I recommend reviewing this PR commit-by-commit.

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough (especially the `detekt` check).
- However, if you really want to be thorough, you could smoke test the `example` and/or the `WPAndroid/WCAndroid` apps to verify that everything works as expected.

PS: Please ignore the failing `connected-tests` check as they are unrelated to this PR. This check has been failing consistency for some time now due to tests being flaky or needing to be updated/fixed.