### PR TITLE
[Woo] Migrate Reviews to use WooNetwork.

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1369,16 +1369,15 @@ class ProductRestClient @Inject constructor(
     ): WooPayload<WCProductReviewModel> {
         val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
         val params = mapOf("status" to newStatus)
-        val response = jetpackTunnelGsonRequestBuilder.syncPutRequest(
-            restClient = this,
-            site = site,
-            url = url,
-            body = params,
-            clazz = ProductReviewApiResponse::class.java
+        val response = wooNetwork.executePutGsonRequest(
+                site = site,
+                path = url,
+                clazz = ProductReviewApiResponse::class.java,
+                body = params
         )
 
         return when (response) {
-            is JetpackSuccess -> {
+            is WPAPIResponse.Success  -> {
                 response.data?.let {
                     val review = productReviewResponseToProductReviewModel(it).apply {
                         localSiteId = site.id
@@ -1392,7 +1391,7 @@ class ProductRestClient @Inject constructor(
                     )
                 )
             }
-            is JetpackError -> WooPayload(error = response.error.toWooError())
+            is WPAPIResponse.Error -> WooPayload(error = response.error.toWooError())
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -32,7 +32,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.*
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1109,7 +1109,7 @@ class ProductRestClient @Inject constructor(
      *
      * Dispatches a WCProductAction.UPDATED_PRODUCT_IMAGES action with the result
      *
-     * @param [site] The site to fetch product reviews for
+     * @param [site] The site to update product images for
      * @param [remoteProductId] Unique server id of the product to update
      * @param [imageList] list of product images to assign to the product
      */

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1326,16 +1326,14 @@ class ProductRestClient @Inject constructor(
      */
     suspend fun fetchProductReviewById(site: SiteModel, remoteReviewId: Long): RemoteProductReviewPayload {
         val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                ProductReviewApiResponse::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+                site = site,
+                path = url,
+                clazz = ProductReviewApiResponse::class.java
         )
 
         return when (response) {
-            is JetpackSuccess -> {
+            is WPAPIResponse.Success  -> {
                 response.data?.let {
                     val review = productReviewResponseToProductReviewModel(it).apply {
                         localSiteId = site.id
@@ -1346,8 +1344,8 @@ class ProductRestClient @Inject constructor(
                         site = site
                 )
             }
-            is JetpackError -> {
-                val productReviewError = networkErrorToProductError(response.error)
+            is WPAPIResponse.Error  -> {
+                val productReviewError = wpAPINetworkErrorToProductError(response.error)
                 RemoteProductReviewPayload(error = productReviewError, site = site)
             }
         }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProductRestClientTest {
@@ -26,6 +27,7 @@ class ProductRestClientTest {
     private val productId = 5L
     private val site = SiteModel()
     private val requestBuilder: JetpackTunnelGsonRequestBuilder = mock()
+    private val wooNetwork: WooNetwork = mock()
 
     @Before fun setUp() {
         requestBuilder.stub {
@@ -35,7 +37,7 @@ class ProductRestClientTest {
                 )
             } doReturn JetpackResponse.JetpackSuccess(null)
         }
-        sut = ProductRestClient(mock(), mock(), mock(), mock(), mock(), requestBuilder)
+        sut = ProductRestClient(mock(), mock(), mock(), mock(), mock(), requestBuilder, wooNetwork)
     }
 
     @Test


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-android/issues/8015

Test instructions:

### 1. For site credentials login

First, apply patch:

```patch
Index: example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(revision ab9379d307673d92659cf08607388d7b549488d7)
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(date 1671447606619)
@@ -7,6 +7,8 @@
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.fragment_woo_products.*
 import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.SiteSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
@@ -23,7 +25,7 @@
                 Button(context).apply {
                     text = "Select Site"
                     setOnClickListener {
-                        showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                        showSiteSelectorDialog(selectedPos, object : SiteSelectorDialog.Listener {
                             override fun onSiteSelected(site: SiteModel, pos: Int) {
                                 onSiteSelected(site)
                                 selectedSite = site
```

1. Start Example app,
2. Sign in using wp-admin credentials and xmlrpc url,
3. Go to Woo > Select Site > pick the site,
4. Go to Products > Select Site > pick the site,
5. Test these buttons and check that changes apply in wp-admin:
   1. Fetch product reviews by product
   2. Fetch product reviews by site
   3. Fetch product review by ID
   4. Update product review status


### 2. For wpcom login
1. Start Example app,
2. Sign in using WordPress.com account,
3. follow step 3-5 on "For site credentials login" instructions.