### PR TITLE
Add support for fetching plugins using Rest WPApi

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PluginsFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.fragment_notifications.*
 import kotlinx.android.synthetic.main.fragment_plugins.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -17,10 +16,10 @@ import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.PluginActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PluginStore
-import org.wordpress.android.fluxc.store.PluginStore.FetchJetpackSitePluginPayload
+import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload
-import org.wordpress.android.fluxc.store.PluginStore.OnJetpackSitePluginFetched
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginConfigured
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginFetched
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled
 import javax.inject.Inject
 
@@ -92,8 +91,11 @@ class PluginsFragment : Fragment() {
                     pluginNameText.text.toString().apply {
                         prependToLog("Fetching plugin: $this")
 
-                        val payload = FetchJetpackSitePluginPayload(site, this)
-                        dispatcher.dispatch(PluginActionBuilder.newFetchJetpackSitePluginAction(payload))
+                        val payload = FetchSitePluginPayload(
+                            site,
+                            this
+                        )
+                        dispatcher.dispatch(PluginActionBuilder.newFetchSitePluginAction(payload))
                     }
                 }
             } ?: prependToLog("Please select a site first.")
@@ -114,7 +116,7 @@ class PluginsFragment : Fragment() {
 
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onSitePluginFetched(event: OnJetpackSitePluginFetched) {
+    fun onSitePluginFetched(event: OnSitePluginFetched) {
         if (!event.isError) {
             prependToLog("${event.plugin.displayName}: ${event.plugin.description}")
         } else {

--- a/example/src/main/res/layout/activity_example.xml
+++ b/example/src/main/res/layout/activity_example.xml
@@ -21,7 +21,7 @@
 
         <LinearLayout
             android:id="@+id/fragment_container"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical" />
     </ScrollView>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -8,9 +8,9 @@ import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeleteSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.DeletedSitePluginPayload;
-import org.wordpress.android.fluxc.store.PluginStore.FetchJetpackSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginDirectoryPayload;
-import org.wordpress.android.fluxc.store.PluginStore.FetchedJetpackSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedPluginDirectoryPayload;
 import org.wordpress.android.fluxc.store.PluginStore.FetchedWPOrgPluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginPayload;
@@ -31,8 +31,8 @@ public enum PluginAction implements IAction {
     FETCH_PLUGIN_DIRECTORY,
     @Action(payloadType = String.class)
     FETCH_WPORG_PLUGIN,
-    @Action(payloadType = FetchJetpackSitePluginPayload.class)
-    FETCH_JETPACK_SITE_PLUGIN,
+    @Action(payloadType = FetchSitePluginPayload.class)
+    FETCH_SITE_PLUGIN,
     @Action(payloadType = InstallSitePluginPayload.class)
     INSTALL_SITE_PLUGIN,
     @Action(payloadType = SearchPluginDirectoryPayload.class)
@@ -49,8 +49,8 @@ public enum PluginAction implements IAction {
     FETCHED_PLUGIN_DIRECTORY,
     @Action(payloadType = FetchedWPOrgPluginPayload.class)
     FETCHED_WPORG_PLUGIN,
-    @Action(payloadType = FetchedJetpackSitePluginPayload.class)
-    FETCHED_JETPACK_SITE_PLUGIN,
+    @Action(payloadType = FetchedSitePluginPayload.class)
+    FETCHED_SITE_PLUGIN,
     @Action(payloadType = InstalledSitePluginPayload.class)
     INSTALLED_SITE_PLUGIN,
     @Action(payloadType = SearchedPluginDirectoryPayload.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequest.java
@@ -51,4 +51,5 @@ public class WPAPIGsonRequest<T> extends GsonRequest<T> {
         }
 
         return error;
-    }}
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
@@ -52,6 +52,22 @@ class PluginWPAPIRestClient @Inject constructor(
         }
     }
 
+    suspend fun fetchPlugin(
+        site: SiteModel,
+        nonce: Nonce?,
+        pluginName: String
+    ): WPApiPluginsPayload<SitePluginModel> {
+        val url = buildUrl(site, pluginName)
+        val response =
+            wpApiGsonRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = url,
+                clazz = PluginResponseModel::class.java,
+                nonce = nonce?.value
+            )
+        return handleResponse(response, site)
+    }
+
     suspend fun installPlugin(
         site: SiteModel,
         nonce: Nonce? = null,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -132,10 +132,7 @@ class PluginJetpackTunnelRestClient @Inject constructor(
                     }
                 },
                 { error ->
-
-                    val configurePluginError = ConfigureSitePluginError(
-                            error.apiError, error.message
-                    )
+                    val configurePluginError = ConfigureSitePluginError(error, active)
 
                     val payload = ConfiguredSitePluginPayload(site, pluginName, configurePluginError)
                     dispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload))

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -18,8 +18,6 @@ import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError
-import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType.GENERIC_ERROR
-import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType.PLUGIN_ALREADY_INSTALLED
 import org.wordpress.android.fluxc.store.PluginStore.InstalledSitePluginPayload
 import javax.inject.Inject
 import javax.inject.Named
@@ -33,10 +31,6 @@ class PluginJetpackTunnelRestClient @Inject constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    companion object {
-        private const val PLUGIN_ALREADY_EXISTS = "Destination folder already exists."
-    }
-
     /**
      * Fetch a plugin's information from a site.
      *
@@ -102,20 +96,7 @@ class PluginJetpackTunnelRestClient @Inject constructor(
                     }
                 },
                 { error ->
-                    val installError = when (error.message) {
-                        PLUGIN_ALREADY_EXISTS -> {
-                            InstallSitePluginError(
-                                    PLUGIN_ALREADY_INSTALLED,
-                                    error.message
-                            )
-                        }
-                        else -> {
-                            InstallSitePluginError(
-                                    GENERIC_ERROR,
-                                    error.message
-                            )
-                        }
-                    }
+                    val installError = InstallSitePluginError(error)
                     val payload = InstalledSitePluginPayload(site, pluginSlug, installError)
                     dispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(payload))
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -15,9 +15,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload
-import org.wordpress.android.fluxc.store.PluginStore.FetchPluginForJetpackSiteError
-import org.wordpress.android.fluxc.store.PluginStore.FetchPluginForJetpackSiteErrorType.PLUGIN_DOES_NOT_EXIST
-import org.wordpress.android.fluxc.store.PluginStore.FetchedJetpackSitePluginPayload
+import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginError
+import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginErrorType.PLUGIN_DOES_NOT_EXIST
+import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType.PLUGIN_ALREADY_INSTALLED
@@ -54,14 +54,21 @@ class PluginJetpackTunnelRestClient @Inject constructor(
                 PluginResponseModel::class.java,
                 { response: PluginResponseModel? ->
                     response?.let {
-                        val payload = FetchedJetpackSitePluginPayload(it.toDomainModel(site.id))
-                        dispatcher.dispatch(PluginActionBuilder.newFetchedJetpackSitePluginAction(payload))
+                        val payload = FetchedSitePluginPayload(
+                            it.toDomainModel(site.id)
+                        )
+                        dispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginAction(payload))
                     }
                 },
                 {
-                    val fetchError = FetchPluginForJetpackSiteError(PLUGIN_DOES_NOT_EXIST)
-                    val payload = FetchedJetpackSitePluginPayload(pluginName, fetchError)
-                    dispatcher.dispatch(PluginActionBuilder.newFetchedJetpackSitePluginAction(payload))
+                    val fetchError = FetchSitePluginError(
+                        PLUGIN_DOES_NOT_EXIST
+                    )
+                    val payload = FetchedSitePluginPayload(
+                        pluginName,
+                        fetchError
+                    )
+                    dispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginAction(payload))
                 },
                 { request: WPComGsonRequest<*> -> add(request) }
         )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginJetpackTunnelRestClient.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.store.PluginStore.ConfigureSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.ConfiguredSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginError
-import org.wordpress.android.fluxc.store.PluginStore.FetchSitePluginErrorType.PLUGIN_DOES_NOT_EXIST
 import org.wordpress.android.fluxc.store.PluginStore.FetchedSitePluginPayload
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginError
 import org.wordpress.android.fluxc.store.PluginStore.InstallSitePluginErrorType.GENERIC_ERROR
@@ -62,7 +61,8 @@ class PluginJetpackTunnelRestClient @Inject constructor(
                 },
                 {
                     val fetchError = FetchSitePluginError(
-                        PLUGIN_DOES_NOT_EXIST
+                        it.type,
+                        it.message
                     )
                     val payload = FetchedSitePluginPayload(
                         pluginName,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -104,6 +104,9 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
                         ConfigureSitePluginError configurePluginError = new ConfigureSitePluginError(
                                 networkError.apiError, networkError.message);
+                        if (networkError.hasVolleyError()) {
+                            configurePluginError.errorCode = networkError.volleyError.networkResponse.statusCode;
+                        }
                         ConfiguredSitePluginPayload payload =
                                 new ConfiguredSitePluginPayload(site, pluginName, slug, configurePluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newConfiguredSitePluginAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -155,6 +155,9 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
                         InstallSitePluginError installPluginError = new InstallSitePluginError(
                                 networkError.apiError, networkError.message);
+                        if (networkError.hasVolleyError()) {
+                            installPluginError.errorCode = networkError.volleyError.networkResponse.statusCode;
+                        }
                         InstalledSitePluginPayload payload = new InstalledSitePluginPayload(site, pluginSlug,
                                 installPluginError);
                         mDispatcher.dispatch(PluginActionBuilder.newInstalledSitePluginAction(payload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginCoroutineStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginCoroutineStore.kt
@@ -130,7 +130,7 @@ class PluginCoroutineStore
         val event = OnSitePluginConfigured(payload.site, pluginName, slug)
         val error = payload.error
         if (error != null) {
-            event.error = ConfigureSitePluginError(error.type, error.message, isActive)
+            event.error = ConfigureSitePluginError(error, isActive)
         } else {
             pluginSqlUtils.insertOrUpdateSitePlugin(site, payload.data)
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginCoroutineStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginCoroutineStore.kt
@@ -152,7 +152,7 @@ class PluginCoroutineStore
         val event = OnSitePluginInstalled(payload.site, payload.data?.slug ?: slug)
         val error = payload.error
         if (error != null) {
-            event.error = InstallSitePluginError(error.type, error.message)
+            event.error = InstallSitePluginError(error)
         } else {
             pluginSqlUtils.insertOrUpdateSitePlugin(site, payload.data)
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginCoroutineStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginCoroutineStore.kt
@@ -70,12 +70,11 @@ class PluginCoroutineStore
         }
         val error = payload.error
         return if (error != null) {
-            OnSitePluginFetched(
-                FetchedSitePluginPayload(
-                    pluginName,
-                    FetchSitePluginError(error.type, error.message)
-                )
-            )
+            val fetchError = FetchSitePluginError(error.type, error.message)
+            OnSitePluginFetched(FetchedSitePluginPayload(pluginName, fetchError))
+                .apply {
+                    this.error = fetchError
+                }
         } else {
             pluginSqlUtils.insertOrUpdateSitePlugin(site, payload.data)
             OnSitePluginFetched(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -297,6 +297,7 @@ public class PluginStore extends Store {
 
     public static class ConfigureSitePluginError implements OnChangedError {
         public ConfigureSitePluginErrorType type;
+        @Nullable public Integer errorCode;
         @Nullable public String message;
 
         ConfigureSitePluginError(ConfigureSitePluginErrorType type) {
@@ -308,9 +309,12 @@ public class PluginStore extends Store {
             this.message = message;
         }
 
-        public ConfigureSitePluginError(GenericErrorType type, @Nullable String message, boolean isActivating) {
-            this.type = ConfigureSitePluginErrorType.fromGenericErrorType(type, isActivating);
-            this.message = message;
+        public ConfigureSitePluginError(BaseNetworkError error, boolean isActivating) {
+            this.type = ConfigureSitePluginErrorType.fromGenericErrorType(error.type, isActivating);
+            this.message = error.message;
+            if (error.hasVolleyError()) {
+                this.errorCode = error.volleyError.networkResponse.statusCode;
+            }
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -562,7 +562,7 @@ public class PluginStore extends Store {
 
     public enum FetchSitePluginErrorType {
         UNAUTHORIZED,
-        NOT_JETPACK_SITE,
+        NOT_AVAILABLE,
         EMPTY_RESPONSE,
         GENERIC_ERROR,
         PLUGIN_DOES_NOT_EXIST;
@@ -962,7 +962,7 @@ public class PluginStore extends Store {
         } else if (!payload.site.isUsingWpComRestApi()){
             mPluginCoroutineStore.fetchWPApiPlugin(payload.site, payload.pluginName);
         } else {
-            FetchSitePluginError error = new FetchSitePluginError(FetchSitePluginErrorType.NOT_JETPACK_SITE, null);
+            FetchSitePluginError error = new FetchSitePluginError(FetchSitePluginErrorType.NOT_AVAILABLE, null);
             FetchedSitePluginPayload errorPayload =
                     new FetchedSitePluginPayload(payload.pluginName, error);
             mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginAction(errorPayload));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -378,7 +378,7 @@ public class PluginStore extends Store {
 
     public static class InstallSitePluginError implements OnChangedError {
         public InstallSitePluginErrorType type;
-        @Nullable  public Integer errorCode;
+        @Nullable public Integer errorCode;
         @Nullable public String message;
 
         InstallSitePluginError(InstallSitePluginErrorType type) {
@@ -606,7 +606,7 @@ public class PluginStore extends Store {
         PLUGIN_ALREADY_INSTALLED,
         UNAUTHORIZED;
 
-        private static final String  PLUGIN_ALREADY_EXISTS = "Destination folder already exists.";
+        private static final String PLUGIN_ALREADY_EXISTS = "Destination folder already exists.";
 
         public static InstallSitePluginErrorType fromString(String string) {
             if (string != null) {
@@ -969,7 +969,7 @@ public class PluginStore extends Store {
     private void fetchSitePlugin(FetchSitePluginPayload payload) {
         if (payload.site.isJetpackConnected() || payload.site.isJetpackCPConnected()) {
             mPluginJetpackTunnelRestClient.fetchPlugin(payload.site, payload.pluginName);
-        } else if (!payload.site.isUsingWpComRestApi()){
+        } else if (!payload.site.isUsingWpComRestApi()) {
             mPluginCoroutineStore.fetchWPApiPlugin(payload.site, payload.pluginName);
         } else {
             FetchSitePluginError error = new FetchSitePluginError(FetchSitePluginErrorType.NOT_AVAILABLE, null);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -79,11 +79,11 @@ public class PluginStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static class FetchJetpackSitePluginPayload extends Payload<BaseNetworkError> {
+    public static class FetchSitePluginPayload extends Payload<BaseNetworkError> {
         public SiteModel site;
         public String pluginName;
 
-        public FetchJetpackSitePluginPayload(SiteModel site, String pluginName) {
+        public FetchSitePluginPayload(SiteModel site, String pluginName) {
             this.site = site;
             this.pluginName = pluginName;
         }
@@ -223,15 +223,15 @@ public class PluginStore extends Store {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static class FetchedJetpackSitePluginPayload extends Payload<FetchPluginForJetpackSiteError> {
+    public static class FetchedSitePluginPayload extends Payload<FetchSitePluginError> {
         public SitePluginModel plugin;
         public String pluginName;
 
-        public FetchedJetpackSitePluginPayload(SitePluginModel plugin) {
+        public FetchedSitePluginPayload(SitePluginModel plugin) {
             this.plugin = plugin;
         }
 
-        public FetchedJetpackSitePluginPayload(String pluginName, FetchPluginForJetpackSiteError error) {
+        public FetchedSitePluginPayload(String pluginName, FetchSitePluginError error) {
             this.pluginName = pluginName;
             this.error = error;
         }
@@ -361,10 +361,10 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class FetchPluginForJetpackSiteError implements OnChangedError {
-        public FetchPluginForJetpackSiteErrorType type;
+    public static class FetchSitePluginError implements OnChangedError {
+        public FetchSitePluginErrorType type;
 
-        public FetchPluginForJetpackSiteError(FetchPluginForJetpackSiteErrorType type) {
+        public FetchSitePluginError(FetchSitePluginErrorType type) {
             this.type = type;
         }
     }
@@ -553,7 +553,7 @@ public class PluginStore extends Store {
         PLUGIN_DOES_NOT_EXIST
     }
 
-    public enum FetchPluginForJetpackSiteErrorType {
+    public enum FetchSitePluginErrorType {
         NOT_JETPACK_SITE,
         EMPTY_RESPONSE,
         GENERIC_ERROR,
@@ -715,11 +715,11 @@ public class PluginStore extends Store {
         }
     }
 
-    public static class OnJetpackSitePluginFetched extends OnChanged<FetchPluginForJetpackSiteError> {
+    public static class OnSitePluginFetched extends OnChanged<FetchSitePluginError> {
         public SitePluginModel plugin;
         public String pluginName;
 
-        public OnJetpackSitePluginFetched(FetchedJetpackSitePluginPayload payload) {
+        public OnSitePluginFetched(FetchedSitePluginPayload payload) {
             this.plugin = payload.plugin;
             this.pluginName = payload.pluginName;
         }
@@ -779,8 +779,8 @@ public class PluginStore extends Store {
             case FETCH_WPORG_PLUGIN:
                 fetchWPOrgPlugin((String) action.getPayload());
                 break;
-            case FETCH_JETPACK_SITE_PLUGIN:
-                fetchPluginForJetpackSite((FetchJetpackSitePluginPayload) action.getPayload());
+            case FETCH_SITE_PLUGIN:
+                fetchSitePlugin((FetchSitePluginPayload) action.getPayload());
                 break;
             case INSTALL_SITE_PLUGIN:
                 installSitePlugin((InstallSitePluginPayload) action.getPayload());
@@ -808,8 +808,8 @@ public class PluginStore extends Store {
             case FETCHED_WPORG_PLUGIN:
                 fetchedWPOrgPlugin((FetchedWPOrgPluginPayload) action.getPayload());
                 break;
-            case FETCHED_JETPACK_SITE_PLUGIN:
-                fetchedJetpackSitePlugin((FetchedJetpackSitePluginPayload) action.getPayload());
+            case FETCHED_SITE_PLUGIN:
+                fetchedSitePlugin((FetchedSitePluginPayload) action.getPayload());
                 break;
             case INSTALLED_SITE_PLUGIN:
                 installedSitePlugin((InstalledSitePluginPayload) action.getPayload());
@@ -924,16 +924,16 @@ public class PluginStore extends Store {
     /* Fetch a single plugin from a site, to get its information and whether it exists or not.
        Currently this is only supported on sites connected using Jetpack plugin or Jetpack Connection Package.
      */
-    private void fetchPluginForJetpackSite(FetchJetpackSitePluginPayload payload) {
+    private void fetchSitePlugin(FetchSitePluginPayload payload) {
         if (payload.site.isJetpackConnected() || payload.site.isJetpackCPConnected()) {
             mPluginJetpackTunnelRestClient.fetchPlugin(payload.site, payload.pluginName);
         } else {
-            FetchPluginForJetpackSiteError error = new FetchPluginForJetpackSiteError(
-                    FetchPluginForJetpackSiteErrorType.NOT_JETPACK_SITE
+            FetchSitePluginError error = new FetchSitePluginError(
+                    FetchSitePluginErrorType.NOT_JETPACK_SITE
             );
-            FetchedJetpackSitePluginPayload errorPayload =
-                    new FetchedJetpackSitePluginPayload(payload.pluginName, error);
-            mDispatcher.dispatch(PluginActionBuilder.newFetchedJetpackSitePluginAction(errorPayload));
+            FetchedSitePluginPayload errorPayload =
+                    new FetchedSitePluginPayload(payload.pluginName, error);
+            mDispatcher.dispatch(PluginActionBuilder.newFetchedSitePluginAction(errorPayload));
         }
     }
 
@@ -1041,8 +1041,8 @@ public class PluginStore extends Store {
         emitChange(event);
     }
 
-    private void fetchedJetpackSitePlugin(FetchedJetpackSitePluginPayload payload) {
-        OnJetpackSitePluginFetched event = new OnJetpackSitePluginFetched(payload);
+    private void fetchedSitePlugin(FetchedSitePluginPayload payload) {
+        OnSitePluginFetched event = new OnSitePluginFetched(payload);
         if (payload.isError()) {
             event.error = payload.error;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -959,6 +959,8 @@ public class PluginStore extends Store {
     private void fetchSitePlugin(FetchSitePluginPayload payload) {
         if (payload.site.isJetpackConnected() || payload.site.isJetpackCPConnected()) {
             mPluginJetpackTunnelRestClient.fetchPlugin(payload.site, payload.pluginName);
+        } else if (!payload.site.isUsingWpComRestApi()){
+            mPluginCoroutineStore.fetchWPApiPlugin(payload.site, payload.pluginName);
         } else {
             FetchSitePluginError error = new FetchSitePluginError(FetchSitePluginErrorType.NOT_JETPACK_SITE, null);
             FetchedSitePluginPayload errorPayload =


### PR DESCRIPTION
This PR adds the following changes to the PluginStore:

1. Adds support for fetching plugins using the WordPress REST API.
2. For plugin installation:
    i. Aligns the returned errors between the different network implementations.
    b. Expose the network error code in the error, to allow explaining to the user the cause of failure.

To keep the changes manageable, I decided to keep using the existing EventBus architecture.

This is needed for https://github.com/woocommerce/woocommerce-android/pull/7832

⚠️ Please don't merge until the above PR is approved.

#### Testing
1. Open the example app.
2. Sign in using the site credentials (enter the XMLRPC URL in the login form).
3. Open the Plugins screen.
4. Test installing a new plugin.
5. Confirm the installation works as expected.
6. Test re-installing the same plugin.
7. Confirm that the error message is correctly printed in the console.
8. Test fetching the plugin.
9. Confirm it works as expected.
