### PR TITLE
Jetpack Connection: register site if needed

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/RawRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/RawRequest.kt
@@ -5,18 +5,25 @@ import com.android.volley.Response
 import com.android.volley.Response.Listener
 import com.android.volley.toolbox.HttpHeaderParser
 
+/**
+ * A request that allows returning the network response untouched, this is useful when
+ * we want to read the network response headers.
+ */
 class RawRequest(
     method: Int,
     url: String,
     private val listener: Listener<NetworkResponse>,
     onErrorListener: BaseErrorListener
 ) : BaseRequest<NetworkResponse>(method, url, onErrorListener) {
-    override fun parseNetworkResponse(p0: NetworkResponse): Response<NetworkResponse> {
-        return Response.success(p0, HttpHeaderParser.parseCacheHeaders(p0))
+    override fun parseNetworkResponse(networkResponse: NetworkResponse): Response<NetworkResponse> {
+        return Response.success(
+            networkResponse,
+            HttpHeaderParser.parseCacheHeaders(networkResponse)
+        )
     }
 
-    override fun deliverResponse(p0: NetworkResponse) {
-        listener.onResponse(p0)
+    override fun deliverResponse(networkResponse: NetworkResponse) {
+        listener.onResponse(networkResponse)
     }
 
     override fun deliverBaseNetworkError(error: BaseNetworkError): BaseNetworkError = error

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/RawRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/RawRequest.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.network
+
+import com.android.volley.NetworkResponse
+import com.android.volley.Response
+import com.android.volley.Response.Listener
+import com.android.volley.toolbox.HttpHeaderParser
+
+class RawRequest(
+    method: Int,
+    url: String,
+    private val listener: Listener<NetworkResponse>,
+    onErrorListener: BaseErrorListener
+) : BaseRequest<NetworkResponse>(method, url, onErrorListener) {
+    override fun parseNetworkResponse(p0: NetworkResponse): Response<NetworkResponse> {
+        return Response.success(p0, HttpHeaderParser.parseCacheHeaders(p0))
+    }
+
+    override fun deliverResponse(p0: NetworkResponse) {
+        listener.onResponse(p0)
+    }
+
+    override fun deliverBaseNetworkError(error: BaseNetworkError): BaseNetworkError = error
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -198,7 +198,10 @@ class JetpackStore
         val message: String? = null
     ) : OnChangedError
 
-    suspend fun fetchJetpackConnectionUrl(site: SiteModel): JetpackConnectionUrlResult {
+    suspend fun fetchJetpackConnectionUrl(
+        site: SiteModel,
+        autoRegisterSiteIfNeeded: Boolean = false
+    ): JetpackConnectionUrlResult {
         if (site.isUsingWpComRestApi) error("This function supports only self-hosted site using WPAPI")
         return coroutineEngine.withDefaultContext(T.API, this, "fetchJetpackConnectionUrl") {
             val result = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
@@ -213,7 +216,7 @@ class JetpackStore
                 else -> {
                     val url = result.result.trim('"').replace("\\", "")
                     val connectionUri = URI.create(url)
-                    if (connectionUri.host == JETPACK_DOMAIN){
+                    if (!autoRegisterSiteIfNeeded || connectionUri.host == JETPACK_DOMAIN) {
                         JetpackConnectionUrlResult(url)
                     } else {
                         registerJetpackSite(url).fold(


### PR DESCRIPTION
Please don't merge until #2537 is merged.

This PR adds support for fetching the Jetpack connection URL even if the site doesn't have any connected accounts (we call it a blog without site level connection).
The flow is simple:
1. We call the API `/jetpack/v4/connection/url`
2. We check if the returned URL is pointing to `jetpack.wordpress.com`.
    i. if it does, then the site have a site-level connection, and we can continue as before.
    ii. if it doesn't, then this means the site is not registered yet, so we call the URL we received using the `no-redirect` OkHttp client, and then we catch the `Location` header from the redirection response. Then we return this location

Check the parent [issue](https://github.com/woocommerce/woocommerce-android/issues/7525) for more details, it explains the two possible approaches to solve this, I went with the second approach because it makes the WordPress.com authentication on the WebView easier.

To test, please check the Woo [PR](https://github.com/woocommerce/woocommerce-android/pull/7545).