### PR TITLE
Adds Jetpack migration API call

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/JetpackMigrationRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/JetpackMigrationRestClientTest.kt
@@ -1,0 +1,97 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.mobile
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.JsonElement
+import junit.framework.AssertionFailedError
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.mobile.MigrationCompleteFetchedPayload
+import org.wordpress.android.fluxc.test
+
+class JetpackMigrationRestClientTest {
+    private val wpComGsonRequestBuilder = mock<WPComGsonRequestBuilder>()
+    private val context = mock<Context>()
+    private val dispatcher = mock<Dispatcher>()
+    private val requestQueue = mock<RequestQueue>()
+    private val accessToken = mock<AccessToken>()
+    private val userAgent = mock<UserAgent>()
+
+    private lateinit var client: JetpackMigrationRestClient
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        client = JetpackMigrationRestClient(
+                wpComGsonRequestBuilder,
+                dispatcher,
+                context,
+                requestQueue,
+                accessToken,
+                userAgent
+        )
+    }
+
+    @Test
+    fun `fetch handles successful response`() = test {
+        val errorHandler: (BaseNetworkError?) -> MigrationCompleteFetchedPayload = { _ ->
+            throw AssertionFailedError("errorHandler should not have been called")
+        }
+
+        val expected = MigrationCompleteFetchedPayload.Success
+        val expectedJson = mock<JsonElement>()
+
+        val expectedRestCallResponse = Success(expectedJson)
+        verifyRestApi(errorHandler, expectedRestCallResponse, expected)
+    }
+
+    @Test
+    fun `fetch handles failure response`() = test {
+        val expected = mock<MigrationCompleteFetchedPayload>()
+        val expectedBaseNetworkError = mock<WPComGsonNetworkError>()
+        val errorHandler = { error: BaseNetworkError? ->
+            if (error != expectedBaseNetworkError) fail("expected error was not passed to errorHandler")
+            expected
+        }
+
+        val mockedRestCallResponse = Error<JsonElement>(expectedBaseNetworkError)
+        verifyRestApi(errorHandler, mockedRestCallResponse, expected)
+    }
+
+    private suspend fun verifyRestApi(
+        errorHandler: (BaseNetworkError?) -> MigrationCompleteFetchedPayload,
+        expectedRestCallResponse: WPComGsonRequestBuilder.Response<JsonElement>,
+        expected: MigrationCompleteFetchedPayload
+    ) {
+        whenever(
+                wpComGsonRequestBuilder.syncPostRequest(
+                        eq(client),
+                        urlCaptor.capture(),
+                        eq(mapOf()),
+                        eq(mapOf()),
+                        eq(JsonElement::class.java),
+                        isNull()
+                )
+        ).thenReturn(expectedRestCallResponse)
+
+        val actual = client.migrationComplete(errorHandler)
+        assertEquals(expected, actual)
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/mobile/JetpackMigrationStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/mobile/JetpackMigrationStoreTest.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.fluxc.store.mobile
+
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.SERVER_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.mobile.JetpackMigrationRestClient
+import org.wordpress.android.fluxc.store.mobile.MigrationCompleteFetchedPayload.Success
+import org.wordpress.android.fluxc.store.mobile.MigrationCompleteFetchedPayload.Error
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunWith(MockitoJUnitRunner::class)
+class JetpackMigrationStoreTest {
+    @Mock private lateinit var restClient: JetpackMigrationRestClient
+    private lateinit var store: JetpackMigrationStore
+
+    private val successResponse = Success
+    private val errorResponse = Error(BaseNetworkError(SERVER_ERROR))
+
+    @Before
+    fun setUp() {
+        store = JetpackMigrationStore(restClient, initCoroutineEngine())
+    }
+
+    @Test
+    fun `given success, a success result is returned`() = test {
+        whenever(restClient.migrationComplete(any())).thenReturn(Success)
+        val response = store.migrationComplete()
+        assertNotNull(response)
+        assertEquals(successResponse, response)
+    }
+
+    @Test
+    fun `when an error occurs, the error is returned`() = test {
+        whenever(restClient.migrationComplete(any())).thenReturn(errorResponse)
+        val response = store.migrationComplete()
+        assertNotNull(response)
+        assertEquals(errorResponse, response)
+    }
+}

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -42,6 +42,7 @@
 
 /mobile/feature-announcements/
 /mobile/feature-flags/
+/mobile/migration
 
 /me/gutenberg/
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/JetpackMigrationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/JetpackMigrationRestClient.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.mobile
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.mobile.MigrationCompleteFetchedPayload
+import org.wordpress.android.fluxc.store.mobile.MigrationCompleteFetchedPayload.Success
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class JetpackMigrationRestClient @Inject constructor(
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    dispatcher: Dispatcher,
+    appContext: Context?,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun migrationComplete(
+        errorHandler: (error: BaseNetworkError?) -> MigrationCompleteFetchedPayload,
+    ): MigrationCompleteFetchedPayload {
+        // https://public-api.wordpress.com/wpcom/v2/mobile/migration
+        val url = WPCOMV2.mobile.migration.url
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                mapOf(),
+                mapOf(),
+                JsonElement::class.java
+        )
+        return when (response) {
+            is Response.Success -> Success
+            is Response.Error -> errorHandler(response.error)
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/JetpackMigrationStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/JetpackMigrationStore.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.fluxc.store.mobile
+
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.mobile.JetpackMigrationRestClient
+import org.wordpress.android.fluxc.store.mobile.MigrationCompleteFetchedPayload.Error
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class JetpackMigrationStore @Inject constructor(
+    private val jetpackMigrationClient: JetpackMigrationRestClient,
+    private val coroutineEngine: CoroutineEngine
+) {
+    suspend fun migrationComplete(
+    ) = coroutineEngine.withDefaultContext(AppLog.T.API, this, "post migration-complete") {
+        return@withDefaultContext jetpackMigrationClient.migrationComplete(::Error)
+    }
+}
+
+sealed class MigrationCompleteFetchedPayload {
+    object Success : MigrationCompleteFetchedPayload()
+    class Error(val error: BaseNetworkError?) : MigrationCompleteFetchedPayload()
+}


### PR DESCRIPTION
Adds a call to the `wpcom/v2/mobile/migration` endpoint (ref `D91729-code`)

To test:
Check steps in https://github.com/wordpress-mobile/WordPress-Android/pull/17531