### PR TITLE
Woo REST API: migrate RefundRestClient

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/refunds/WooRefundsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/refunds/WooRefundsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_refunds.*
@@ -15,6 +14,7 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R.layout
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
-class WooRefundsFragment : Fragment() {
+class WooRefundsFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var refundsStore: WCRefundStore
     @Inject internal lateinit var ordersStore: WCOrderStore
@@ -42,7 +42,7 @@ class WooRefundsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         create_full_refund.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter the order ID:") { orderEditText ->
                     showSingleLineDialog(activity, "Enter the refund amount:") { amountEditText ->
                         showSingleLineDialog(activity, "Enter refund reason:") { reasonEditText ->
@@ -70,7 +70,7 @@ class WooRefundsFragment : Fragment() {
         }
 
         fetch_refund.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter the order ID:") { orderEditText ->
                     showSingleLineDialog(activity, "Enter the refund ID:") { refundEditText ->
                         lifecycleScope.launch(Dispatchers.IO) {
@@ -95,7 +95,7 @@ class WooRefundsFragment : Fragment() {
         }
 
         fetch_all_refunds.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter the order ID:") { orderEditText ->
                     lifecycleScope.launch(Dispatchers.IO) {
                         try {
@@ -133,6 +133,4 @@ class WooRefundsFragment : Fragment() {
             prependToLog("Refund: $refund")
         }
     }
-
-    private fun getFirstWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(0)
 }

--- a/example/src/main/res/layout/fragment_woo_refunds.xml
+++ b/example/src/main/res/layout/fragment_woo_refunds.xml
@@ -7,6 +7,7 @@
     tools:ignore="HardcodedText">
 
     <LinearLayout
+        android:id="@+id/buttonContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
@@ -15,18 +16,21 @@
             android:id="@+id/create_full_refund"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="Create full refund" />
 
         <Button
             android:id="@+id/fetch_refund"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="Fetch refund" />
 
         <Button
             android:id="@+id/fetch_all_refunds"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="Fetch all refunds" />
 
     </LinearLayout>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
@@ -91,21 +91,12 @@ class RefundRestClient @Inject constructor(
     ): WooPayload<RefundResponse> {
         val url = WOOCOMMERCE.orders.id(orderId).refunds.refund(refundId).pathV3
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                RefundResponse::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = RefundResponse::class.java
         )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return response.toWooPayload()
     }
 
     suspend fun fetchAllRefunds(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
@@ -14,11 +14,8 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.utils.sumBy
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
@@ -107,24 +104,16 @@ class RefundRestClient @Inject constructor(
     ): WooPayload<Array<RefundResponse>> {
         val url = WOOCOMMERCE.orders.id(orderId).refunds.pathV3
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                mapOf(
-                        "page" to page.toString(),
-                        "per_page" to pageSize.toString()
-                ),
-                Array<RefundResponse>::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<RefundResponse>::class.java,
+            params = mapOf(
+                "page" to page.toString(),
+                "per_page" to pageSize.toString()
+            )
         )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return response.toWooPayload()
     }
 
     data class RefundResponse(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
@@ -1,37 +1,19 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds
 
-import android.content.Context
-import com.android.volley.RequestQueue
 import com.google.gson.annotations.SerializedName
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundFeeLine
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundShippingLine
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.utils.sumBy
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
-class RefundRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class RefundRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun createRefundByAmount(
         site: SiteModel,
         orderId: Long,


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/8069

This PR migrates `RefundRestClient` to the new architecture using `WooNetwork`.

The last commit e522154 is not related to the migration itself, but it's just an improvement to the Refunds test fragment to allow selecting a specific site.

### Test
As with all the migration PRs, the focus should be on the code review by confirming we didn't miss any argument or used the wrong HTTP method.

But a small smoke test to the feature wouldn't hurt:
##### WordPress.com login
1. Open the example app.
2. Sign in using WordPress.com.
3. Click on Woo, then pick a site.
4. Click on Refunds then pick a site.
5. Test some refund scenarios and confirm they work as expected.

##### Site Credentials login (bonus)
1. Apply the following patch
```patch
Index: example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(revision e522154c8bc2f74f9d2039917d9de31eaf2b3240)
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(date 1671625263544)
@@ -7,6 +7,8 @@
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.fragment_woo_products.*
 import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.SiteSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
@@ -23,7 +25,7 @@
                 Button(context).apply {
                     text = "Select Site"
                     setOnClickListener {
-                        showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                        showSiteSelectorDialog(selectedPos, object : SiteSelectorDialog.Listener {
                             override fun onSiteSelected(site: SiteModel, pos: Int) {
                                 onSiteSelected(site)
                                 selectedSite = site
```
2. Open the app then sign in using site credentials (enter site address in the login dialog).
3. Repeat steps 3 to 5 from the above test case.