### PR TITLE
Use apiKey from the GatewayId enum for constructing the URL.

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
@@ -56,7 +56,7 @@ class GatewayRestClient @Inject constructor(
         enabled: Boolean? = null,
         title: String? = null
     ): WooPayload<GatewayResponse> {
-        val url = WOOCOMMERCE.payment_gateways.gateway(gatewayId.toString()).pathV3
+        val url = WOOCOMMERCE.payment_gateways.gateway(gatewayId.apiKey).pathV3
         val params = mutableMapOf<String, Any>().apply {
             enabled?.let { put("enabled", enabled) }
             title?.let { put("title", title) }


### PR DESCRIPTION
### NOTE: Please ensure to review [this](https://github.com/woocommerce/woocommerce-android/pull/7205) PR soon after merging this one.

This PR basically removes `gatewayId.toString()` and instead uses `gatewayId.apiKey` for constructing the payment gateway URL.

**Why?**
Because, using  `gatewayId.toString()` returns `CASH_ON_DELIVERY`. Whereas for payment gateway URL to work we need `cod` which is returned when `gatewayId.apiKey` is used.