### PR TITLE
Jetpack Focus: Add Jetpack app id for feature announcements

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/WhatsNewStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/WhatsNewStore.kt
@@ -102,6 +102,7 @@ class WhatsNewStore @Inject constructor(
 
     enum class WhatsNewAppId(val id: Int) {
         WP_ANDROID(1),
-        WOO_ANDROID(3)
+        WOO_ANDROID(3),
+        JP_ANDROID(5)
     }
 }


### PR DESCRIPTION
This PR adds the Jetpack app id to the `WhatsNewAppId` enum to separate Jetpack feature announcements from WordPress feature announcements.

See WPAndroid PR for testing instructions