### PR TITLE
Feature/7254 reduce infinte loading

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/GatewayRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/GatewayRestClientTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
 import com.android.volley.RequestQueue
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
@@ -51,7 +52,8 @@ class GatewayRestClientTest {
                     any<Class<GatewayRestClient.GatewayResponse>>(),
                     any(),
                     any(),
-                    any()
+                    any(),
+                    anyOrNull()
                 )
             ).thenReturn(
                 JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess(mock())
@@ -59,7 +61,7 @@ class GatewayRestClientTest {
 
             val actualResponse = gatewayRestClient.fetchGateway(
                 SiteModel(),
-            ""
+                ""
             )
 
             Assertions.assertThat(actualResponse.isError).isFalse
@@ -70,7 +72,8 @@ class GatewayRestClientTest {
     @Test
     fun `given error response, when fetch gateway, return error`() {
         runBlocking {
-            val expectedError = mock<WPComGsonNetworkError>().apply { type = mock()
+            val expectedError = mock<WPComGsonNetworkError>().apply {
+                type = mock()
             }
             whenever(
                 jetpackTunnelGsonRequestBuilder.syncGetRequest(
@@ -81,7 +84,8 @@ class GatewayRestClientTest {
                     any<Class<GatewayRestClient.GatewayResponse>>(),
                     any(),
                     any(),
-                    any()
+                    any(),
+                    anyOrNull()
                 )
             ).thenReturn(
                 JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError(expectedError)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
@@ -32,7 +32,7 @@ class JetpackTimeoutRequestHandler<T>(
     }
 
     companion object {
-        const val DEFAULT_MAX_RETRIES = 2
+        const val DEFAULT_MAX_RETRIES = 1
         const val ADDITIONAL_RETRY_DELAY_MS = 5000L
 
         @JvmStatic

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
@@ -63,14 +63,14 @@ class JetpackTimeoutRequestHandler<T>(
                 if (numRetries < maxRetries) {
                     AppLog.e(
                         AppLog.T.API,
-                        "5-second timeout reached for endpoint $wpApiEndpoint, retrying..."
+                        "30-second timeout reached for endpoint $wpApiEndpoint, retrying..."
                     )
                     jpTimeoutListener(gsonRequest.apply { increaseManualRetryCount() })
                     numRetries++
                 } else {
                     AppLog.e(
                         AppLog.T.API,
-                        "5-second timeout reached for endpoint $wpApiEndpoint - maximum retries reached"
+                        "30-second timeout reached for endpoint $wpApiEndpoint - maximum retries reached"
                     )
                     wpComErrorListener.onErrorResponse(error)
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTimeoutRequestHandler.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
 
-import android.os.Handler
 import com.android.volley.Response.Listener
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
@@ -28,12 +27,17 @@ class JetpackTimeoutRequestHandler<T>(
 
     init {
         val wrappedErrorListener = buildJPTimeoutRetryListener(url, errorListener, retryListener)
-        gsonRequest = WPComGsonRequest.buildGetRequest(url, params, type, listener, wrappedErrorListener)
+        gsonRequest = WPComGsonRequest.buildGetRequest(
+            url,
+            params,
+            type,
+            listener,
+            wrappedErrorListener
+        )
     }
 
     companion object {
         const val DEFAULT_MAX_RETRIES = 1
-        const val ADDITIONAL_RETRY_DELAY_MS = 5000L
 
         @JvmStatic
         fun WPComGsonNetworkError.isJetpackTimeoutError(): Boolean {
@@ -57,21 +61,16 @@ class JetpackTimeoutRequestHandler<T>(
         return WPComErrorListener { error ->
             if (error.isJetpackTimeoutError()) {
                 if (numRetries < maxRetries) {
-                    AppLog.e(AppLog.T.API, "5-second timeout reached for endpoint $wpApiEndpoint, retrying...")
-                    if (numRetries > 0) {
-                        // Delay retries after the first by a bit
-                        with(Handler()) {
-                            postDelayed({ jpTimeoutListener(gsonRequest.apply { increaseManualRetryCount() }) },
-                                    ADDITIONAL_RETRY_DELAY_MS)
-                        }
-                    } else {
-                        jpTimeoutListener(gsonRequest.apply { increaseManualRetryCount() })
-                    }
+                    AppLog.e(
+                        AppLog.T.API,
+                        "5-second timeout reached for endpoint $wpApiEndpoint, retrying..."
+                    )
+                    jpTimeoutListener(gsonRequest.apply { increaseManualRetryCount() })
                     numRetries++
                 } else {
                     AppLog.e(
-                            AppLog.T.API,
-                            "5-second timeout reached for endpoint $wpApiEndpoint - maximum retries reached"
+                        AppLog.T.API,
+                        "5-second timeout reached for endpoint $wpApiEndpoint - maximum retries reached"
                     )
                     wpComErrorListener.onErrorResponse(error)
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
@@ -67,6 +67,7 @@ class JetpackTunnelGsonRequestBuilder @Inject constructor() {
      * @param params the parameters to append to the request URL
      * @param clazz the class defining the expected response
      */
+    @Suppress("LongParameterList")
     suspend fun <T : Any> syncGetRequest(
         restClient: BaseWPComRestClient,
         site: SiteModel,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
@@ -79,13 +79,15 @@ class JetpackTunnelGsonRequestBuilder @Inject constructor() {
         forced: Boolean = false,
         retryPolicy: RetryPolicy? = null
     ) = suspendCancellableCoroutine<JetpackResponse<T>> { cont ->
-        val request = JetpackTunnelGsonRequest.buildGetRequest<T>(url, site.siteId, params, clazz, {
-            cont.resume(JetpackResponse.JetpackSuccess(it))
-        }, {
-            cont.resume(JetpackResponse.JetpackError(it))
-        }, { request: WPComGsonRequest<*> ->
-            restClient.add(request)
-        })
+        val request = JetpackTunnelGsonRequest.buildGetRequest<T>(
+            url,
+            site.siteId,
+            params,
+            clazz,
+            listener = { cont.resume(JetpackResponse.JetpackSuccess(it)) },
+            errorListener = { cont.resume(JetpackResponse.JetpackError(it)) },
+            jpTimeoutListener = { request: WPComGsonRequest<*> -> restClient.add(request) }
+        )
         cont.invokeOnCancellation {
             request?.cancel()
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
@@ -93,7 +94,8 @@ class JetpackTunnelGsonRequestBuilder @Inject constructor() {
         if (forced) {
             request?.setShouldForceUpdate()
         }
-        retryPolicy.let {
+        retryPolicy?.let {
+            AppLog.i(AppLog.T.API, "Timeout set to: ${it.currentTimeout}")
             request?.setRetryPolicy(it)
         }
         restClient.add(request)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
@@ -147,11 +147,13 @@ class JetpackTunnelGsonRequestBuilder @Inject constructor() {
         body: Map<String, Any>,
         clazz: Class<T>
     ) = suspendCancellableCoroutine<JetpackResponse<T>> { cont ->
-        val request = JetpackTunnelGsonRequest.buildPostRequest<T>(url, site.siteId, body, clazz, {
-            cont.resume(JetpackSuccess(it))
-        }, {
-            cont.resume(JetpackError(it))
-        })
+        val request = JetpackTunnelGsonRequest.buildPostRequest<T>(
+            url,
+            site.siteId, body,
+            clazz,
+            listener = { cont.resume(JetpackSuccess(it)) },
+            errorListener = { cont.resume(JetpackError(it)) }
+        )
         cont.invokeOnCancellation {
             request?.cancel()
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -20,7 +20,7 @@ import javax.inject.Singleton
 @Singleton
 class WooCommerceRestClient @Inject constructor(
     appContext: Context,
-    private val dispatcher: Dispatcher,
+    dispatcher: Dispatcher,
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
     @Named("regular") requestQueue: RequestQueue,
     accessToken: AccessToken,
@@ -44,7 +44,8 @@ class WooCommerceRestClient @Inject constructor(
             site,
             url,
             mapOf("_fields" to "authentication,namespaces"),
-            RootWPAPIRestResponse::class.java
+            RootWPAPIRestResponse::class.java,
+            retryPolicy = jetpackTunnelGsonRequestBuilder.buildDefaultTimeoutRetryPolicy()
         )
         return when (response) {
             is JetpackSuccess -> WooPayload(response.data)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7254 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
We want to mitigate the "endless loading" experience for users overall the app. We're going to start by:
- Reducing for all Jetpack tunnel requests the retry policy from 2 to 1
- Reducing the timeout time from 30s to 15s. Currently this time reduction will only apply to site verification request.


### Testing instructions
In order to test this WooCommerce app pointing to this FluxC version is needed. So I'll request testing of these changes in [this PR](https://github.com/woocommerce/woocommerce-android/pull/7271). Nothing to test here. 


Connected tests are failing due to unrelated reasons https://a8c.slack.com/archives/C02QANACA/p1661424977107179
