### PR TITLE
Hide Scan Login Code when 2FA is active.

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/account/AccountModelTest.java
@@ -37,11 +37,13 @@ public class AccountModelTest {
         copyAccount.setVisibleSiteCount(testAccount.getVisibleSiteCount() + 1);
         copyAccount.setEmail("copyEmail");
         copyAccount.setPendingEmailChange(!testAccount.getPendingEmailChange());
+        copyAccount.setTwoStepEnabled(!testAccount.getTwoStepEnabled());
         copyAccount.setTracksOptOut(!testAccount.getTracksOptOut());
         Assert.assertFalse(copyAccount.equals(testAccount));
         testAccount.copyAccountAttributes(copyAccount);
         Assert.assertFalse(copyAccount.equals(testAccount));
         copyAccount.setPendingEmailChange(testAccount.getPendingEmailChange());
+        copyAccount.setTwoStepEnabled(testAccount.getTwoStepEnabled());
         copyAccount.setTracksOptOut(testAccount.getTracksOptOut());
         Assert.assertTrue(copyAccount.equals(testAccount));
     }
@@ -58,6 +60,7 @@ public class AccountModelTest {
         copyAccount.setDate("copyDate");
         copyAccount.setNewEmail("copyNewEmail");
         copyAccount.setPendingEmailChange(!testAccount.getPendingEmailChange());
+        copyAccount.setTwoStepEnabled(!testAccount.getTwoStepEnabled());
         copyAccount.setTracksOptOut(!testAccount.getTracksOptOut());
         copyAccount.setUsernameCanBeChanged(!testAccount.getUsernameCanBeChanged());
         copyAccount.setWebAddress("copyWebAddress");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/AccountModel.java
@@ -34,6 +34,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
     @Column private String mDate;
     @Column private String mNewEmail;
     @Column private boolean mPendingEmailChange;
+    @Column private boolean mTwoStepEnabled;
     @Column private String mWebAddress; // WPCom rest API: user_URL
     @Column private boolean mTracksOptOut;
     @Column private boolean mUsernameCanBeChanged;
@@ -75,6 +76,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
                && StringUtils.equals(getDate(), otherAccount.getDate())
                && StringUtils.equals(getNewEmail(), otherAccount.getNewEmail())
                && getPendingEmailChange() == otherAccount.getPendingEmailChange()
+               && getTwoStepEnabled() == otherAccount.getTwoStepEnabled()
                && StringUtils.equals(getWebAddress(), otherAccount.getWebAddress())
                && getHasUnseenNotes() == otherAccount.getHasUnseenNotes()
                && getTracksOptOut() == otherAccount.getTracksOptOut()
@@ -98,6 +100,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
         mDate = "";
         mNewEmail = "";
         mPendingEmailChange = false;
+        mTwoStepEnabled = false;
         mWebAddress = "";
         mTracksOptOut = false;
         mUsernameCanBeChanged = false;
@@ -134,6 +137,7 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
         setDate(other.getDate());
         setNewEmail(other.getNewEmail());
         setPendingEmailChange(other.getPendingEmailChange());
+        setTwoStepEnabled(other.getTwoStepEnabled());
         setTracksOptOut(other.getTracksOptOut());
         setWebAddress(other.getWebAddress());
         setDisplayName(other.getDisplayName());
@@ -266,6 +270,14 @@ public class AccountModel extends Payload<BaseNetworkError> implements Identifia
 
     public boolean getPendingEmailChange() {
         return mPendingEmailChange;
+    }
+
+    public void setTwoStepEnabled(boolean twoStepEnabled) {
+        mTwoStepEnabled = twoStepEnabled;
+    }
+
+    public boolean getTwoStepEnabled() {
+        return mTwoStepEnabled;
     }
 
     public void setWebAddress(String webAddress) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -1177,7 +1177,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         }
         if (from.containsKey("two_step_enabled")) {
             Object twoStepEnabledValue = from.get("two_step_enabled");
-            accountModel.setTwoStepEnabled(twoStepEnabledValue != null && (Boolean) twoStepEnabledValue);
+            accountModel.setTwoStepEnabled(twoStepEnabledValue instanceof Boolean && (Boolean) twoStepEnabledValue);
         }
         if (from.containsKey("tracks_opt_out")) {
             accountModel.setTracksOptOut((Boolean) from.get("tracks_opt_out"));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -1176,8 +1176,8 @@ public class AccountRestClient extends BaseWPComRestClient {
             accountModel.setPendingEmailChange((Boolean) from.get("user_email_change_pending"));
         }
         if (from.containsKey("two_step_enabled")) {
-            Object two_step_enabled_value =  from.get("two_step_enabled");
-            accountModel.setTwoStepEnabled(two_step_enabled_value != null && (Boolean) two_step_enabled_value);
+            Object twoStepEnabledValue = from.get("two_step_enabled");
+            accountModel.setTwoStepEnabled(twoStepEnabledValue != null && (Boolean) twoStepEnabledValue);
         }
         if (from.containsKey("tracks_opt_out")) {
             accountModel.setTracksOptOut((Boolean) from.get("tracks_opt_out"));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -1145,6 +1145,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         account.setNewEmail(from.new_user_email);
         account.setAvatarUrl(from.avatar_URL);
         account.setPendingEmailChange(from.user_email_change_pending);
+        account.setTwoStepEnabled(from.two_step_enabled);
         account.setUsernameCanBeChanged(from.user_login_can_be_changed);
         account.setTracksOptOut(from.tracks_opt_out);
         account.setWebAddress(from.user_URL);
@@ -1173,6 +1174,10 @@ public class AccountRestClient extends BaseWPComRestClient {
         if (from.containsKey("user_email")) accountModel.setEmail((String) from.get("user_email"));
         if (from.containsKey("user_email_change_pending")) {
             accountModel.setPendingEmailChange((Boolean) from.get("user_email_change_pending"));
+        }
+        if (from.containsKey("two_step_enabled")) {
+            Object two_step_enabled_value =  from.get("two_step_enabled");
+            accountModel.setTwoStepEnabled(two_step_enabled_value != null && (Boolean) two_step_enabled_value);
         }
         if (from.containsKey("tracks_opt_out")) {
             accountModel.setTracksOptOut((Boolean) from.get("tracks_opt_out"));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSettingsResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSettingsResponse.java
@@ -15,6 +15,7 @@ public class AccountSettingsResponse implements Response {
     public String last_name;
     public String description;
     public String new_user_email;
+    public boolean two_step_enabled;
     public boolean user_email_change_pending;
     public boolean user_login_can_be_changed;
     public String user_URL;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 179
+        return 180
     }
 
     override fun getDbName(): String {
@@ -1887,6 +1887,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 178 -> migrate(version) {
                     db.execSQL("ALTER TABLE EditorTheme ADD LIST_BLOCK_V2 BOOLEAN")
+                }
+                179 -> migrate(version) {
+                    db.execSQL("ALTER TABLE AccountModel ADD TWO_STEP_ENABLED BOOLEAN")
                 }
             }
         }


### PR DESCRIPTION
Fixes wordpress-mobile/WordPress-Android#17434 

This PR adds a new `mTwoStepEnabled` field and its management in the AccountModel/AccountRestClient + adds DB migration step.

It has a companion WP Android PR [here](https://github.com/wordpress-mobile/WordPress-Android/pull/17662) (please follow the instructions there for testing).
