### PR TITLE
Update `minSdkVersion` (from `21` to `24`)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ allprojects {
 }
 
 ext {
-    minSdkVersion = 21
+    minSdkVersion = 24
     compileSdkVersion = 31
     targetSdkVersion = 31
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -44,7 +44,6 @@ android {
 
     lintOptions {
         warning 'InvalidPackage'
-        disable 'ExpiredTargetSdkVersion'
     }
 
     testOptions {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
@@ -1,11 +1,9 @@
 package org.wordpress.android.fluxc.mocked
 
-import android.os.Build
 import com.yarolegovich.wellsql.WellSql
 import org.greenrobot.eventbus.Subscribe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.TestUtils
@@ -55,11 +53,6 @@ class MockedStack_WCBaseStoreTest : MockedStack_Base() {
     // stubbed in a unit test environment, giving results inconsistent with a normal running app
     @Test
     fun testGetLocalizedCurrencySymbolForCode() {
-        assumeTrue(
-                "Requires API 23 or higher due to localized currency values differing on older versions",
-                Build.VERSION.SDK_INT >= 23
-        )
-
         Locale("en", "US").let { localeEnUS ->
             assertEquals("$", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("USD", localeEnUS))
             assertEquals("CA$", WCCurrencyUtils.getLocalizedCurrencySymbolForCode("CAD", localeEnUS))
@@ -84,11 +77,6 @@ class MockedStack_WCBaseStoreTest : MockedStack_Base() {
 
     @Test
     fun testGetSiteCurrency() {
-        assumeTrue(
-                "Requires API 23 or higher due to localized currency values differing on older versions",
-                Build.VERSION.SDK_INT >= 23
-        )
-
         // Override device locale and use en_US so currency symbols can be predicted
         TestUtils.updateLocale(mAppContext, Locale("en", "US"))
 
@@ -175,11 +163,6 @@ class MockedStack_WCBaseStoreTest : MockedStack_Base() {
 
     @Test
     fun testFormatCurrencyForDisplay() {
-        assumeTrue(
-                "Requires API 23 or higher due to localized currency values differing on older versions",
-                Build.VERSION.SDK_INT >= 23
-        )
-
         // Override device locale and use en_US so currency symbols can be predicted
         TestUtils.updateLocale(mAppContext, Locale("en", "US"))
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/OpenJdkCookieManager.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/OpenJdkCookieManager.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.network;
 
-import android.os.Build;
-
 import androidx.annotation.NonNull;
 
 import java.io.IOException;
@@ -83,7 +81,7 @@ public class OpenJdkCookieManager extends CookieManager {
             if (pathMatches(path, cookie.getPath()) &&
                     (secureLink || !cookie.getSecure())) {
                 // Enforce httponly attribute
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && cookie.isHttpOnly()) {
+                if (cookie.isHttpOnly()) {
                     String s = uri.getScheme();
                     if (!"http".equalsIgnoreCase(s) && !"https".equalsIgnoreCase(s)) {
                         continue;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -4,7 +4,6 @@ package org.wordpress.android.fluxc.persistence
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
-import android.os.Build
 import android.preference.PreferenceManager
 import android.view.Gravity
 import android.widget.Toast
@@ -1918,13 +1917,8 @@ open class WellSqlConfig : DefaultWellConfig {
         }
     }
 
-    @Suppress("CheckStyle")
     override fun onConfigure(db: SQLiteDatabase, helper: WellTableManager?) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            db.setForeignKeyConstraintsEnabled(true)
-        } else {
-            db.execSQL("PRAGMA foreign_keys=ON")
-        }
+        db.setForeignKeyConstraintsEnabled(true)
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards
 
-import android.annotation.TargetApi
-import android.os.Build
 import android.text.Html
 import android.text.SpannableStringBuilder
 import android.text.style.URLSpan
@@ -175,11 +173,9 @@ class LeaderboardProductItem(
             getSpans(0, length, URLSpan::class.java)
                     .toList()
 
-    @TargetApi(Build.VERSION_CODES.N)
-    private fun fromHtmlWithSafeApiCall(source: String?) = source
-            ?.takeIf { Build.VERSION.SDK_INT >= Build.VERSION_CODES.N }?.let {
-                Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY)
-            } ?: Html.fromHtml(source)
+    private fun fromHtmlWithSafeApiCall(source: String?) = source?.let {
+        Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY)
+    } ?: Html.fromHtml(source)
 
     /**
      * Returns the second object of the Top Performer Item Array if exists

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards
 import android.text.Html
 import android.text.SpannableStringBuilder
 import android.text.style.URLSpan
-import androidx.core.text.HtmlCompat
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.LeaderboardItemRow
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.PRODUCTS
 
@@ -85,7 +84,7 @@ class LeaderboardProductItem(
                 ?.split(";")
                 ?.filter { it.contains("&#") }
                 ?.reduce { total, new -> "$total$new" }
-                ?.run { HtmlCompat.fromHtml(this, HtmlCompat.FROM_HTML_MODE_LEGACY) }
+                ?.run { Html.fromHtml(this, Html.FROM_HTML_MODE_LEGACY) }
                 ?: plainTextCurrency
     }
 
@@ -106,7 +105,7 @@ class LeaderboardProductItem(
      *      Output: DKK
      */
     @Suppress("MaxLineLength") private val plainTextCurrency by lazy {
-        Html.fromHtml(priceAmountHtmlTag)
+        Html.fromHtml(priceAmountHtmlTag, Html.FROM_HTML_MODE_LEGACY)
                 .toString()
                 .replace(Regex("[0-9.,]"), "")
     }
@@ -151,7 +150,7 @@ class LeaderboardProductItem(
      * using the [SpannableStringBuilder] implementation in order to parse it
      */
     private val link by lazy {
-        Html.fromHtml(itemHtmlTag)
+        Html.fromHtml(itemHtmlTag, Html.FROM_HTML_MODE_LEGACY)
                 .run { this as? SpannableStringBuilder }
                 ?.spansAsList()
                 ?.firstOrNull()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
@@ -84,7 +84,7 @@ class LeaderboardProductItem(
                 ?.split(";")
                 ?.filter { it.contains("&#") }
                 ?.reduce { total, new -> "$total$new" }
-                ?.run { fromHtmlWithSafeApiCall(this) }
+                ?.run { Html.fromHtml(this) }
                 ?: plainTextCurrency
     }
 
@@ -105,7 +105,7 @@ class LeaderboardProductItem(
      *      Output: DKK
      */
     @Suppress("MaxLineLength") private val plainTextCurrency by lazy {
-        fromHtmlWithSafeApiCall(priceAmountHtmlTag)
+        Html.fromHtml(priceAmountHtmlTag)
                 .toString()
                 .replace(Regex("[0-9.,]"), "")
     }
@@ -150,7 +150,7 @@ class LeaderboardProductItem(
      * using the [SpannableStringBuilder] implementation in order to parse it
      */
     private val link by lazy {
-        fromHtmlWithSafeApiCall(itemHtmlTag)
+        Html.fromHtml(itemHtmlTag)
                 .run { this as? SpannableStringBuilder }
                 ?.spansAsList()
                 ?.firstOrNull()
@@ -172,10 +172,6 @@ class LeaderboardProductItem(
     private fun SpannableStringBuilder.spansAsList() =
             getSpans(0, length, URLSpan::class.java)
                     .toList()
-
-    private fun fromHtmlWithSafeApiCall(source: String?) = source?.let {
-        Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY)
-    } ?: Html.fromHtml(source)
 
     /**
      * Returns the second object of the Top Performer Item Array if exists

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardProductItem.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards
 import android.text.Html
 import android.text.SpannableStringBuilder
 import android.text.style.URLSpan
+import androidx.core.text.HtmlCompat
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.LeaderboardItemRow
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.PRODUCTS
 
@@ -84,7 +85,7 @@ class LeaderboardProductItem(
                 ?.split(";")
                 ?.filter { it.contains("&#") }
                 ?.reduce { total, new -> "$total$new" }
-                ?.run { Html.fromHtml(this) }
+                ?.run { HtmlCompat.fromHtml(this, HtmlCompat.FROM_HTML_MODE_LEGACY) }
                 ?: plainTextCurrency
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -88,7 +88,7 @@ include ':fluxc',
         ':tests:api'
 
 gradle.ext {
-    minSdkVersion = 21
+    minSdkVersion = 24
     compileSdkVersion = 31
     targetSdkVersion = 31
 }


### PR DESCRIPTION
This PR upgrades FluxC to `minSdkVersion` to `24`. This has been unblocked because:
- `WPAndroid` was already on `minSdkVersion = 24`, for some time now (see [here](https://github.com/wordpress-mobile/WordPress-Android/pull/15135)).
- `WCAndroid` has been recently upgraded to `minSdkVersion = 24` as well (see [here](https://github.com/woocommerce/woocommerce-android/pull/7643)).

-----

Warning (⚠️): This update is currently blocked by the common upgrade of `targetSdkVersion` to `31` (see [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2563)).

-----

As part of this `minSdkVersion = 24` upgrade the below changes were also applied in order to fix any additional warnings that this change brought-up:

Warnings Resolution List:

1. [Resolve obsolete sdk int lint warning for well sql config.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/986fc83303eb5472d38ff18a25982c17ceff64f5)
2. [Resolve obsolete sdk int lint warning for open jdk cookie mng.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/3400d7b0a8a6e33a3ca2c943a47107376be896c2)
3. [Resolve obsolete sdk int lint warning for leaderboard prd item.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/ea8f79dc9f1bd4a7977cbd0386f21f7caf4e0a2c)
4. [Resolve obsolete sdk int lint warning for mocked statck test.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/ef933c2349c6d66cc545aba6f03d0dfee1271694)

-----

PS: @hichamboushaba @ovitrif I added you as the main reviewers, that is, in addition to the @wordpress-mobile/apps-infrastructure team itself, but randomly, since I just wanted someone from both, the `WordPress` and `Woo Commerce` teams, to sign-off on that change for WPAndroid and WCAndroid alike.

-----

### Testing instructions

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could:
    - Quickly smoke test the `FluxC Example` app and see if it works as expected.
    - Try and install the `FluxC Example` app on Android 5 (`API 21/22`) and Android 6 (`API 23`) devices and verify that you can't (see [API Levels](https://apilevels.com/)).

-----

### Merge instructions

- [x] Wait for #2563 to be approved and merged to `trunk`.
- [x] Make sure this PR's base is automatically updated to `trunk`.
- [x] Update PR with latest `trunk`.
- [x] Remove `[PR] Not Ready For Merge]` label.
- [ ] Merge PR to `trunk`.