### PR TITLE
Release `1.56.1`

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.java
@@ -1,25 +1,20 @@
 package org.wordpress.android.fluxc.network;
 
 import android.content.Context;
-import android.webkit.WebView;
+import android.webkit.WebSettings;
 
 import org.wordpress.android.util.PackageUtils;
 
 public class UserAgent {
-    private String mUserAgent;
-    private String mDefaultUserAgent;
+    private final String mUserAgent;
+    private final String mDefaultUserAgent;
 
     public UserAgent(Context appContext, String appName) {
         // Device's default User-Agent string.
         // E.g.:
         //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
         //   AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
-        try {
-            mDefaultUserAgent = new WebView(appContext).getSettings().getUserAgentString();
-        } catch (RuntimeException re) {
-            mDefaultUserAgent = "Mozilla/5.0 (Linux; Android 6.0; default FluxC UA; wv) AppleWebKit/537.36"
-                    + "(KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36";
-        }
+        mDefaultUserAgent = WebSettings.getDefaultUserAgent(appContext);
         // User-Agent string when making HTTP connections, for both API traffic and WebViews.
         // Appends "wp-android/version" to WebView's default User-Agent string for the webservers
         // to get the full feature list of the browser and serve content accordingly, e.g.:


### PR DESCRIPTION
This release contains only a [hotfix](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2546), which has already been merged into the trunk.


