### PR TITLE
Add a field to allow updating instructions when COD is enabled.

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.fluxc.store.Settings
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -56,12 +57,14 @@ class GatewayRestClient @Inject constructor(
         enabled: Boolean? = null,
         title: String? = null,
         description: String? = null,
+        settings: Settings? = null
     ): WooPayload<GatewayResponse> {
         val url = WOOCOMMERCE.payment_gateways.gateway(gatewayId.apiKey).pathV3
         val params = mutableMapOf<String, Any>().apply {
             enabled?.let { put("enabled", enabled) }
             title?.let { put("title", title) }
             description?.let { put("description", description) }
+            settings?.let { put("settings", settings) }
         }
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
             this,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGatewayStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGatewayStore.kt
@@ -44,9 +44,10 @@ class WCGatewayStore @Inject constructor(
         enabled: Boolean? = null,
         title: String? = null,
         description: String? = null,
+        settings: Settings? = null
     ): WooResult<WCGatewayModel> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "updatePaymentGateway") {
-            val response = restClient.updatePaymentGateway(site, gatewayId, enabled, title, description)
+            val response = restClient.updatePaymentGateway(site, gatewayId, enabled, title, description, settings)
             return@withDefaultContext when {
                 response.isError -> {
                     WooResult(response.error)
@@ -79,3 +80,7 @@ class WCGatewayStore @Inject constructor(
         }
     }
 }
+
+data class Settings(
+    val instructions: String,
+)


### PR DESCRIPTION
### NOTE: Please review [this](https://github.com/woocommerce/woocommerce-android/pull/7262) WooCommerce PR as soon as this PR is merged.

This PR adds a field to allow updating instructions when COD is enabled

Instructions are displayed on the post-checkout Thank You screen, and in the confirmation email.