### PR TITLE
Fix 0 author id issue on postModelToParams

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -595,8 +595,9 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("content", StringUtils.notNullStr(post.getContent()));
         params.put("excerpt", StringUtils.notNullStr(post.getExcerpt()));
         params.put("slug", StringUtils.notNullStr(post.getSlug()));
-        params.put("author", String.valueOf(post.getAuthorId()));
-
+        if (post.getAuthorId() > 0) {
+            params.put("author", String.valueOf(post.getAuthorId()));
+        }
 
         if (!TextUtils.isEmpty(post.getDateCreated())) {
             params.put("date", post.getDateCreated());


### PR DESCRIPTION
This PR adds 0 author id check to `postModelToParams` function. `author` param won't be added to the endpoint request if the author id is zero. 
This will prevent sending `author=0` to the endpoint when publishing a post.