### PR TITLE
Fix connected tests of Jetpack sites

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ActivityLogTestJetpack.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.UrlUtils
 import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -271,7 +272,7 @@ class ReleaseStack_ActivityLogTestJetpack : ReleaseStack_Base() {
     private fun authenticate(site: Sites): SiteModel {
         authenticateWPComAndFetchSites(site.wpUserName, site.wpPassword)
 
-        return siteStore.sites.find { it.unmappedUrl == site.siteUrl }!!
+        return siteStore.sites.find { UrlUtils.removeScheme(it.unmappedUrl) == UrlUtils.removeScheme(site.siteUrl) }!!
     }
 
     private fun activityLogModel(index: Long, rewindable: Boolean): ActivityLogModel {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ScanTestJetpack.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.UrlUtils
 import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -214,7 +215,7 @@ class ReleaseStack_ScanTestJetpack : ReleaseStack_Base() {
     private fun authenticate(site: Sites): SiteModel {
         authenticateWPComAndFetchSites(site.wpUserName, site.wpPassword)
 
-        return siteStore.sites.find { it.unmappedUrl == site.siteUrl }!!
+        return siteStore.sites.find { UrlUtils.removeScheme(it.unmappedUrl) == UrlUtils.removeScheme(site.siteUrl) }!!
     }
 
     @Throws(InterruptedException::class)


### PR DESCRIPTION
While working on #2594, I noticed that some unrelated connected tests were failing, after checking I found out that it's because of a similar issue that we had last year p1625713520033400/1625704778.033300-slack-C0QB79UV8

To avoid having the issues in the future, we decided to make a change on the code side to exclude the site protocol when comparing the URLs.

Note: it seems the test `testInstallAndDeleteSitePlugin` is still failing, but from what I see, this was failing for at least a month, I don't have time to spend investigating it, so I'll leave it to someone else 🙂.