### PR TITLE
Woo REST API: migrate OrderStatsRestClient

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -47,6 +47,7 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     private var countDownLatch: CountDownLatch by notNull()
 
     private val siteModel = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
         id = 5
         siteId = 567
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
@@ -31,14 +32,20 @@ class JetpackTunnelWPAPINetwork @Inject constructor(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        params: Map<String, String> = emptyMap()
+        params: Map<String, String> = emptyMap(),
+        enableCaching: Boolean = false,
+        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
+        forced: Boolean = false
     ): JetpackResponse<T> {
         return jetpackTunnelGsonRequestBuilder.syncGetRequest(
             restClient = this,
             site = site,
             url = path,
             params = params,
-            clazz = clazz
+            clazz = clazz,
+            enableCaching = enableCaching,
+            cacheTimeToLive = cacheTimeToLive,
+            forced = forced
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComNetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComNetwork.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom
 import android.content.Context
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import javax.inject.Inject
@@ -27,13 +28,19 @@ class WPComNetwork @Inject constructor(
     suspend fun <T : Any> executeGetGsonRequest(
         url: String,
         clazz: Class<T>,
-        params: Map<String, String> = emptyMap()
+        params: Map<String, String> = emptyMap(),
+        enableCaching: Boolean = false,
+        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
+        forced: Boolean = false
     ): WPComGsonRequestBuilder.Response<T> {
         return wpComGsonRequestBuilder.syncGetRequest(
             restClient = this,
             url = url,
             params = params,
-            clazz = clazz
+            clazz = clazz,
+            enableCaching = enableCaching,
+            cacheTimeToLive = cacheTimeToLive,
+            forced = forced
         )
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
@@ -26,12 +27,18 @@ class WooNetwork @Inject constructor(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        params: Map<String, String> = emptyMap()
+        params: Map<String, String> = emptyMap(),
+        enableCaching: Boolean = false,
+        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
+        forced: Boolean = false
     ): WPAPIResponse<T> {
         return when (site.origin) {
-            SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executeGetGsonRequest(site, path, clazz, params)
-                .toWPAPIResponse()
-            SiteModel.ORIGIN_XMLRPC -> applicationPasswordsNetwork.executeGetGsonRequest(site, path, clazz, params)
+            SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executeGetGsonRequest(
+                site, path, clazz, params, enableCaching, cacheTimeToLive, forced
+            ).toWPAPIResponse()
+            SiteModel.ORIGIN_XMLRPC -> applicationPasswordsNetwork.executeGetGsonRequest(
+                site, path, clazz, params, enableCaching, cacheTimeToLive, forced
+            )
             else -> error("Site with unsupported origin")
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats
 
-import android.content.Context
-import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
@@ -13,15 +11,11 @@ import org.wordpress.android.fluxc.model.WCOrderStatsModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.model.WCTopEarnerModel
 import org.wordpress.android.fluxc.model.WCVisitorStatsModel
-import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchNewVisitorStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload
@@ -35,22 +29,13 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
 class OrderStatsRestClient @Inject constructor(
-    appContext: Context,
-    dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
-    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
+    private val dispatcher: Dispatcher,
     private val wooNetwork: WooNetwork,
     private val wpComNetwork: WPComNetwork,
     private val coroutineEngine: CoroutineEngine
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+) {
     enum class OrderStatsApiUnit {
         HOUR, DAY, WEEK, MONTH, YEAR;
 
@@ -155,13 +140,13 @@ class OrderStatsRestClient @Inject constructor(
                             }
                         }
                         val payload = FetchOrderStatsResponsePayload(site, unit, model)
-                        mDispatcher.dispatch(WCStatsActionBuilder.newFetchedOrderStatsAction(payload))
+                        dispatcher.dispatch(WCStatsActionBuilder.newFetchedOrderStatsAction(payload))
                     }
                 }
                 is WPComGsonRequestBuilder.Response.Error -> {
                     val orderError = response.error.toOrderError()
                     val payload = FetchOrderStatsResponsePayload(orderError, site, unit)
-                    mDispatcher.dispatch(WCStatsActionBuilder.newFetchedOrderStatsAction(payload))
+                    dispatcher.dispatch(WCStatsActionBuilder.newFetchedOrderStatsAction(payload))
                 }
             }
         }
@@ -267,12 +252,12 @@ class OrderStatsRestClient @Inject constructor(
             when (response) {
                 is WPAPIResponse.Success -> {
                     val payload = FetchRevenueStatsAvailabilityResponsePayload(site, true)
-                    mDispatcher.dispatch(WCStatsActionBuilder.newFetchedRevenueStatsAvailabilityAction(payload))
+                    dispatcher.dispatch(WCStatsActionBuilder.newFetchedRevenueStatsAvailabilityAction(payload))
                 }
                 is WPAPIResponse.Error -> {
                     val orderError = response.error.toOrderError()
                     val payload = FetchRevenueStatsAvailabilityResponsePayload(orderError, site, false)
-                    mDispatcher.dispatch(WCStatsActionBuilder.newFetchedRevenueStatsAvailabilityAction(payload))
+                    dispatcher.dispatch(WCStatsActionBuilder.newFetchedRevenueStatsAvailabilityAction(payload))
                 }
             }
         }
@@ -319,12 +304,12 @@ class OrderStatsRestClient @Inject constructor(
                         }
                     }
                     val payload = FetchVisitorStatsResponsePayload(site, unit, model)
-                    mDispatcher.dispatch(WCStatsActionBuilder.newFetchedVisitorStatsAction(payload))
+                    dispatcher.dispatch(WCStatsActionBuilder.newFetchedVisitorStatsAction(payload))
                 }
                 is WPComGsonRequestBuilder.Response.Error -> {
                     val orderError = response.error.toOrderError()
                     val payload = FetchVisitorStatsResponsePayload(orderError, site, unit)
-                    mDispatcher.dispatch(WCStatsActionBuilder.newFetchedVisitorStatsAction(payload))
+                    dispatcher.dispatch(WCStatsActionBuilder.newFetchedVisitorStatsAction(payload))
                 }
             }
         }
