### PR TITLE
Woo REST API: Migrate Products endpoints to use WooNetwork

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.android.volley.RequestQueue
 import com.google.gson.JsonArray
 import com.google.gson.JsonParser
-import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCProductAction
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
@@ -1200,7 +1199,6 @@ class ProductRestClient @Inject constructor(
             }
 
             val url = WOOCOMMERCE.products.categories.pathV3
-            val responseType = object : TypeToken<List<ProductCategoryApiResponse>>() {}.type
             val params = mutableMapOf(
                 "per_page" to pageSize.toString(),
                 "offset" to offset.toString(),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -340,12 +340,15 @@ class ProductRestClient @Inject constructor(
         val url = WOOCOMMERCE.products.id(remoteProductId).variations.variation(remoteVariationId).pathV3
         val params = emptyMap<String, String>()
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this, site, url, params, ProductVariationApiResponse::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            params = params,
+            clazz = ProductVariationApiResponse::class.java
         )
 
         return when (response) {
-            is JetpackSuccess -> {
+            is WPAPIResponse.Success -> {
                 val productData = response.data
                 if (productData != null) {
                     RemoteVariationPayload(
@@ -366,9 +369,9 @@ class ProductRestClient @Inject constructor(
                     )
                 }
             }
-            is JetpackError -> {
+            is WPAPIResponse.Error -> {
                 RemoteVariationPayload(
-                    networkErrorToProductError(response.error),
+                    wpAPINetworkErrorToProductError(response.error),
                     WCProductVariationModel().apply {
                         this.remoteProductId = remoteProductId
                         this.remoteVariationId = remoteVariationId

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1083,15 +1083,14 @@ class ProductRestClient @Inject constructor(
         variationId: Long,
         attributesJson: String
     ) = WOOCOMMERCE.products.id(productId).variations.variation(variationId).pathV3
-                .let { url ->
-                    jetpackTunnelGsonRequestBuilder.syncPutRequest(
-                            this@ProductRestClient,
-                            site,
-                            url,
-                            mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray),
-                            ProductVariationApiResponse::class.java
-                    ).handleResult()
-                }
+        .let { url ->
+            wooNetwork.executePutGsonRequest(
+                site = site,
+                path = url,
+                clazz = ProductVariationApiResponse::class.java,
+                body = mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray)
+            ).handleResult()
+        }
 
     /**
      * Makes a PUT request to `/wp-json/wc/v3/products/[WCProductModel.remoteProductId]`

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -91,7 +91,6 @@ class ProductRestClient @Inject constructor(
     @Named("regular") requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
     private val wooNetwork: WooNetwork,
     private val coroutineEngine: CoroutineEngine
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1106,15 +1106,14 @@ class ProductRestClient @Inject constructor(
         productId: Long,
         attributesJson: String
     ) = WOOCOMMERCE.products.id(productId).pathV3
-            .let { url ->
-                jetpackTunnelGsonRequestBuilder.syncPutRequest(
-                        this,
-                        site,
-                        url,
-                        mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray),
-                        ProductApiResponse::class.java
-                ).handleResult()
-            }
+        .let { url ->
+            wooNetwork.executePutGsonRequest(
+                site = site,
+                path = url,
+                clazz = ProductApiResponse::class.java,
+                body = mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray)
+            ).handleResult()
+        }
 
     /**
      * Makes a PUT request to `/wp-json/wc/v3/products/[remoteProductId]` to replace a product's images

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -913,11 +913,15 @@ class ProductRestClient @Inject constructor(
         val url = WOOCOMMERCE.products.id(remoteProductId).variations.variation(remoteVariationId).pathV3
         val body = variantModelToProductJsonBody(storedWCProductVariationModel, updatedProductVariationModel)
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPutRequest(
-            this, site, url, body, ProductVariationApiResponse::class.java
+        val response = wooNetwork.executePutGsonRequest(
+            site = site,
+            path = url,
+            body = body,
+            clazz = ProductVariationApiResponse::class.java
         )
+
         return when (response) {
-            is JetpackSuccess -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let {
                     val newModel = it.asProductVariationModel().apply {
                         this.remoteProductId = remoteProductId
@@ -933,8 +937,8 @@ class ProductRestClient @Inject constructor(
                     }
                 )
             }
-            is JetpackError -> {
-                val productError = networkErrorToProductError(response.error)
+            is WPAPIResponse.Error -> {
+                val productError = wpAPINetworkErrorToProductError(response.error)
                 RemoteUpdateVariationPayload(
                     productError,
                     site,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1058,14 +1058,13 @@ class ProductRestClient @Inject constructor(
         productId: Long,
         variationId: Long
     ) = WOOCOMMERCE.products.id(productId).variations.variation(variationId).pathV3
-            .let { url ->
-                jetpackTunnelGsonRequestBuilder.syncDeleteRequest(
-                        this@ProductRestClient,
-                        site,
-                        url,
-                        ProductVariationApiResponse::class.java
-                ).handleResult()
-            }
+        .let { url ->
+            wooNetwork.executeDeleteGsonRequest(
+                site = site,
+                path = url,
+                clazz = ProductVariationApiResponse::class.java
+            ).handleResult()
+        }
 
     /**
      * Makes a PUT request to

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -753,17 +753,21 @@ class ProductRestClient @Inject constructor(
     ): RemoteProductVariationsPayload {
         val url = WOOCOMMERCE.products.id(productId).variations.pathV3
         val params = mutableMapOf(
-                "per_page" to pageSize.toString(),
-                "offset" to offset.toString(),
-                "order" to "asc",
-                "orderby" to "date"
+            "per_page" to pageSize.toString(),
+            "offset" to offset.toString(),
+            "order" to "asc",
+            "orderby" to "date"
         )
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this, site, url, params, Array<ProductVariationApiResponse>::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            params = params,
+            clazz = Array<ProductVariationApiResponse>::class.java
         )
+
         when (response) {
-            is JetpackSuccess -> {
+            is WPAPIResponse.Success -> {
                 val variationModels = response.data?.map {
                     it.asProductVariationModel().apply {
                         localSiteId = site.id
@@ -777,8 +781,8 @@ class ProductRestClient @Inject constructor(
                     site, productId, variationModels, offset, loadedMore, canLoadMore
                 )
             }
-            is JetpackError -> {
-                val productError = networkErrorToProductError(response.error)
+            is WPAPIResponse.Error -> {
+                val productError = wpAPINetworkErrorToProductError(response.error)
                 return RemoteProductVariationsPayload(
                     productError,
                     site,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1035,15 +1035,14 @@ class ProductRestClient @Inject constructor(
         productId: Long,
         attributesJson: String
     ) = WOOCOMMERCE.products.id(productId).variations.pathV3
-            .let { url ->
-                jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                        this@ProductRestClient,
-                        site,
-                        url,
-                        mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray),
-                        ProductVariationApiResponse::class.java
-                ).handleResult()
-            }
+        .let { url ->
+            wooNetwork.executePostGsonRequest(
+                site = site,
+                path = url,
+                clazz = ProductVariationApiResponse::class.java,
+                body = mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray)
+            ).handleResult()
+        }
 
     /**
      * Makes a DELETE request to `/wp-json/wc/v3/products/<id>` to delete a product

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -28,8 +28,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
@@ -976,12 +974,11 @@ class ProductRestClient @Inject constructor(
             // No changes need to be executed, no need to call the API
             if (body.isEmpty()) return@let WooPayload()
 
-            jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                this@ProductRestClient,
-                site,
-                url,
-                body,
-                BatchProductApiResponse::class.java
+            wooNetwork.executePostGsonRequest(
+                site = site,
+                path = url,
+                clazz = BatchProductApiResponse::class.java,
+                body = body
             ).handleResult()
         }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1015,12 +1015,11 @@ class ProductRestClient @Inject constructor(
 
                 require(body.isNotEmpty())
 
-                jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                    this@ProductRestClient,
-                    site,
-                    url,
-                    body,
-                    BatchProductVariationsApiResponse::class.java
+                wooNetwork.executePostGsonRequest(
+                    site = site,
+                    path = url,
+                    clazz = BatchProductVariationsApiResponse::class.java,
+                    body = body
                 ).handleResult()
             }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WPAPIResponseExt.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WPAPIResponseExt.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.utils
+
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+
+fun <T> WPAPIResponse<T>.handleResult() =
+    when (this) {
+        is WPAPIResponse.Success -> WooPayload(data)
+        is WPAPIResponse.Error -> WooPayload(error.toWooError())
+    }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -11,14 +11,13 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
-import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.utils.initCoroutineEngine
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProductRestClientTest {
@@ -26,18 +25,16 @@ class ProductRestClientTest {
 
     private val productId = 5L
     private val site = SiteModel()
-    private val requestBuilder: JetpackTunnelGsonRequestBuilder = mock()
-    private val wooNetwork: WooNetwork = mock()
+    private val wooNetwork: WooNetwork = mock() {
+        onBlocking {
+            executePostGsonRequest(
+                any(), any(), eq(BatchProductApiResponse::class.java), any()
+            )
+        } doReturn WPAPIResponse.Success(null)
+    }
 
     @Before fun setUp() {
-        requestBuilder.stub {
-            onBlocking {
-                syncPostRequest(
-                    any(), any(), any(), any(), eq(BatchProductApiResponse::class.java)
-                )
-            } doReturn JetpackResponse.JetpackSuccess(null)
-        }
-        sut = ProductRestClient(mock(), mock(), mock(), mock(), mock(), requestBuilder, wooNetwork)
+        sut = ProductRestClient(mock(), mock(), mock(), mock(), mock(), wooNetwork, initCoroutineEngine())
     }
 
     @Test
@@ -58,12 +55,11 @@ class ProductRestClientTest {
         )
 
         // then
-        verify(requestBuilder).syncPostRequest(
-            eq(sut),
-            eq(site),
-            eq(WOOCOMMERCE.products.batch.pathV3),
-            bodyCaptor.capture(),
-            eq(BatchProductApiResponse::class.java),
+        verify(wooNetwork).executePostGsonRequest(
+            site = eq(site),
+            path = eq(WOOCOMMERCE.products.batch.pathV3),
+            clazz = eq(BatchProductApiResponse::class.java),
+            body = bodyCaptor.capture()
         )
         assertThat(bodyCaptor.allValues).hasSize(1)
         assertThat(bodyCaptor.firstValue).isEqualTo(
@@ -100,12 +96,11 @@ class ProductRestClientTest {
         )
 
         // then
-        verify(requestBuilder, never()).syncPostRequest(
-            eq(sut),
-            eq(site),
-            eq(WOOCOMMERCE.products.batch.pathV3),
-            bodyCaptor.capture(),
-            eq(BatchProductApiResponse::class.java),
+        verify(wooNetwork, never()).executePostGsonRequest(
+            site = eq(site),
+            path = eq(WOOCOMMERCE.products.batch.pathV3),
+            clazz = eq(BatchProductApiResponse::class.java),
+            body = bodyCaptor.capture()
         )
     }
 

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/CoroutineEngineUtils.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/CoroutineEngineUtils.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.fluxc.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.mockito.Mockito.lenient
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+
+fun initCoroutineEngine() = runBlocking {
+    val coroutineEngine = mock<CoroutineEngine>()
+    lenient().doAnswer {
+        return@doAnswer runBlocking {
+            it.getArgument<(suspend CoroutineScope.() -> Any)>(3).invoke(this)
+        }
+    }.whenever(coroutineEngine).withDefaultContext(
+            any(),
+            any(),
+            any(),
+            any<(suspend CoroutineScope.() -> Any)>()
+    )
+    lenient().doAnswer {
+        it.getArgument<(() -> Any)>(3).invoke()
+    }.whenever(coroutineEngine).run(
+            any(),
+            any(),
+            any(),
+            any<(() -> Any)>()
+    )
+    lenient().doAnswer {
+        runBlocking {
+            it.getArgument<(suspend CoroutineScope.() -> Any)>(3).invoke(this)
+        }
+        return@doAnswer mock<Job>()
+    }.whenever(coroutineEngine).launch(
+            any(),
+            any(),
+            any(),
+            any<(suspend CoroutineScope.() -> Any)>()
+    )
+    lenient().doAnswer {
+        return@doAnswer runBlocking {
+            flow { it.getArgument<(suspend FlowCollector<Any>.() -> Unit)>(3).invoke(this) }
+        }
+    }.whenever(coroutineEngine).flowWithDefaultContext(
+            any(),
+            any(),
+            any(),
+            any<(suspend FlowCollector<Any>.() -> Unit)>()
+    )
+    coroutineEngine
+}


### PR DESCRIPTION
This PR migrates all of the remaining Jetpack requests in ProductRestClient to use `WooNetwork`.

### Notes for review
- You may want to review commit by commit to review small chunks of the changes at a time.
- Most of the changes are purely migration, but for three commits (e9dcab9babc5dad67c1ccccc49e446c819f01d96 and 31cabd4f99568099cba230ba03d298460afb4405 and 328e1d771b9dd000e0882c289bb38df6369d04c8) I did some small refactorings, I removed the extensive usage of extensions as it made the code harder to follow and read and wasn't consistent with what we do in the other places.

### Testing
IMO the code review should be the main part here, as the behavior was tested in previous PRs.
But if you want to test some endpoints, follow the below steps:

#### Site Credentials login
1. Apply this patch
```
Index: example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(revision ab9379d307673d92659cf08607388d7b549488d7)
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(date 1671447606619)
@@ -7,6 +7,8 @@
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.fragment_woo_products.*
 import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.SiteSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
@@ -23,7 +25,7 @@
                 Button(context).apply {
                     text = "Select Site"
                     setOnClickListener {
-                        showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                        showSiteSelectorDialog(selectedPos, object : SiteSelectorDialog.Listener {
                             override fun onSiteSelected(site: SiteModel, pos: Int) {
                                 onSiteSelected(site)
                                 selectedSite = site
```
2. Start Example app.
3. Sign in using wp-admin credentials and xmlrpc url.
4. Go to Woo > Select Site > pick the site
5. Go to Products > Select Site > pick the site
6. Test some product related scenarios

#### WordPress.com login
1. Start the example app, then sign in using your WordPress.com account.
2. Repeat 4 to 6 from previous test.