### PR TITLE
Fix Mocked Tests

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedNetworkAppComponent.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.mocked;
 
 import org.wordpress.android.fluxc.di.WCDatabaseModule;
 import org.wordpress.android.fluxc.example.di.AppConfigModule;
+import org.wordpress.android.fluxc.example.di.ApplicationPasswordsModule;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.MockedNetworkModule;
 
@@ -14,7 +15,8 @@ import dagger.Component;
         AppContextModule.class,
         AppConfigModule.class,
         MockedNetworkModule.class,
-        WCDatabaseModule.class
+        WCDatabaseModule.class,
+        ApplicationPasswordsModule.class
 })
 public interface MockedNetworkAppComponent {
     void inject(MockedStack_AccountTest object);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -60,6 +60,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     private val searchQuery = "test"
 
     private val siteModel = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
         email = "test@example.org"
         name = "Test Site"
         siteId = 24

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/module/MockedNetworkModule.java
@@ -24,7 +24,10 @@ import kotlin.coroutines.CoroutineContext;
 import kotlinx.coroutines.Dispatchers;
 import okhttp3.OkHttpClient;
 
-@Module(includes = MockedNetworkModuleBindings.class)
+@Module(includes = {
+        MockedNetworkModuleBindings.class,
+        ApplicationPasswordsModule.class
+})
 public class MockedNetworkModule {
     @Module
     interface MockedNetworkModuleBindings {
@@ -36,6 +39,9 @@ public class MockedNetworkModule {
 
         @Named("no-redirects")
         @Binds OkHttpClient bindsNoRedirectsOkHttpClient(OkHttpClient okHttpClient);
+
+        @Named("no-cookies")
+        @Binds OkHttpClient bindsNoCookiesOkHttpClient(OkHttpClient okHttpClient);
     }
 
     @Provides
@@ -55,7 +61,7 @@ public class MockedNetworkModule {
     @Named("regular")
     @Provides
     public RequestQueue provideRegularRequestQueue(@Named("regular") OkHttpClient okHttpClient,
-                                                          Context appContext) {
+                                                   Context appContext) {
         return Volley.newRequestQueue(appContext, new OkHttpStack(okHttpClient));
     }
 
@@ -63,7 +69,7 @@ public class MockedNetworkModule {
     @Named("no-redirects")
     @Provides
     public RequestQueue provideNoRedirectsRequestQueue(@Named("no-redirects") OkHttpClient okHttpClient,
-                                                              Context appContext) {
+                                                       Context appContext) {
         return provideRegularRequestQueue(okHttpClient, appContext);
     }
 
@@ -71,7 +77,15 @@ public class MockedNetworkModule {
     @Named("custom-ssl")
     @Provides
     public RequestQueue provideCustomRequestQueue(@Named("custom-ssl") OkHttpClient okHttpClient,
-                                                         Context appContext) {
+                                                  Context appContext) {
+        return Volley.newRequestQueue(appContext, new OkHttpStack(okHttpClient));
+    }
+
+    @Singleton
+    @Named("no-cookies")
+    @Provides
+    public RequestQueue provideNoCookiesRequestQueue(@Named("no-cookies") OkHttpClient okHttpClient,
+                                                     Context appContext) {
         return Volley.newRequestQueue(appContext, new OkHttpStack(okHttpClient));
     }
 


### PR DESCRIPTION
After merging #2601, we broke the instrumented tests, they don't build anymore.

This PR does two things:
1. Fixes the build issue by providing the necessary dependencies to the Mocked modules.
2. Fixes the mocked Products tests.