### PR TITLE
New overrideRetryPolicy param to enable A/B testing

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -67,7 +67,7 @@ class WooCommerceFragment : StoreSelectingFragment() {
             for (site in wooCommerceStore.getWooCommerceSites()) {
                 coroutineScope.launch {
                     val result = withContext(Dispatchers.Default) {
-                        wooCommerceStore.fetchSupportedApiVersion(site, overrideRetryPolicy = false)
+                        wooCommerceStore.fetchSupportedApiVersion(site)
                     }
                     result.error?.let {
                         prependToLog("Error in onApiVersionFetched: ${it.type} - ${it.message}")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -67,7 +67,7 @@ class WooCommerceFragment : StoreSelectingFragment() {
             for (site in wooCommerceStore.getWooCommerceSites()) {
                 coroutineScope.launch {
                     val result = withContext(Dispatchers.Default) {
-                        wooCommerceStore.fetchSupportedApiVersion(site)
+                        wooCommerceStore.fetchSupportedApiVersion(site, overrideRetryPolicy = false)
                     }
                     result.error?.let {
                         prependToLog("Error in onApiVersionFetched: ${it.type} - ${it.message}")

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -340,7 +340,7 @@ class WooCommerceStoreTest {
         } else {
             whenever(wcrestClient.fetchSupportedWooApiVersion(any(), any())).thenReturn(payload)
         }
-        return wooCommerceStore.fetchSupportedApiVersion(site, overrideRetryPolicy = false)
+        return wooCommerceStore.fetchSupportedApiVersion(site)
     }
 
     private suspend fun fetchSiteSettings(isError: Boolean = false): WooResult<WCSettingsModel> {

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -336,11 +336,11 @@ class WooCommerceStoreTest {
     ): WooResult<WCApiVersionResponse> {
         val payload = WooPayload(response)
         if (isError) {
-            whenever(wcrestClient.fetchSupportedWooApiVersion(any())).thenReturn(WooPayload(error))
+            whenever(wcrestClient.fetchSupportedWooApiVersion(any(), any())).thenReturn(WooPayload(error))
         } else {
-            whenever(wcrestClient.fetchSupportedWooApiVersion(any())).thenReturn(payload)
+            whenever(wcrestClient.fetchSupportedWooApiVersion(any(), any())).thenReturn(payload)
         }
-        return wooCommerceStore.fetchSupportedApiVersion(site)
+        return wooCommerceStore.fetchSupportedApiVersion(site, overrideRetryPolicy = false)
     }
 
     private suspend fun fetchSiteSettings(isError: Boolean = false): WooResult<WCSettingsModel> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -39,7 +39,7 @@ class WooCommerceRestClient @Inject constructor(
      */
     suspend fun fetchSupportedWooApiVersion(
         site: SiteModel,
-        overrideRetryPolicy: Boolean
+        overrideRetryPolicy: Boolean = false
     ): WooPayload<RootWPAPIRestResponse> {
         val url = "/"
         val retryPolicy = when (overrideRetryPolicy) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -37,15 +37,22 @@ class WooCommerceRestClient @Inject constructor(
      * of the Woo API.
      *
      */
-    suspend fun fetchSupportedWooApiVersion(site: SiteModel): WooPayload<RootWPAPIRestResponse> {
+    suspend fun fetchSupportedWooApiVersion(
+        site: SiteModel,
+        overrideRetryPolicy: Boolean
+    ): WooPayload<RootWPAPIRestResponse> {
         val url = "/"
+        val retryPolicy = when (overrideRetryPolicy) {
+            true -> jetpackTunnelGsonRequestBuilder.buildDefaultTimeoutRetryPolicy()
+            false -> null
+        }
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
             this,
             site,
             url,
             mapOf("_fields" to "authentication,namespaces"),
             RootWPAPIRestResponse::class.java,
-            retryPolicy = jetpackTunnelGsonRequestBuilder.buildDefaultTimeoutRetryPolicy()
+            retryPolicy = retryPolicy
         )
         return when (response) {
             is JetpackSuccess -> WooPayload(response.data)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -275,7 +275,7 @@ open class WooCommerceStore @Inject constructor(
 
     suspend fun fetchSupportedApiVersion(
         site: SiteModel,
-        overrideRetryPolicy: Boolean
+        overrideRetryPolicy: Boolean = false
     ): WooResult<WCApiVersionResponse> {
         return coroutineEngine.withDefaultContext(T.API, this, "fetchSupportedWooApiVersion") {
             val response = wcCoreRestClient.fetchSupportedWooApiVersion(site, overrideRetryPolicy)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -273,9 +273,12 @@ open class WooCommerceStore @Inject constructor(
         }
     }
 
-    suspend fun fetchSupportedApiVersion(site: SiteModel): WooResult<WCApiVersionResponse> {
+    suspend fun fetchSupportedApiVersion(
+        site: SiteModel,
+        overrideRetryPolicy: Boolean
+    ): WooResult<WCApiVersionResponse> {
         return coroutineEngine.withDefaultContext(T.API, this, "fetchSupportedWooApiVersion") {
-            val response = wcCoreRestClient.fetchSupportedWooApiVersion(site)
+            val response = wcCoreRestClient.fetchSupportedWooApiVersion(site, overrideRetryPolicy)
             return@withDefaultContext when {
                 response.isError -> {
                     AppLog.w(


### PR DESCRIPTION
A/B test for : [#7254](https://github.com/woocommerce/woocommerce-android/issues/7254)

### Description

Adds new optional parameter so that we can use this in A/B tests in WooCommerce Android. Once A/B test is finished parameter will be removed. 

If the value is true we will apply the new `jetpackTunnelGsonRequestBuilder.buildDefaultTimeoutRetryPolicy()` that I added in [this PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2512#issue-1349299146) that basically reduces the default tiemout from 30s to 15s. 

How the A/B test is set in WooCommerce Android can be reviewed and [tested here. ](https://github.com/woocommerce/woocommerce-android/pull/7313)

### Testing

Nothing to test from this changes