### PR TITLE
Top performers with date period

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/LeaderboardsRestClientTest.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsRestClient
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.wc.leaderboards.WCLeaderboardsTestFixtures.generateSampleLeaderboardsApiResponse
 import org.wordpress.android.fluxc.wc.leaderboards.WCLeaderboardsTestFixtures.stubSite
@@ -48,12 +47,12 @@ class LeaderboardsRestClientTest {
         val expectedResult = generateSampleLeaderboardsApiResponse()
         configureSuccessRequest(expectedResult!!)
         val response = restClientUnderTest.fetchLeaderboards(
-            stubSite,
-            DAYS,
-            "10-10-2022",
-            "22-10-2022",
+            site = stubSite,
+            startDate = "10-10-2022",
+            endDate = "22-10-2022",
             quantity = 5,
-            forceRefresh = false
+            forceRefresh = false,
+            interval = "day"
         )
 
         verify(requestBuilder, times(1)).syncGetRequest(
@@ -79,12 +78,12 @@ class LeaderboardsRestClientTest {
     fun `fetch leaderboards should correctly return failure as WooError`() = test {
         configureErrorRequest()
         val response = restClientUnderTest.fetchLeaderboards(
-            stubSite,
-            DAYS,
-            "10-10-2022",
-            "22-10-2022",
+            site = stubSite,
+            startDate = "10-10-2022",
+            endDate = "22-10-2022",
             forceRefresh = false,
-            quantity = 5
+            quantity = 5,
+            interval = "day"
         )
 
         assertThat(response).isNotNull

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsStoreTest.kt
@@ -66,7 +66,7 @@ class WCLeaderboardsStoreTest {
         givenFetchLeaderBoardsReturns(emptyArray())
         setup()
 
-        val result = storeUnderTest.fetchTopPerformerProducts(stubSite)
+        val result = storeUnderTest.fetchTopPerformerProducts(stubSite, DAYS)
 
         assertThat(result.model).isNull()
         assertThat(result.error).isNotNull
@@ -78,13 +78,13 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         givenFetchLeaderBoardsReturns(response)
 
-        storeUnderTest.fetchTopPerformerProducts(stubSite)
+        storeUnderTest.fetchTopPerformerProducts(stubSite, DAYS)
 
         verify(mapper).mapTopPerformerProductsEntity(
             response?.firstOrNull { it.type == PRODUCTS }!!,
             stubSite,
             productStore,
-            DAYS
+            DAYS.datePeriod(stubSite)
         )
     }
 
@@ -94,7 +94,7 @@ class WCLeaderboardsStoreTest {
         val response = generateSampleLeaderboardsApiResponse()
         givenFetchLeaderBoardsReturns(response)
 
-        storeUnderTest.fetchTopPerformerProducts(stubSite)
+        storeUnderTest.fetchTopPerformerProducts(stubSite, DAYS)
 
         verify(mapper, times(1)).mapTopPerformerProductsEntity(any(), any(), any(), any())
     }
@@ -110,7 +110,7 @@ class WCLeaderboardsStoreTest {
                 returnedTopPerformersList = TOP_PERFORMER_ENTITY_LIST
             )
 
-            val result = storeUnderTest.fetchTopPerformerProducts(stubSite)
+            val result = storeUnderTest.fetchTopPerformerProducts(stubSite, DAYS)
 
             assertThat(result.model).isNotNull
             assertThat(result.model).isEqualTo(TOP_PERFORMER_ENTITY_LIST)
@@ -129,7 +129,7 @@ class WCLeaderboardsStoreTest {
                 SiteModel().apply { id = 100 },
             )
 
-            val result = storeUnderTest.fetchTopPerformerProducts(stubSite)
+            val result = storeUnderTest.fetchTopPerformerProducts(stubSite, DAYS)
 
             assertThat(result.model).isNull()
             assertThat(result.error).isNotNull
@@ -146,12 +146,12 @@ class WCLeaderboardsStoreTest {
                 returnedTopPerformersList = TOP_PERFORMER_ENTITY_LIST
             )
 
-            storeUnderTest.fetchTopPerformerProducts(stubSite)
+            storeUnderTest.fetchTopPerformerProducts(stubSite, DAYS)
 
             verify(topPerformersDao, times(1))
                 .updateTopPerformerProductsFor(
                     stubSite.siteId,
-                    DAYS.toString(),
+                    DAYS.datePeriod(stubSite),
                     TOP_PERFORMER_ENTITY_LIST
                 )
         }
@@ -183,12 +183,12 @@ class WCLeaderboardsStoreTest {
         whenever(
             restClient.fetchLeaderboards(
                 site = any(),
-                unit = anyOrNull(),
-                startDate = anyOrNull(),
-                endDate = anyOrNull(),
+                startDate = any(),
+                endDate = any(),
                 quantity = anyOrNull(),
-                addProductsPath = any(),
                 forceRefresh = any(),
+                interval = any(),
+                addProductsPath = any(),
             )
         ).thenReturn(WooPayload(response))
     }
@@ -213,7 +213,7 @@ class WCLeaderboardsStoreTest {
                 givenResponse,
                 siteModel,
                 productStore,
-                DAYS
+                DAYS.datePeriod(siteModel)
             )
         ).thenReturn(returnedTopPerformersList)
     }
@@ -223,7 +223,7 @@ class WCLeaderboardsStoreTest {
             listOf(
                 TopPerformerProductEntity(
                     siteId = 1,
-                    granularity = "Today",
+                    datePeriod = DAYS.datePeriod(stubSite),
                     productId = 123,
                     name = "product",
                     imageUrl = null,
@@ -237,7 +237,7 @@ class WCLeaderboardsStoreTest {
             listOf(
                 TopPerformerProductEntity(
                     siteId = 1,
-                    granularity = "Today",
+                    datePeriod = DAYS.datePeriod(stubSite),
                     productId = 123,
                     name = "product",
                     imageUrl = null,

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCProductLeaderboardsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCProductLeaderboardsMapperTest.kt
@@ -56,7 +56,7 @@ class WCProductLeaderboardsMapperTest {
                 productApiResponse!!,
                 stubSite,
                 productStore,
-                DAYS
+                DAYS.datePeriod(stubSite)
         )
         assertThat(result).isNotNull
         assertThat(result.size).isEqualTo(3)
@@ -70,7 +70,7 @@ class WCProductLeaderboardsMapperTest {
                 productApiResponse!!,
                 stubSite,
                 productStore,
-                DAYS
+                DAYS.datePeriod(stubSite)
         )
         assertThat(result).isNotNull
         assertThat(result.size).isEqualTo(2)
@@ -83,7 +83,7 @@ class WCProductLeaderboardsMapperTest {
                 productApiResponse!!,
                 stubSite,
                 productStore,
-                DAYS
+                DAYS.datePeriod(stubSite)
         )
         assertThat(result).isNotNull
         assertThat(result).isEmpty()

--- a/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
+++ b/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_6_7
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_7_8
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_8_9
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_20_21
 
 @RunWith(AndroidJUnit4::class)
 class MigrationTests {
@@ -144,6 +145,41 @@ class MigrationTests {
                     """.trimIndent()
             )
             // Ensure we delete all saved OrderEntities and use the API as the source of true
+            assertThat(cursor.count).isEqualTo(0)
+            cursor.close()
+        }
+    }
+
+    @Test
+    fun testMigrate20to21() {
+        helper.apply {
+            createDatabase(TEST_DB, 20).apply {
+                execSQL(
+                    // language=RoomSql
+                    """
+                    INSERT INTO TopPerformerProducts VALUES(
+                        202934350,
+                        "2022-10-01T00:00:00-2022-10-31T23:59:59",
+                        78,
+                        "WooCommerce Tote Bag",
+                        "https://samplesite.com/awesomeproduct.jpg",
+                        2,
+                        "/$",
+                        11.0,
+                        1666727639491 
+                    )
+                    """.trimIndent()
+                )
+            }.close()
+
+            val migratedDb = runMigrationsAndValidate(TEST_DB, 21, true, MIGRATION_20_21)
+            val cursor = migratedDb.query(
+                // language=RoomSql
+                """
+                        SELECT * FROM TopPerformerProducts
+                    """.trimIndent()
+            )
+            // Ensure we delete all saved TopPerformerProducts
             assertThat(cursor.count).isEqualTo(0)
             cursor.close()
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/leaderboards/WCProductLeaderboardsMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/leaderboards/WCProductLeaderboardsMapper.kt
@@ -8,7 +8,6 @@ import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils.geProductExistsByRemoteId
 import org.wordpress.android.fluxc.persistence.entity.TopPerformerProductEntity
 import org.wordpress.android.fluxc.store.WCProductStore
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import javax.inject.Inject
 
 class WCProductLeaderboardsMapper @Inject constructor() {
@@ -16,7 +15,7 @@ class WCProductLeaderboardsMapper @Inject constructor() {
         response: LeaderboardsApiResponse,
         site: SiteModel,
         productStore: WCProductStore,
-        granularity: StatsGranularity
+        datePeriod: String
     ): List<TopPerformerProductEntity> = response.products
         ?.takeIf { it.isNotEmpty() }
         ?.mapNotNull { it.productId }
@@ -24,7 +23,7 @@ class WCProductLeaderboardsMapper @Inject constructor() {
         ?.mapNotNull { product ->
             response.products
                 ?.find { it.productId == product.remoteProductId }
-                ?.let { product.toTopPerformerProductEntity(it, site, granularity) }
+                ?.let { product.toTopPerformerProductEntity(it, site, datePeriod) }
         }.orEmpty()
 
     /**
@@ -61,10 +60,10 @@ class WCProductLeaderboardsMapper @Inject constructor() {
     private fun WCProductModel.toTopPerformerProductEntity(
         productItem: LeaderboardProductItem,
         site: SiteModel,
-        granularity: StatsGranularity
+        datePeriod: String
     ) = TopPerformerProductEntity(
         siteId = site.siteId,
-        granularity = granularity.toString(),
+        datePeriod = datePeriod,
         productId = remoteProductId,
         name = name,
         imageUrl = getFirstImageUrl(),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -38,6 +38,7 @@ import org.wordpress.android.fluxc.persistence.migrations.AutoMigration19to20
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_10_11
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_11_12
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_15_16
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_20_21
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
@@ -47,7 +48,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_8_9
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
 
 @Database(
-        version = 20,
+        version = 21,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,
@@ -106,6 +107,7 @@ abstract class WCAndroidDatabase : RoomDatabase(), TransactionExecutor {
                 .addMigrations(MIGRATION_10_11)
                 .addMigrations(MIGRATION_11_12)
                 .addMigrations(MIGRATION_15_16)
+                .addMigrations(MIGRATION_20_21)
                 .build()
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/TopPerformerProductsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/TopPerformerProductsDao.kt
@@ -10,16 +10,16 @@ import org.wordpress.android.fluxc.persistence.entity.TopPerformerProductEntity
 
 @Dao
 interface TopPerformerProductsDao {
-    @Query("SELECT * FROM TopPerformerProducts WHERE granularity = :granularity AND siteId = :siteId")
+    @Query("SELECT * FROM TopPerformerProducts WHERE datePeriod = :datePeriod AND siteId = :siteId")
     fun observeTopPerformerProducts(
         siteId: Long,
-        granularity: String
+        datePeriod: String
     ): Flow<List<TopPerformerProductEntity>>
 
-    @Query("SELECT * FROM TopPerformerProducts WHERE granularity = :granularity AND siteId = :siteId")
+    @Query("SELECT * FROM TopPerformerProducts WHERE datePeriod = :datePeriod AND siteId = :siteId")
     suspend fun getTopPerformerProductsFor(
         siteId: Long,
-        granularity: String
+        datePeriod: String
     ): List<TopPerformerProductEntity>
 
     @Query("SELECT * FROM TopPerformerProducts WHERE siteId = :siteId")
@@ -30,16 +30,16 @@ interface TopPerformerProductsDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(entity: TopPerformerProductEntity)
 
-    @Query("DELETE FROM TopPerformerProducts WHERE granularity = :granularity AND siteId = :siteId")
-    suspend fun deleteAllFor(siteId: Long, granularity: String)
+    @Query("DELETE FROM TopPerformerProducts WHERE datePeriod = :datePeriod AND siteId = :siteId")
+    suspend fun deleteAllFor(siteId: Long, datePeriod: String)
 
     @Transaction
     suspend fun updateTopPerformerProductsFor(
         siteId: Long,
-        granularity: String,
+        datePeriod: String,
         topPerformerProducts: List<TopPerformerProductEntity>
     ) {
-        deleteAllFor(siteId, granularity)
+        deleteAllFor(siteId, datePeriod)
         topPerformerProducts.forEach { topPerformerProduct ->
             insert(topPerformerProduct)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/TopPerformerProductEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/TopPerformerProductEntity.kt
@@ -4,11 +4,11 @@ import androidx.room.Entity
 
 @Entity(
     tableName = "TopPerformerProducts",
-    primaryKeys = ["granularity", "productId", "siteId"]
+    primaryKeys = ["datePeriod", "productId", "siteId"]
 )
 data class TopPerformerProductEntity(
     val siteId: Long,
-    val granularity: String,
+    val datePeriod: String,
     val productId: Long,
     val name: String,
     val imageUrl: String?,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -603,3 +603,27 @@ internal class AutoMigration17to18 : AutoMigrationSpec
 internal class AutoMigration18to19 : AutoMigrationSpec
 
 internal class AutoMigration19to20 : AutoMigrationSpec
+
+internal val MIGRATION_20_21 = object : Migration(20, 21) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.apply {
+            execSQL("DROP TABLE TopPerformerProducts")
+            execSQL(
+                // language=RoomSql
+                """CREATE TABLE IF NOT EXISTS `TopPerformerProducts` (
+                    `siteId` INTEGER NOT NULL,
+                    `datePeriod` TEXT NOT NULL,
+                    `productId` INTEGER NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `imageUrl` TEXT,
+                    `quantity` INTEGER NOT NULL,
+                    `currency` TEXT NOT NULL,
+                    `total` REAL NOT NULL,
+                    `millisSinceLastUpdated` INTEGER NOT NULL,
+                    PRIMARY KEY(`datePeriod`,`productId`,`siteId`)
+                    )
+                    """.trimIndent()
+            )
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -31,7 +31,7 @@ class WCLeaderboardsStore @Inject constructor(
 ) {
     fun observeTopPerformerProducts(
         siteId: Long,
-        granularity: StatsGranularity
+        datePeriod: String
     ): Flow<List<TopPerformerProductEntity>> =
         topPerformersDao
             .observeTopPerformerProducts(siteId, granularity.toString())
@@ -39,7 +39,7 @@ class WCLeaderboardsStore @Inject constructor(
 
     suspend fun getCachedTopPerformerProducts(
         siteId: Long,
-        granularity: StatsGranularity
+        datePeriod: String
     ): List<TopPerformerProductEntity> =
         topPerformersDao.getTopPerformerProductsFor(siteId, granularity.toString())
 
@@ -66,16 +66,16 @@ class WCLeaderboardsStore @Inject constructor(
                 ?.firstOrNull { it.type == PRODUCTS }
                 ?.run {
                     mapper.mapTopPerformerProductsEntity(
-                        this,
-                        site,
-                        productStore,
-                        granularity
+                        response = this,
+                        site = site,
+                        productStore = productStore,
+                        datePeriod = period
                     )
                 }
                 ?.let {
                     topPerformersDao.updateTopPerformerProductsFor(
-                        site.siteId,
-                        granularity.toString(),
+                        siteId = site.siteId,
+                        datePeriod = period,
                         it
                     )
                     WooResult(it)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -11,10 +11,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.PRODUCTS
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
 import org.wordpress.android.fluxc.persistence.dao.TopPerformerProductsDao
 import org.wordpress.android.fluxc.persistence.entity.TopPerformerProductEntity
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.DateUtils
 import org.wordpress.android.util.AppLog
@@ -29,38 +29,63 @@ class WCLeaderboardsStore @Inject constructor(
     private val coroutineEngine: CoroutineEngine,
     private val topPerformersDao: TopPerformerProductsDao,
 ) {
+    @Suppress("Unused")
     fun observeTopPerformerProducts(
         siteId: Long,
         datePeriod: String
     ): Flow<List<TopPerformerProductEntity>> =
         topPerformersDao
-            .observeTopPerformerProducts(siteId, granularity.toString())
+            .observeTopPerformerProducts(siteId, datePeriod)
             .distinctUntilChanged()
 
+    @Suppress("Unused")
     suspend fun getCachedTopPerformerProducts(
         siteId: Long,
         datePeriod: String
     ): List<TopPerformerProductEntity> =
-        topPerformersDao.getTopPerformerProductsFor(siteId, granularity.toString())
+        topPerformersDao.getTopPerformerProductsFor(siteId, datePeriod)
 
     suspend fun fetchTopPerformerProducts(
         site: SiteModel,
-        granularity: StatsGranularity = DAYS,
+        granularity: StatsGranularity,
         quantity: Int? = null,
         addProductsPath: Boolean = false,
         forceRefresh: Boolean = false,
-        startDate: String? = null,
-        endDate: String? = null,
-    ): WooResult<List<TopPerformerProductEntity>> =
-        coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchLeaderboards") {
+    ): WooResult<List<TopPerformerProductEntity>> {
+        val startDate = granularity.startDateTime(site)
+        val endDate = granularity.endDateTime(site)
+        val interval = OrderStatsRestClient.OrderStatsApiUnit.fromStatsGranularity(granularity).toString()
+        return fetchTopPerformerProducts(
+            site = site,
+            startDate = startDate,
+            endDate = endDate,
+            quantity = quantity,
+            addProductsPath = addProductsPath,
+            forceRefresh = forceRefresh,
+            interval = interval
+        )
+    }
+
+    @Suppress("LongParameterList")
+    suspend fun fetchTopPerformerProducts(
+        site: SiteModel,
+        startDate: String,
+        endDate: String,
+        quantity: Int? = null,
+        addProductsPath: Boolean = false,
+        forceRefresh: Boolean = false,
+        interval: String = ""
+    ): WooResult<List<TopPerformerProductEntity>> {
+        val period = DateUtils.getDatePeriod(startDate, endDate)
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchLeaderboards") {
             fetchAllLeaderboards(
-                site,
-                granularity,
-                quantity,
-                addProductsPath,
-                forceRefresh,
-                getStartDateForProductsLeaderboards(site, granularity, startDate),
-                getEndDateForProductsLeaderboards(site, granularity, endDate),
+                site = site,
+                startDate = startDate,
+                endDate = endDate,
+                quantity = quantity,
+                addProductsPath = addProductsPath,
+                forceRefresh = forceRefresh,
+                interval = interval
             )
                 .model
                 ?.firstOrNull { it.type == PRODUCTS }
@@ -81,72 +106,32 @@ class WCLeaderboardsStore @Inject constructor(
                     WooResult(it)
                 } ?: WooResult(WooError(GENERIC_ERROR, UNKNOWN))
         }
+    }
 
+    @Suppress("LongParameterList")
     private suspend fun fetchAllLeaderboards(
         site: SiteModel,
-        unit: StatsGranularity? = null,
-        quantity: Int? = null,
-        addProductsPath: Boolean = false,
+        startDate: String,
+        endDate: String,
+        quantity: Int?,
+        addProductsPath: Boolean,
         forceRefresh: Boolean,
-        startDate: String? = null,
-        endDate: String? = null,
+        interval: String,
     ): WooResult<List<LeaderboardsApiResponse>> {
-        val fetchLeaderboards = restClient.fetchLeaderboards(
-            site,
-            unit,
-            startDate,
-            endDate,
-            quantity,
-            addProductsPath,
-            forceRefresh
+        val response = restClient.fetchLeaderboards(
+            site = site,
+            startDate = startDate,
+            endDate = endDate,
+            quantity = quantity,
+            addProductsPath = addProductsPath,
+            interval = interval,
+            forceRefresh = forceRefresh
         )
 
         return when {
-                fetchLeaderboards.isError -> WooResult(fetchLeaderboards.error)
-                fetchLeaderboards.result != null -> WooResult(fetchLeaderboards.result.toList())
-                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
-            }
-        }
-
-    /**
-     * Given a [startDate], formats the date based on the site's timezone in format yyyy-MM-dd'T'hh:mm:ss
-     * If the start date is empty, fetches the date based on the [granularity]
-     */
-    private fun getStartDateForProductsLeaderboards(
-        site: SiteModel,
-        granularity: StatsGranularity,
-        startDate: String?
-    ): String {
-        return if (startDate.isNullOrEmpty()) {
-            when (granularity) {
-                StatsGranularity.DAYS -> DateUtils.getStartDateForSite(site, DateUtils.getStartOfCurrentDay())
-                StatsGranularity.WEEKS -> DateUtils.getFirstDayOfCurrentWeekBySite(site)
-                StatsGranularity.MONTHS -> DateUtils.getFirstDayOfCurrentMonthBySite(site)
-                StatsGranularity.YEARS -> DateUtils.getFirstDayOfCurrentYearBySite(site)
-            }
-        } else {
-            DateUtils.getStartDateForSite(site, startDate)
-        }
-    }
-
-    /**
-     * Given a [endDate], formats the date based on the site's timezone in format yyyy-MM-dd'T'hh:mm:ss
-     * If the end date is empty, fetches the date based on the [granularity]
-     */
-    private fun getEndDateForProductsLeaderboards(
-        site: SiteModel,
-        granularity: StatsGranularity,
-        endDate: String?
-    ): String {
-        return if (endDate.isNullOrEmpty()) {
-            when (granularity) {
-                StatsGranularity.DAYS -> DateUtils.getEndDateForSite(site)
-                StatsGranularity.WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
-                StatsGranularity.MONTHS -> DateUtils.getLastDayOfCurrentMonthForSite(site)
-                StatsGranularity.YEARS -> DateUtils.getLastDayOfCurrentYearForSite(site)
-            }
-        } else {
-            DateUtils.getEndDateForSite(site, endDate)
+            response.isError -> WooResult(response.error)
+            response.result != null -> WooResult(response.result.toList())
+            else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -78,6 +78,19 @@ class WCStatsStore @Inject constructor(
             MONTHS -> DateUtils.getFirstDayOfCurrentMonthBySite(site)
             YEARS -> DateUtils.getFirstDayOfCurrentYearBySite(site)
         }
+
+        fun endDateTime(site: SiteModel) = when (this) {
+            DAYS -> DateUtils.getEndDateForSite(site)
+            WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
+            MONTHS -> DateUtils.getLastDayOfCurrentMonthForSite(site)
+            YEARS -> DateUtils.getLastDayOfCurrentYearForSite(site)
+        }
+
+        fun datePeriod(site: SiteModel): String {
+            val startDate = startDateTime(site)
+            val endDate = endDateTime(site)
+            return DateUtils.getDatePeriod(startDate, endDate)
+        }
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -372,4 +372,6 @@ object DateUtils {
         val dateString = SiteUtils.getCurrentDateTimeForSite(site, DATE_TIME_FORMAT_START)
         return getDateFromString(dateString, DATE_TIME_FORMAT_START)
     }
+
+    fun getDatePeriod(startDate: String, endDate: String) = "$startDate-$endDate"
 }


### PR DESCRIPTION
⚠️ This PR can't be merged until https://github.com/woocommerce/woocommerce-android/pull/7626 is approved

This PR changes the `granularity` id on `TopPerformerProducts` Entity in favour of `datePeriod`.
```
granularity -> datePeriod
```
The `granularity` id was introduced on [this PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2526/files) to provide better offline support for top performers products and reduce the loading "slowness". 
As part of the new changes we are introducing to support Analytics hub, we were in the need to allow merchants to query top performance products not only by our defined granularities but also by customs date ranges. The main idea of this PR is to change the `granularity` field that would have the format of `granularity=today` for a new format that would allow us to maintain the improvements on top performers products and extend the range of the query to periods outside the defined granularities. This new format is `datePeriod=$startDate-$endDate`

### Testing instructions
This PR can be tested alongside the changes from WooCommerce Android. Please follow the test instructions from https://github.com/woocommerce/woocommerce-android/pull/7626.

TC 2
Test the new DB Migraction:

1. Install the Woo version from branch `feature/analytics`
2. Change between different MyStore Tabs
3. Open the Database Inspector on Android Studio or Flipper and check that the TopPerformerProducts table has data and the granularity column is present
4. Install this new version
5. Check that the app doesn't crash, the old cached data is wiped and the new datePeriod column is present

| Old TopPerformerProducts   | New TopPerformerProducts |
| ------------- | ------------- |
| <img width="300"  src="https://user-images.githubusercontent.com/18119390/197874497-3138dd25-c71b-4bfb-80d1-7047ded61bdc.png">| <img width="300"  src="https://user-images.githubusercontent.com/18119390/197874500-17893f77-96cf-4096-9a1f-26719652749a.png">  |



