### PR TITLE
Woo REST API: Finish migration of ProductRestClient

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComNetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComNetwork.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.fluxc.network.rest.wpcom
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+/**
+ * This class acts as a network engine for using Jetpack Tunnel to call WP API endpoints.
+ * The goal of adding this class instead of directly inheriting from [BaseWPComRestClient] is allowing to move away
+ * from the traditional model of inheritance, and allowing the feature RestClients to have multiple network
+ * implementations at the same time when it's needed
+ */
+@Singleton
+class WPComNetwork @Inject constructor(
+    appContext: Context,
+    dispatcher: Dispatcher,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun <T : Any> executeGetGsonRequest(
+        url: String,
+        clazz: Class<T>,
+        params: Map<String, String> = emptyMap()
+    ): WPComGsonRequestBuilder.Response<T> {
+        return wpComGsonRequestBuilder.syncGetRequest(
+            restClient = this,
+            url = url,
+            params = params,
+            clazz = clazz
+        )
+    }
+
+    suspend fun <T : Any> executePostGsonRequest(
+        url: String,
+        clazz: Class<T>,
+        params: Map<String, String> = emptyMap(),
+        body: Map<String, Any> = emptyMap(),
+    ): WPComGsonRequestBuilder.Response<T> {
+        return wpComGsonRequestBuilder.syncPostRequest(
+            restClient = this,
+            url = url,
+            clazz = clazz,
+            params = params,
+            body = body
+        )
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1315,9 +1315,9 @@ class ProductRestClient @Inject constructor(
 
         val url = WOOCOMMERCE.products.reviews.pathV3
         val params = mutableMapOf(
-                "per_page" to WCProductStore.NUM_REVIEWS_PER_FETCH.toString(),
-                "offset" to offset.toString(),
-                "status" to statusFilter
+            "per_page" to WCProductStore.NUM_REVIEWS_PER_FETCH.toString(),
+            "offset" to offset.toString(),
+            "status" to statusFilter
         )
         reviewIds?.let { ids ->
             params.put("include", ids.map { it }.joinToString())
@@ -1327,10 +1327,10 @@ class ProductRestClient @Inject constructor(
         }
 
         val response = wooNetwork.executeGetGsonRequest(
-                site = site,
-                path = url,
-                clazz = Array<ProductReviewApiResponse>::class.java,
-                params = params
+            site = site,
+            path = url,
+            clazz = Array<ProductReviewApiResponse>::class.java,
+            params = params
         )
 
         return when (response) {
@@ -1378,24 +1378,24 @@ class ProductRestClient @Inject constructor(
     suspend fun fetchProductReviewById(site: SiteModel, remoteReviewId: Long): RemoteProductReviewPayload {
         val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
         val response = wooNetwork.executeGetGsonRequest(
-                site = site,
-                path = url,
-                clazz = ProductReviewApiResponse::class.java
+            site = site,
+            path = url,
+            clazz = ProductReviewApiResponse::class.java
         )
 
         return when (response) {
-            is WPAPIResponse.Success  -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let {
                     val review = productReviewResponseToProductReviewModel(it).apply {
                         localSiteId = site.id
                     }
                     RemoteProductReviewPayload(site, review)
                 } ?: RemoteProductReviewPayload(
-                        error = ProductError(GENERIC_ERROR, "Success response with empty data"),
-                        site = site
+                    error = ProductError(GENERIC_ERROR, "Success response with empty data"),
+                    site = site
                 )
             }
-            is WPAPIResponse.Error  -> {
+            is WPAPIResponse.Error -> {
                 val productReviewError = wpAPINetworkErrorToProductError(response.error)
                 RemoteProductReviewPayload(error = productReviewError, site = site)
             }
@@ -1421,14 +1421,14 @@ class ProductRestClient @Inject constructor(
         val url = WOOCOMMERCE.products.reviews.id(remoteReviewId).pathV3
         val params = mapOf("status" to newStatus)
         val response = wooNetwork.executePutGsonRequest(
-                site = site,
-                path = url,
-                clazz = ProductReviewApiResponse::class.java,
-                body = params
+            site = site,
+            path = url,
+            clazz = ProductReviewApiResponse::class.java,
+            body = params
         )
 
         return when (response) {
-            is WPAPIResponse.Success  -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let {
                     val review = productReviewResponseToProductReviewModel(it).apply {
                         localSiteId = site.id

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
-import android.content.Context
-import com.android.volley.RequestQueue
 import com.google.gson.JsonArray
 import com.google.gson.JsonParser
 import org.wordpress.android.fluxc.Dispatcher
@@ -18,14 +16,11 @@ import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
-import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
@@ -80,21 +75,14 @@ import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.fluxc.utils.putIfNotNull
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
 @Suppress("LargeClass")
-@Singleton
 class ProductRestClient @Inject constructor(
-    appContext: Context,
     private val dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
     private val wooNetwork: WooNetwork,
     private val wpComNetwork: WPComNetwork,
     private val coroutineEngine: CoroutineEngine
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+) {
     /**
      * Makes a GET request to `/wp-json/wc/v3/products/shipping_classes/[remoteShippingClassId]`
      * to fetch a single product shipping class

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -988,7 +988,7 @@ class ProductRestClient @Inject constructor(
             path = WPAPI.comments.urlV2,
             clazz = Unit::class.java,
             body = body
-        ).handleResult()
+        ).toWooPayload()
     }
 
     /**

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.utils.initCoroutineEngine
 
@@ -32,9 +33,10 @@ class ProductRestClientTest {
             )
         } doReturn WPAPIResponse.Success(null)
     }
+    private val wpComNetwork: WPComNetwork = mock()
 
     @Before fun setUp() {
-        sut = ProductRestClient(mock(), mock(), mock(), mock(), mock(), wooNetwork, initCoroutineEngine())
+        sut = ProductRestClient(mock(), wooNetwork, wpComNetwork, initCoroutineEngine())
     }
 
     @Test


### PR DESCRIPTION
⚠️ Please don't merge until #2602 is merged.

This finishes the migration of ProductRestClient to the new architecture by introducing a new `Network` class: `WPComNetwork`, this allows getting rid of the base class and the unused arguments.

For review, it's better to review cce651717a5dda51e12694314424989c879ef269 separately, as it simply reformats the file to follow the new Kotlin coding style. 

### Test
This change applies only to WPCom login, we will check later if there is an WP or WC based API to handle the password change.

1. Open the example app then sign in using WordPress.com account.
2. Click on Woo, then select a site.
3. Click on Products then select a site.
4. Click on Update Product.
5. Enter a product ID.
6. Make sure visibility is set to `publish`.
7. Scroll to the bottom then change the password.
8. Confirm the change and fetch work as expected.