### PR TITLE
feat: pass customer id when creating a new order

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/UpdateOrderRequest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.model.order
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 
 data class UpdateOrderRequest(
+    val customerId: Long? = null,
     val status: WCOrderStatusModel? = null,
     val lineItems: List<LineItem>? = null,
     val shippingAddress: OrderAddress.Shipping? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -838,6 +838,7 @@ class OrderRestClient @Inject constructor(
 
     private fun UpdateOrderRequest.toNetworkRequest(): Map<String, Any> {
         return mutableMapOf<String, Any>().apply {
+            customerId?.let { put("customer_id", it) }
             status?.let { put("status", it.statusKey) }
             lineItems?.let { put("line_items", it) }
             shippingAddress?.toDto()?.let { put("shipping", it) }


### PR DESCRIPTION
### Description

This PR adds a feature of including `customer_id` property when creating a new order from the app.

More context for this change is in WooCommerce PR: https://github.com/woocommerce/woocommerce-android/pull/8106