### PR TITLE
Update Apache Commons Text to 1.10.0

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -139,7 +139,6 @@ dependencies {
     testImplementation sharedLibs.androidx.arch.core.testing
 
     androidTestImplementation sharedLibs.mockito.android
-    androidTestImplementation sharedLibs.apache.commons.lang3
     androidTestImplementation sharedLibs.assertj.core
     androidTestImplementation sharedLibs.androidx.arch.core.testing
     kaptAndroidTest sharedLibs.google.dagger.compiler

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -108,7 +108,6 @@ dependencies {
     implementation sharedLibs.androidx.arch.core.common
     implementation sharedLibs.androidx.arch.core.runtime
     implementation sharedLibs.androidx.lifecycle.runtime.ktx
-    implementation sharedLibs.apache.commons.lang3
 
     implementation(sharedLibs.wordpress.utils) {
         // Using official volley package

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountAvailabilityTest.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.example.utils.RandomStringUtils;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.IsAvailableErrorType;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AccountTest.java
@@ -1,11 +1,11 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.example.utils.RandomStringUtils;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -5,13 +5,13 @@ import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.example.utils.ArrayUtils;
+import org.wordpress.android.fluxc.example.utils.RandomStringUtils;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.StockMediaModel;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -5,13 +5,13 @@ import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.example.utils.ArrayUtils;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.StockMediaModel;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -2,12 +2,12 @@ package org.wordpress.android.fluxc.release;
 
 import android.annotation.SuppressLint;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.example.utils.RandomStringUtils;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestWPCom.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.example.utils.RandomStringUtils;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged;
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.DeletePost;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_PostTestXMLRPC.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
 import org.wordpress.android.fluxc.example.BuildConfig;
+import org.wordpress.android.fluxc.example.utils.RandomStringUtils;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged;
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.DeletePost;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.example.utils.RandomStringUtils;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.fluxc.release;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
+import org.wordpress.android.fluxc.example.utils.RandomStringUtils;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
 import org.wordpress.android.fluxc.model.TaxonomyModel;
 import org.wordpress.android.fluxc.model.TermModel;

--- a/example/src/main/java/org/wordpress/android/fluxc/example/WCOrderListActivity.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/WCOrderListActivity.kt
@@ -13,7 +13,6 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.activity_wc_order_list.*
-import org.apache.commons.lang3.time.DateUtils
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.fluxc.Dispatcher
@@ -28,6 +27,7 @@ import org.wordpress.android.fluxc.example.WCOrderListItemIdentifier.SectionHead
 import org.wordpress.android.fluxc.example.WCOrderListItemUIType.LoadingItem
 import org.wordpress.android.fluxc.example.WCOrderListItemUIType.SectionHeader
 import org.wordpress.android.fluxc.example.WCOrderListItemUIType.WCOrderListUIItem
+import org.wordpress.android.fluxc.example.utils.DateUtils
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/ArrayUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/ArrayUtils.kt
@@ -1,10 +1,15 @@
 package org.wordpress.android.fluxc.example.utils
 
-import org.apache.commons.lang3.ArrayUtils
-
 object ArrayUtils {
+    private const val INDEX_NOT_FOUND = -1
+
     @JvmStatic
     fun contains(stringArray: Array<String>, string: String): Boolean {
-        return ArrayUtils.contains(stringArray, string)
+        return indexOf(stringArray, string) != INDEX_NOT_FOUND
+    }
+
+    @JvmStatic
+    fun indexOf(stringArray: Array<String>, string: String): Int {
+        return stringArray.indexOf(string)
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/ArrayUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/ArrayUtils.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.fluxc.example.utils
+
+import org.apache.commons.lang3.ArrayUtils
+
+object ArrayUtils {
+    @JvmStatic
+    fun contains(stringArray: Array<String>, string: String): Boolean {
+        return ArrayUtils.contains(stringArray, string)
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/DateUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/DateUtils.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.fluxc.example.utils
+
+import java.util.Calendar
+import java.util.Date
+
+object DateUtils {
+    @JvmStatic
+    fun addMonths(date: Date?, amount: Int) = add(date, Calendar.MONTH, amount)
+
+    @JvmStatic
+    fun addWeeks(date: Date?, amount: Int) = add(date, Calendar.WEEK_OF_YEAR, amount)
+
+    @JvmStatic
+    fun addDays(date: Date?, amount: Int) = add(date, Calendar.DAY_OF_MONTH, amount)
+
+    private fun add(date: Date?, calendarField: Int, amount: Int): Date? {
+        requireNotNull(date) { "The date must not be null" }
+        val calendar = Calendar.getInstance()
+        calendar.time = date
+        calendar.add(calendarField, amount)
+        return calendar.time
+    }
+
+    @JvmStatic
+    fun isSameDay(date1: Date?, date2: Date?): Boolean {
+        require(!(date1 == null || date2 == null)) { "The date must not be null" }
+        val calendar1 = Calendar.getInstance()
+        calendar1.time = date1
+        val calendar2 = Calendar.getInstance()
+        calendar2.time = date2
+        return isSameDay(calendar1, calendar2)
+    }
+
+    private fun isSameDay(calendar1: Calendar?, calendar2: Calendar?): Boolean {
+        require(!(calendar1 == null || calendar2 == null)) { "The calendar must not be null" }
+        return calendar1[Calendar.ERA] == calendar2[Calendar.ERA] &&
+            calendar1[Calendar.YEAR] == calendar2[Calendar.YEAR] &&
+            calendar1[Calendar.DAY_OF_YEAR] == calendar2[Calendar.DAY_OF_YEAR]
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/DateUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/DateUtils.kt
@@ -31,8 +31,7 @@ object DateUtils {
         return isSameDay(calendar1, calendar2)
     }
 
-    private fun isSameDay(calendar1: Calendar?, calendar2: Calendar?): Boolean {
-        require(!(calendar1 == null || calendar2 == null)) { "The calendar must not be null" }
+    private fun isSameDay(calendar1: Calendar, calendar2: Calendar): Boolean {
         return calendar1[Calendar.ERA] == calendar2[Calendar.ERA] &&
             calendar1[Calendar.YEAR] == calendar2[Calendar.YEAR] &&
             calendar1[Calendar.DAY_OF_YEAR] == calendar2[Calendar.DAY_OF_YEAR]

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/RandomStringUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/RandomStringUtils.kt
@@ -3,32 +3,24 @@ package org.wordpress.android.fluxc.example.utils
 object RandomStringUtils {
     @JvmStatic
     fun randomAlphanumeric(count: Int): String {
-        return randomString(
-            count = count,
-            letters = true,
-            numbers = true
-        )
+        return randomString(count)
     }
 
     @JvmStatic
     fun randomAlphabetic(count: Int): String {
-        return randomString(
-            count = count,
-            letters = true,
-            numbers = false
-        )
+        return randomString(count, numbers = false)
     }
 
     @JvmStatic
     fun randomNumeric(count: Int): String {
-        return randomString(
-            count = count,
-            letters = false,
-            numbers = true
-        )
+        return randomString(count, letters = false)
     }
 
-    private fun randomString(count: Int, letters: Boolean, numbers: Boolean): String {
+    private fun randomString(
+        count: Int,
+        letters: Boolean = true,
+        numbers: Boolean = true
+    ): String {
         val alphabetic: List<Char> = ('A'..'Z') + ('a'..'z')
         val numeric = ('0'..'9').toList()
         val allowedChars: List<Char> = when {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/RandomStringUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/RandomStringUtils.kt
@@ -1,20 +1,44 @@
 package org.wordpress.android.fluxc.example.utils
 
-import org.apache.commons.lang3.RandomStringUtils
-
 object RandomStringUtils {
     @JvmStatic
     fun randomAlphanumeric(count: Int): String {
-        return RandomStringUtils.randomAlphanumeric(count)
+        return randomString(
+            count = count,
+            letters = true,
+            numbers = true
+        )
     }
 
     @JvmStatic
     fun randomAlphabetic(count: Int): String {
-        return RandomStringUtils.randomAlphabetic(count)
+        return randomString(
+            count = count,
+            letters = true,
+            numbers = false
+        )
     }
 
     @JvmStatic
     fun randomNumeric(count: Int): String {
-        return RandomStringUtils.randomNumeric(count)
+        return randomString(
+            count = count,
+            letters = false,
+            numbers = true
+        )
+    }
+
+    private fun randomString(count: Int, letters: Boolean, numbers: Boolean): String {
+        val alphabetic: List<Char> = ('A'..'Z') + ('a'..'z')
+        val numeric = ('0'..'9').toList()
+        val allowedChars: List<Char> = when {
+            letters && numbers -> alphabetic + numeric
+            letters -> alphabetic
+            numbers -> numeric
+            else -> throw UnsupportedOperationException("Neither letters nor numbers")
+        }
+        return (1..count)
+            .map { allowedChars.random() }
+            .joinToString("")
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/RandomStringUtils.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/RandomStringUtils.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.fluxc.example.utils
+
+import org.apache.commons.lang3.RandomStringUtils
+
+object RandomStringUtils {
+    @JvmStatic
+    fun randomAlphanumeric(count: Int): String {
+        return RandomStringUtils.randomAlphanumeric(count)
+    }
+
+    @JvmStatic
+    fun randomAlphabetic(count: Int): String {
+        return RandomStringUtils.randomAlphabetic(count)
+    }
+
+    @JvmStatic
+    fun randomNumeric(count: Int): String {
+        return RandomStringUtils.randomNumeric(count)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/example/utils/ArrayUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/example/utils/ArrayUtilsTest.kt
@@ -1,0 +1,45 @@
+package org.wordpress.android.fluxc.example.utils
+
+import org.assertj.core.api.Assertions.assertThat
+
+import org.junit.Test
+
+class ArrayUtilsTest {
+    /* CONTAINS */
+
+    @Test
+    fun `given valid string, when checking contains start of array, then the result is true`() {
+        val stringArray = arrayOf("one", "two", "three", "four", "five")
+
+        val result = ArrayUtils.contains(stringArray, "three")
+
+        assertThat(result).isEqualTo(true)
+    }
+
+    @Test
+    fun `given valid string, when checking contains middle of array, then the result is true`() {
+        val stringArray = arrayOf("one", "two", "three", "four", "five")
+
+        val result = ArrayUtils.contains(stringArray, "one")
+
+        assertThat(result).isEqualTo(true)
+    }
+
+    @Test
+    fun `given valid string, when checking contains end of array, then the result is true`() {
+        val stringArray = arrayOf("one", "two", "three", "four", "five")
+
+        val result = ArrayUtils.contains(stringArray, "five")
+
+        assertThat(result).isEqualTo(true)
+    }
+
+    @Test
+    fun `given invalid string, when checking contains of array, then the result is false`() {
+        val stringArray = arrayOf("one", "two", "three", "four", "five")
+
+        val result = ArrayUtils.contains(stringArray, "ottff")
+
+        assertThat(result).isEqualTo(false)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/example/utils/ArrayUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/example/utils/ArrayUtilsTest.kt
@@ -42,4 +42,42 @@ class ArrayUtilsTest {
 
         assertThat(result).isEqualTo(false)
     }
+
+    /* INDEX OF */
+
+    @Test
+    fun `given valid string, when getting the index start of array, then the result is the expected one`() {
+        val stringArray = arrayOf("one", "two", "three", "four", "five")
+
+        val result = ArrayUtils.indexOf(stringArray, "three")
+
+        assertThat(result).isEqualTo(2)
+    }
+
+    @Test
+    fun `given valid string, when getting the index middle of array, then the result is the expected one`() {
+        val stringArray = arrayOf("one", "two", "three", "four", "five")
+
+        val result = ArrayUtils.indexOf(stringArray, "one")
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `given valid string, when getting the index end of array, then the result is the expected one`() {
+        val stringArray = arrayOf("one", "two", "three", "four", "five")
+
+        val result = ArrayUtils.indexOf(stringArray, "five")
+
+        assertThat(result).isEqualTo(4)
+    }
+
+    @Test
+    fun `given invalid string, when getting the index of array, then the resulting index is minus one`() {
+        val stringArray = arrayOf("one", "two", "three", "four", "five")
+
+        val result = ArrayUtils.indexOf(stringArray, "ottff")
+
+        assertThat(result).isEqualTo(-1)
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteUtils.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.utils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wordpress.android.fluxc.model.PostFormatModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.util.MapUtils;
@@ -14,8 +15,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-
-import static org.apache.commons.lang3.StringUtils.split;
 
 public class SiteUtils {
     /**
@@ -82,7 +81,7 @@ public class SiteUtils {
         if (wpTimeZone == null || wpTimeZone.isEmpty() || wpTimeZone.equals("0") || wpTimeZone.equals("0.0")) {
             timezoneNormalized = "GMT";
         } else {
-            String[] timezoneSplit = split(wpTimeZone, ".");
+            String[] timezoneSplit = StringUtils.split(wpTimeZone, ".");
             timezoneNormalized = timezoneSplit[0];
             if (timezoneSplit.length > 1) {
                 switch (timezoneSplit[1]) {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -51,8 +51,6 @@ android {
 dependencies {
     implementation fluxcProjectDependency
 
-    implementation sharedLibs.apache.commons.lang3
-
     // WordPress libs
     implementation(sharedLibs.wordpress.utils) {
         // Using official volley package

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
             version("androidx-appcompat", "1.0.2")
             version("androidx-constraintlayout", "1.1.3")
             version("androidx-recyclerview", "1.0.0")
-            version("apache-commons-text", "1.1")
+            version("apache-commons-text", "1.10.0")
             version("facebook-flipper", "0.51.0")
             version("facebook-soloader", "0.9.0")
             version("kotlinx-coroutines", "1.3.9")


### PR DESCRIPTION
After an internal discussion (see `peaMlT-2f-p2` and `peaMlT-2f-p2#comment-80`, this PR upgrades Apache's `Commons Text` library to [1.10.0](https://commons.apache.org/proper/commons-text/changes-report.html#a1.10.0) in order fix the possible `StringSubstitutor` related vulnerability in the library.

For more details see: https://commons.apache.org/proper/commons-text/changes-report.html#a1.10.0

And more specifically see release notes entry below:

```
Make default string lookups configurable via system property. Remove
dns, url, and script lookups from defaults. If these lookups are
required for use in StringSubstitutor.createInterpolator(), they must be
enabled via system property. See StringLookupFactory for details.
```

-----

As part of this `commonsText = '1.10.0'` update the below changes were also applied in order to try and strip down as of the Apache Commons dependency as possible:

Remove `Apache Commons` from `Plugins:WooCommerce` module:

1. [Remove unnecessary org apache commons lang dependency for woo.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2573/commits/ac2e1a4962c0022926d638fe63a725b2ecdc4fcf)

Remove `Apache Commons` from `Example` module:

1. [Replace unnecessary commons lang date utils for example.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2573/commits/1c082d95ae56be3c4b493093c7dd17349395cc5f)
2. [Replace commons lang array utils contains with array utils.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2573/commits/292be05c04f28b8fc41e4a5005246b7a6d1a58e9)
3. [Remove unnecessary commons lang array utils contains.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2573/commits/5e95cd079e1ba1b84db25edd11cf3102d9f6b6cd)
4. [Replace commons lang random utils strings with custom one.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2573/commits/5e3b9ed85c6dcb5913354ffc997e3e7b6fa3b9b8)
5. [Remove unnecessary commons lang random string utils.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2573/commits/fafc3e86c156f572e706968dbd7ec65a5d569fdf)

Refactoring List:

1. [Optimize string utils import for site utils.](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2573/commits/a4b468acb20a066f4812e98c79a6f2f35a6ad078)

-----

With this change the only Apache's `Commons Lang` and `Commons Text` related utilities that this project is using are the below:

1. `Commons Lang` -> `org.apache.commons.lang3.StringUtils`
    1. `StringUtils.split(...)` -> See `SiteUtils.java` class.
    2. `StringUtils.equals(...)` -> See `MediaUploadModel.java` class.
2. `Commons Text` -> `org.apache.commons.text.StringEscapeUtils`
    1. `StringEscapeUtils.unescapeHtml4(...)` -> 17 usages in project.
3. (⚠️)* `Commons Lang` -> `org.apache.commons.lang3.StringEscapeUtils`
    1. Deprecated `StringEscapeUtils.escapeXml(...)` -> See `XmlrpcUploadRequestBody`

-----

A quick diff of the previous usage of `commons-lang3-3.8.1` vs. the current usage of `commons-lang3-3.12.0` showed that only the `StringUtils.equals(...)` got updated, see `Step-wise comparison` below:

`commons-lang3-3.8.1`
```
    public static boolean equals(final CharSequence cs1, final CharSequence cs2) {
        ...
        return CharSequenceUtils.regionMatches(cs1, false, 0, cs2, 0, cs1.length());
    }
```

`commons-lang3-3.12.0`
```
    public static boolean equals(final CharSequence cs1, final CharSequence cs2) {
        ...
        // Step-wise comparison
        final int length = cs1.length();
        for (int i = 0; i < length; i++) {
            if (cs1.charAt(i) != cs2.charAt(i)) {
                return false;
            }
        }
        return true;
    }
```

-----

A quick diff of the previous usage of `commons-text-1.1` vs. the current usage of `commons-text-1.10.0` showed that only the inner to `translate(...)` method of `StringEscapeUtils.unescapeHtml4(...)` got slightly updated, see `RuntimeException` vs. `UncheckedIOException` below:

`commons-text-1.1`
```
    public final String translate(final CharSequence input) {
        ...
        } catch (final IOException ioe) {
            // this should never ever happen while writing to a StringWriter
            throw new RuntimeException(ioe);
        }
    }
```

`commons-text-1.10.0`
```
    public final String translate(final CharSequence input) {
        ...
        } catch (final IOException ioe) {
            // this should never ever happen while writing to a StringWriter
            throw new UncheckedIOException(ioe);
        }
    }
```

-----

(*) Warning (⚠️)

About the warning above, note the fact that this project uses two similar imports for `StringEscapeUtils`:
- org.apache.commons.text.StringEscapeUtils ✅ (see 17 usages)
- org.apache.commons.lang3.StringEscapeUtils ⚠️ (see `XmlrpcUploadRequestBody`)

However, note that this `lang3` import is necessary, as the `text` import does not expose the `StringEscapeUtils.escapeXml(...)` api, instead it only exposed the `StringEscapeUtils.escapeXml10(...)` and `StringEscapeUtils.escapeXml11(...)` apis. As such, and until `XmlrpcUploadRequestBody` to either using `xml10` or `xml11`, it is necessary for this class to use the `lang3` import instead of the `text` import. 🤔

In addition to the above, note the `TODO` comment on `XmlrpcUploadRequestBody`, close to the `mPrependString` field and its usage of `StringEscapeUtils.escapeXml(...)` (see below). As such, this means that a proper future solution on that would be to completely remove this custom `String.format(...)` logic and replace that with `XMLRPCSerializer`, that is, instead of going for updating `xml` with either `xml10` or `xml11`. 🔍

`// TODO: we should use the XMLRPCSerializer instead of doing this`

-----

To test:

1. First, quickly smoke test the `FluxC Example` app and see if it works as expected.
2. Then, try and be more specific by taking a look at the code changes, associate those to some screens and make sure everything is working as expected (such an example could be `WCOrderListActivity`).
3. Finally, quickly smoke test, either the `WordPress` or `Woo Commerce` apps, with this version of `FluxC`, and see if it works as expected.

-----

Finally, as a regression note, note the fact that the `MediaUploadModel.equals(...)` method might be producing different results before and after the change, that is, since the `StringUtils.equals(...)` implementation was slightly changed.