### PR TITLE
Woo: Store creation REST client

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -45,6 +45,7 @@ import org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFra
 import org.wordpress.android.fluxc.example.ui.shippinglabels.WooVerifyAddressFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
+import org.wordpress.android.fluxc.example.ui.storecreation.WooStoreCreationFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
 
 @Module
@@ -180,4 +181,7 @@ internal interface FragmentsModule {
 
     @ContributesAndroidInjector
     fun providePluginsFragment(): PluginsFragment
+
+    @ContributesAndroidInjector
+    fun provideWooStoreCreationFragment(): WooStoreCreationFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.example.ui.refunds.WooRefundsFragment
 import org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
+import org.wordpress.android.fluxc.example.ui.storecreation.WooStoreCreationFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
 import org.wordpress.android.fluxc.store.WCDataStore
 import org.wordpress.android.fluxc.store.WCUserStore
@@ -201,6 +202,10 @@ class WooCommerceFragment : StoreSelectingFragment() {
             selectedSite?.let {
                 replaceFragment(WooCustomersFragment())
             } ?: showNoWCSitesToast()
+        }
+
+        store_creation.setOnClickListener {
+            replaceFragment(WooStoreCreationFragment())
         }
 
         coupons.setOnClickListener {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/storecreation/WooStoreCreationFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/storecreation/WooStoreCreationFragment.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.fluxc.example.ui.storecreation
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
+import kotlinx.android.synthetic.main.fragment_woo_store_creation.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingCartStore
+import javax.inject.Inject
+
+class WooStoreCreationFragment : StoreSelectingFragment() {
+    @Inject internal lateinit var shoppingCartStore: ShoppingCartStore
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_woo_store_creation, container, false)
+
+    @Suppress("LongMethod", "ComplexMethod")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        btnAddPlanToCart.setOnClickListener {
+            selectedSite?.let { site ->
+                prependToLog("Adding eCommerce plan to a shopping cart for site ${site.id}")
+                lifecycleScope.launch(Dispatchers.IO) {
+                    try {
+                        val response = shoppingCartStore.addWooCommercePlanToCart(site.siteId)
+                        withContext(Dispatchers.Main) {
+                            response.error?.let {
+                                prependToLog("${it.type}: ${it.message}")
+                            }
+                            response.model?.let {
+                                prependToLog("Shopping cart content: $it")
+                            }
+                        }
+                    } catch (e: Exception) {
+                        withContext(Dispatchers.Main) {
+                            prependToLog("Error: ${e.message}")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/storecreation/WooStoreCreationFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/storecreation/WooStoreCreationFragment.kt
@@ -21,7 +21,7 @@ class WooStoreCreationFragment : StoreSelectingFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
             inflater.inflate(R.layout.fragment_woo_store_creation, container, false)
 
-    @Suppress("LongMethod", "ComplexMethod")
+    @Suppress("LongMethod", "ComplexMethod", "TooGenericExceptionCaught")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/example/src/main/res/layout/fragment_woo_store_creation.xml
+++ b/example/src/main/res/layout/fragment_woo_store_creation.xml
@@ -1,0 +1,24 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    tools:ignore="HardcodedText">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp">
+
+        <Button
+            android:id="@+id/btnAddPlanToCart"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Add eCommerce plan to cart" />
+
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -130,6 +130,12 @@
             android:text="Coupons" />
 
         <Button
+            android:id="@+id/store_creation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Store creation" />
+
+        <Button
             android:id="@+id/help_support"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartRestClient.kt
@@ -1,0 +1,105 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.network.Response
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingCartRestClient.ShoppingCart.CartProduct
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import javax.inject.Inject
+import javax.inject.Named
+
+class ShoppingCartRestClient @Inject constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun addProductsToShoppingCart(
+        siteId: Long,
+        products: List<CartProduct>,
+        isTemporary: Boolean
+    ): WooPayload<ShoppingCart> {
+        val url = WPCOMREST.me.shopping_cart.site(siteId).urlV1_1
+
+        val body = mapOf(
+            "temporary" to isTemporary,
+            "products" to products
+        )
+
+        return when (val response = wpComGsonRequestBuilder.syncPostRequest(
+            restClient = this,
+            url = url,
+            params = null,
+            body = body,
+            clazz = ShoppingCart::class.java
+        )) {
+            is Success -> {
+                WooPayload(response.data)
+            }
+            is WPComGsonRequestBuilder.Response.Error -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
+    suspend fun completePurchase(
+        cart: ShoppingCart,
+        paymentMethod: PaymentMethod
+    ): WooPayload<ShoppingCart> {
+        val url = WPCOMREST.me.transactions.urlV1_1
+
+        val payment = mapOf(
+            "payment_method" to paymentMethod.value
+        )
+
+        val body = mapOf(
+            "cart" to cart,
+            "payment" to payment
+        )
+
+        return when (val response = wpComGsonRequestBuilder.syncPostRequest(
+            restClient = this,
+            url = url,
+            params = null,
+            body = body,
+            clazz = ShoppingCart::class.java
+        )) {
+            is Success -> {
+                WooPayload(response.data)
+            }
+            is WPComGsonRequestBuilder.Response.Error -> {
+                WooPayload(response.error.toWooError())
+            }
+        }
+    }
+
+    data class ShoppingCart(
+        @SerializedName("blog_id") val blogId: Int,
+        @SerializedName("cart_key") val cartKey: Int,
+        val products: List<CartProduct>?
+    ) : Response {
+        data class CartProduct(
+            @SerializedName("product_id") val productId: Int,
+            val volume: Int = 1,
+            val quantity: Int? = null,
+            val meta: String? = null,
+            val extra: Map<String, Any> = emptyMap()
+        )
+    }
+
+    enum class PaymentMethod(val value: String) {
+        CREDIT_PAYMENT_METHOD("WPCOM_Billing_WPCOM"),
+        CREDIT_CARD_PAYMENT_METHOD("WPCOM_Billing_MoneyPress_Stored")
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartRestClient.kt
@@ -16,7 +16,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingC
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 
+@Singleton
 class ShoppingCartRestClient @Inject constructor(
     dispatcher: Dispatcher,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartStore.kt
@@ -1,0 +1,68 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation
+
+import com.google.gson.Gson
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingCartRestClient.PaymentMethod
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingCartRestClient.PaymentMethod.CREDIT_CARD_PAYMENT_METHOD
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingCartRestClient.PaymentMethod.CREDIT_PAYMENT_METHOD
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingCartRestClient.ShoppingCart
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingCartRestClient.ShoppingCart.CartProduct
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog.T.API
+import javax.inject.Inject
+
+class ShoppingCartStore @Inject constructor(
+    private val restClient: ShoppingCartRestClient,
+    private val coroutineEngine: CoroutineEngine
+) {
+    private val eCommerceProduct = CartProduct(
+        productId = 1021,
+        extra = mapOf(
+            "context" to "signup",
+            "signup_flow" to "ecommerce-monthly"
+        )
+    )
+
+    suspend fun addWooCommercePlanToCart(siteId: Long) = addProductToCart(siteId, eCommerceProduct)
+
+    suspend fun completePurchaseWithCredit(cart: ShoppingCart) =
+        completePurchase(cart, CREDIT_PAYMENT_METHOD)
+
+    suspend fun completePurchaseWithCreditCard(cart: ShoppingCart) =
+        completePurchase(cart, CREDIT_CARD_PAYMENT_METHOD)
+
+    private suspend fun addProductToCart(
+        siteId: Long,
+        product: CartProduct
+    ): WooResult<ShoppingCart> {
+        return coroutineEngine.withDefaultContext(API, this, "addProductPlanToCart") {
+            val response = restClient.addProductsToShoppingCart(
+                siteId = siteId,
+                products = listOf(product),
+                isTemporary = false
+            )
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> WooResult(response.result)
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+
+    private suspend fun completePurchase(
+        cart: ShoppingCart,
+        payment: PaymentMethod
+    ): WooResult<Unit> {
+        return coroutineEngine.withDefaultContext(API, this, "completePurchase") {
+            val response = restClient.completePurchase(cart, payment)
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> WooResult(Unit)
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartStore.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation
 
-import com.google.gson.Gson
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -13,7 +12,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingC
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog.T.API
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class ShoppingCartStore @Inject constructor(
     private val restClient: ShoppingCartRestClient,
     private val coroutineEngine: CoroutineEngine


### PR DESCRIPTION
This PR adds the REST client and a Store for adding products to a WP.com shopping cart, which is required to enable store creation flow.

**To test:**
1. Start the example app
2. Sign in
3. Tap on Woo -> Store creation
4. Select a site
5. Tap on `Add eCommerce plan to cart` button
6. Verify the request is successful and the contents of a cart is logged