### PR TITLE
fix: crash on getting `UserAgent` on thread different than the main

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network;
 
 import android.content.Context;
-import android.os.Looper;
 import android.webkit.WebView;
 
 import org.wordpress.android.util.PackageUtils;
@@ -10,23 +9,16 @@ public class UserAgent {
     private String mUserAgent;
     private String mDefaultUserAgent;
 
-    private static final String DEFAULT_USER_AGENT =
-            "Mozilla/5.0 (Linux; Android 6.0; default FluxC UA; wv) AppleWebKit/537.36"
-            + "(KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36";
-
     public UserAgent(Context appContext, String appName) {
-        if (isMainThread()) {
-            // Device's default User-Agent string.
-            // E.g.:
-            //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
-            //   AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
-            try {
-                mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
-            } catch (RuntimeException re) {
-                mDefaultUserAgent = DEFAULT_USER_AGENT;
-            }
-        } else {
-            mDefaultUserAgent = DEFAULT_USER_AGENT;
+        // Device's default User-Agent string.
+        // E.g.:
+        //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
+        //   AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
+        try {
+            mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
+        } catch (RuntimeException re) {
+            mDefaultUserAgent = "Mozilla/5.0 (Linux; Android 6.0; default FluxC UA; wv) AppleWebKit/537.36"
+                    + "(KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36";
         }
         // User-Agent string when making HTTP connections, for both API traffic and WebViews.
         // Appends "wp-android/version" to WebView's default User-Agent string for the webservers
@@ -35,10 +27,6 @@ public class UserAgent {
         //    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
         //    wp-android/4.7"
         mUserAgent = mDefaultUserAgent + " " + appName + "/" + PackageUtils.getVersionName(appContext);
-    }
-
-    private boolean isMainThread() {
-        return Looper.myLooper() == Looper.getMainLooper();
     }
 
     public String getUserAgent() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
@@ -1,25 +1,20 @@
 package org.wordpress.android.fluxc.network;
 
 import android.content.Context;
-import android.webkit.WebView;
+import android.webkit.WebSettings;
 
 import org.wordpress.android.util.PackageUtils;
 
 public class UserAgent {
-    private String mUserAgent;
-    private String mDefaultUserAgent;
+    private final String mUserAgent;
+    private final String mDefaultUserAgent;
 
     public UserAgent(Context appContext, String appName) {
         // Device's default User-Agent string.
         // E.g.:
         //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
         //   AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
-        try {
-            mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
-        } catch (RuntimeException re) {
-            mDefaultUserAgent = "Mozilla/5.0 (Linux; Android 6.0; default FluxC UA; wv) AppleWebKit/537.36"
-                    + "(KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36";
-        }
+        mDefaultUserAgent = WebSettings.getDefaultUserAgent(appContext);
         // User-Agent string when making HTTP connections, for both API traffic and WebViews.
         // Appends "wp-android/version" to WebView's default User-Agent string for the webservers
         // to get the full feature list of the browser and serve content accordingly, e.g.:

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network;
 
 import android.content.Context;
+import android.os.Looper;
 import android.webkit.WebView;
 
 import org.wordpress.android.util.PackageUtils;
@@ -9,16 +10,23 @@ public class UserAgent {
     private String mUserAgent;
     private String mDefaultUserAgent;
 
+    private static final String DEFAULT_USER_AGENT =
+            "Mozilla/5.0 (Linux; Android 6.0; default FluxC UA; wv) AppleWebKit/537.36"
+            + "(KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36";
+
     public UserAgent(Context appContext, String appName) {
-        // Device's default User-Agent string.
-        // E.g.:
-        //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
-        //   AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
-        try {
-            mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
-        } catch (RuntimeException re) {
-            mDefaultUserAgent = "Mozilla/5.0 (Linux; Android 6.0; default FluxC UA; wv) AppleWebKit/537.36"
-                    + "(KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36";
+        if (isMainThread()) {
+            // Device's default User-Agent string.
+            // E.g.:
+            //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
+            //   AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
+            try {
+                mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
+            } catch (RuntimeException re) {
+                mDefaultUserAgent = DEFAULT_USER_AGENT;
+            }
+        } else {
+            mDefaultUserAgent = DEFAULT_USER_AGENT;
         }
         // User-Agent string when making HTTP connections, for both API traffic and WebViews.
         // Appends "wp-android/version" to WebView's default User-Agent string for the webservers
@@ -27,6 +35,10 @@ public class UserAgent {
         //    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
         //    wp-android/4.7"
         mUserAgent = mDefaultUserAgent + " " + appName + "/" + PackageUtils.getVersionName(appContext);
+    }
+
+    private boolean isMainThread() {
+        return Looper.myLooper() == Looper.getMainLooper();
     }
 
     public String getUserAgent() {


### PR DESCRIPTION
Internal: p91TBi-9Zw-p2#comment-11208

Description:

This PR changes how we get a default `UserAgent` for HTTP requests. Instead of creating WebView and getting the default UserAgent from it, we use a native `WebSettings#getDefaultUserAgent` method which **does not crash when called from a background thread**.

For more details, please see the internal link above.

---

I've tested values of the default `UserAgent` and they are precisely the same before and after this change.

For safety, I ensured it did not crash on API version 21 when the call was executed on a background thread.

```kotlin
// does not crash on API 21. Returns a valid value.
        Thread {
            WebSettings.getDefaultUserAgent(this@MainActivity)
        }.start()
```
