### PR TITLE
[Detekt Baseline Warnings] Plugins Woo Commerce Module - Resolve/Suppress Other Warnings

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -4,10 +4,6 @@
   <CurrentIssues>
     <!-- plugins:woocommerce -->
     <ID>ImplicitDefaultLocale:DateUtils.kt$DateUtils$String.format("%d-%02d-%02d", year, (month + 1), dayOfMonth)</ID>
-    <ID>SpreadOperator:WCInboxStore.kt$WCInboxStore$(siteId, *notesWithActions.toTypedArray())</ID>
-    <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*it.result!!.toTypedArray())</ID>
-    <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*payload.fetchedOrders.toTypedArray())</ID>
-    <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*payload.ordersWithMeta.toTypedArray())</ID>
     <!-- example -->
     <ID>ComplexCondition:WooShippingLabelFragment.kt$WooShippingLabelFragment$boxId == null || height == null || width == null || length == null || weight == null</ID>
     <ID>ComplexCondition:WooShippingLabelFragment.kt$WooShippingLabelFragment$height == null || width == null || length == null || weight == null</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -2,8 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <!-- plugins:woocommerce -->
-    <ID>ImplicitDefaultLocale:DateUtils.kt$DateUtils$String.format("%d-%02d-%02d", year, (month + 1), dayOfMonth)</ID>
     <!-- example -->
     <ID>ComplexCondition:WooShippingLabelFragment.kt$WooShippingLabelFragment$boxId == null || height == null || width == null || length == null || weight == null</ID>
     <ID>ComplexCondition:WooShippingLabelFragment.kt$WooShippingLabelFragment$height == null || width == null || length == null || weight == null</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -10,8 +10,6 @@
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*it.result!!.toTypedArray())</ID>
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*payload.fetchedOrders.toTypedArray())</ID>
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*payload.ordersWithMeta.toTypedArray())</ID>
-    <ID>SwallowedException:ProductRestClient.kt$ProductRestClient$ex: Exception</ID>
-    <ID>SwallowedException:WCProductModel.kt$WCProductModel$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:ProductRestClient.kt$ProductRestClient$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:WCProductModel.kt$WCProductModel$ex: Exception</ID>
     <!-- example -->

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -3,8 +3,6 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <!-- plugins:woocommerce -->
-    <ID>ArrayPrimitive:CouponRestClient.kt$CouponRestClient$Array&lt;Long></ID>
-    <ID>ArrayPrimitive:JsonObjectBuilder.kt$JsonObjectBuilder$Array&lt;Int></ID>
     <ID>ImplicitDefaultLocale:DateUtils.kt$DateUtils$String.format("%d-%02d-%02d", year, (month + 1), dayOfMonth)</ID>
     <ID>SpreadOperator:WCInboxStore.kt$WCInboxStore$(siteId, *notesWithActions.toTypedArray())</ID>
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*it.result!!.toTypedArray())</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -5,7 +5,6 @@
     <!-- plugins:woocommerce -->
     <ID>ArrayPrimitive:CouponRestClient.kt$CouponRestClient$Array&lt;Long></ID>
     <ID>ArrayPrimitive:JsonObjectBuilder.kt$JsonObjectBuilder$Array&lt;Int></ID>
-    <ID>EmptyFunctionBlock:WooCommerceStore.kt$WooCommerceStore${ }</ID>
     <ID>ImplicitDefaultLocale:DateUtils.kt$DateUtils$String.format("%d-%02d-%02d", year, (month + 1), dayOfMonth)</ID>
     <ID>SpreadOperator:WCInboxStore.kt$WCInboxStore$(siteId, *notesWithActions.toTypedArray())</ID>
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*it.result!!.toTypedArray())</ID>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -10,8 +10,6 @@
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*it.result!!.toTypedArray())</ID>
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*payload.fetchedOrders.toTypedArray())</ID>
     <ID>SpreadOperator:WCOrderStore.kt$WCOrderStore$(*payload.ordersWithMeta.toTypedArray())</ID>
