### PR TITLE
Containment fix for My Site > Comments crash with standalone JP plugins.

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
@@ -150,6 +150,74 @@ class CommentsXMLRPCClientTest {
     }
 
     @Test
+    fun `fetchCommentsPage returns error without crashing when username is null`() = test {
+        mockedResponse = """<?xml version="1.0" encoding="UTF-8"?>
+                            <methodResponse>
+                              <fault>
+                                <value>
+                                  <struct>
+                                    <member>
+                                      <name>faultCode</name>
+                                      <value><int>403</int></value>
+                                    </member>
+                                    <member>
+                                      <name>faultString</name>
+                                      <value><string>Incorrect username or password.</string></value>
+                                    </member>
+                                  </struct>
+                                </value>
+                              </fault>
+                            </methodResponse>
+        """
+
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any())).thenReturn(CommentError(GENERIC_ERROR, ""))
+        whenever(site.username).thenReturn(null)
+
+        val payload = xmlRpcClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isTrue
+    }
+
+    @Test
+    fun `fetchCommentsPage returns error without crashing when password is null`() = test {
+        mockedResponse = """<?xml version="1.0" encoding="UTF-8"?>
+                            <methodResponse>
+                              <fault>
+                                <value>
+                                  <struct>
+                                    <member>
+                                      <name>faultCode</name>
+                                      <value><int>403</int></value>
+                                    </member>
+                                    <member>
+                                      <name>faultString</name>
+                                      <value><string>Incorrect username or password.</string></value>
+                                    </member>
+                                  </struct>
+                                </value>
+                              </fault>
+                            </methodResponse>
+        """
+
+        whenever(commentErrorUtilsWrapper.networkToCommentError(any())).thenReturn(CommentError(GENERIC_ERROR, ""))
+        whenever(site.password).thenReturn(null)
+
+        val payload = xmlRpcClient.fetchCommentsPage(
+                site = site,
+                number = PAGE_LEN,
+                offset = 0,
+                status = APPROVED
+        )
+
+        assertThat(payload.isError).isTrue
+    }
+
+    @Test
     fun `pushComment returns pushed comment`() = test {
         mockedResponse = """
             <?xml version="1.0" encoding="UTF-8"?>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -54,8 +54,8 @@ class CommentsXMLRPCClient @Inject constructor(
         }
 
         params.add(site.selfHostedSiteId)
-        params.add(site.username)
-        params.add(site.password)
+        params.add(site.notNullUserName())
+        params.add(site.notNullPassword())
         params.add(commentParams)
 
         val response = xmlrpcRequestBuilder.syncGetRequest(
@@ -105,8 +105,8 @@ class CommentsXMLRPCClient @Inject constructor(
         val params: MutableList<Any> = ArrayList()
 
         params.add(site.selfHostedSiteId)
-        params.add(site.username)
-        params.add(site.password)
+        params.add(site.notNullUserName())
+        params.add(site.notNullPassword())
         params.add(comment.remoteCommentId)
         params.add(commentParams)
 
@@ -132,8 +132,8 @@ class CommentsXMLRPCClient @Inject constructor(
         val params: MutableList<Any> = ArrayList()
 
         params.add(site.selfHostedSiteId)
-        params.add(site.username)
-        params.add(site.password)
+        params.add(site.notNullUserName())
+        params.add(site.notNullPassword())
         params.add(remoteCommentId)
 
         val response = xmlrpcRequestBuilder.syncGetRequest(
@@ -158,8 +158,8 @@ class CommentsXMLRPCClient @Inject constructor(
         val params: MutableList<Any> = ArrayList()
 
         params.add(site.selfHostedSiteId)
-        params.add(site.username)
-        params.add(site.password)
+        params.add(site.notNullUserName())
+        params.add(site.notNullPassword())
         params.add(remoteCommentId)
 
         val response = xmlrpcRequestBuilder.syncGetRequest(
@@ -241,8 +241,8 @@ class CommentsXMLRPCClient @Inject constructor(
         val params: MutableList<Any> = ArrayList()
 
         params.add(site.selfHostedSiteId)
-        params.add(site.username)
-        params.add(site.password)
+        params.add(site.notNullUserName())
+        params.add(site.notNullPassword())
         params.add(remotePostId)
         params.add(commentParams)
 
@@ -282,4 +282,14 @@ class CommentsXMLRPCClient @Inject constructor(
             else -> "approve"
         }
     }
+
+    // This functions are part of a containment fix to avoid a crash happening in the Jetpack app for My Site > Comments
+    // on self-hosted sites not having the full Jetpack plugin but only one of the standalone plugins (like the
+    // jetpack backup plugin). This only avoids the crash allowing the relevant error to be displayed.
+    // For sites like those, the full rest api is not available but the username and password are actually null as well.
+    // This creates some not consistent behaviours in various areas of the app that needs a more broad fix and review
+    // (more details in the internal p2 post and comments pe8j1f-V-p2); numbers of such cases are pretty low actually
+    // and this fix prioritizes the mentioned crash.
+    private fun SiteModel.notNullUserName() = this.username ?: ""
+    private fun SiteModel.notNullPassword() = this.password ?: ""
 }


### PR DESCRIPTION
This has a companion WordPress android PR [here](https://github.com/wordpress-mobile/WordPress-Android/pull/17456) 

This PR is part of a containment fix to avoid a crash happening in the Jetpack app for My Site > Comments on self-hosted sites not having the full Jetpack plugin but only one of the standalone plugins (like the jetpack backup plugin). This only avoids the crash allowing the relevant error to be displayed. For sites like those, the full rest api is not available but the username and password are actually null as well. This creates some not consistent behaviors in various areas of the app that need a more broad fix and review (more details in the internal p2 post and comments pe8j1f-V-p2); numbers of such cases are pretty low currently and this fix prioritizes the mentioned crash.

NOTE: the issue is only present in the JP app since the WP app was already filtering out the standalone JP plugin sites from the list of sites.

## To test

Prerequisite: install the JP backup plugin on a self-hosted site

### Replicate
- Install the JP app from WP Mobile trunk, and Login with the same user used to connect the backup plugin
- Select the backup plugin site from the list
- Go to My Site > Comments and notice the following crash in logcat `java.lang.NullPointerException: site.username must not be null`

### Check the fix
- Login in the WP app with the same user used to connect the backup plugin and notice the site IS NOT in the list of sites since it's filtered out
- Login in the JP app with the same user used to connect the backup plugin and notice the site IS in the list of sites
- Select the backup plugin site from the list
- Go to My Site > Comments, also move in between the different tabs and notice the crash is not happening and an error message for wrong username and password is displayed (since those fields are actually null/empty)
