### PR TITLE
Add author param to posts endpoint request

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -595,6 +595,8 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("content", StringUtils.notNullStr(post.getContent()));
         params.put("excerpt", StringUtils.notNullStr(post.getExcerpt()));
         params.put("slug", StringUtils.notNullStr(post.getSlug()));
+        params.put("author", String.valueOf(post.getAuthorId()));
+
 
         if (!TextUtils.isEmpty(post.getDateCreated())) {
             params.put("date", post.getDateCreated());


### PR DESCRIPTION
This PR adds "author" to the request of `posts` endpoint. It'll help the WPAndroid project to change the post's author.

This can be tested through https://github.com/wordpress-mobile/WordPress-Android/pull/17120