### PR TITLE
Added description field to the COD enable POST request

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
@@ -54,12 +54,14 @@ class GatewayRestClient @Inject constructor(
         site: SiteModel,
         gatewayId: GatewayId,
         enabled: Boolean? = null,
-        title: String? = null
+        title: String? = null,
+        description: String? = null,
     ): WooPayload<GatewayResponse> {
         val url = WOOCOMMERCE.payment_gateways.gateway(gatewayId.apiKey).pathV3
         val params = mutableMapOf<String, Any>().apply {
             enabled?.let { put("enabled", enabled) }
             title?.let { put("title", title) }
+            description?.let { put("description", description) }
         }
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
             this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGatewayStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGatewayStore.kt
@@ -42,10 +42,11 @@ class WCGatewayStore @Inject constructor(
         site: SiteModel,
         gatewayId: GatewayId,
         enabled: Boolean? = null,
-        title: String? = null
+        title: String? = null,
+        description: String? = null,
     ): WooResult<WCGatewayModel> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "updatePaymentGateway") {
-            val response = restClient.updatePaymentGateway(site, gatewayId, enabled, title)
+            val response = restClient.updatePaymentGateway(site, gatewayId, enabled, title, description)
             return@withDefaultContext when {
                 response.isError -> {
                     WooResult(response.error)


### PR DESCRIPTION
### NOTE:
Please ensure you review [this](https://github.com/woocommerce/woocommerce-android/pull/7224) PR as soon as the fluxc PR is merged.  

This PR adds a description field to the COD enable POST request so that the description on the checkout page is updated to reflect the new description.

<img width="681" alt="Screenshot 2022-08-18 at 4 21 00 PM" src="https://user-images.githubusercontent.com/1331230/185379065-9e01ee5a-f492-434e-b500-bd48db327119.png">
<img width="1744" alt="Screenshot 2022-08-18 at 4 21 32 PM" src="https://user-images.githubusercontent.com/1331230/185379071-13e2bbb1-c0d6-4688-ab86-112bb63e559f.png">
