### PR TITLE
Application Passwords: expose a function to delete passwords

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -24,7 +24,10 @@ import kotlin.coroutines.CoroutineContext;
 import kotlinx.coroutines.Dispatchers;
 import okhttp3.OkHttpClient;
 
-@Module(includes = MockedNetworkModuleBindings.class)
+@Module(includes = {
+        MockedNetworkModuleBindings.class,
+        ApplicationPasswordsModule.class
+})
 public class MockedNetworkModule {
     @Module
     interface MockedNetworkModuleBindings {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ApplicationPasswordNetwork.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ApplicationPasswordNetwork.kt
@@ -69,7 +69,7 @@ internal class ReleaseStack_ApplicationPasswordNetwork(
 
     override fun tearDown() {
         runBlocking {
-            applicationPasswordsNetwork.deleteApplicationPassword(site)
+            siteStore.deleteApplicationPassword(site)
         }
         super.tearDown()
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ApplicationPasswordsModule.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ApplicationPasswordsModule.kt
@@ -8,4 +8,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.Appli
 interface ApplicationPasswordsModule {
     @BindsOptionalOf
     fun bindOptionalApplicationPasswordsListener(): ApplicationPasswordsListener
+    @BindsOptionalOf
+    @ApplicationPasswordsClientId
+    fun bindOptionalApplicationPasswordsClientId(): String
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -9,19 +9,34 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
+import java.util.Optional
 import javax.inject.Inject
 
 private const val CONFLICT = 409
 private const val NOT_FOUND = 404
 private const val APPLICATION_PASSWORDS_DISABLED_ERROR_CODE = "application_passwords_disabled"
 
+/**
+ * Note: the [ApplicationPasswordsClientId] is provided as [Optional] because we want to keep the feature optional and
+ * to not force the client apps to provide it. With this change, we will keep Dagger happy, and we move from a compile
+ * error to a runtime error if it's missing.
+ */
 internal class ApplicationPasswordsManager @Inject constructor(
     private val applicationPasswordsStore: ApplicationPasswordsStore,
-    @ApplicationPasswordsClientId private val applicationName: String,
+    @ApplicationPasswordsClientId private val applicationNameOptional: Optional<String>,
     private val jetpackApplicationPasswordsRestClient: JetpackApplicationPasswordsRestClient,
     private val wpApiApplicationPasswordsRestClient: WPApiApplicationPasswordsRestClient,
     private val appLogWrapper: AppLogWrapper
 ) {
+    private val applicationName
+        get() = applicationNameOptional.orElseThrow {
+            NoSuchElementException(
+                "Please make sure to inject a String instance with " +
+                    "the annotation @${ApplicationPasswordsClientId::class.simpleName} to the Dagger graph" +
+                    "to be able to use the Application Passwords feature"
+            )
+        }
+
     @Suppress("ReturnCount")
     suspend fun getApplicationCredentials(
         site: SiteModel

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -23,19 +23,12 @@ private const val APPLICATION_PASSWORDS_DISABLED_ERROR_CODE = "application_passw
  */
 internal class ApplicationPasswordsManager @Inject constructor(
     private val applicationPasswordsStore: ApplicationPasswordsStore,
-    @ApplicationPasswordsClientId private val applicationNameOptional: Optional<String>,
     private val jetpackApplicationPasswordsRestClient: JetpackApplicationPasswordsRestClient,
     private val wpApiApplicationPasswordsRestClient: WPApiApplicationPasswordsRestClient,
     private val appLogWrapper: AppLogWrapper
 ) {
     private val applicationName
-        get() = applicationNameOptional.orElseThrow {
-            NoSuchElementException(
-                "Please make sure to inject a String instance with " +
-                    "the annotation @${ApplicationPasswordsClientId::class.simpleName} to the Dagger graph" +
-                    "to be able to use the Application Passwords feature"
-            )
-        }
+        get() = applicationPasswordsStore.applicationName
 
     @Suppress("ReturnCount")
     suspend fun getApplicationCredentials(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -103,10 +103,6 @@ class ApplicationPasswordsNetwork @Inject constructor(
         }
     }
 
-    suspend fun deleteApplicationPassword(site: SiteModel) {
-        mApplicationPasswordsManager.deleteApplicationCredentials(site)
-    }
-
     suspend fun <T> executeGetGsonRequest(
         site: SiteModel,
         path: String,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -6,18 +6,28 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import org.wordpress.android.fluxc.module.ApplicationPasswordsClientId
 import org.wordpress.android.util.AppLog
+import java.util.Optional
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 internal class ApplicationPasswordsStore @Inject constructor(
     private val context: Context,
-    @ApplicationPasswordsClientId private val applicationName: String,
+    @ApplicationPasswordsClientId private val applicationNameOptional: Optional<String>,
 ) {
     companion object {
         private const val USERNAME_PREFERENCE_KEY_PREFIX = "username_"
         private const val PASSWORD_PREFERENCE_KEY_PREFIX = "app_password_"
     }
+
+    private val applicationName
+        get() = applicationNameOptional.orElseThrow {
+            NoSuchElementException(
+                "Please make sure to inject a String instance with " +
+                    "the annotation @${ApplicationPasswordsClientId::class.simpleName} to the Dagger graph" +
+                    "to be able to use the Application Passwords feature"
+            )
+        }
 
     private val encryptedPreferences by lazy {
         initEncryptedPrefs()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -20,7 +20,7 @@ internal class ApplicationPasswordsStore @Inject constructor(
         private const val PASSWORD_PREFERENCE_KEY_PREFIX = "app_password_"
     }
 
-    private val applicationName
+    val applicationName: String
         get() = applicationNameOptional.orElseThrow {
             NoSuchElementException(
                 "Please make sure to inject a String instance with " +

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -135,7 +135,6 @@ open class SiteStore @Inject constructor(
     private val siteSqlUtils: SiteSqlUtils,
     private val coroutineEngine: CoroutineEngine
 ) : Store(dispatcher) {
-
     @Inject internal lateinit var applicationPasswordsManagerProvider: Provider<ApplicationPasswordsManager>
 
     // Payloads

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -14,7 +15,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
-import java.util.Optional
 import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
@@ -28,7 +28,9 @@ class ApplicationPasswordManagerTests {
         userName = "username",
         password = "password"
     )
-    private val applicationPasswordsStore: ApplicationPasswordsStore = mock()
+    private val applicationPasswordsStore: ApplicationPasswordsStore = mock() {
+        on { applicationName } doReturn applicationName
+    }
     private val mJetpackApplicationPasswordsRestClient: JetpackApplicationPasswordsRestClient = mock()
     private val mWpApiApplicationPasswordsRestClient: WPApiApplicationPasswordsRestClient = mock()
 
@@ -38,7 +40,6 @@ class ApplicationPasswordManagerTests {
     fun setup() {
         mApplicationPasswordsManager = ApplicationPasswordsManager(
             applicationPasswordsStore = applicationPasswordsStore,
-            applicationNameOptional = Optional.of(applicationName),
             jetpackApplicationPasswordsRestClient = mJetpackApplicationPasswordsRestClient,
             wpApiApplicationPasswordsRestClient = mWpApiApplicationPasswordsRestClient,
             appLogWrapper = mock()

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import java.util.Optional
 import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
@@ -37,7 +38,7 @@ class ApplicationPasswordManagerTests {
     fun setup() {
         mApplicationPasswordsManager = ApplicationPasswordsManager(
             applicationPasswordsStore = applicationPasswordsStore,
-            applicationName = applicationName,
+            applicationNameOptional = Optional.of(applicationName),
             jetpackApplicationPasswordsRestClient = mJetpackApplicationPasswordsRestClient,
             wpApiApplicationPasswordsRestClient = mWpApiApplicationPasswordsRestClient,
             appLogWrapper = mock()


### PR DESCRIPTION
@hafizrahman let's continue the [discussion ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2594#discussion_r1050465079) we started in the other PR here.

In this PR, I made two main changes:
1. I removed the `deleteApplicationPassword` from `ApplicationPasswordsNetwork` and moved it to `SiteStore`. For this part, I was torn between `SiteStore` and `AccountStore`, but I decided to go with `SiteStore` for two reasons: it's already in Kotlin 😄, and `AccountStore` is more about the WPCom account than this.
2. I updated the DI configuration to make `@ApplicationPasswordsClientId` as `Optional`, this allows moving from a compile error to a runtime error if it's missing, and with this we won't impact the other clients if they don't want to use the feature.

Let me know what you think about these two changes.