### PR TITLE
Net revenue and average order value to interval subtotals

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -40,6 +40,10 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
         val ordersCount: Long? = null
         @SerializedName("total_sales")
         val totalSales: Double? = null
+        @SerializedName("net_revenue")
+        val netRevenue: Double? = null
+        @SerializedName("avg_order_value")
+        val avgOrderValue: Double? = null
     }
 
     /**


### PR DESCRIPTION
### Why
Calling the function  `getIntervalList()` from the `WCRevenueStatsModel` class deserializes the JSON revenues into a list of Interval objects. These Intervals objects contained only the `ordersCount` and `totalSales` information for the selected interval. 
As part of the new Analytics Hub feature, we also require the Intervals objects to retrieve the  `net revenue` and the `average order value` information to be able to display these values charts, as shown in the image below.

<img width="400" src="https://user-images.githubusercontent.com/18119390/199600743-217113b1-ee79-4493-92d2-386b6e451e90.png" />


### Description
This small PR adds the net revenue and average order value to the SubTotal class, so these values can be retrieved by the Interval class and consumed by the Analytics Hub.

### Testing instructions
This PR can be tested alongside the Woo PR