### PR TITLE
Adds dependency cache support for Buildkite

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Note that as the script is sourced, not run directly, the shebang line will be ignored
+# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
+
+set -e
+
+restore_gradle_dependency_cache || true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,7 @@ steps:
           cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
           ./gradlew checkstyle
         artifact_paths: *artifact_paths
+        plugins: *common_plugins
         notify:
           - github_commit_status:
               context: "checkstyle"
@@ -32,6 +33,7 @@ steps:
           cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
           ./gradlew detekt
         artifact_paths: *artifact_paths
+        plugins: *common_plugins
         notify:
           - github_commit_status:
               context: "detekt"
@@ -42,6 +44,7 @@ steps:
           ./gradlew lintRelease || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1);
           find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || exit 0;
         artifact_paths: *artifact_paths
+        plugins: *common_plugins
         notify:
           - github_commit_status:
               context: "Lint"


### PR DESCRIPTION
This PR adds a pre-command hook to all Buildkite steps to restore the read only Gradle dependency cache we keep in our S3. It works [the same way WCAndroid does](https://github.com/woocommerce/woocommerce-android/blob/trunk/.buildkite/hooks/pre-command) and uses the `restore_gradle_dependency_cache` [script](https://github.com/Automattic/bash-cache-buildkite-plugin/blob/trunk/bin/restore_gradle_dependency_cache) from `bash-cache-buildkite-plugin`. The dependency cache is [generated](https://github.com/Automattic/android-dependency-catalog/blob/trunk/.buildkite/pipeline.yml#L23) from `android-dependency-catalog` project.

Using the cache saves us roughly 10-30 seconds per step for the moment.

---

You can verify this change by checking a Buildkite job from current `trunk` which will have the following in its logs:
> The read-only dependency cache is disabled because of a configuration problem

You can then check the Buildkite logs for de7fbabb5f4edf9819ca38efba508a8fc6aba32a and verify that it's no longer present.

---

Alternatively, you can check the build scans for the `Publish FluxC` task from `trunk` and de7fbabb5f4edf9819ca38efba508a8fc6aba32a and compare the information under `Performance -> Network Activity`. Here are some screenshots from before & after:

<img width="1102" alt="before" src="https://user-images.githubusercontent.com/662023/193063286-5b4be82a-9e24-46e2-ac0c-49dc23e5f54c.png">

<img width="1183" alt="after" src="https://user-images.githubusercontent.com/662023/193063354-23423590-6037-4b3a-a6c5-e20fc7050e23.png">

