### PR TITLE
Woo REST API: Migrate WooCommerceStore REST clients

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCBaseStoreTest.kt
@@ -37,6 +37,7 @@ class MockedStack_WCBaseStoreTest : MockedStack_Base() {
     private var countDownLatch: CountDownLatch by notNull()
 
     private val siteModel = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
         id = 5
         siteId = 567
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -65,17 +65,17 @@ class WooCommerceFragment : StoreSelectingFragment() {
         }
 
         log_woo_api_versions.setOnClickListener {
-            for (site in wooCommerceStore.getWooCommerceSites()) {
+            selectedSite?.let { selectedSite ->
                 coroutineScope.launch {
                     val result = withContext(Dispatchers.Default) {
-                        wooCommerceStore.fetchSupportedApiVersion(site)
+                        wooCommerceStore.fetchSupportedApiVersion(selectedSite)
                     }
                     result.error?.let {
                         prependToLog("Error in onApiVersionFetched: ${it.type} - ${it.message}")
                     }
                     result.model?.let {
                         val formattedVersion = it.apiVersion?.substringAfterLast("/")
-                        prependToLog("Max Woo version for ${site.name}: $formattedVersion")
+                        prependToLog("Max Woo version for ${selectedSite.name}: $formattedVersion")
                     }
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -35,6 +35,7 @@ import static org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErr
 
 public abstract class BaseRequest<T> extends Request<T> {
     public static final int DEFAULT_REQUEST_TIMEOUT = 30000;
+    public static final int DEFAULT_MAX_RETRIES = DefaultRetryPolicy.DEFAULT_MAX_RETRIES;
     public static final int UPLOAD_REQUEST_READ_TIMEOUT = 60000;
 
     // Only used when enabledCaching is called - caching is off by default for all requests

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 
+import com.android.volley.DefaultRetryPolicy
 import com.android.volley.RequestQueue
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Credentials
@@ -44,7 +45,9 @@ class ApplicationPasswordsNetwork @Inject constructor(
         body: Map<String, Any> = emptyMap(),
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        forced: Boolean = false
+        forced: Boolean = false,
+        requestTimeout: Int = BaseRequest.DEFAULT_REQUEST_TIMEOUT,
+        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES
     ): WPAPIResponse<T> {
         fun buildRequest(
             continuation: Continuation<WPAPIResponse<T>>,
@@ -69,6 +72,12 @@ class ApplicationPasswordsNetwork @Inject constructor(
             if (forced) {
                 request.setShouldForceUpdate()
             }
+
+            request.retryPolicy = DefaultRetryPolicy(
+                requestTimeout,
+                retries,
+                DefaultRetryPolicy.DEFAULT_BACKOFF_MULT
+            )
 
             return request
         }
@@ -131,7 +140,9 @@ class ApplicationPasswordsNetwork @Inject constructor(
         params: Map<String, String> = emptyMap(),
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        forced: Boolean = false
+        forced: Boolean = false,
+        requestTimeout: Int = BaseRequest.DEFAULT_REQUEST_TIMEOUT,
+        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES
     ) = executeGsonRequest(
         site = site,
         method = HttpMethod.GET,
@@ -140,7 +151,9 @@ class ApplicationPasswordsNetwork @Inject constructor(
         params = params,
         enableCaching = enableCaching,
         cacheTimeToLive = cacheTimeToLive,
-        forced = forced
+        forced = forced,
+        requestTimeout = requestTimeout,
+        retries = retries
     )
 
     suspend fun <T> executePostGsonRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom
 
 import android.content.Context
+import com.android.volley.DefaultRetryPolicy
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
@@ -35,7 +36,9 @@ class JetpackTunnelWPAPINetwork @Inject constructor(
         params: Map<String, String> = emptyMap(),
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        forced: Boolean = false
+        forced: Boolean = false,
+        requestTimeout: Int = BaseRequest.DEFAULT_REQUEST_TIMEOUT,
+        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES
     ): JetpackResponse<T> {
         return jetpackTunnelGsonRequestBuilder.syncGetRequest(
             restClient = this,
@@ -45,7 +48,12 @@ class JetpackTunnelWPAPINetwork @Inject constructor(
             clazz = clazz,
             enableCaching = enableCaching,
             cacheTimeToLive = cacheTimeToLive,
-            forced = forced
+            forced = forced,
+            retryPolicy = DefaultRetryPolicy(
+                requestTimeout,
+                retries,
+                DefaultRetryPolicy.DEFAULT_BACKOFF_MULT
+            )
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpacktunnel/JetpackTunnelGsonRequestBuilder.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel
 
-import com.android.volley.DefaultRetryPolicy
 import com.android.volley.RetryPolicy
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.fluxc.model.SiteModel
@@ -18,21 +17,6 @@ import kotlin.coroutines.resume
 
 @Singleton
 class JetpackTunnelGsonRequestBuilder @Inject constructor() {
-    companion object {
-        const val DEFAULT_JETPACK_TUNNEL_TIMEOUT_MS = 15000
-        const val DEFAULT_JETPACK_TUNNEL_MAX_RETRIES = 1
-    }
-
-    fun buildDefaultTimeoutRetryPolicy(
-        timeout: Int = DEFAULT_JETPACK_TUNNEL_TIMEOUT_MS,
-        retries: Int = DEFAULT_JETPACK_TUNNEL_MAX_RETRIES
-    ): DefaultRetryPolicy =
-        DefaultRetryPolicy(
-            timeout,
-            retries,
-            DefaultRetryPolicy.DEFAULT_BACKOFF_MULT
-        )
-
     /**
      * Creates a new GET request.
      * @param url the request URL

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -77,17 +77,12 @@ class WooCommerceRestClient @Inject constructor(
 
     suspend fun fetchSiteSettingsProducts(site: SiteModel): WooPayload<List<SiteSettingsResponse>> {
         val url = WOOCOMMERCE.settings.products.pathV3
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this,
-            site,
-            url,
-            emptyMap(),
-            Array<SiteSettingsResponse>::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<SiteSettingsResponse>::class.java
         )
-        return when (response) {
-            is JetpackSuccess -> WooPayload(response.data?.toList())
-            is JetpackError -> WooPayload(response.error.toWooError())
-        }
+        return response.toWooPayload { it.toList() }
     }
 
     suspend fun enableCoupons(site: SiteModel): WooPayload<Boolean> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -12,8 +12,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
 import javax.inject.Named
@@ -89,23 +87,13 @@ class WooCommerceRestClient @Inject constructor(
         val url = WOOCOMMERCE.settings.group(COUPONS_SETTING_GROUP).id(COUPONS_SETTING_ID).pathV3
         val param = mapOf("value" to "yes")
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPutRequest(
-            this,
-            site,
-            url,
-            param,
-            SiteSettingOptionResponse::class.java
+        val response = wooNetwork.executePutGsonRequest(
+            site = site,
+            path = url,
+            clazz = SiteSettingOptionResponse::class.java,
+            body = param
         )
 
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(
-                    result = response.data?.let { it.value == "yes" } ?: false
-                )
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return response.toWooPayload { it.let { it.value == "yes" } }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -67,17 +67,12 @@ class WooCommerceRestClient @Inject constructor(
      */
     suspend fun fetchSiteSettingsGeneral(site: SiteModel): WooPayload<List<SiteSettingsResponse>> {
         val url = WOOCOMMERCE.settings.general.pathV3
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this,
-            site,
-            url,
-            emptyMap(),
-            Array<SiteSettingsResponse>::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<SiteSettingsResponse>::class.java
         )
-        return when (response) {
-            is JetpackSuccess -> WooPayload(response.data?.toList())
-            is JetpackError -> WooPayload(response.error.toWooError())
-        }
+        return response.toWooPayload { it.toList() }
     }
 
     suspend fun fetchSiteSettingsProducts(site: SiteModel): WooPayload<List<SiteSettingsResponse>> {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -1,32 +1,16 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
-import android.content.Context
-import com.android.volley.RequestQueue
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest
-import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
-class WooCommerceRestClient @Inject constructor(
-    appContext: Context,
-    dispatcher: Dispatcher,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class WooCommerceRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     companion object {
         const val COUPONS_SETTING_GROUP = "general"
         const val COUPONS_SETTING_ID = "woocommerce_enable_coupons"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
@@ -30,14 +30,16 @@ class WooNetwork @Inject constructor(
         params: Map<String, String> = emptyMap(),
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        forced: Boolean = false
+        forced: Boolean = false,
+        requestTimeout: Int = BaseRequest.DEFAULT_REQUEST_TIMEOUT,
+        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES
     ): WPAPIResponse<T> {
         return when (site.origin) {
             SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executeGetGsonRequest(
-                site, path, clazz, params, enableCaching, cacheTimeToLive, forced
+                site, path, clazz, params, enableCaching, cacheTimeToLive, forced, requestTimeout, retries
             ).toWPAPIResponse()
             SiteModel.ORIGIN_XMLRPC -> applicationPasswordsNetwork.executeGetGsonRequest(
-                site, path, clazz, params, enableCaching, cacheTimeToLive, forced
+                site, path, clazz, params, enableCaching, cacheTimeToLive, forced, requestTimeout, retries
             )
             else -> error("Site with unsupported origin")
         }
@@ -47,7 +49,7 @@ class WooNetwork @Inject constructor(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any> = emptyMap(),
+        body: Map<String, Any> = emptyMap()
     ): WPAPIResponse<T> {
         return when (site.origin) {
             SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executePostGsonRequest(site, path, clazz, body)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
@@ -68,17 +69,16 @@ class WooSystemRestClient @Inject constructor(
     suspend fun checkIfWooCommerceIsAvailable(site: SiteModel): WooPayload<Boolean> {
         val url = WOOCOMMERCE.settings.pathV3
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this,
-            site,
-            url,
-            mapOf("_fields" to ""),
-            Any::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            params = mapOf("_fields" to ""),
+            clazz = Unit::class.java
         )
 
         return when (response) {
-            is JetpackSuccess -> WooPayload(true)
-            is JetpackError -> {
+            is WPAPIResponse.Success -> WooPayload(true)
+            is WPAPIResponse.Error -> {
                 if (response.error.type == NOT_FOUND) {
                     WooPayload(false)
                 } else {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -1,37 +1,19 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.system
 
-import android.content.Context
-import com.android.volley.RequestQueue
 import com.google.gson.JsonElement
 import com.google.gson.annotations.SerializedName
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
-import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
-class WooSystemRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class WooSystemRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun fetchInstalledPlugins(site: SiteModel): WooPayload<WCSystemPluginResponse> {
         val url = WOOCOMMERCE.system_status.pathV3
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -14,8 +14,6 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
@@ -91,18 +89,13 @@ class WooSystemRestClient @Inject constructor(
     suspend fun fetchSiteSettings(site: SiteModel): WooPayload<WPSiteSettingsResponse> {
         val url = WPAPI.settings.urlV2
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                WPSiteSettingsResponse::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = WPSiteSettingsResponse::class.java
         )
 
-        return when (response) {
-            is JetpackSuccess -> WooPayload(response.data)
-            is JetpackError -> WooPayload(response.error.toWooError())
-        }
+        return response.toWooPayload()
     }
 
     data class SSRResponse(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -53,7 +53,7 @@ class WooSystemRestClient @Inject constructor(private val wooNetwork: WooNetwork
             site = site,
             path = url,
             params = mapOf("_fields" to ""),
-            clazz = Unit::class.java
+            clazz = Any::class.java
         )
 
         return when (response) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -49,21 +49,13 @@ class WooSystemRestClient @Inject constructor(
     suspend fun fetchSSR(site: SiteModel): WooPayload<SSRResponse> {
         val url = WOOCOMMERCE.system_status.pathV3
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this,
-            site,
-            url,
-            mapOf("_fields" to "environment,database,active_plugins,theme,settings,security,pages"),
-            SSRResponse::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            params = mapOf("_fields" to "environment,database,active_plugins,theme,settings,security,pages"),
+            clazz = SSRResponse::class.java
         )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return response.toWooPayload()
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRestClient.kt
@@ -1,46 +1,29 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.user
 
-import android.content.Context
-import com.android.volley.RequestQueue
 import com.google.gson.JsonElement
 import com.google.gson.annotations.SerializedName
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.utils.handleResult
+import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
-class WCUserRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class WCUserRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun fetchUserInfo(
         site: SiteModel
     ): WooPayload<UserApiResponse> {
         val url = WPAPI.users.me.urlV2
         val params = mapOf(
-                "context" to "edit"
+            "context" to "edit"
         )
 
-        return jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                params,
-                UserApiResponse::class.java
-        ).handleResult()
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            params = params,
+            clazz = UserApiResponse::class.java
+        ).toWooPayload()
     }
 
     data class UserApiResponse(


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/8077
Closes https://github.com/woocommerce/woocommerce-android/issues/8076
Closes https://github.com/woocommerce/woocommerce-android/issues/8070

This PR migrates three rest clients:
1. `WooCommerceRestClient`
1. `WooSystemRestClient`
1. `WCUserRestClient` 

For the first rest client, as I wanted to keep the logic for customizing the timeout, I updated all the `Network` classes to do so by adding two new parameters: `requestTimeout` and `retries` to the GET functions (we can add them to the other functions if needed).
I didn't use the `RetryPolicy` as I don't want our `Network` classes to expose anything about `Volley`.

@JorgeMucientes I saw that we decided to keep the 15s timeout after the last experiment pe5sF9-vT-p2#comment-1227, is this specific to the `fetchSupportedWooApiVersion` function or all of the app's endpoints?
Anyway, we don't need to make any changes as part of this PR, since now with the `WooNetwork` class centralizing the logic for the WCAndroid app, we can easily specify a different timeout without impacting the other clients.

### Test
As with all the migration PRs, the focus should be on the code review by confirming we didn't miss any argument or used the wrong HTTP method.

For a small smoke test:
##### WordPress.com login

1. Open the example app.
2. Sign in using WordPress.com.
3. Click on Woo, then pick a site.
4. Click on "Log Woo Api Versions" and confirm it works.
5. Click on "Fetch WC Site Settings" and confirm it works.
6. Click on "Fetch WC Product Settings" and confirm it works.
7. Click on "GET USER_ROLE" and confirm it works.

###### Site Credentials login

1. Apply the following patch
```patch
Index: example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(revision e522154c8bc2f74f9d2039917d9de31eaf2b3240)
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/StoreSelectingFragment.kt	(date 1671625263544)
@@ -7,6 +7,8 @@
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.fragment_woo_products.*
 import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.SiteSelectorDialog
+import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.example.ui.common.showStoreSelectorDialog
 import org.wordpress.android.fluxc.example.utils.toggleSiteDependentButtons
 import org.wordpress.android.fluxc.model.SiteModel
@@ -23,7 +25,7 @@
                 Button(context).apply {
                     text = "Select Site"
                     setOnClickListener {
-                        showStoreSelectorDialog(selectedPos, object : StoreSelectorDialog.Listener {
+                        showSiteSelectorDialog(selectedPos, object : SiteSelectorDialog.Listener {
                             override fun onSiteSelected(site: SiteModel, pos: Int) {
                                 onSiteSelected(site)
                                 selectedSite = site
```
2. Open the app then sign in using site credentials (enter site address in the login
3. Repeat steps 3 to 7 from the above test case.