### PR TITLE
Enhance the mapper function from WPAPIResponse to WooPayload

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -32,7 +32,8 @@ enum class WooErrorType {
     INVALID_RESPONSE,
     AUTHORIZATION_REQUIRED,
     INVALID_PARAM,
-    PLUGIN_NOT_ACTIVE
+    PLUGIN_NOT_ACTIVE,
+    EMPTY_RESPONSE
 }
 
 fun WPComGsonNetworkError.toWooError(): WooError {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -74,7 +74,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPay
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
-import org.wordpress.android.fluxc.utils.handleResult
+import org.wordpress.android.fluxc.utils.toWooPayload
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.fluxc.utils.putIfNotNull
 import org.wordpress.android.util.AppLog
@@ -984,7 +984,7 @@ class ProductRestClient @Inject constructor(
                 path = url,
                 clazz = BatchProductApiResponse::class.java,
                 body = body
-            ).handleResult()
+            ).toWooPayload()
         }
 
     /**
@@ -1025,7 +1025,7 @@ class ProductRestClient @Inject constructor(
                     path = url,
                     clazz = BatchProductVariationsApiResponse::class.java,
                     body = body
-                ).handleResult()
+                ).toWooPayload()
             }
 
     /**
@@ -1046,7 +1046,7 @@ class ProductRestClient @Inject constructor(
                 path = url,
                 clazz = ProductVariationApiResponse::class.java,
                 body = mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray)
-            ).handleResult()
+            ).toWooPayload()
         }
 
     /**
@@ -1068,7 +1068,7 @@ class ProductRestClient @Inject constructor(
                 site = site,
                 path = url,
                 clazz = ProductVariationApiResponse::class.java
-            ).handleResult()
+            ).toWooPayload()
         }
 
     /**
@@ -1094,7 +1094,7 @@ class ProductRestClient @Inject constructor(
                 path = url,
                 clazz = ProductVariationApiResponse::class.java,
                 body = mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray)
-            ).handleResult()
+            ).toWooPayload()
         }
 
     /**
@@ -1117,7 +1117,7 @@ class ProductRestClient @Inject constructor(
                 path = url,
                 clazz = ProductApiResponse::class.java,
                 body = mapOf("attributes" to JsonParser().parse(attributesJson).asJsonArray)
-            ).handleResult()
+            ).toWooPayload()
         }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
-import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
@@ -28,11 +27,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE
@@ -74,9 +70,9 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPay
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
-import org.wordpress.android.fluxc.utils.toWooPayload
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.fluxc.utils.putIfNotNull
+import org.wordpress.android.fluxc.utils.toWooPayload
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Named
@@ -525,18 +521,10 @@ class ProductRestClient @Inject constructor(
             clazz = Array<ProductApiResponse>::class.java
         )
 
-        return when (response) {
-            is WPAPIResponse.Success -> {
-                response.data
-                    ?.map {
-                        it.asProductModel()
-                            .apply { localSiteId = site.id }
-                    }
-                    .orEmpty()
-                    .let { WooPayload(it.toList()) }
-            }
-            is WPAPIResponse.Error -> {
-                WooPayload(response.error.toWooError())
+        return response.toWooPayload { products ->
+            products.map {
+                it.asProductModel()
+                    .apply { localSiteId = site.id }
             }
         }
     }
@@ -632,18 +620,10 @@ class ProductRestClient @Inject constructor(
             clazz = Array<ProductCategoryApiResponse>::class.java
         )
 
-        return when (response) {
-            is WPAPIResponse.Success -> {
-                response.data
-                    ?.map {
-                        it.asProductCategoryModel()
-                            .apply { localSiteId = site.id }
-                    }
-                    .orEmpty()
-                    .let { WooPayload(it.toList()) }
-            }
-            is WPAPIResponse.Error -> {
-                WooPayload(response.error.toWooError())
+        return response.toWooPayload { categories ->
+            categories.map {
+                it.asProductCategoryModel()
+                    .apply { localSiteId = site.id }
             }
         }
     }
@@ -832,20 +812,13 @@ class ProductRestClient @Inject constructor(
             clazz = Array<ProductVariationApiResponse>::class.java
         )
 
-        return when (response) {
-            is WPAPIResponse.Success -> {
-                response.data?.map {
-                    it.asProductVariationModel()
-                        .apply {
-                            localSiteId = site.id
-                            remoteProductId = productId
-                        }
-                }
-                    .orEmpty()
-                    .let { WooPayload(it.toList()) }
-            }
-            is WPAPIResponse.Error -> {
-                WooPayload(response.error.toWooError())
+        return response.toWooPayload { variations ->
+            variations.map {
+                it.asProductVariationModel()
+                    .apply {
+                        localSiteId = site.id
+                        remoteProductId = productId
+                    }
             }
         }
     }
@@ -1418,22 +1391,10 @@ class ProductRestClient @Inject constructor(
                 body = params
         )
 
-        return when (response) {
-            is WPAPIResponse.Success  -> {
-                response.data?.let {
-                    val review = productReviewResponseToProductReviewModel(it).apply {
-                        localSiteId = site.id
-                    }
-                    WooPayload(review)
-                } ?: WooPayload(
-                    error = WooError(
-                        type = WooErrorType.GENERIC_ERROR,
-                        original = GenericErrorType.UNKNOWN,
-                        message = "Success response with empty data"
-                    )
-                )
+        return response.toWooPayload {
+            productReviewResponseToProductReviewModel(it).apply {
+                localSiteId = site.id
             }
-            is WPAPIResponse.Error -> WooPayload(error = response.error.toWooError())
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WPAPIResponseExt.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WPAPIResponseExt.kt
@@ -21,13 +21,17 @@ inline fun <reified T, reified R> WPAPIResponse<T>.toWooPayload(
     is WPAPIResponse.Success -> {
         val result = data
         if (result == null) {
-            WooPayload(
-                WooError(
-                    type = WooErrorType.EMPTY_RESPONSE,
-                    original = BaseRequest.GenericErrorType.UNKNOWN,
-                    message = "Success response with empty data"
+            if (null !is R) {
+                WooPayload(
+                    WooError(
+                        type = WooErrorType.EMPTY_RESPONSE,
+                        original = BaseRequest.GenericErrorType.UNKNOWN,
+                        message = "Success response with empty data"
+                    )
                 )
-            )
+            } else {
+                WooPayload(null)
+            }
         } else {
             WooPayload(mapper(result))
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WPAPIResponseExt.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WPAPIResponseExt.kt
@@ -1,11 +1,36 @@
 package org.wordpress.android.fluxc.utils
 
+import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 
-fun <T> WPAPIResponse<T>.toWooPayload() =
-    when (this) {
-        is WPAPIResponse.Success -> WooPayload(data)
-        is WPAPIResponse.Error -> WooPayload(error.toWooError())
+inline fun <reified T> WPAPIResponse<T>.toWooPayload(): WooPayload<T> =
+    this.toWooPayload { it }
+
+/**
+ * Converts a [WPAPIResponse] to [WooPayload] by using the provided [mapper] for the conversion.
+ *
+ * @param mapper a mapper function to map between the input and return types
+ */
+inline fun <reified T, reified R> WPAPIResponse<T>.toWooPayload(
+    mapper: (T) -> R
+): WooPayload<R> = when (this) {
+    is WPAPIResponse.Success -> {
+        val result = data
+        if (result == null) {
+            WooPayload(
+                WooError(
+                    type = WooErrorType.EMPTY_RESPONSE,
+                    original = BaseRequest.GenericErrorType.UNKNOWN,
+                    message = "Success response with empty data"
+                )
+            )
+        } else {
+            WooPayload(mapper(result))
+        }
     }
+    is WPAPIResponse.Error -> WooPayload(error.toWooError())
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WPAPIResponseExt.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/WPAPIResponseExt.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 
-fun <T> WPAPIResponse<T>.handleResult() =
+fun <T> WPAPIResponse<T>.toWooPayload() =
     when (this) {
         is WPAPIResponse.Success -> WooPayload(data)
         is WPAPIResponse.Error -> WooPayload(error.toWooError())

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/WPAPIResponseExtTests.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/WPAPIResponseExtTests.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+
+class WPAPIResponseExtTests {
+    @Test
+    fun `given a null response with success status, when converting, then return an error`() {
+        val response = WPAPIResponse.Success<String>(null)
+
+        val result = response.toWooPayload { "Got response: $it" }
+
+        assertThat(result.isError).isTrue
+        assertThat(result.error.type).isEqualTo(WooErrorType.EMPTY_RESPONSE)
+        assertThat(result.error.original).isEqualTo(BaseRequest.GenericErrorType.UNKNOWN)
+        assertThat(result.error.message).isEqualTo("Success response with empty data")
+    }
+
+    @Test
+    fun `given a non-null success response, when converting, then map the types`() {
+        val response = WPAPIResponse.Success("message")
+
+        val result = response.toWooPayload { it.hashCode() }
+
+        assertThat(result.isError).isFalse
+        assertThat(result.result).isEqualTo("message".hashCode())
+    }
+
+    @Test
+    fun `given an error, when converting, then map the error type`() {
+        val error = WPAPINetworkError(BaseNetworkError(BaseRequest.GenericErrorType.SERVER_ERROR))
+        val response = WPAPIResponse.Error<String>(error)
+
+        val result = response.toWooPayload { it.hashCode() }
+
+        assertThat(result.isError).isTrue
+        assertThat(result.error.type).isEqualTo(error.toWooError().type)
+        assertThat(result.error.original).isEqualTo(error.toWooError().original)
+        assertThat(result.error.message).isEqualTo(error.toWooError().message)
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/WPAPIResponseExtTests.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/WPAPIResponseExtTests.kt
@@ -23,6 +23,16 @@ class WPAPIResponseExtTests {
     }
 
     @Test
+    fun `given a null response and nullable type, when converting, then return null wrapped in success`() {
+        val response = WPAPIResponse.Success<String>(null)
+
+        val result = response.toWooPayload<String, String?> { "Got response: $it" }
+
+        assertThat(result.isError).isFalse
+        assertThat(result.result).isEqualTo(null)
+    }
+
+    @Test
     fun `given a non-null success response, when converting, then map the types`() {
         val response = WPAPIResponse.Success("message")
 


### PR DESCRIPTION
During the migration of `ProductRestClient`, I noticed the extension `JetpackResponse#handleResult`, and I created a similar one for `WPAPIResponse`, but I was concerned about two issues with the extension:
1. It considers success responses with `null` data as success results.
2. It doesn't allow a way to map the response to another type.

So in this PR, I attempted to solve the two issues, and I renamed it from `handleResult` to `toWooPayload`.

I'll try to explain my reasoning for why point 1 should be changed:
- This logic will have no impact on the existing Jetpack sites: given the [logic](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/b40e9c214fc20537f960d7fb8fa611cd6dd34812/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java#L87-L101) we have for parsing the JSON responses, there is no way we'll receive a `null` object from the Jetpack tunnel, because it will always return a `data` property (I can share the code internally if needed), this means that we will always get an object, what could be `null` if the site's response is empty is the object's properties.
- For application passwords login: if we get a `null` object because we receive an empty response, it's better to report it as an error, and not as a success, this would allow better detection for errors, and would lead to more robust handling.
- When needed and with the commit 66bb579, we can still accept `null` as a success by explicitly using a nullable type as the argument of `WooPayload` (check unit tests for an example).

### Testing
I don't think there is much to test, it's all just code refactoring, but feel free to repeat the steps from #2602.