### PR TITLE
Woo REST API: detect WooCommerce installation status

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import kotlinx.android.synthetic.main.fragment_woocommerce.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -48,6 +49,11 @@ class WooCommerceFragment : StoreSelectingFragment() {
     @Suppress("LongMethod", "ComplexMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        lifecycleScope.launch {
+            // Fetch sites to make sure we have the correct status of WooCommerce installation
+            wooCommerceStore.fetchWooCommerceSites()
+        }
 
         log_sites.setOnClickListener {
             coroutineScope.launch {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -105,7 +105,7 @@ open class WooCommerceStore @Inject constructor(
 
         emitChange(OnSiteChanged(rowsAffected, fetchResult.updatedSites))
 
-        return WooResult(getWooCommerceSites())
+        return withContext(Dispatchers.IO) { WooResult(getWooCommerceSites()) }
     }
 
     @Suppress("ReturnCount")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -123,15 +123,14 @@ open class WooCommerceStore @Inject constructor(
             }
         }
 
-        val isUpdated = if (!site.isJetpackConnected || site.origin != SiteModel.ORIGIN_WPCOM_REST) {
-            fetchAndUpdateNonJetpackSite(site).let {
+        if (!site.isJetpackConnected || site.origin != SiteModel.ORIGIN_WPCOM_REST) {
+            fetchAndUpdateNonJetpackSite(site).also {
                 if (it.isError) return WooResult(it.error)
-                it.model!!
-            }
-        } else false
 
-        if (isUpdated) {
-            emitChange(OnSiteChanged(1, listOf(site)))
+                if (it.model == true) {
+                    emitChange(OnSiteChanged(1, listOf(site)))
+                }
+            }
         }
 
         return WooResult(siteStore.getSiteByLocalId(site.id))

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -95,8 +95,8 @@ open class WooCommerceStore @Inject constructor(
         siteStore.sites
             .filterNot { it.origin == SiteModel.ORIGIN_WPCOM_REST && it.isJetpackConnected }
             .forEach { site ->
-                val isUpdatedResult = fetchAndUpdateNonJetpackSite(site)
-                if (isUpdatedResult.model == true && !fetchResult.updatedSites.contains(site)) {
+                val isResultUpdated = fetchAndUpdateNonJetpackSite(site)
+                if (isResultUpdated.model == true && !fetchResult.updatedSites.contains(site)) {
                     rowsAffected++
                 }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -106,6 +106,7 @@ open class WooCommerceStore @Inject constructor(
         return WooResult(getWooCommerceSites())
     }
 
+    @Suppress("ReturnCount")
     suspend fun fetchWooCommerceSite(site: SiteModel): WooResult<SiteModel> {
         if (!site.isJetpackCPConnected) {
             // The endpoint used by siteStore to fetch a single site is broken for Jetpack CP sites, so skip it for them
@@ -226,6 +227,7 @@ open class WooCommerceStore @Inject constructor(
      *
      * @return [WooResult] representing whether the result succeeded and whether the site was updated
      */
+    @Suppress("ReturnCount")
     private suspend fun fetchAndUpdateNonJetpackSite(site: SiteModel): WooResult<Boolean> {
         // Fetch site metadata for Jetpack CP sites
         val isMetadataUpdated = if (site.isJetpackCPConnected) {


### PR DESCRIPTION
⚠️ Please don't merge until #2611 is merged

With this PR, the `WooCommerceStore` will handle detecting the Woo installation status when fetching self-hosted sites, and it will persist the status in the column `hasWooCommerce`, with this.

With this change, we don't need the `patch` we've been using to test the example app with self-hosted sites, and we'll use this in the WCAndroid in the future to show an error if WooCommerce is not installed.

### Testing
1. Open the example app.
2. Sign in using site credentials.
3. Click on Woo.
4. Click on Select Site.
5. Confirm your site is shown.
6. Click on Log Sites.
7. Confirm the sites are fetched.