### PR TITLE
Assign correct causeOfChange when dispatching signout event

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -1194,6 +1194,7 @@ public class AccountStore extends Store {
     private void signOut() {
         clearAccountAndAccessToken();
         OnAccountChanged accountChanged = new OnAccountChanged();
+        accountChanged.causeOfChange = AccountAction.SIGN_OUT;
         accountChanged.accountInfosChanged = true;
         emitChange(accountChanged);
         emitChange(new OnAuthenticationChanged());


### PR DESCRIPTION
When dispatching the event `OnAccountChanged` after signing out, we don't set the correct causeOfChange, and this caused recently an issue in WCAndroid.