### PR TITLE
Updates the target sdk version to 31 for Android 12 migration 

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments += [

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,7 +50,7 @@ dependencyResolutionManagement {
             version("facebook-soloader", "0.9.0")
             version("kotlinx-coroutines", "1.3.9")
             version("mockito", "3.3.3")
-            version("wordpress-utils", "develop-13b4f06680ed8c145cbd09d63c4998dfe8b3b9de")
+            version("wordpress-utils", "develop-eebc5d8e91a1d90190919f900f924b39c861a528")
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,7 +50,7 @@ dependencyResolutionManagement {
             version("facebook-soloader", "0.9.0")
             version("kotlinx-coroutines", "1.3.9")
             version("mockito", "3.3.3")
-            version("wordpress-utils", "develop-eebc5d8e91a1d90190919f900f924b39c861a528")
+            version("wordpress-utils", "develop-13b4f06680ed8c145cbd09d63c4998dfe8b3b9de")
         }
     }
 }


### PR DESCRIPTION
Part of #2529 

This PR updates the target SDK version to 31 for the Android 12 migration 

Test Instructions 
- Install the app from the Parent PR 
- Make sure the functionalities provided by the library work as expected 