### PR TITLE
Save shippingPhone value in OrderEntity

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -68,6 +68,7 @@ class OrderDtoMapper @Inject internal constructor(
                     shippingState = this.shipping?.state ?: "",
                     shippingPostcode = this.shipping?.postcode ?: "",
                     shippingCountry = this.shipping?.country ?: "",
+                    shippingPhone = this.shipping?.phone ?: "",
                     lineItems = this.line_items.toString(),
                     shippingLines = this.shipping_lines.toString(),
                     feeLines = this.fee_lines.toString(),


### PR DESCRIPTION
Closes #2516 
This small PR adds the shipping phone information into OrderEntity. Before this change, the shipping phone information was never saved, causing the shipping phone value always to be an empty string