### PR TITLE
Call to the API only when needed

### DIFF
--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
@@ -97,18 +98,12 @@ class ProductRestClientTest {
         )
 
         // then
-        verify(requestBuilder).syncPostRequest(
+        verify(requestBuilder, never()).syncPostRequest(
             eq(sut),
             eq(site),
             eq(WOOCOMMERCE.products.batch.pathV3),
             bodyCaptor.capture(),
             eq(BatchProductApiResponse::class.java),
-        )
-        assertThat(bodyCaptor.allValues).hasSize(1)
-        assertThat(bodyCaptor.firstValue).isEqualTo(
-            mapOf(
-                ("update" to emptyList<Map<String, Any>>())
-            )
         )
     }
 


### PR DESCRIPTION
### Why
We optimized the data we sent to the API when bulk-updating products. But when the optimization is optimal (no data needs to be sent), we should avoid sending that request and can, instead, show a success message.

https://user-images.githubusercontent.com/18119390/206819018-dd5d06cd-5990-40b6-a69b-cb62caf69872.mp4

### Description
This small PR checks if no change needs to be executed on the API before sending the request. If no change needs to be executed, it sends an early success response

### Testing instruction
You can use the [bulk update PR](https://github.com/woocommerce/woocommerce-android/pull/7971) to test the changes
1. Enter on selection mode
2. Tap on more -> Update status
3. Select the same status as the product selected
4. Check that no request is sent
5. Check that a success message is shown