### PR TITLE
Allow passing `filterOptions` to `::searchProducts`

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -416,7 +416,8 @@ class ProductRestClient @Inject constructor(
                             error = productError,
                             site = site,
                             query = searchQuery,
-                            skuSearch = isSkuSearch
+                            skuSearch = isSkuSearch,
+                            filterOptions = filterOptions
                         )
                         dispatcher.dispatch(WCProductActionBuilder.newSearchedProductsAction(payload))
                     }
@@ -432,7 +433,8 @@ class ProductRestClient @Inject constructor(
         pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         offset: Int = 0,
         sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
-        excludedProductIds: List<Long>? = null
+        excludedProductIds: List<Long>? = null,
+        filterOptions: Map<ProductFilterOption, String>? = null
     ) {
         fetchProducts(
             site = site,
@@ -441,7 +443,9 @@ class ProductRestClient @Inject constructor(
             sortType = sorting,
             searchQuery = searchQuery,
             isSkuSearch = isSkuSearch,
-            excludedProductIds = excludedProductIds)
+            excludedProductIds = excludedProductIds,
+            filterOptions = filterOptions
+        )
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -104,7 +104,8 @@ class WCProductStore @Inject constructor(
         var pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         var offset: Int = 0,
         var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
-        var excludedProductIds: List<Long>? = null
+        var excludedProductIds: List<Long>? = null,
+        var filterOptions: Map<ProductFilterOption, String>? = null,
     ) : Payload<BaseNetworkError>()
 
     class FetchProductVariationsPayload(
@@ -416,12 +417,20 @@ class WCProductStore @Inject constructor(
         var products: List<WCProductModel> = emptyList(),
         var offset: Int = 0,
         var loadedMore: Boolean = false,
-        var canLoadMore: Boolean = false
+        var canLoadMore: Boolean = false,
+        var filterOptions: Map<ProductFilterOption, String>? = null
     ) : Payload<ProductError>() {
-        constructor(error: ProductError, site: SiteModel, query: String?, skuSearch: Boolean) : this(
+        constructor(
+            error: ProductError,
+            site: SiteModel,
+            query: String?,
+            skuSearch: Boolean,
+            filterOptions: Map<ProductFilterOption, String>?
+        ) : this(
             site = site,
             searchQuery = query,
-            isSkuSearch = skuSearch
+            isSkuSearch = skuSearch,
+            filterOptions = filterOptions
         ) {
             this.error = error
         }
@@ -1099,7 +1108,8 @@ class WCProductStore @Inject constructor(
                 pageSize = pageSize,
                 offset = offset,
                 sorting = sorting,
-                excludedProductIds = excludedProductIds
+                excludedProductIds = excludedProductIds,
+                filterOptions = filterOptions
             )
         }
     }


### PR DESCRIPTION
This PR adds optional param `filterOptions` to `ProductRestClient::searchProducts` function. 

The goal is to allow search and filter in a single operation in `woocommerce/woocommerce-android/` app.

Original issue: https://github.com/woocommerce/woocommerce-android/issues/3554

Target PR: https://github.com/woocommerce/woocommerce-android/pull/7696

Closes: https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/2555