@@ -421,12 +406,12 @@ class OrderStatsRestClient @Inject constructor(
                     } ?: emptyList()
 
                     val payload = FetchTopEarnersStatsResponsePayload(site, unit, wcTopEarners)
-                    mDispatcher.dispatch(WCStatsActionBuilder.newFetchedTopEarnersStatsAction(payload))
+                    dispatcher.dispatch(WCStatsActionBuilder.newFetchedTopEarnersStatsAction(payload))
                 }
                 is WPComGsonRequestBuilder.Response.Error -> {
                     val orderError = response.error.toOrderError()
                     val payload = FetchTopEarnersStatsResponsePayload(orderError, site, unit)
-                    mDispatcher.dispatch(WCStatsActionBuilder.newFetchedTopEarnersStatsAction(payload))
+                    dispatcher.dispatch(WCStatsActionBuilder.newFetchedTopEarnersStatsAction(payload))
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -120,6 +120,7 @@ class OrderStatsRestClient @Inject constructor(
                 url = url,
                 params = params,
                 clazz = OrderStatsApiResponse::class.java,
+                enableCaching = true,
                 forced = force
             )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -350,11 +350,10 @@ class OrderStatsRestClient @Inject constructor(
             "stat_fields" to "visitors"
         )
 
-        val response = wpComGsonRequestBuilder.syncGetRequest(
-            this,
-            url,
-            params,
-            VisitorStatsApiResponse::class.java,
+        val response = wpComNetwork.executeGetGsonRequest(
+            url = url,
+            params = params,
+            clazz = VisitorStatsApiResponse::class.java,
             forced = force
         )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -23,11 +23,13 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchNewVisitorStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchOrderStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityResponsePayload
@@ -37,6 +39,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.FetchVisitorStatsResponseP
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
@@ -51,7 +54,10 @@ class OrderStatsRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
     accessToken: AccessToken,
-    userAgent: UserAgent
+    userAgent: UserAgent,
+    private val wooNetwork: WooNetwork,
+    private val wpComNetwork: WPComNetwork,
+    private val coroutineEngine: CoroutineEngine
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     enum class OrderStatsApiUnit {
         HOUR, DAY, WEEK, MONTH, YEAR;

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -354,6 +354,7 @@ class OrderStatsRestClient @Inject constructor(
             url = url,
             params = params,
             clazz = VisitorStatsApiResponse::class.java,
+            enableCaching = true,
             forced = force
         )
 


### PR DESCRIPTION
This PR migrates OrderStatsRestClient to the new architecture:

1. Four functions were refactored to use the `WPComNetwork`.
2. Two functions that used Jetpack were refactored to use `WooNetwork`.

To handle the migration, I had to update the `Network` classes to allow customizing the cache behavior, I used the same arguments and defaults we had in the request builders.

#### Testing
##### Mocked Tests
Confirm that `MockedStack_WCStatsTest` is green.

##### WPCom login
1. Open the example app.
2. Sign in using WordPress.com.
3. Click on Woo, then pick a site.
4. Click on "Stats", test the different scenarios.
5. Click on "Revenue stats", test the different scenarios.

##### Site Credentials login
1. Apply the below patch:
```patch
Index: example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(revision cfb84ac6fd9d7ea3de917ab5dd1bec8722607e23)
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(date 1671614795399)
@@ -7,6 +7,8 @@
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.fragment_woo_products.*
 import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.SiteSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
@@ -23,7 +25,7 @@
                 Button(context).apply {
                     text = "Select Site"
                     setOnClickListener {
-                        showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                        showSiteSelectorDialog(selectedPos, object : SiteSelectorDialog.Listener {
                             override fun onSiteSelected(site: SiteModel, pos: Int) {
                                 onSiteSelected(site)
                                 selectedSite = site
```
2. Open the example app.
3. Sign in using site credentials.
4. Click on Woo, then pick a site.
5. Click on "Revenue stats", confirm the different scenarios work.