### PR TITLE
Feature/6719 add support force refresh

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -485,9 +485,9 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
         // Make the same stats request, but this time pass force=true to force a network request
         interceptor.respondWith("wc-revenue-stats-response-success.json")
         orderStatsRestClient.fetchRevenueStats(
-                site = siteModel, granularity = StatsGranularity.DAYS,
-                startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
-                perPage = 35, force = true
+            site = siteModel, granularity = StatsGranularity.DAYS,
+            startDate = "2019-07-01T00:00:00", endDate = "2019-07-07T23:59:59",
+            perPage = 35, forceRefresh = true
         )
 
         val thirdRequestCacheEntry = requestQueue.cache.get(interceptor.lastRequestUrl)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
@@ -4,7 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.fragment_woo_leaderboards.*
+import kotlinx.android.synthetic.main.fragment_woo_leaderboards.fetch_product_leaderboards_of_day
+import kotlinx.android.synthetic.main.fragment_woo_leaderboards.fetch_product_leaderboards_of_month
+import kotlinx.android.synthetic.main.fragment_woo_leaderboards.fetch_product_leaderboards_of_week
+import kotlinx.android.synthetic.main.fragment_woo_leaderboards.fetch_product_leaderboards_of_year
+import kotlinx.android.synthetic.main.fragment_woo_leaderboards.retrieve_cached_leaderboards_of_day
+import kotlinx.android.synthetic.main.fragment_woo_leaderboards.retrieve_cached_leaderboards_of_month
+import kotlinx.android.synthetic.main.fragment_woo_leaderboards.retrieve_cached_leaderboards_of_week
+import kotlinx.android.synthetic.main.fragment_woo_leaderboards.retrieve_cached_leaderboards_of_year
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -74,7 +81,13 @@ class WooLeaderboardsFragment : StoreSelectingFragment() {
     private fun launchProductLeaderboardsRequest(unit: StatsGranularity) {
         coroutineScope.launch {
             try {
-                takeAsyncRequestWithValidSite { wcLeaderboardsStore.fetchProductLeaderboards(it, unit) }
+                takeAsyncRequestWithValidSite {
+                    wcLeaderboardsStore.fetchProductLeaderboards(
+                        it,
+                        unit,
+                        forceRefresh = false
+                    )
+                }
                         ?.model
                         ?.let { logLeaderboardResponse(it, unit) }
                         ?: prependToLog("Couldn't fetch Products Leaderboards.")

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
@@ -34,12 +34,12 @@ class LeaderboardsRestClientTest {
         jetpackSuccessResponse = mock()
         jetpackErrorResponse = mock()
         restClientUnderTest = LeaderboardsRestClient(
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                requestBuilder
+            mock(),
+            mock(),
+            mock(),
+            mock(),
+            mock(),
+            requestBuilder
         )
     }
 
@@ -47,19 +47,26 @@ class LeaderboardsRestClientTest {
     fun `fetch leaderboards should call syncGetRequest with correct parameters and return expected response`() = test {
         val expectedResult = generateSampleLeaderboardsApiResponse()
         configureSuccessRequest(expectedResult!!)
+        val response = restClientUnderTest.fetchLeaderboards(
+            stubSite,
+            DAYS,
+            queryTimeRange = 1L..22L,
+            quantity = 5,
+            forceRefresh = false
+        )
 
-        val response = restClientUnderTest.fetchLeaderboards(stubSite, DAYS, 1L..22L, 5)
         verify(requestBuilder, times(1)).syncGetRequest(
-                restClientUnderTest,
-                stubSite,
-                WOOCOMMERCE.leaderboards.pathV4Analytics,
-                mapOf(
-                        "before" to "22",
-                        "after" to "1",
-                        "per_page" to "5",
-                        "interval" to "day"
-                ),
-                Array<LeaderboardsApiResponse>::class.java
+            restClientUnderTest,
+            stubSite,
+            WOOCOMMERCE.leaderboards.pathV4Analytics,
+            mapOf(
+                "before" to "22",
+                "after" to "1",
+                "per_page" to "5",
+                "interval" to "day",
+                "force_cache_refresh" to "false",
+            ),
+            Array<LeaderboardsApiResponse>::class.java
         )
         assertThat(response).isNotNull
         assertThat(response.result).isNotNull
@@ -71,10 +78,11 @@ class LeaderboardsRestClientTest {
     fun `fetch leaderboards should correctly return failure as WooError`() = test {
         configureErrorRequest()
         val response = restClientUnderTest.fetchLeaderboards(
-                stubSite,
-                DAYS,
-                1L..22L,
-                5
+            stubSite,
+            DAYS,
+            1L..22L,
+            5,
+            forceRefresh = false
         )
 
         assertThat(response).isNotNull
@@ -86,36 +94,38 @@ class LeaderboardsRestClientTest {
     private suspend fun configureSuccessRequest(expectedResult: Array<LeaderboardsApiResponse>) {
         whenever(jetpackSuccessResponse.data).thenReturn(expectedResult)
         whenever(
-                requestBuilder.syncGetRequest(
-                        restClientUnderTest,
-                        stubSite,
-                        WOOCOMMERCE.leaderboards.pathV4Analytics,
-                        mapOf(
-                                "after" to "1",
-                                "before" to "22",
-                                "per_page" to "5",
-                                "interval" to "day"
-                        ),
-                        Array<LeaderboardsApiResponse>::class.java
-                )
+            requestBuilder.syncGetRequest(
+                restClientUnderTest,
+                stubSite,
+                WOOCOMMERCE.leaderboards.pathV4Analytics,
+                mapOf(
+                    "after" to "1",
+                    "before" to "22",
+                    "per_page" to "5",
+                    "interval" to "day",
+                    "force_cache_refresh" to "false",
+                ),
+                Array<LeaderboardsApiResponse>::class.java
+            )
         ).thenReturn(jetpackSuccessResponse)
     }
 
     private suspend fun configureErrorRequest() {
         whenever(jetpackErrorResponse.error).thenReturn(WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
         whenever(
-                requestBuilder.syncGetRequest(
-                        restClientUnderTest,
-                        stubSite,
-                        WOOCOMMERCE.leaderboards.pathV4Analytics,
-                        mapOf(
-                                "after" to "1",
-                                "before" to "22",
-                                "per_page" to "5",
-                                "interval" to "day"
-                        ),
-                        Array<LeaderboardsApiResponse>::class.java
-                )
+            requestBuilder.syncGetRequest(
+                restClientUnderTest,
+                stubSite,
+                WOOCOMMERCE.leaderboards.pathV4Analytics,
+                mapOf(
+                    "after" to "1",
+                    "before" to "22",
+                    "per_page" to "5",
+                    "interval" to "day",
+                    "force_cache_refresh" to "false",
+                ),
+                Array<LeaderboardsApiResponse>::class.java
+            )
         ).thenReturn(jetpackErrorResponse)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
@@ -57,7 +57,7 @@ class WCLeaderboardsStoreTest {
 
     @Test
     fun `fetch product leaderboards with empty result should return WooError`() = test {
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, forceRefresh = true))
                 .thenReturn(WooPayload(emptyArray()))
 
         val result = storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -72,7 +72,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, forceRefresh = false))
                 .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -85,7 +85,7 @@ class WCLeaderboardsStoreTest {
         createStoreUnderTest()
         val response = generateSampleLeaderboardsApiResponse()
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, forceRefresh = false))
                 .thenReturn(WooPayload(response))
 
         storeUnderTest.fetchProductLeaderboards(stubSite)
@@ -97,7 +97,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, forceRefresh = false))
                 .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(stubbedTopPerformersList)
@@ -113,7 +113,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, forceRefresh = false))
                 .thenReturn(WooPayload(response))
 
         whenever(mapper.map(
@@ -133,7 +133,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         val filteredResponse = response?.firstOrNull { it.type == PRODUCTS }
 
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, forceRefresh = false))
                 .thenReturn(WooPayload(response))
 
         whenever(mapper.map(filteredResponse!!, stubSite, productStore, DAYS)).thenReturn(duplicatedTopPerformersList)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
@@ -57,7 +57,7 @@ class WCLeaderboardsStoreTest {
 
     @Test
     fun `fetch product leaderboards with empty result should return WooError`() = test {
-        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, forceRefresh = true))
+        whenever(restClient.fetchLeaderboards(stubSite, DAYS, null, null, forceRefresh = false))
                 .thenReturn(WooPayload(emptyArray()))
 
         val result = storeUnderTest.fetchProductLeaderboards(stubSite)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsRestClient.kt
@@ -31,22 +31,24 @@ class LeaderboardsRestClient @Inject constructor(
         unit: StatsGranularity?,
         queryTimeRange: LongRange?,
         quantity: Int?,
-        addProductsPath: Boolean = false
+        addProductsPath: Boolean = false,
+        forceRefresh: Boolean
     ) = when (addProductsPath) {
         true -> WOOCOMMERCE.leaderboards.products.pathV4Analytics
         else -> WOOCOMMERCE.leaderboards.pathV4Analytics
-    }.requestTo(site, unit, queryTimeRange, quantity).handleResult()
+    }.requestTo(site, unit, queryTimeRange, quantity, forceRefresh).handleResult()
 
     private suspend fun String.requestTo(
         site: SiteModel,
         unit: StatsGranularity?,
         queryTimeRange: LongRange?,
-        quantity: Int?
+        quantity: Int?,
+        forceRefresh: Boolean
     ) = jetpackTunnelGsonRequestBuilder.syncGetRequest(
         this@LeaderboardsRestClient,
         site,
         this,
-        createParameters(site, unit, queryTimeRange, quantity),
+        createParameters(site, unit, queryTimeRange, quantity, forceRefresh),
         Array<LeaderboardsApiResponse>::class.java
     )
 
@@ -54,7 +56,8 @@ class LeaderboardsRestClient @Inject constructor(
         site: SiteModel,
         unit: StatsGranularity?,
         queryTimeRange: LongRange?,
-        quantity: Int?
+        quantity: Int?,
+        forceRefresh: Boolean
     ) = mapOf(
         "before" to (
                 queryTimeRange?.endInclusive
@@ -66,6 +69,7 @@ class LeaderboardsRestClient @Inject constructor(
                     ?: "")
             .toString(),
         "per_page" to quantity?.toString().orEmpty(),
-        "interval" to (unit?.let { OrderStatsApiUnit.fromStatsGranularity(it).toString() } ?: "")
+        "interval" to (unit?.let { OrderStatsApiUnit.fromStatsGranularity(it).toString() } ?: ""),
+        "force_cache_refresh" to forceRefresh.toString()
     ).filter { it.value.isNotEmpty() }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -17,12 +17,12 @@ import org.wordpress.android.fluxc.model.WCVisitorStatsModel
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
@@ -187,15 +187,16 @@ class OrderStatsRestClient @Inject constructor(
         startDate: String,
         endDate: String,
         perPage: Int,
-        force: Boolean = false
+        forceRefresh: Boolean = false
     ): FetchRevenueStatsResponsePayload {
         val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
         val params = mapOf(
-                "interval" to OrderStatsApiUnit.convertToRevenueStatsInterval(granularity).toString(),
-                "after" to startDate,
-                "before" to endDate,
-                "per_page" to perPage.toString(),
-                "order" to "asc"
+            "interval" to OrderStatsApiUnit.convertToRevenueStatsInterval(granularity).toString(),
+            "after" to startDate,
+            "before" to endDate,
+            "per_page" to perPage.toString(),
+            "order" to "asc",
+            "force_cache_refresh" to forceRefresh.toString()
         )
 
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
@@ -205,7 +206,7 @@ class OrderStatsRestClient @Inject constructor(
                 params = params,
                 clazz = RevenueStatsApiResponse::class.java,
                 enableCaching = true,
-                forced = force
+            forced = forceRefresh
         )
 
         return when (response) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -31,10 +31,11 @@ class WCLeaderboardsStore @Inject constructor(
         unit: StatsGranularity = DAYS,
         queryTimeRange: LongRange? = null,
         quantity: Int? = null,
-        addProductsPath: Boolean = false
+        addProductsPath: Boolean = false,
+        forceRefresh: Boolean
     ): WooResult<List<WCTopPerformerProductModel>> =
         coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchLeaderboards") {
-            fetchAllLeaderboards(site, unit, queryTimeRange, quantity, addProductsPath)
+            fetchAllLeaderboards(site, unit, queryTimeRange, quantity, addProductsPath, forceRefresh)
                 .model
                 ?.firstOrNull { it.type == PRODUCTS }
                 ?.run { mapper.map(this, site, productStore, unit) }
@@ -60,9 +61,19 @@ class WCLeaderboardsStore @Inject constructor(
         unit: StatsGranularity? = null,
         queryTimeRange: LongRange? = null,
         quantity: Int? = null,
-        addProductsPath: Boolean = false
+        addProductsPath: Boolean = false,
+        forceRefresh: Boolean
     ): WooResult<List<LeaderboardsApiResponse>> =
-        with(restClient.fetchLeaderboards(site, unit, queryTimeRange, quantity, addProductsPath)) {
+        with(
+            restClient.fetchLeaderboards(
+                site,
+                unit,
+                queryTimeRange,
+                quantity,
+                addProductsPath,
+                forceRefresh
+            )
+        ) {
             return when {
                 isError -> WooResult(error)
                 result != null -> WooResult(result.toList())

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -25,8 +25,7 @@ class WCLeaderboardsStore @Inject constructor(
     private val productStore: WCProductStore,
     private val mapper: WCProductLeaderboardsMapper,
     private val coroutineEngine: CoroutineEngine,
-
-    ) {
+) {
     suspend fun fetchProductLeaderboards(
         site: SiteModel,
         unit: StatsGranularity = DAYS,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -32,7 +32,7 @@ class WCLeaderboardsStore @Inject constructor(
         queryTimeRange: LongRange? = null,
         quantity: Int? = null,
         addProductsPath: Boolean = false,
-        forceRefresh: Boolean
+        forceRefresh: Boolean = false
     ): WooResult<List<WCTopPerformerProductModel>> =
         coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchLeaderboards") {
             fetchAllLeaderboards(site, unit, queryTimeRange, quantity, addProductsPath, forceRefresh)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -659,7 +659,7 @@ class WCStatsStore @Inject constructor(
                 startDate = startDate,
                 endDate = endDate,
                 perPage = perPage,
-                force = payload.forced
+                forceRefresh = payload.forced
             )
 
             with(result) {


### PR DESCRIPTION
Closes:[ #6719](https://github.com/woocommerce/woocommerce-android/issues/6719)
<!-- Id number of the GitHub issue this PR addresses. -->

This FluxC changes work along with [this small changes](https://github.com/woocommerce/woocommerce-android/pull/7335) in WooCommerce-Android.

### Context 

https://github.com/woocommerce/woocommerce/pull/33325 will add a new parameter to `wc-analytics` API endpoints, `force_cache_refresh`, which will cause the current request to bypass the cache, re-run the queries for the requested data, and overwrite the previous cache entry with the new results. The motivation behind this change is to make it possible to refresh cached data from the apps without having to resort to [cache-busting parameter hacks](https://github.com/woocommerce/woocommerce-ios/issues/1183).

In Android realized, we are not applying that hacky workaround to bypass the cache[ like iOS does](https://github.com/woocommerce/woocommerce-ios/issues/1183). That means that stats are not refreshed in "real time" after new orders come in, even if you swipe to refresh multiple times. It will take a couple mins or less to refresh data. Don't really know what are the conditions to get fresh data, but its a bit random from what I've seen. 

We do have a `force` parameter that we sometimes pass all the way through to the Jetpack tunnel request, but from my tests this parameter is ignored for the `wc-analytics` stats requests. 

### Description 

This PR  adds the new parameter `force_cache_refresh` to two API requests: revenue stats and product leaderboards. The parameter doesn't make a difference right now, but will be necessary when the cache changes are implemented in a future WC version.

Minor: I also renamed the parameters from `force` to `forceRefresh` as I though better explains what the value is for

### Testing instructions

We can't verify that the new parameter works for now, as it hasn't been released yet. The only thing we can do is tests [in this PR](https://github.com/woocommerce/woocommerce-android/pull/7335) that stats for "My Store Screen" are loaded correctly for all 4 granularities.
