### PR TITLE
Woo: Remove hardcoded eCommerce plan purchase

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/storecreation/WooStoreCreationFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/storecreation/WooStoreCreationFragment.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingCartRestClient.ShoppingCart.CartProduct
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.storecreation.ShoppingCartStore
 import javax.inject.Inject
 
@@ -30,7 +31,17 @@ class WooStoreCreationFragment : StoreSelectingFragment() {
                 prependToLog("Adding eCommerce plan to a shopping cart for site ${site.id}")
                 lifecycleScope.launch(Dispatchers.IO) {
                     try {
-                        val response = shoppingCartStore.addWooCommercePlanToCart(site.siteId)
+                        val eCommerceProduct = CartProduct(
+                            productId = 1021,
+                            extra = mapOf(
+                                "context" to "signup",
+                                "signup_flow" to "ecommerce-monthly"
+                            )
+                        )
+                        val response = shoppingCartStore.addProductToCart(
+                            site.siteId,
+                            eCommerceProduct
+                        )
                         withContext(Dispatchers.Main) {
                             response.error?.let {
                                 prependToLog("${it.type}: ${it.message}")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/plans/full/Plan.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/plans/full/Plan.kt
@@ -18,6 +18,7 @@ data class Plan(
     @SerializedName("orig_cost") val originalCost: String? = null,
     @SerializedName("is_cost_from_introductory_offer") val isCostFromIntroductoryOffer: Boolean = false,
     @SerializedName("product_slug") val productSlug: String? = null,
+    @SerializedName("path_slug") val pathSlug: String? = null,
     @SerializedName("description") val description: String? = null,
     @SerializedName("bill_period") val billPeriod: Int? = null,
     @SerializedName("product_type") val productType: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/storecreation/ShoppingCartStore.kt
@@ -19,23 +19,13 @@ class ShoppingCartStore @Inject constructor(
     private val restClient: ShoppingCartRestClient,
     private val coroutineEngine: CoroutineEngine
 ) {
-    private val eCommerceProduct = CartProduct(
-        productId = 1021,
-        extra = mapOf(
-            "context" to "signup",
-            "signup_flow" to "ecommerce-monthly"
-        )
-    )
-
-    suspend fun addWooCommercePlanToCart(siteId: Long) = addProductToCart(siteId, eCommerceProduct)
-
     suspend fun completePurchaseWithCredit(cart: ShoppingCart) =
         completePurchase(cart, CREDIT_PAYMENT_METHOD)
 
     suspend fun completePurchaseWithCreditCard(cart: ShoppingCart) =
         completePurchase(cart, CREDIT_CARD_PAYMENT_METHOD)
 
-    private suspend fun addProductToCart(
+    suspend fun addProductToCart(
         siteId: Long,
         product: CartProduct
     ): WooResult<ShoppingCart> {


### PR DESCRIPTION
FluxC now provides a way to fetch plan data, which can be then used to make a purchase, so there is no reason to use the hardcoded values to add a monthly eCommerce plan to a cart. This allows for more flexibility in the future when we add options to buy different plans/periods.

**To test:**
1. Start the example app
2. Go to Woo -> Store creation
3. Select a site
4. Tap on the Add plan to cart button
5. Verify a response with a cart content is returned in the console