### PR TITLE
REST API: Migrate CouponStore to use application passwords

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
@@ -8,7 +8,6 @@ import com.goterl.lazysodium.exceptions.SodiumException;
 import org.wordpress.android.fluxc.example.BuildConfig;
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLoggingKey;
 import org.wordpress.android.fluxc.model.encryptedlogging.EncryptionUtils;
-import org.wordpress.android.fluxc.module.ApplicationPasswordClientId;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 import org.wordpress.android.util.AppLog;
@@ -42,14 +41,8 @@ public class AppConfigModule {
     }
 
     @Provides
-    public UserAgent provideUserAgent(Context appContext, @ApplicationPasswordClientId String applicationName) {
-        return new UserAgent(appContext, applicationName);
-    }
-
-    @Provides
-    @ApplicationPasswordClientId
-    public String provideApplicationName() {
-        return "fluxc-example-android";
+    public UserAgent provideUserAgent(Context appContext) {
+        return new UserAgent(appContext, "fluxc-example-android");
     }
 
     @Provides

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/ApplicationPasswordsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/ApplicationPasswordsModule.kt
@@ -2,11 +2,21 @@ package org.wordpress.android.fluxc.example.di
 
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import org.wordpress.android.fluxc.example.ApplicationPasswordsLogger
+import org.wordpress.android.fluxc.module.ApplicationPasswordClientId
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsListener
 
 @Module
 interface ApplicationPasswordsModule {
     @Binds
     fun bindApplicationPasswordsListener(logger: ApplicationPasswordsLogger): ApplicationPasswordsListener
+
+    companion object {
+        @Provides
+        @ApplicationPasswordClientId
+        fun provideApplicationName(): String {
+            return "fluxc-example-android"
+        }
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.AUTHORIZATION_REQUIRED
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.CENSORED
@@ -54,6 +55,27 @@ fun WPComGsonNetworkError.toWooError(): WooError {
                 "rest_no_route" -> WooErrorType.PLUGIN_NOT_ACTIVE
                 else -> WooErrorType.GENERIC_ERROR
             }
+        }
+    }
+    return WooError(type, this.type, message)
+}
+
+fun BaseNetworkError.toWooError(): WooError {
+    val type = when (type) {
+        TIMEOUT -> WooErrorType.TIMEOUT
+        NO_CONNECTION,
+        SERVER_ERROR,
+        INVALID_SSL_CERTIFICATE,
+        NETWORK_ERROR -> WooErrorType.API_ERROR
+        PARSE_ERROR,
+        CENSORED,
+        INVALID_RESPONSE -> WooErrorType.INVALID_RESPONSE
+        HTTP_AUTH_ERROR,
+        AUTHORIZATION_REQUIRED,
+        NOT_AUTHENTICATED -> WooErrorType.AUTHORIZATION_REQUIRED
+        NOT_FOUND -> WooErrorType.INVALID_ID
+        UNKNOWN, null -> {
+            WooErrorType.GENERIC_ERROR
         }
     }
     return WooError(type, this.type, message)


### PR DESCRIPTION
This PR migrates the CouponStore to use application passwords using the work done in the PRs #2586 and #2589, and #2592.

⚠️ Please don't merge before #2592.

##### WordPress.com login:
1. Open the example app, then sign in using your WordPress.com account.
2. Click on Woo, then Coupons.
3. Select a site.
4. Click on Fetch Coupons (or any other operation)
5. Confirm that it works successfully.
6. Open the users page in `wp-admin` and confirm that the app created an application password (the page is available only for self-hosted sites).
7. Revoke the password.
8. Retest the feature, and confirm it stills works as expected, the app will create a second password.

##### Site credentials login:
1. Apply the patch from below (we don't check for Woo installation for site credentials login yet)
2. Open the app, then sign in using your wp-admin credentials (enter site URL in the address form).
3. Repeat steps 2 to 8 from the above test.

```patch
Index: example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(revision 679271e71db3fb58b5e7fbc58545bd14886f4a40)
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(date 1653478977241)
@@ -7,6 +7,8 @@
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.fragment_woo_products.*
 import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.SiteSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
@@ -23,7 +25,7 @@
                 Button(context).apply {
                     text = "Select Site"
                     setOnClickListener {
-                        showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                        showSiteSelectorDialog(selectedPos, object : SiteSelectorDialog.Listener {
                             override fun onSiteSelected(site: SiteModel, pos: Int) {
                                 onSiteSelected(site)
                                 selectedSite = site
```