### PR TITLE
Add product path to product leather board request when available

### DIFF
--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -76,6 +76,7 @@
 /connect/account/settings
 
 /leaderboards
+/leaderboards/products
 
 /data/countries
 /system_status


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: [#6688 ](https://github.com/woocommerce/woocommerce-android/issues/6688)

### Description
`/wc-analytics/leaderboards/products` Was added along with individual endpoints for the other leaderboards. Since we only need the product leaderboard in the apps, we should switch to that new endpoint. This will be faster, lessen the load on the origin site, and transfer less data that we don't need.

In this PR I've added the minimal changes to support using the new endpoint easily from WC android repo. Changes in `wc-android` have been applied [here](https://github.com/woocommerce/woocommerce-android/pull/7308). 

### Testing instructions
This PR adds no breaking change. But to make sure that the request `/leaderboards` keeps working as expected, inside FluxC sample app: 
- Go to Woo -> Leaderboards
- Select any site that has product purchases
- Fetch leaderboards for different granularities and verify request is successful.