-    <ID>TooGenericExceptionCaught:ProductRestClient.kt$ProductRestClient$ex: Exception</ID>
-    <ID>TooGenericExceptionCaught:WCProductModel.kt$WCProductModel$ex: Exception</ID>
     <!-- example -->
     <ID>ComplexCondition:WooShippingLabelFragment.kt$WooShippingLabelFragment$boxId == null || height == null || width == null || length == null || weight == null</ID>
     <ID>ComplexCondition:WooShippingLabelFragment.kt$WooShippingLabelFragment$height == null || width == null || length == null || weight == null</ID>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -116,7 +116,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             ?.find { it.key == ADDONS_METADATA_KEY }
             ?.addons
 
-    private val WCMetaData.addons
+    @Suppress("SwallowedException") private val WCMetaData.addons
         get() =
             try {
                 Gson().run {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -116,7 +116,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             ?.find { it.key == ADDONS_METADATA_KEY }
             ?.addons
 
-    @Suppress("SwallowedException") private val WCMetaData.addons
+    @Suppress("SwallowedException", "TooGenericExceptionCaught") private val WCMetaData.addons
         get() =
             try {
                 Gson().run {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
@@ -161,7 +161,7 @@ class CouponRestClient @Inject constructor(
 
     suspend fun fetchCouponsReports(
         site: SiteModel,
-        couponsIds: Array<Long> = emptyArray(),
+        couponsIds: LongArray = longArrayOf(),
         after: Date
     ): WooPayload<List<CouponReportDto>> {
         val url = WOOCOMMERCE.reports.coupons.pathV4Analytics
@@ -193,7 +193,7 @@ class CouponRestClient @Inject constructor(
     ): WooPayload<CouponReportDto> {
         return fetchCouponsReports(
             site = site,
-            couponsIds = arrayOf(couponId),
+            couponsIds = longArrayOf(couponId),
             after = after
         ).let {
             when {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1440,7 +1440,7 @@ class ProductRestClient @Inject constructor(
      * and verifies that the [updatedProductModel] has fields that are different from the default
      * fields of [productModel]. This is to ensure that we do not update product fields that do not contain any changes
      */
-    @Suppress("LongMethod", "ComplexMethod")
+    @Suppress("LongMethod", "ComplexMethod", "SwallowedException")
     private fun productModelToProductJsonBody(
         productModel: WCProductModel?,
         updatedProductModel: WCProductModel
@@ -1627,7 +1627,7 @@ class ProductRestClient @Inject constructor(
      * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any
      * changes.
      */
-    @Suppress("ForbiddenComment", "LongMethod", "ComplexMethod")
+    @Suppress("ForbiddenComment", "LongMethod", "ComplexMethod", "SwallowedException")
     private fun variantModelToProductJsonBody(
         variationModel: WCProductVariationModel?,
         updatedVariationModel: WCProductVariationModel

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1440,7 +1440,7 @@ class ProductRestClient @Inject constructor(
      * and verifies that the [updatedProductModel] has fields that are different from the default
      * fields of [productModel]. This is to ensure that we do not update product fields that do not contain any changes
      */
-    @Suppress("LongMethod", "ComplexMethod", "SwallowedException")
+    @Suppress("LongMethod", "ComplexMethod", "SwallowedException", "TooGenericExceptionCaught")
     private fun productModelToProductJsonBody(
         productModel: WCProductModel?,
         updatedProductModel: WCProductModel
@@ -1627,7 +1627,7 @@ class ProductRestClient @Inject constructor(
      * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any
      * changes.
      */
-    @Suppress("ForbiddenComment", "LongMethod", "ComplexMethod", "SwallowedException")
+    @Suppress("ForbiddenComment", "LongMethod", "ComplexMethod", "SwallowedException", "TooGenericExceptionCaught")
     private fun variantModelToProductJsonBody(
         variationModel: WCProductVariationModel?,
         updatedVariationModel: WCProductVariationModel

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInboxStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCInboxStore.kt
@@ -119,6 +119,7 @@ class WCInboxStore @Inject constructor(
         return numberOfPagesToDelete
     }
 
+    @Suppress("SpreadOperator")
     private suspend fun saveInboxNotes(result: Array<InboxNoteDto>, siteId: Long) {
         val notesWithActions = result.map { it.toInboxNoteWithActionsEntity(siteId) }
         inboxNotesDao.deleteAllAndInsertInboxNotes(siteId, *notesWithActions.toTypedArray())

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -594,6 +594,7 @@ class WCOrderStore @Inject constructor(
         ordersDao.insertOrUpdateOrder(updatedOrder)
     }
 
+    @Suppress("SpreadOperator")
     suspend fun fetchOrderNotes(
         site: SiteModel,
         orderId: Long
@@ -717,6 +718,7 @@ class WCOrderStore @Inject constructor(
         }
     }
 
+    @Suppress("SpreadOperator")
     private fun handleFetchOrdersCompleted(payload: FetchOrdersResponsePayload) {
         coroutineEngine.launch(API, this, "handleFetchOrdersCompleted") {
             val onOrderChanged: OnOrderChanged = if (payload.isError) {
@@ -800,6 +802,7 @@ class WCOrderStore @Inject constructor(
         )
     }
 
+    @Suppress("SpreadOperator")
     private fun handleFetchOrderByIdsCompleted(payload: FetchOrdersByIdsResponsePayload) {
         coroutineEngine.launch(API, this, "handleFetchOrderByIdsCompleted") {
             val onOrdersFetchedByIds = if (payload.isError) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -65,7 +65,7 @@ open class WooCommerceStore @Inject constructor(
     override fun onRegister() = AppLog.d(T.API, "WooCommerceStore onRegister")
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
-    override fun onAction(action: Action<*>) { }
+    override fun onAction(action: Action<*>) = Unit // Do nothing (ignore)
 
     suspend fun fetchWooCommerceSites(): WooResult<List<SiteModel>> {
         val fetchResult = siteStore.fetchSites(FetchSitesPayload())

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -246,7 +246,7 @@ object DateUtils {
      *
      */
     fun getFormattedDateString(year: Int, month: Int, dayOfMonth: Int): String {
-        return String.format("%d-%02d-%02d", year, (month + 1), dayOfMonth)
+        return String.format(Locale.US, "%d-%02d-%02d", year, (month + 1), dayOfMonth)
     }
 
     /**

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonObjectBuilder.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonObjectBuilder.kt
@@ -40,7 +40,7 @@ internal class JsonObjectBuilder {
         )
     }
 
-    infix fun String.To(value: Array<Int>) {
+    infix fun String.To(value: IntArray) {
         deque.peek().add(this,
                 JsonArray().apply {
                     value.forEach { item ->


### PR DESCRIPTION
Parent #2479
Partially Closes: #2486

This PR resolves/suppresses all `other` related warnings for the `plugins:woocommerce` module:

- `1` x empty-blocks
    1. 1 x EmptyFunctionBlock (Resolve: 3c69c77c3633e54ff4c603f87ee4671caf370cbe)
- `4` x exceptions
    1. `2` x SwallowedException (Suppress: 25e0c06452c3b391fdb655089448aac9712d7579)
    2. `2` x TooGenericExceptionCaught (Suppress: 7a84c6aa2471e9c10388e3d7489e819ef8c9fe12)
- `6` x performance
    1. `2` x ArrayPrimitive (Resolve: 4615434da27660008b5bf4db1e4e5b7bef04ba5f)
    2. `4` x SpreadOperator (Suppress: 39d409d789a87c7f0edba7ac0611a10a1e41c0db)
- `1` x potential-bugs
    1. `1` x ImplicitDefaultLocale (Resolve: 626157e94c9e26f04928c43913b906345a05a33a)

PS.1: I am randomly adding an engineer from the WCAndroid team as the main reviewers, that is, in addition to the @wordpress-mobile/owl-team team itself, since I just want someone from that team to sign-off on that change as well (or additionally to the 🦉 team).

PS.2: I recommend reviewing this PR commit-by-commit.

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough (especially the `detekt` check).
- However, if you really want to be thorough, you could smoke test the `example` and/or the `WCAndroid` apps to verify that everything works as expected.

PS: Please ignore the failing `connected-tests` check as they are unrelated to this PR. This check has been failing consistency for some time now due to tests being flaky or needing to be updated/fixed.