### PR TITLE
Fixes to error handling of plugin installation and jetpack connection

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/plugin/PluginRestClient.java
@@ -104,7 +104,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
                         ConfigureSitePluginError configurePluginError = new ConfigureSitePluginError(
                                 networkError.apiError, networkError.message);
-                        if (networkError.hasVolleyError()) {
+                        if (networkError.hasVolleyError() && networkError.volleyError.networkResponse != null) {
                             configurePluginError.errorCode = networkError.volleyError.networkResponse.statusCode;
                         }
                         ConfiguredSitePluginPayload payload =
@@ -158,7 +158,7 @@ public class PluginRestClient extends BaseWPComRestClient {
                     public void onErrorResponse(@NonNull WPComGsonNetworkError networkError) {
                         InstallSitePluginError installPluginError = new InstallSitePluginError(
                                 networkError.apiError, networkError.message);
-                        if (networkError.hasVolleyError()) {
+                        if (networkError.hasVolleyError() && networkError.volleyError.networkResponse != null) {
                             installPluginError.errorCode = networkError.volleyError.networkResponse.statusCode;
                         }
                         InstalledSitePluginPayload payload = new InstalledSitePluginPayload(site, pluginSlug,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import com.android.volley.VolleyError
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.greenrobot.eventbus.Subscribe
@@ -209,7 +210,12 @@ class JetpackStore
             }
 
             when {
-                result.isError -> JetpackConnectionUrlResult(JetpackConnectionUrlError(result.error?.message))
+                result.isError -> JetpackConnectionUrlResult(
+                    JetpackConnectionUrlError(
+                        message = result.error?.message,
+                        errorCode = result.error?.volleyError?.networkResponse?.statusCode
+                    )
+                )
                 result.result.isNullOrEmpty() -> JetpackConnectionUrlResult(
                     JetpackConnectionUrlError("Response Empty")
                 )
@@ -224,7 +230,13 @@ class JetpackStore
                                 JetpackConnectionUrlResult(it)
                             },
                             onFailure = {
-                                JetpackConnectionUrlResult(JetpackConnectionUrlError(it.message))
+                                val errorCode = (it as? VolleyError)?.networkResponse?.statusCode
+                                JetpackConnectionUrlResult(
+                                    JetpackConnectionUrlError(
+                                        message = it.message,
+                                        errorCode = errorCode
+                                    )
+                                )
                             }
                         )
                     }
@@ -245,7 +257,8 @@ class JetpackStore
     }
 
     class JetpackConnectionUrlError(
-        val message: String? = null
+        val message: String? = null,
+        val errorCode: Int? = null
     ) : OnChangedError
 
     suspend fun fetchJetpackUser(site: SiteModel): JetpackUserResult {
@@ -256,7 +269,12 @@ class JetpackStore
             }
 
             when {
-                result.isError -> JetpackUserResult(JetpackUserError(result.error?.message))
+                result.isError -> JetpackUserResult(
+                    JetpackUserError(
+                        message = result.error?.message,
+                        errorCode = result.error?.volleyError?.networkResponse?.statusCode
+                    )
+                )
                 result.result == null -> JetpackUserResult(
                     JetpackUserError("Response Empty")
                 )
@@ -276,7 +294,8 @@ class JetpackStore
     }
 
     class JetpackUserError(
-        val message: String? = null
+        val message: String? = null,
+        val errorCode: Int? = null
     ) : OnChangedError
 
     // Actions

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PluginStore.java
@@ -312,7 +312,7 @@ public class PluginStore extends Store {
         public ConfigureSitePluginError(BaseNetworkError error, boolean isActivating) {
             this.type = ConfigureSitePluginErrorType.fromGenericErrorType(error.type, isActivating);
             this.message = error.message;
-            if (error.hasVolleyError()) {
+            if (error.hasVolleyError() && error.volleyError.networkResponse != null) {
                 this.errorCode = error.volleyError.networkResponse.statusCode;
             }
         }
@@ -402,7 +402,7 @@ public class PluginStore extends Store {
         public InstallSitePluginError(BaseNetworkError error) {
             this.type = InstallSitePluginErrorType.fromNetworkError(error);
             this.message = error.message;
-            if (error.hasVolleyError()) {
+            if (error.hasVolleyError() && error.volleyError.networkResponse != null) {
                 this.errorCode = error.volleyError.networkResponse.statusCode;
             }
         }


### PR DESCRIPTION
This PR adds two changes:

1. Fixes an NPE when trying to read the `statusCode` from the network errors when an error occurs during plugin fetching/installation.
2. Exposes the network error code to the Jetpack connection functions.

#### Testing
To confirm the point 1:
1. Install the example app.
2. Sign in using wp-admin credentials (enter the XMLRPC URL in the login form).
3. Open plugins.
4. Select a site.
5. Enable airplane mode.
6. Click on Install plugin.
7. Enter the slug of a plugin.
8. Confirm the app doesn't crash.