### PR TITLE
Woo REST API: Migrate GatewayRestClient and WCTaxRestClient

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCGatewayTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCGatewayTest.kt
@@ -16,6 +16,11 @@ class MockedStack_WCGatewayTest : MockedStack_Base() {
     @Inject internal lateinit var restClient: GatewayRestClient
     @Inject internal lateinit var interceptor: ResponseMockingInterceptor
 
+    private val testSite = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
+        siteId = 123L
+    }
+
     @Throws(Exception::class)
     override fun setUp() {
         super.setUp()
@@ -27,8 +32,8 @@ class MockedStack_WCGatewayTest : MockedStack_Base() {
         interceptor.respondWith("wc-pay-fetch-gateway-response-success.json")
 
         val result = restClient.fetchGateway(
-            SiteModel().apply { siteId = 123L },
-            "cod"
+            site = testSite,
+            gatewayId = "cod"
         )
 
         assertTrue(result.result != null)
@@ -40,8 +45,8 @@ class MockedStack_WCGatewayTest : MockedStack_Base() {
         interceptor.respondWithError("wc-pay-fetch-gateway-response-error.json", 500)
 
         val result = restClient.fetchGateway(
-            SiteModel().apply { siteId = 123L },
-            "cod"
+            site = testSite,
+            gatewayId = "cod"
         )
 
         assertTrue(result.isError)
@@ -53,8 +58,8 @@ class MockedStack_WCGatewayTest : MockedStack_Base() {
         interceptor.respondWith("wc-pay-update-gateway-response-success.json")
 
         val result = restClient.updatePaymentGateway(
-            SiteModel().apply { siteId = 123L },
-            CASH_ON_DELIVERY,
+            site = testSite,
+            gatewayId = CASH_ON_DELIVERY,
             enabled = true,
             title = "Pay on Delivery",
             description = "Pay by cash or card on delivery"
@@ -69,8 +74,8 @@ class MockedStack_WCGatewayTest : MockedStack_Base() {
         interceptor.respondWithError("wc-pay-update-gateway-response-error.json", 500)
 
         val result = restClient.updatePaymentGateway(
-            SiteModel().apply { siteId = 123L },
-            CASH_ON_DELIVERY,
+            site = testSite,
+            gatewayId = CASH_ON_DELIVERY,
             enabled = false,
             title = "Pay on Delivery",
             description = "Pay by cash or card on delivery"
@@ -85,7 +90,7 @@ class MockedStack_WCGatewayTest : MockedStack_Base() {
         interceptor.respondWithError("wc-pay-update-gateway-invalid-data-response-error.json", 500)
 
         val result = restClient.updatePaymentGateway(
-            SiteModel().apply { siteId = 123L },
+            site = testSite,
             enabled = true,
             title = "THIS IS INVALID TITLE",
             description = "THIS IS INVALID DESCRIPTION",
@@ -100,9 +105,7 @@ class MockedStack_WCGatewayTest : MockedStack_Base() {
     fun whenFetchAllGatewaysSucceedsReturnSuccess() = runBlocking {
         interceptor.respondWith("wc-pay-fetch-all-gateways-response-success.json")
 
-        val result = restClient.fetchAllGateways(
-            SiteModel().apply { siteId = 123L }
-        )
+        val result = restClient.fetchAllGateways(testSite)
 
         Assert.assertFalse(result.isError)
         assertTrue(result.result != null)
@@ -112,9 +115,7 @@ class MockedStack_WCGatewayTest : MockedStack_Base() {
     fun whenFetchAllGatewaysErrorReturnError() = runBlocking {
         interceptor.respondWithError("wc-pay-fetch-all-gateways-response-error.json", 500)
 
-        val result = restClient.fetchAllGateways(
-            SiteModel().apply { siteId = 123L }
-        )
+        val result = restClient.fetchAllGateways(testSite)
 
         assertTrue(result.isError)
         assertEquals(API_ERROR, result.error.type)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/gateways/WooGatewaysFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/gateways/WooGatewaysFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_gateways.*
@@ -15,15 +14,15 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.model.gateways.WCGatewayModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-
 import org.wordpress.android.fluxc.store.WCGatewayStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
-class WooGatewaysFragment : Fragment() {
+class WooGatewaysFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var gatewayStore: WCGatewayStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
@@ -41,7 +40,7 @@ class WooGatewaysFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         fetch_gateway.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 showSingleLineDialog(activity, "Enter the gateway ID:") { gatewayEditText ->
                     lifecycleScope.launch(Dispatchers.IO) {
                         try {
@@ -60,7 +59,7 @@ class WooGatewaysFragment : Fragment() {
         }
 
         fetch_all_gateways.setOnClickListener {
-            getFirstWCSite()?.let { site ->
+            selectedSite?.let { site ->
                 lifecycleScope.launch(Dispatchers.IO) {
                     try {
                         val response = gatewayStore.fetchAllGateways(site)
@@ -93,6 +92,4 @@ class WooGatewaysFragment : Fragment() {
             prependToLog("Gateway: $gateway")
         }
     }
-
-    private fun getFirstWCSite() = wooCommerceStore.getWooCommerceSites().getOrNull(0)
 }

--- a/example/src/main/res/layout/fragment_woo_gateways.xml
+++ b/example/src/main/res/layout/fragment_woo_gateways.xml
@@ -7,6 +7,7 @@
     tools:ignore="HardcodedText">
 
     <LinearLayout
+        android:id="@+id/buttonContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
@@ -15,12 +16,14 @@
             android:id="@+id/fetch_gateway"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="Fetch gateway" />
 
         <Button
             android:id="@+id/fetch_all_gateways"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:text="Fetch all gateways" />
 
     </LinearLayout>

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/GatewayRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/GatewayRestClientTest.kt
@@ -1,62 +1,44 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
-import com.android.volley.RequestQueue
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways.GatewayRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways.GatewayRestClient.GatewayId.CASH_ON_DELIVERY
 
 class GatewayRestClientTest {
-    private lateinit var jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder
-    private lateinit var requestQueue: RequestQueue
-    private lateinit var accessToken: AccessToken
-    private lateinit var userAgent: UserAgent
+    private val wooNetwork: WooNetwork = mock()
     private lateinit var gatewayRestClient: GatewayRestClient
 
     @Before
     fun setup() {
-        jetpackTunnelGsonRequestBuilder = mock()
-        requestQueue = mock()
-        accessToken = mock()
-        userAgent = mock()
-        gatewayRestClient = GatewayRestClient(
-            mock(),
-            jetpackTunnelGsonRequestBuilder,
-            mock(),
-            requestQueue,
-            accessToken,
-            userAgent
-        )
+        gatewayRestClient = GatewayRestClient(wooNetwork)
     }
 
     @Test
     fun `given success response, when fetch gateway, return success`() {
         runBlocking {
             whenever(
-                jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any<Class<GatewayRestClient.GatewayResponse>>(),
-                    any(),
-                    any(),
-                    any(),
-                    anyOrNull()
+                wooNetwork.executeGetGsonRequest(
+                    site = any(),
+                    path = any(),
+                    clazz = any<Class<GatewayRestClient.GatewayResponse>>(),
+                    params = any(),
+                    enableCaching = any(),
+                    cacheTimeToLive = any(),
+                    forced = any(),
+                    requestTimeout = any(),
+                    retries = any()
                 )
             ).thenReturn(
-                JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess(mock())
+                WPAPIResponse.Success(mock())
             )
 
             val actualResponse = gatewayRestClient.fetchGateway(
@@ -72,23 +54,23 @@ class GatewayRestClientTest {
     @Test
     fun `given error response, when fetch gateway, return error`() {
         runBlocking {
-            val expectedError = mock<WPComGsonNetworkError>().apply {
+            val expectedError = mock<WPAPINetworkError>().apply {
                 type = mock()
             }
             whenever(
-                jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any<Class<GatewayRestClient.GatewayResponse>>(),
-                    any(),
-                    any(),
-                    any(),
-                    anyOrNull()
+                wooNetwork.executeGetGsonRequest(
+                    site = any(),
+                    path = any(),
+                    clazz = any<Class<GatewayRestClient.GatewayResponse>>(),
+                    params = any(),
+                    enableCaching = any(),
+                    cacheTimeToLive = any(),
+                    forced = any(),
+                    requestTimeout = any(),
+                    retries = any()
                 )
             ).thenReturn(
-                JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError(expectedError)
+                WPAPIResponse.Error(expectedError)
             )
 
             val actualResponse = gatewayRestClient.fetchGateway(SiteModel(), "")
@@ -102,15 +84,14 @@ class GatewayRestClientTest {
     fun `given success response, when update gateway, return success`() {
         runBlocking {
             whenever(
-                jetpackTunnelGsonRequestBuilder.syncPostRequest(
+                wooNetwork.executePostGsonRequest(
                     any(),
                     any(),
-                    any(),
-                    any(),
-                    any<Class<GatewayRestClient.GatewayResponse>>()
+                    any<Class<GatewayRestClient.GatewayResponse>>(),
+                    any()
                 )
             ).thenReturn(
-                JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess(mock())
+                WPAPIResponse.Success(mock())
             )
 
             val actualResponse = gatewayRestClient.updatePaymentGateway(
@@ -128,19 +109,18 @@ class GatewayRestClientTest {
     @Test
     fun `given error response, when update gateway, return error`() {
         runBlocking {
-            val expectedError = mock<WPComGsonNetworkError>().apply {
+            val expectedError = mock<WPAPINetworkError>().apply {
                 type = mock()
             }
             whenever(
-                jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                    any(),
-                    any(),
+                wooNetwork.executePostGsonRequest(
                     any(),
                     any(),
                     any<Class<GatewayRestClient.GatewayResponse>>(),
+                    any()
                 )
             ).thenReturn(
-                JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError(expectedError)
+                WPAPIResponse.Error(expectedError)
             )
 
             val actualResponse = gatewayRestClient.updatePaymentGateway(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
@@ -10,11 +10,8 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.store.Settings
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
@@ -75,21 +72,12 @@ class GatewayRestClient @Inject constructor(
     ): WooPayload<Array<GatewayResponse>> {
         val url = WOOCOMMERCE.payment_gateways.pathV3
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this,
-            site,
-            url,
-            emptyMap(),
-            Array<GatewayResponse>::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<GatewayResponse>::class.java
         )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return response.toWooPayload()
     }
 
     data class GatewayResponse(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
@@ -54,28 +54,20 @@ class GatewayRestClient @Inject constructor(
         settings: Settings? = null
     ): WooPayload<GatewayResponse> {
         val url = WOOCOMMERCE.payment_gateways.gateway(gatewayId.apiKey).pathV3
-        val params = mutableMapOf<String, Any>().apply {
+        val body = mutableMapOf<String, Any>().apply {
             enabled?.let { put("enabled", enabled) }
             title?.let { put("title", title) }
             description?.let { put("description", description) }
             settings?.let { put("settings", settings) }
         }
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-            this,
-            site,
-            url,
-            params,
-            GatewayResponse::class.java
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = GatewayResponse::class.java,
+            body = body
         )
 
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return response.toWooPayload()
     }
 
     suspend fun fetchAllGateways(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
@@ -12,9 +12,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.store.Settings
+import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -26,7 +28,8 @@ class GatewayRestClient @Inject constructor(
     appContext: Context?,
     @Named("regular") requestQueue: RequestQueue,
     accessToken: AccessToken,
-    userAgent: UserAgent
+    userAgent: UserAgent,
+    private val wooNetwork: WooNetwork
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     suspend fun fetchGateway(
         site: SiteModel,
@@ -34,21 +37,12 @@ class GatewayRestClient @Inject constructor(
     ): WooPayload<GatewayResponse> {
         val url = WOOCOMMERCE.payment_gateways.gateway(gatewayId).pathV3
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this,
-            site,
-            url,
-            emptyMap(),
-            GatewayResponse::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = GatewayResponse::class.java
         )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return response.toWooPayload()
     }
 
     suspend fun updatePaymentGateway(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/gateways/GatewayRestClient.kt
@@ -1,33 +1,15 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.gateways
 
-import android.content.Context
-import com.android.volley.RequestQueue
 import com.google.gson.annotations.SerializedName
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.store.Settings
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
-class GatewayRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class GatewayRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun fetchGateway(
         site: SiteModel,
         gatewayId: String

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/taxes/WCTaxRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/taxes/WCTaxRestClient.kt
@@ -1,51 +1,26 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes
 
-import android.content.Context
-import com.android.volley.RequestQueue
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
-class WCTaxRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class WCTaxRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun fetchTaxClassList(
         site: SiteModel
     ): WooPayload<Array<TaxClassApiResponse>> {
         val url = WOOCOMMERCE.taxes.classes.pathV3
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                Array<TaxClassApiResponse>::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site,
+            url,
+            Array<TaxClassApiResponse>::class.java
         )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return response.toWooPayload()
     }
 
     data class TaxClassApiResponse(


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/8072
Closes https://github.com/woocommerce/woocommerce-android/issues/8073

This PR migrates `GatewayRestClient` and `WCTaxRestClient`, as they are quite small and related, and both touch orders, I decided to migrate them on the same PR.

### Test
As with all the migration PRs, the focus should be on the code review by confirming we didn't miss any argument or used the wrong HTTP method.

But a small smoke test to the feature wouldn't hurt:
##### WordPress.com login

1. Open the example app.
2. Sign in using WordPress.com.
3. Click on Woo, then pick a site.
4. Click on Gateways then pick a site.
5. Test fetching gateways and confirm they work as expected.
6. Click on Taxes then pick a site.
7. Test fetching tax classes and confirm it works as expected.

##### Site Credentials login

1. Open the app then sign in using site credentials (enter site address in the login dialog)
2. Repeat steps 3 to 7 from the above test case.
