### PR TITLE
Fetch Jetpack connection URL

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
@@ -16,6 +16,8 @@ import org.wordpress.android.fluxc.action.JetpackAction.ACTIVATE_STATS_MODULE
 import org.wordpress.android.fluxc.action.JetpackAction.INSTALL_JETPACK
 import org.wordpress.android.fluxc.generated.JetpackActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient
 import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModuleError
 import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModuleErrorType
@@ -34,6 +36,8 @@ import org.wordpress.android.fluxc.tools.initCoroutineEngine
 @RunWith(MockitoJUnitRunner::class)
 class JetpackStoreTest {
     @Mock private lateinit var jetpackRestClient: JetpackRestClient
+    @Mock private lateinit var jetpackWPAPIRestClient: JetpackWPAPIRestClient
+    @Mock private lateinit var wpApiAuthenticator: WPAPIAuthenticator
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var siteStore: SiteStore
     @Mock private lateinit var site: SiteModel
@@ -41,7 +45,14 @@ class JetpackStoreTest {
 
     @Before
     fun setUp() {
-        jetpackStore = JetpackStore(jetpackRestClient, siteStore, initCoroutineEngine(), dispatcher)
+        jetpackStore = JetpackStore(
+            jetpackRestClient,
+            jetpackWPAPIRestClient,
+            siteStore,
+            initCoroutineEngine(),
+            wpApiAuthenticator,
+            dispatcher
+        )
         val siteId = 1
         whenever(site.id).thenReturn(siteId)
         whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)

--- a/fluxc-processor/src/main/resources/jp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/jp-api-endpoints.txt
@@ -1,1 +1,2 @@
 /module/stats/active
+/connection/url

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIAuthenticator.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIAuthenticator.kt
@@ -1,0 +1,87 @@
+package org.wordpress.android.fluxc.network.rest.wpapi
+
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Unknown
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.store.ReactNativeStore
+import org.wordpress.android.fluxc.utils.CurrentTimeProvider
+import javax.inject.Inject
+
+private const val FIVE_MIN_MILLIS: Long = 5 * 60 * 1000
+
+class WPAPIAuthenticator @Inject constructor(
+    private val nonceRestClient: NonceRestClient,
+    private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
+    private val siteSqlUtils: SiteSqlUtils,
+    private val currentTimeProvider: CurrentTimeProvider
+) {
+    suspend fun <T : Payload<BaseNetworkError?>> makeAuthenticatedWPAPIRequest(
+        site: SiteModel,
+        fetchMethod: suspend (Nonce?) -> T
+    ): T {
+        val usingSavedRestUrl = site.wpApiRestUrl != null
+        if (!usingSavedRestUrl) {
+            site.wpApiRestUrl = discoveryWPAPIRestClient.discoverWPAPIBaseURL(site.url) // discover rest api endpoint
+                ?: ReactNativeStore.slashJoin(
+                    site.url,
+                    "wp-json/"
+                ) // fallback to ".../wp-json/" default if discovery fails
+            (siteSqlUtils::insertOrUpdateSite)(site)
+        }
+        var nonce = nonceRestClient.getNonce(site)
+        val usingSavedNonce = nonce is Available
+        val failedRecently = true == (nonce as? FailedRequest)?.timeOfResponse?.let {
+            it + FIVE_MIN_MILLIS > currentTimeProvider.currentDate().time
+        }
+        if (nonce is Unknown || !(usingSavedNonce || failedRecently)) {
+            nonce = nonceRestClient.requestNonce(site)
+        }
+
+        val response = fetchMethod(nonce)
+        return when (response.isError) {
+            false -> response
+            else -> when (response.error?.volleyError?.networkResponse?.statusCode) {
+                401 -> {
+                    if (usingSavedNonce) {
+                        // Call with saved nonce failed, so try getting a new one
+                        val previousNonce = nonce
+                        val newNonce = nonceRestClient.requestNonce(site)
+
+                        // Try original call again if we have a new nonce
+                        val nonceIsUpdated = newNonce != null && newNonce != previousNonce
+                        if (nonceIsUpdated) {
+                            return fetchMethod(newNonce)
+                        }
+                    }
+                    response
+                }
+
+                404 -> {
+                    // call failed with 'not found' so clear the (failing) rest url
+                    site.wpApiRestUrl = null
+                    (siteSqlUtils::insertOrUpdateSite)(site)
+
+                    if (usingSavedRestUrl) {
+                        // If we did the previous call with a saved rest url, try again by making
+                        // recursive call. This time there is no saved rest url to use
+                        // so the rest url will be retrieved using discovery
+                        makeAuthenticatedWPAPIRequest(site, fetchMethod)
+                    } else {
+                        // Already used discovery to fetch the rest base url and still got 'not found', so
+                        // just return the error response
+                        response
+                    }
+
+                    // For all other failures just return the error response
+                }
+
+                else -> response
+            }
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIEncodedBodyRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIEncodedBodyRequestBuilder.kt
@@ -1,25 +1,55 @@
 package org.wordpress.android.fluxc.network.rest.wpapi
 
 import com.android.volley.Request.Method
-import com.android.volley.Response
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import javax.inject.Inject
 import kotlin.coroutines.resume
 
 class WPAPIEncodedBodyRequestBuilder @Inject constructor() {
+    suspend fun syncGetRequest(
+        restClient: BaseWPAPIRestClient,
+        url: String,
+        params: Map<String, String> = emptyMap(),
+        body: Map<String, String> = emptyMap(),
+        enableCaching: Boolean = false,
+        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
+        nonce: String? = null
+    ) = suspendCancellableCoroutine<WPAPIResponse<String>> { cont ->
+        callMethod(Method.GET, url, params, body, cont, enableCaching, cacheTimeToLive, nonce, restClient)
+    }
+
     suspend fun syncPostRequest(
         restClient: BaseWPAPIRestClient,
         url: String,
         params: Map<String, String> = emptyMap(),
         body: Map<String, String> = emptyMap(),
         enableCaching: Boolean = false,
-        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME
+        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
+        nonce: String? = null
     ) = suspendCancellableCoroutine<WPAPIResponse<String>> { cont ->
-        val request = WPAPIEncodedBodyRequest(Method.POST, url, params, body, Response.Listener { response ->
-            cont.resume(WPAPIResponse.Success(response))
-        }, BaseRequest.BaseErrorListener { error ->
-            cont.resume(WPAPIResponse.Error(error))
+        callMethod(Method.POST, url, params, body, cont, enableCaching, cacheTimeToLive, nonce, restClient)
+    }
+
+    @Suppress("LongParameterList")
+    private fun callMethod(
+        method: Int,
+        url: String,
+        params: Map<String, String>,
+        body: Map<String, String>,
+        cont: CancellableContinuation<WPAPIResponse<String>>,
+        enableCaching: Boolean,
+        cacheTimeToLive: Int,
+        nonce: String?,
+        restClient: BaseWPAPIRestClient
+    ) {
+        val request = WPAPIEncodedBodyRequest(method, url, params, body, { response ->
+            cont.resume(Success(response))
+        }, { error ->
+            cont.resume(Error(error))
         })
 
         cont.invokeOnCancellation {
@@ -28,6 +58,10 @@ class WPAPIEncodedBodyRequestBuilder @Inject constructor() {
 
         if (enableCaching) {
             request.enableCaching(cacheTimeToLive)
+        }
+
+        if (nonce != null) {
+            request.addHeader("x-wp-nonce", nonce)
         }
 
         restClient.add(request)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -14,7 +14,9 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 
+@Singleton
 class JetpackWPAPIRestClient @Inject constructor(
     private val wpApiEncodedBodyRequestBuilder: WPAPIEncodedBodyRequestBuilder,
     dispatcher: Dispatcher,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.jetpack
+
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.generated.endpoint.JPAPI
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIEncodedBodyRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
+import javax.inject.Inject
+import javax.inject.Named
+
+class JetpackWPAPIRestClient @Inject constructor(
+    private val wpApiEncodedBodyRequestBuilder: WPAPIEncodedBodyRequestBuilder,
+    dispatcher: Dispatcher,
+    @Named("custom-ssl") requestQueue: RequestQueue,
+    userAgent: UserAgent
+) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
+    suspend fun fetchJetpackConnectionUrl(
+        site: SiteModel,
+        nonce: Nonce?
+    ): JetpackConnectionUrlPayload {
+        val baseUrl = site.wpApiRestUrl ?: "${site.url}/wp-json"
+        val url = "${baseUrl.trimEnd('/')}/${JPAPI.connection.url.pathV4.trimStart('/')}"
+
+        val response = wpApiEncodedBodyRequestBuilder.syncGetRequest(
+            restClient = this,
+            url = url,
+            nonce = nonce?.value
+        )
+
+        return when (response) {
+            is Success<String> -> JetpackConnectionUrlPayload(response.data)
+            is Error -> JetpackConnectionUrlPayload(response.error)
+        }
+    }
+
+    data class JetpackConnectionUrlPayload(
+        val response: String?
+    ) : Payload<BaseNetworkError?>() {
+        constructor(error: BaseNetworkError): this(null) {
+            this.error = error
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginCoroutineStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginCoroutineStore.kt
@@ -6,15 +6,9 @@ import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType.SITE
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Unknown
-import org.wordpress.android.fluxc.network.rest.wpapi.NonceRestClient
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.plugin.PluginWPAPIRestClient
 import org.wordpress.android.fluxc.persistence.PluginSqlUtilsWrapper
-import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginErrorType.UNKNOWN_PLUGIN
@@ -25,9 +19,7 @@ import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginDeleted
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled
 import org.wordpress.android.fluxc.store.PluginStore.PluginDirectoryError
 import org.wordpress.android.fluxc.tools.CoroutineEngine
-import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import org.wordpress.android.util.AppLog.T
-import java.net.HttpURLConnection
 import javax.inject.Inject
 
 private const val PLUGIN_CONFIGURATION_DELAY = 1000L
@@ -37,10 +29,7 @@ class PluginCoroutineStore
     private val coroutineEngine: CoroutineEngine,
     private val dispatcher: Dispatcher,
     private val pluginWPAPIRestClient: PluginWPAPIRestClient,
-    private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
-    private val siteSqlUtils: SiteSqlUtils,
-    private val nonceRestClient: NonceRestClient,
-    private val currentTimeProvider: CurrentTimeProvider,
+    private val wpapiAuthenticator: WPAPIAuthenticator,
     private val pluginSqlUtils: PluginSqlUtilsWrapper
 ) {
     fun fetchWPApiPlugins(siteModel: SiteModel) = coroutineEngine.launch(T.PLUGINS, this, "Fetching WPAPI plugins") {
@@ -51,7 +40,9 @@ class PluginCoroutineStore
     suspend fun syncFetchWPApiPlugins(
         siteModel: SiteModel
     ): OnPluginDirectoryFetched {
-        val payload = executeWPAPIRequest(siteModel, true, pluginWPAPIRestClient::fetchPlugins)
+        val payload = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(siteModel) { nonce ->
+            pluginWPAPIRestClient.fetchPlugins(siteModel, nonce)
+        }
         val event = OnPluginDirectoryFetched(SITE, false)
         val error = payload.error
         if (error != null) {
@@ -75,8 +66,8 @@ class PluginCoroutineStore
         slug: String
     ): OnSitePluginDeleted {
         val plugin = pluginSqlUtils.getSitePluginBySlug(site, slug)
-        val payload = executeWPAPIRequest(site, false) { siteModel, nonce, _ ->
-            pluginWPAPIRestClient.deletePlugin(siteModel, nonce, plugin?.name ?: pluginName)
+        val payload = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+            pluginWPAPIRestClient.deletePlugin(site, nonce, plugin?.name ?: pluginName)
         }
         val event = OnSitePluginDeleted(payload.site, pluginName, slug)
         val error = payload.error?.let {
@@ -103,8 +94,8 @@ class PluginCoroutineStore
         isActive: Boolean
     ): OnSitePluginConfigured {
         val plugin = pluginSqlUtils.getSitePluginBySlug(site, slug)
-        val payload = executeWPAPIRequest(site, false) { siteModel, nonce, _ ->
-            pluginWPAPIRestClient.updatePlugin(siteModel, nonce, plugin?.name ?: pluginName, isActive)
+        val payload = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce, ->
+            pluginWPAPIRestClient.updatePlugin(site, nonce, plugin?.name ?: pluginName, isActive)
         }
         val event = OnSitePluginConfigured(payload.site, pluginName, slug)
         val error = payload.error
@@ -125,8 +116,8 @@ class PluginCoroutineStore
         site: SiteModel,
         slug: String
     ): OnSitePluginInstalled {
-        val payload = executeWPAPIRequest(site, false) { siteModel, nonce, _ ->
-            pluginWPAPIRestClient.installPlugin(siteModel, nonce, slug)
+        val payload = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+            pluginWPAPIRestClient.installPlugin(site, nonce, slug)
         }
         val event = OnSitePluginInstalled(payload.site, payload.data?.slug ?: slug)
         val error = payload.error
@@ -147,75 +138,6 @@ class PluginCoroutineStore
         return event
     }
 
-    @Suppress("ComplexMethod", "NestedBlockDepth")
-    private suspend fun <T : Payload<BaseNetworkError?>> executeWPAPIRequest(
-        site: SiteModel,
-        enableCaching: Boolean,
-        fetchMethod: suspend (SiteModel, Nonce?, enableCaching: Boolean) -> T
-    ): T {
-        val usingSavedRestUrl = site.wpApiRestUrl != null
-        if (!usingSavedRestUrl) {
-            site.wpApiRestUrl = discoveryWPAPIRestClient.discoverWPAPIBaseURL(site.url) // discover rest api endpoint
-                    ?: ReactNativeStore.slashJoin(
-                            site.url,
-                            "wp-json/"
-                    ) // fallback to ".../wp-json/" default if discovery fails
-            (siteSqlUtils::insertOrUpdateSite)(site)
-        }
-        var nonce = nonceRestClient.getNonce(site)
-        val usingSavedNonce = nonce is Available
-        val failedRecently = true == (nonce as? FailedRequest)?.timeOfResponse?.let {
-            it + FIVE_MIN_MILLIS > currentTimeProvider.currentDate().time
-        }
-        if (nonce is Unknown || !(usingSavedNonce || failedRecently)) {
-            nonce = nonceRestClient.requestNonce(site)
-        }
-
-        val response = fetchMethod(site, nonce, enableCaching)
-        return when (response.isError) {
-            false -> response
-            else -> when (response.error?.volleyError?.networkResponse?.statusCode) {
-                HttpURLConnection.HTTP_UNAUTHORIZED -> {
-                    if (usingSavedNonce) {
-                        // Call with saved nonce failed, so try getting a new one
-                        val previousNonce = nonce
-                        val newNonce = nonceRestClient.requestNonce(site)
-
-                        // Try original call again if we have a new nonce
-                        val nonceIsUpdated = newNonce != null && newNonce != previousNonce
-                        if (nonceIsUpdated) {
-                            return fetchMethod(site, newNonce, enableCaching)
-                        }
-                    }
-                    response
-                }
-
-                HttpURLConnection.HTTP_NOT_FOUND -> {
-                    // call failed with 'not found' so clear the (failing) rest url
-                    site.wpApiRestUrl = null
-                    (siteSqlUtils::insertOrUpdateSite)(site)
-
-                    if (usingSavedRestUrl) {
-                        // If we did the previous call with a saved rest url, try again by making
-                        // recursive call. This time there is no saved rest url to use
-                        // so the rest url will be retrieved using discovery
-                        executeWPAPIRequest(site, enableCaching, fetchMethod)
-                    } else {
-                        // Already used discovery to fetch the rest base url and still got 'not found', so
-                        // just return the error response
-                        response
-                    }
-
-                    // For all other failures just return the error response
-                }
-
-                else -> response
-            }
-        }
-    }
-
-    private fun getNonce(site: SiteModel) = nonceRestClient.getNonce(site)
-
     class WPApiPluginsPayload<T>(
         val site: SiteModel?,
         val data: T?
@@ -223,9 +145,5 @@ class PluginCoroutineStore
         constructor(error: BaseNetworkError) : this(null, null) {
             this.error = error
         }
-    }
-
-    companion object {
-        private const val FIVE_MIN_MILLIS: Long = 5 * 60 * 1000
     }
 }


### PR DESCRIPTION
This PR adds support for fetching Jetpack connection URL using the endpoint: `jetpack/connection/url`.

Since this needs the nonce authentication using wp-admin credentials, I extracted the logic from `PluginCoroutineStore` to a class `WPAPIAuthenticator`.

Check WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/7342 for test instructions.