### PR TITLE
Add @Nullable annotation to AccountStore#getAccessToken 

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -1213,7 +1213,10 @@ public class AccountStore extends Store {
 
     /**
      * Should be used for very specific purpose (like forwarding the token to a Webview)
+     *
+     * @return the access token if it was already set, otherwise null
      */
+    @Nullable
     public String getAccessToken() {
         return mAccessToken.get();
     }


### PR DESCRIPTION
Adds `@Nullable` to `AccountStore#getAccessToken` method, so we get a compilation error when calling it from Kotlin.

Before:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/14964993/197650788-3ee19544-0498-4090-be39-b2dbf027b5b7.png">

After:
<img width="816" alt="image" src="https://user-images.githubusercontent.com/14964993/197650768-8c1e195c-02ec-4bf5-be48-9dc52b42409c.png">
