### PR TITLE
Issue/7857 generate product variants

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragme
 import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooAddonsTestFragment
+import org.wordpress.android.fluxc.example.ui.products.WooBatchGenerateVariationsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooBatchUpdateVariationsFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductAttributeFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesFragment
@@ -104,6 +105,9 @@ internal interface FragmentsModule {
 
     @ContributesAndroidInjector
     fun provideWooBatchUpdateVariationsFragmentInjector(): WooBatchUpdateVariationsFragment
+
+    @ContributesAndroidInjector
+    fun provideWooBatchGenerateVariationsFragmentInjector(): WooBatchGenerateVariationsFragment
 
     @ContributesAndroidInjector
     fun provideWooProductFiltersFragmentInjector(): WooProductFiltersFragment

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchGenerateVariationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchGenerateVariationsFragment.kt
@@ -1,0 +1,195 @@
+package org.wordpress.android.fluxc.example.ui.products
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_woo_batch_generate_variations.*
+import kotlinx.android.synthetic.main.fragment_woo_batch_update_variations.product_id
+import kotlinx.android.synthetic.main.fragment_woo_batch_update_variations.status
+import kotlinx.android.synthetic.main.fragment_woo_batch_update_variations.update_product_info
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsApiResponse
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.BatchGenerateVariationsPayload
+import org.wordpress.android.fluxc.store.WCProductStore.BatchGenerateVariationsPayload.Builder
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class WooBatchGenerateVariationsFragment : Fragment() {
+    @Inject internal lateinit var wcProductStore: WCProductStore
+    @Inject internal lateinit var wooCommerceStore: WooCommerceStore
+
+    private var selectedSitePosition: Int = -1
+
+    private lateinit var generateVariationsPayloadBuilder: Builder
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        arguments?.let {
+            selectedSitePosition = it.getInt(ARG_SELECTED_SITE_POS, 0)
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
+        inflater.inflate(layout.fragment_woo_batch_generate_variations, container, false)
+
+    @Suppress("LongMethod")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        enableVariationModificationInputs(false)
+        update_product_info.setOnClickListener {
+            val site = wooCommerceStore.getWooCommerceSites().getOrNull(selectedSitePosition)
+            if (site == null) {
+                prependToLog("No valid site found...doing nothing")
+                return@setOnClickListener
+            }
+
+            val productId = product_id.getText().toLongOrNull()
+            if (productId == null) {
+                prependToLog("Product with id is empty or has wrong format...doing nothing")
+                return@setOnClickListener
+            }
+            val product = wcProductStore.getProductByRemoteId(site, productId)
+            if (product == null) {
+                prependToLog("Product with id: $productId not found in DB. Did you forget to fetch?...doing nothing")
+                return@setOnClickListener
+            }
+
+            status.text = "Selected product: $productId"
+
+            generateVariationsPayloadBuilder = Builder(site, productId)
+
+            enableVariationModificationInputs(true)
+        }
+        add_attribute.setOnClickListener {
+            val attrId = attr_id.getText().toLongOrNull()
+            val attrName = attr_name.getText()
+            val attrOption = attr_option.getText()
+
+            attr_id.setText("")
+            attr_name.setText("")
+            attr_option.setText("")
+
+            if (attrId == null || attrName.isEmpty()) {
+                prependToLog("Invalid attribute params...doing nothing")
+                return@setOnClickListener
+            }
+            generateVariationsPayloadBuilder.addVariationAttribute(attrId, attrName, attrOption)
+            displayAttributes()
+        }
+        add_variation.setOnClickListener {
+            generateVariationsPayloadBuilder.addVariation()
+            displayVariations()
+            displayAttributes()
+        }
+
+        generate_variation.setOnClickListener {
+            runBatchCreate(generateVariationsPayloadBuilder.build())
+        }
+    }
+
+    private fun displayVariations() {
+        val variationsString = variationsToString(
+            generateVariationsPayloadBuilder.getVariations()
+        )
+        variation_status.text = if (variationsString.isNotEmpty()) {
+            "Current variations: \n $variationsString"
+        } else {
+            ""
+        }
+    }
+
+    private fun displayAttributes() {
+        val currentAttributesString = attributesToString(
+            generateVariationsPayloadBuilder.getCurrentAttributes()
+        )
+        attr_status.text = if (currentAttributesString.isNotEmpty()) {
+            "Current attribute: \n $currentAttributesString"
+        } else {
+            ""
+        }
+    }
+
+    private fun variationsToString(variations: List<List<Map<String, Any>>>): String {
+        val stringBuffer = StringBuffer()
+        variations.forEach { attributes ->
+            attributes.forEach {
+                stringBuffer.append(it.values.toString())
+                stringBuffer.append("  ")
+            }
+            stringBuffer.append("\n")
+        }
+        return stringBuffer.toString()
+    }
+
+    private fun attributesToString(attribute: List<Map<String, Any>>): String {
+        val stringBuffer = StringBuffer()
+        attribute.forEach {
+            stringBuffer.append(it.values.toString())
+            stringBuffer.append("\n")
+        }
+        return stringBuffer.toString()
+    }
+
+    private fun runBatchCreate(payload: BatchGenerateVariationsPayload) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            val result: WooResult<BatchProductVariationsApiResponse> =
+                wcProductStore.batchGenerateVariations(payload)
+
+            withContext(Dispatchers.Main) {
+                if (result.isError) {
+                    prependToLog("Error: ${result.error.message}")
+                } else {
+                    val count = result.model?.createdVariations?.count() ?: 0
+                    prependToLog("Success: $count variations created")
+                }
+                // reset product selection
+                product_id.setText("")
+                status.text = ""
+                variation_status.text = ""
+                attr_status.text = ""
+                enableVariationModificationInputs(false)
+            }
+        }
+    }
+
+    private fun enableVariationModificationInputs(value: Boolean) {
+        attr_id.isEnabled = value
+        attr_name.isEnabled = value
+        attr_option.isEnabled = value
+        add_attribute.isEnabled = value
+        add_variation.isEnabled = value
+        generate_variation.isEnabled = value
+    }
+
+    companion object {
+        const val ARG_SELECTED_SITE_POS = "ARG_SELECTED_SITE_POS"
+
+        fun newInstance(selectedSitePosition: Int): WooBatchGenerateVariationsFragment {
+            val fragment = WooBatchGenerateVariationsFragment()
+            val args = Bundle()
+            args.putInt(ARG_SELECTED_SITE_POS, selectedSitePosition)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooBatchUpdateVariationsFragment.kt
@@ -19,7 +19,7 @@ import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.ListSelectorDialog
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsUpdateApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.BatchUpdateVariationsPayload
@@ -173,7 +173,7 @@ class WooBatchUpdateVariationsFragment : Fragment() {
 
     private fun runBatchUpdate(payload: BatchUpdateVariationsPayload) {
         lifecycleScope.launch(Dispatchers.IO) {
-            val result: WooResult<BatchProductVariationsUpdateApiResponse> =
+            val result: WooResult<BatchProductVariationsApiResponse> =
                 wcProductStore.batchUpdateVariations(payload)
 
             withContext(Dispatchers.Main) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -570,6 +570,10 @@ class WooProductsFragment : StoreSelectingFragment() {
         batch_update_variations.setOnClickListener {
             replaceFragment(WooBatchUpdateVariationsFragment.newInstance(selectedPos))
         }
+
+        batch_generate_variations.setOnClickListener{
+            replaceFragment(WooBatchGenerateVariationsFragment.newInstance(selectedPos))
+        }
     }
 
     /**

--- a/example/src/main/res/layout/fragment_woo_batch_generate_variations.xml
+++ b/example/src/main/res/layout/fragment_woo_batch_generate_variations.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="12dp"
+    tools:context="org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment"
+    tools:ignore="HardcodedText">
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/product_id"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="true"
+        android:inputType="textMultiLine"
+        android:lines="2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:textHint="Remote product ID" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/update_product_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Set up product ID 💾"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/product_id" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:textColor="#00f"
+        app:layout_constraintTop_toBottomOf="@+id/update_product_info"
+        tools:text="Selected product ID: 123456" />
+
+    <View
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#eee"
+        app:layout_constraintTop_toBottomOf="@+id/status"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/attr_status"/>
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/attr_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:text="Attributes"
+        android:layout_marginStart="8dp"
+        app:layout_constraintTop_toBottomOf="@+id/status"
+        app:layout_constraintStart_toStartOf="parent"
+        />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/attr_id"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="number"
+        android:lines="1"
+        android:layout_marginStart="8dp"
+        app:layout_constraintEnd_toStartOf="@+id/attr_name"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/attr_label"
+        app:textHint="Id" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/attr_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textCapWords"
+        android:lines="1"
+        app:layout_constraintEnd_toStartOf="@+id/attr_option"
+        app:layout_constraintStart_toEndOf="@+id/attr_id"
+        app:layout_constraintTop_toTopOf="@+id/attr_id"
+        app:textHint="Name" />
+
+    <org.wordpress.android.fluxc.example.ui.FloatingLabelEditText
+        android:id="@+id/attr_option"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:inputType="textCapWords"
+        android:lines="1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/attr_name"
+        app:layout_constraintTop_toTopOf="@+id/attr_id"
+        app:textHint="Option" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/add_attribute"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add attribute 💾"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/attr_option" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/attr_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginBottom="18dp"
+        android:textColor="#00f"
+        app:layout_constraintTop_toBottomOf="@+id/add_attribute"
+        tools:text="Current Attributes:\n[1,Size, L]\n[2,Color, Blue]" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/add_variation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add variation 💾"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/attr_status" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/variation_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginBottom="18dp"
+        android:textColor="#00f"
+        app:layout_constraintTop_toBottomOf="@+id/add_variation"
+        tools:text="Current Variations:\n[4,Size, M] [5,Color, Red] \n[6,Size, L] [7,Color, Green]" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/generate_variation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="generate variations 🚀"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/variation_status" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -229,5 +229,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Batch update variations"/>
+
+        <Button
+            android:id="@+id/batch_generate_variations"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Batch generate variations"/>
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -378,9 +379,7 @@ class WCProductStoreTest {
                 product.remoteProductId,
                 variationsIds
             ).build()
-            val response = BatchProductVariationsApiResponse().apply {
-                updatedVariations = emptyList()
-            }
+            val response = BatchProductVariationsApiResponse(updatedVariations = emptyList())
             whenever(
                 productRestClient.batchUpdateVariations(
                     any(),
@@ -462,9 +461,7 @@ class WCProductStoreTest {
                     sale_price = newSalePrice
                 }
             }
-            val response = BatchProductVariationsApiResponse().apply {
-                updatedVariations = variationsReturnedFromBackend
-            }
+            val response = BatchProductVariationsApiResponse(updatedVariations = variationsReturnedFromBackend)
             whenever(
                 productRestClient.batchUpdateVariations(
                     any(),
@@ -601,28 +598,32 @@ class WCProductStoreTest {
             // given
             val productId = 6L
             val site = SiteModel()
+            val firstVariationAttributes = listOf(
+                ProductVariantOption( id = 1, name = "Size", option = "L"),
+                ProductVariantOption( id = 2, name = "Color", option = "Blue"),
+            )
+            val secondVariationAttributes = listOf(
+                ProductVariantOption( id = 1, name = "Size", option = "L"),
+                ProductVariantOption( id = 2, name = "Color", option = "Red"),
+            )
+
+            val variations = listOf(firstVariationAttributes,secondVariationAttributes)
 
             // when API call succeed
-            val variationsPayload = BatchGenerateVariationsPayload.Builder(
+            val variationsPayload = BatchGenerateVariationsPayload(
                 site,
-                productId
-            ).run {
-                addVariationAttribute(0, "Size", "M")
-                addVariation()
-
-                addVariationAttribute(0, "Size", "L")
-                addVariation()
-
-                build()
-            }
+                productId,
+                variations
+            )
 
             val createdVariationsResponse = List(variationsPayload.variations.size) { index ->
                 ProductVariationApiResponse().apply { id = index.toLong() }
             }
 
-            val response = BatchProductVariationsApiResponse().apply {
+            val response = BatchProductVariationsApiResponse(
                 createdVariations = createdVariationsResponse
-            }
+            )
+
             whenever(
                 productRestClient.batchUpdateVariations(
                     any(),
@@ -651,20 +652,22 @@ class WCProductStoreTest {
             // given
             val productId = 6L
             val site = SiteModel()
+            val firstVariationAttributes = listOf(
+                ProductVariantOption( id = 1, name = "Size", option = "L"),
+                ProductVariantOption( id = 2, name = "Color", option = "Blue"),
+            )
+            val secondVariationAttributes = listOf(
+                ProductVariantOption( id = 1, name = "Size", option = "L"),
+                ProductVariantOption( id = 2, name = "Color", option = "Red"),
+            )
+            val variations = listOf(firstVariationAttributes,secondVariationAttributes)
 
-            // when API call fails
-            val variationsPayload = BatchGenerateVariationsPayload.Builder(
+            // when API call failed
+            val variationsPayload = BatchGenerateVariationsPayload(
                 site,
-                productId
-            ).run {
-                addVariationAttribute(0, "Size", "M")
-                addVariation()
-
-                addVariationAttribute(0, "Size", "L")
-                addVariation()
-
-                build()
-            }
+                productId,
+                variations
+            )
 
             val errorResponse = WooError(GENERIC_ERROR, NETWORK_ERROR, "🔴")
             whenever(

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -9,6 +9,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -28,7 +29,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsUpdateApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductVariationApiResponse
@@ -376,15 +377,16 @@ class WCProductStoreTest {
                 product.remoteProductId,
                 variationsIds
             ).build()
-            val response = BatchProductVariationsUpdateApiResponse().apply {
+            val response = BatchProductVariationsApiResponse().apply {
                 updatedVariations = emptyList()
             }
             whenever(
                 productRestClient.batchUpdateVariations(
                     any(),
                     any(),
+                    anyOrNull(),
                     any(),
-                    any()
+                    anyOrNull()
                 )
             ) doReturn WooPayload(response)
             val result = productStore.batchUpdateVariations(variationsUpdatePayload)
@@ -417,8 +419,9 @@ class WCProductStoreTest {
                 productRestClient.batchUpdateVariations(
                     any(),
                     any(),
+                    anyOrNull(),
                     any(),
-                    any()
+                    anyOrNull()
                 )
             ) doReturn WooPayload(errorResponse)
             val result = productStore.batchUpdateVariations(variationsUpdatePayload)
@@ -458,15 +461,16 @@ class WCProductStoreTest {
                     sale_price = newSalePrice
                 }
             }
-            val response = BatchProductVariationsUpdateApiResponse().apply {
+            val response = BatchProductVariationsApiResponse().apply {
                 updatedVariations = variationsReturnedFromBackend
             }
             whenever(
                 productRestClient.batchUpdateVariations(
                     any(),
                     any(),
+                    anyOrNull(),
                     any(),
-                    any()
+                    anyOrNull()
                 )
             ) doReturn WooPayload(response)
             val result = productStore.batchUpdateVariations(variationsUpdatePayload)
@@ -511,8 +515,9 @@ class WCProductStoreTest {
                 productRestClient.batchUpdateVariations(
                     any(),
                     any(),
+                    anyOrNull(),
                     any(),
-                    any()
+                    anyOrNull()
                 )
             ) doReturn WooPayload(errorResponse)
             val result = productStore.batchUpdateVariations(variationsUpdatePayload)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -8,12 +8,15 @@ import com.yarolegovich.wellsql.core.Identifiable
 import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
+import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
 import org.wordpress.android.fluxc.network.utils.getLong
 import org.wordpress.android.fluxc.network.utils.getString
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.lang.IllegalStateException
+
+typealias VariationAttributes = List<ProductVariantOption>
 
 /**
  * Product variations - see http://woocommerce.github.io/woocommerce-rest-api-docs/#product-variations

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/BatchProductVariationsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/BatchProductVariationsApiResponse.kt
@@ -6,7 +6,11 @@ import org.wordpress.android.fluxc.network.Response
 /**
  * Representation of Batch Update Product Variations API response.
  */
-class BatchProductVariationsUpdateApiResponse : Response {
+class BatchProductVariationsApiResponse : Response {
+    @SerializedName("create")
+    var createdVariations: List<ProductVariationApiResponse>? = null
     @SerializedName("update")
     var updatedVariations: List<ProductVariationApiResponse>? = null
+    @SerializedName("delete")
+    var deletedVariations: List<Long>? = null
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/BatchProductVariationsApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/BatchProductVariationsApiResponse.kt
@@ -6,11 +6,8 @@ import org.wordpress.android.fluxc.network.Response
 /**
  * Representation of Batch Update Product Variations API response.
  */
-class BatchProductVariationsApiResponse : Response {
-    @SerializedName("create")
-    var createdVariations: List<ProductVariationApiResponse>? = null
-    @SerializedName("update")
-    var updatedVariations: List<ProductVariationApiResponse>? = null
-    @SerializedName("delete")
-    var deletedVariations: List<Long>? = null
-}
+data class BatchProductVariationsApiResponse(
+    @SerializedName("create") val createdVariations: List<ProductVariationApiResponse>? = null,
+    @SerializedName("update") val updatedVariations: List<ProductVariationApiResponse>? = null,
+    @SerializedName("delete") val deletedVariations: List<Long>? = null
+) : Response

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -962,12 +962,7 @@ class ProductRestClient @Inject constructor(
                     putIfNotNull("delete" to deleteVariations)
                 }
 
-                if (body.isEmpty()) {
-                    throw IllegalArgumentException(
-                        "At least one of createVariations, updateVariations or deleteVariations" +
-                            " should not be null"
-                    )
-                }
+                require(body.isNotEmpty())
 
                 jetpackTunnelGsonRequestBuilder.syncPostRequest(
                     this@ProductRestClient,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -172,6 +172,43 @@ class WCProductStore @Inject constructor(
         val variation: WCProductVariationModel
     ) : Payload<BaseNetworkError>()
 
+    class BatchGenerateVariationsPayload(
+        val site: SiteModel,
+        val remoteProductId: Long,
+        val variations: List<List<Map<String, Any>>>
+    ) : Payload<BaseNetworkError>() {
+        class Builder(
+            private val site: SiteModel,
+            private val remoteProductId: Long
+        ) {
+            private val variations = mutableListOf<List<Map<String, Any>>>()
+            fun getVariations() = variations.toList()
+
+            private val currentAttributes = mutableListOf<Map<String, Any>>()
+            fun getCurrentAttributes() = currentAttributes.toList()
+
+            fun addVariationAttribute(id: Long, name: String, option: String) {
+                currentAttributes.add( buildMap {
+                    put("id", id)
+                    put("name", name)
+                    put("option", option)
+                })
+            }
+
+            fun addVariation() {
+                if(currentAttributes.isEmpty()) return
+                variations.add(currentAttributes.toList())
+                currentAttributes.clear()
+            }
+
+            fun build() = BatchGenerateVariationsPayload(
+                site = site,
+                remoteProductId = remoteProductId,
+                variations = variations
+            )
+        }
+    }
+
     /**
      * Payload used by [batchUpdateVariations] function.
      *
@@ -1273,6 +1310,44 @@ class WCProductStore @Inject constructor(
             }
         }
     }
+
+    /**
+     * Batch create variations on the backend and save result locally.
+     * For each variant, it only receives the list of attributes. The rest of the variant properties
+     * will use the default values.
+     *
+     * @param payload Instance of [BatchGenerateVariationsPayload]. It can be produced using
+     * [BatchGenerateVariationsPayload.Builder] class.
+     */
+    suspend fun batchGenerateVariations(payload: BatchGenerateVariationsPayload):
+        WooResult<BatchProductVariationsApiResponse> =
+        coroutineEngine.withDefaultContext(API, this, "batchCreateVariations") {
+            val createVariations = payload.variations.map {
+                buildMap { put("attributes", it) }
+            }
+
+            with(payload) {
+                val result: WooPayload<BatchProductVariationsApiResponse> =
+                    wcProductRestClient.batchUpdateVariations(
+                        site = site,
+                        productId = remoteProductId,
+                        createVariations = createVariations
+                    )
+
+                return@withDefaultContext if (result.isError) {
+                    WooResult(result.error)
+                } else {
+                    val generatedVariations = result.result?.createdVariations?.map { response ->
+                        response.asProductVariationModel().apply {
+                            remoteProductId = payload.remoteProductId
+                            localSiteId = payload.site.id
+                        }
+                    } ?: emptyList()
+                    ProductSqlUtils.insertOrUpdateProductVariations(generatedVariations)
+                    WooResult(result.result)
+                }
+            }
+        }
 
     /**
      * Batch updates variations on the backend and updates variations locally after successful request.

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -31,7 +31,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.mappers.MappingRemoteException
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.addons.mappers.RemoteAddonMapper
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsUpdateApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.BatchProductVariationsApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
@@ -1281,15 +1281,18 @@ class WCProductStore @Inject constructor(
      * [BatchUpdateVariationsPayload.Builder] class.
      */
     suspend fun batchUpdateVariations(payload: BatchUpdateVariationsPayload):
-        WooResult<BatchProductVariationsUpdateApiResponse> =
+        WooResult<BatchProductVariationsApiResponse> =
         coroutineEngine.withDefaultContext(API, this, "batchUpdateVariations") {
             with(payload) {
-                val result: WooPayload<BatchProductVariationsUpdateApiResponse> =
+                val updateVariations: List<Map<String, Any>> = remoteVariationsIds.map { variationId ->
+                    modifiedProperties.toMutableMap()
+                        .also { properties -> properties["id"] = variationId }
+                }
+                val result: WooPayload<BatchProductVariationsApiResponse> =
                     wcProductRestClient.batchUpdateVariations(
-                        site,
-                        remoteProductId,
-                        remoteVariationsIds,
-                        modifiedProperties
+                        site = site,
+                        productId = remoteProductId,
+                        updateVariations = updateVariations
                     )
 
                 return@withDefaultContext if (result.isError) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.fluxc.action.WCProductAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.domain.Addon
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.VariationAttributes
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
@@ -175,39 +176,8 @@ class WCProductStore @Inject constructor(
     class BatchGenerateVariationsPayload(
         val site: SiteModel,
         val remoteProductId: Long,
-        val variations: List<List<Map<String, Any>>>
-    ) : Payload<BaseNetworkError>() {
-        class Builder(
-            private val site: SiteModel,
-            private val remoteProductId: Long
-        ) {
-            private val variations = mutableListOf<List<Map<String, Any>>>()
-            fun getVariations() = variations.toList()
-
-            private val currentAttributes = mutableListOf<Map<String, Any>>()
-            fun getCurrentAttributes() = currentAttributes.toList()
-
-            fun addVariationAttribute(id: Long, name: String, option: String) {
-                currentAttributes.add( buildMap {
-                    put("id", id)
-                    put("name", name)
-                    put("option", option)
-                })
-            }
-
-            fun addVariation() {
-                if(currentAttributes.isEmpty()) return
-                variations.add(currentAttributes.toList())
-                currentAttributes.clear()
-            }
-
-            fun build() = BatchGenerateVariationsPayload(
-                site = site,
-                remoteProductId = remoteProductId,
-                variations = variations
-            )
-        }
-    }
+        val variations: List<VariationAttributes>
+    ) : Payload<BaseNetworkError>()
 
     /**
      * Payload used by [batchUpdateVariations] function.
@@ -1316,8 +1286,7 @@ class WCProductStore @Inject constructor(
      * For each variant, it only receives the list of attributes. The rest of the variant properties
      * will use the default values.
      *
-     * @param payload Instance of [BatchGenerateVariationsPayload]. It can be produced using
-     * [BatchGenerateVariationsPayload.Builder] class.
+     * @param payload Instance of [BatchGenerateVariationsPayload].
      */
     suspend fun batchGenerateVariations(payload: BatchGenerateVariationsPayload):
         WooResult<BatchProductVariationsApiResponse> =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/MapExt.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/MapExt.kt
@@ -6,3 +6,9 @@ fun <T> MutableMap<T, String>.putIfNotEmpty(vararg pairs: Pair<T, String?>) = ap
                 ?.let { put(pair.first, it) }
     }
 }
+
+fun <T, K> MutableMap<T, K>.putIfNotNull(vararg pairs: Pair<T, K?>) = apply {
+    pairs.forEach { pair ->
+        pair.second?.let { put(pair.first, it) }
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/7857

### Why
We need to be able to create many variations for the Generate all combinations of variations project.
Creating all the variations in one request is the solution we agreed on after discussion, taking into account that it is fast and makes good use of resources. To achieve this solution, we'll use this endpoint from Woo REST API: https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-product-variations.

### Description
This PR adds support to create product variations using the batch-update-product-variations endpoint. It accomplishes its goal by modifying the batchUpdateVariations function and adding the missing parameters to match the API request. It also adds a UI to the FluxC example app to make it easier to test the request.

### Testing instructions

1. Open the FluxC example app
2. Tap on Woo
3. Tap on Select Site
4. Select a Site
5. Tap on Products
6. Tap on Select Site
7. Select a Site
8. Scroll to Batch Generate Variations 
9. Tap on Batch Generate Variations 
10. Enter a valid variable product id
11. Tap on Set Product ID
12. Enter a valid Attribute Id, Name, and Option
13. Tap on Add Attribute
14. Tap on Add Variation
15. Repeat steps 12 to 14 (as many variations as you want to add)
16. Tap on Generate Variation
17. Check that the variations are created successfully

### Images

| Adding variants | Success response |
| ------------- | ------------- |
| <img width="300" src="https://user-images.githubusercontent.com/18119390/202299981-b134620f-ba28-4b9a-ad46-264059fe1e5a.png" />  | <img width="300" src="https://user-images.githubusercontent.com/18119390/202299987-6aba77c4-c417-4b6d-b6b4-e778721e2fc1.png" />  |

![zCfsHr.png](https://user-images.githubusercontent.com/18119390/202300704-43d07a69-076c-4b73-ac68-7b1ae361c3db.png)