### PR TITLE
Woo: Refactor logic of providing the JITM endpoint path

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jitm/JitmRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jitm/JitmRestClientTest.kt
@@ -7,7 +7,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
@@ -93,7 +93,7 @@ class JitmRestClientTest {
                 jetpackTunnelGsonRequestBuilder.syncGetRequest(
                     jitmRestClient,
                     site,
-                    WPCOMREST.jetpack_blogs.site(1234).rest_api.jitmPath,
+                    JPAPI.jitm.pathV4,
                     mapOf(
                         "message_path" to "",
                         "query" to "",
@@ -128,7 +128,7 @@ class JitmRestClientTest {
                 jetpackTunnelGsonRequestBuilder.syncGetRequest(
                     jitmRestClient,
                     site,
-                    WPCOMREST.jetpack_blogs.site(1234).rest_api.jitmPath,
+                    JPAPI.jitm.pathV4,
                     mapOf(
                         "message_path" to "",
                         "query" to "",
@@ -154,7 +154,7 @@ class JitmRestClientTest {
                 jetpackTunnelGsonRequestBuilder.syncPostRequest(
                     jitmRestClient,
                     site,
-                    WPCOMREST.jetpack_blogs.site(1234).rest_api.jitmPath,
+                    JPAPI.jitm.pathV4,
                     mapOf(
                         "id" to "",
                         "feature_class" to ""
@@ -189,7 +189,7 @@ class JitmRestClientTest {
                 jetpackTunnelGsonRequestBuilder.syncPostRequest(
                     jitmRestClient,
                     site,
-                    WPCOMREST.jetpack_blogs.site(1234).rest_api.jitmPath,
+                    JPAPI.jitm.pathV4,
                     mapOf(
                         "id" to "",
                         "feature_class" to ""

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPComEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPComEndpoint.java
@@ -35,10 +35,6 @@ public class WPComEndpoint {
         return WPCOM_PREFIX_V1_1 + mEndpoint;
     }
 
-    public String getJitmPath() {
-        return "/jetpack/v4/jitm";
-    }
-
     public String getUrlV1_2() {
         return WPCOM_PREFIX_V1_2 + mEndpoint;
     }

--- a/fluxc-processor/src/main/resources/jp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/jp-api-endpoints.txt
@@ -1,3 +1,4 @@
 /module/stats/active
 /connection/url
 /connection/data
+/jitm

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JitmRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JitmRestClient.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm
 import android.content.Context
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
@@ -30,7 +30,7 @@ class JitmRestClient @Inject constructor(
         messagePath: String,
         query: String,
     ): WooPayload<Array<JITMApiResponse>> {
-        val url = WPCOMREST.jetpack_blogs.site(site.siteId).rest_api.jitmPath
+        val url = JPAPI.jitm.pathV4
 
         val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
             this,
@@ -58,7 +58,7 @@ class JitmRestClient @Inject constructor(
         jitmId: String,
         featureClass: String,
     ): WooPayload<Boolean> {
-        val url = WPCOMREST.jetpack_blogs.site(site.siteId).rest_api.jitmPath
+        val url = JPAPI.jitm.pathV4
 
         val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
             this,


### PR DESCRIPTION
As we are working on the REST API project, we are planning on migrating all of the `RestClients` in the app to a new architecture that uses the class `WooNetwork`. And while I was looking at the different `RestClients`, I was confused by how the JITM endpoint path was provided, as it references the `WPCom` base URL and the site ID, even though it's a WordPress REST API that uses the Jetpack namespace `/jetpack/v4`.

But after checking the code of `getJitmPath`, it clarified my confusion, as it simply returned a constant String `/jetpack/v4/jitm` without any reference to the other endpoint arguments.

This PR updates the logic to align with how we construct the endpoints in FluxC (the `txt` endpoint files), this would help avoid any confusion in the future when we want to migrate this class, the PR doesn't have any effect on the runtime:

| Before | After |
| --- | --- |
| <img width="661" alt="Screen Shot 2022-12-22 at 13 03 13" src="https://user-images.githubusercontent.com/1657201/209131607-0b9ecef5-f3a4-4b53-9bce-0de7044c8a92.png"> | <img width="661" alt="Screen Shot 2022-12-22 at 13 04 41" src="https://user-images.githubusercontent.com/1657201/209131629-cb49aaf3-4702-4c03-a8a3-4c8cdbc5acbb.png"> |

I tested and confirmed that the API still works as expected using local composite builds, but I don't think this requires updating FluxC in WCAndroid right now, the change will be picked up when we update FluxC to include other changes.