### PR TITLE
[Build] Remove Fetch Style Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ plugins {
     alias(sharedLibs.plugins.kotlin.jvm).apply(false)
     alias(sharedLibs.plugins.kotlin.kapt).apply(false)
 
-    alias(sharedLibs.plugins.automattic.fetchstyle)
     alias(sharedLibs.plugins.automattic.configure)
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,6 @@ pluginManagement {
             filter {
                 includeGroup "com.automattic.android"
                 includeGroup "com.automattic.android.configure"
-                includeGroup "com.automattic.android.fetchstyle"
                 includeGroup "com.automattic.android.publish-to-s3"
             }
         }


### PR DESCRIPTION
This PR removes the [fetchstyle](https://github.com/Automattic/style-config-android) plugin from the project.

This `style-config-android` plugin is mostly unused and very outdated.

To the Apps Infra's knowledge and checking GE stats no-one is using the `./gradlew downloadConfigs` task to fetch/update the style config files. For years now, almost all Android engineers depend on the default AS style and such like `.idea` configuration.

PS: For more info please refer to this internal discussion here: `C02QANACA/p1667910471807479`

-----

To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could try and run the `./gradlew downloadConfigs` task and verify that it is no longer found in the root project for FluxC.