### PR TITLE
[Application Passwords] Return correct error for WPCom simple sites

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ApplicationPasswordsLogger.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ApplicationPasswordsLogger.kt
@@ -50,6 +50,7 @@ class ApplicationPasswordsLogger @Inject constructor(
         invokeOnUiThread {
             prependToLog(
                 "Application Passwords are not supported on site ${siteModel.url}\n" +
+                    "Error message: ${networkError.message}\n" +
                     "Cause: ${networkError.errorCode} \n" +
                     "Status Code: ${networkError.volleyError?.networkResponse?.statusCode}"
             )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/HttpMethod.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/HttpMethod.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.fluxc.network
+
+import com.android.volley.Request.Method as VolleyMethod
+
+enum class HttpMethod {
+    GET, POST, DELETE, PUT, HEAD, OPTIONS, TRACE, PATCH
+}
+
+fun HttpMethod.toVolleyMethod(): Int = when (this) {
+    HttpMethod.GET -> VolleyMethod.GET
+    HttpMethod.POST -> VolleyMethod.POST
+    HttpMethod.DELETE -> VolleyMethod.DELETE
+    HttpMethod.PUT -> VolleyMethod.PUT
+    HttpMethod.HEAD -> VolleyMethod.HEAD
+    HttpMethod.OPTIONS -> VolleyMethod.OPTIONS
+    HttpMethod.TRACE -> VolleyMethod.TRACE
+    HttpMethod.PATCH -> VolleyMethod.PATCH
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManager.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.module.ApplicationPasswordClientId
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.util.AppLog
@@ -26,6 +26,14 @@ internal class ApplicationPasswordManager @Inject constructor(
     internal suspend fun getApplicationCredentials(
         site: SiteModel
     ): ApplicationPasswordCreationResult {
+        if (site.isWPCom) return ApplicationPasswordCreationResult.NotSupported(
+            WPAPINetworkError(
+                BaseNetworkError(
+                    GenericErrorType.UNKNOWN,
+                    "Simple WPCom sites don't support application passwords"
+                )
+            )
+        )
         val existingPassword = applicationPasswordsStore.getCredentials(site.domainName)
         if (existingPassword != null) {
             return ApplicationPasswordCreationResult.Existing(existingPassword)
@@ -139,7 +147,7 @@ internal class ApplicationPasswordManager @Inject constructor(
                     AppLog.w(AppLog.T.MAIN, "Application password deletion failed")
                     ApplicationPasswordDeletionResult.Failure(
                         BaseNetworkError(
-                            UNKNOWN,
+                            GenericErrorType.UNKNOWN,
                             "Deletion not confirmed by API"
                         )
                     )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManager.kt
@@ -23,6 +23,7 @@ internal class ApplicationPasswordManager @Inject constructor(
 ) {
     private val applicationPasswordsStore = ApplicationPasswordsStore(context, applicationName)
 
+    @Suppress("ReturnCount")
     internal suspend fun getApplicationCredentials(
         site: SiteModel
     ): ApplicationPasswordCreationResult {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordNetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordNetwork.kt
@@ -1,16 +1,17 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 
-import com.android.volley.Request.Method
 import com.android.volley.RequestQueue
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Credentials
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.HttpMethod
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.toVolleyMethod
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.AppLog
 import java.util.Optional
@@ -34,7 +35,7 @@ class ApplicationPasswordNetwork @Inject constructor(
     @Suppress("ReturnCount")
     suspend fun <T> executeGsonRequest(
         site: SiteModel,
-        method: Int,
+        method: HttpMethod,
         path: String,
         clazz: Class<T>,
         params: Map<String, String> = emptyMap(),
@@ -64,7 +65,7 @@ class ApplicationPasswordNetwork @Inject constructor(
 
         val response = suspendCancellableCoroutine<WPAPIResponse<T>> { continuation ->
             val request = WPAPIGsonRequest(
-                method,
+                method.toVolleyMethod(),
                 (site.wpApiRestUrl ?: site.url.slashJoin("wp-json")).slashJoin(path),
                 params,
                 body,
@@ -107,7 +108,7 @@ class ApplicationPasswordNetwork @Inject constructor(
         path: String,
         clazz: Class<T>,
         params: Map<String, String> = emptyMap()
-    ) = executeGsonRequest(site, Method.GET, path, clazz, params)
+    ) = executeGsonRequest(site, HttpMethod.GET, path, clazz, params)
 
     suspend fun <T> executePostGsonRequest(
         site: SiteModel,
@@ -115,7 +116,7 @@ class ApplicationPasswordNetwork @Inject constructor(
         clazz: Class<T>,
         body: Map<String, Any> = emptyMap(),
         params: Map<String, String> = emptyMap()
-    ) = executeGsonRequest(site, Method.POST, path, clazz, params, body)
+    ) = executeGsonRequest(site, HttpMethod.POST, path, clazz, params, body)
 
     suspend fun <T> executePutGsonRequest(
         site: SiteModel,
@@ -123,7 +124,7 @@ class ApplicationPasswordNetwork @Inject constructor(
         clazz: Class<T>,
         body: Map<String, Any> = emptyMap(),
         params: Map<String, String> = emptyMap()
-    ) = executeGsonRequest(site, Method.PUT, path, clazz, params, body)
+    ) = executeGsonRequest(site, HttpMethod.PUT, path, clazz, params, body)
 
     suspend fun <T> executeDeleteGsonRequest(
         site: SiteModel,
@@ -131,7 +132,7 @@ class ApplicationPasswordNetwork @Inject constructor(
         clazz: Class<T>,
         params: Map<String, String> = emptyMap(),
         body: Map<String, Any> = emptyMap()
-    ) = executeGsonRequest(site, Method.DELETE, path, clazz, params, body)
+    ) = executeGsonRequest(site, HttpMethod.DELETE, path, clazz, params, body)
 }
 
 private fun BaseNetworkError.toWPAPINetworkError(): WPAPINetworkError {


### PR DESCRIPTION
Part of #2588 

This PR has two changes:
1. The main change is in the commit f5098e6, it returns the `ApplicationPasswordCreationResult.NotSupported` error if the application passwords feature is attempted using a simple WPCom site.
2. The second change is 52c19d5, this is a change that I forgot to push in the previous PR, it just furthers the hiding of implementation details in the `ApplicationPasswordNetwork` class by not depending on `Volley`'s `Method` constants.

##### Test
To test the main change, checkout the branch of #2587, then apply the patch mentioned in that PR, then follow the steps:
1. Make sure to have a simple site in your WordPress.com account.
2. Sign in using WordPess.com account.
3. Click on Woo, then Coupons.
4. Click on "Fetch Coupons".
5. Confirm that the correct error is printed.