### PR TITLE
Woo REST API: migrate CustomerRestClient and WCDataRestClient

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -229,11 +229,12 @@ class WooCommerceFragment : StoreSelectingFragment() {
     private fun launchCountriesRequest() {
         coroutineScope.launch {
             try {
-                selectedSite?.let {
-                    wooDataStore.fetchCountriesAndStates(it).model?.let { country ->
-                        country.forEach { location ->
-                            prependToLog(location.name)
-                        }
+                selectedSite?.let { selectedSite ->
+                    wooDataStore.fetchCountriesAndStates(selectedSite).model?.let { country ->
+                        country.filter { it.parentCode.isEmpty() }
+                            .forEach { location ->
+                                prependToLog(location.name)
+                            }
                     }
                         ?: prependToLog("Couldn't fetch countries.")
                 } ?: showNoWCSitesToast()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
@@ -119,17 +119,13 @@ class CustomerRestClient @Inject constructor(
     suspend fun createCustomer(site: SiteModel, customer: CustomerDTO): WooPayload<CustomerDTO> {
         val url = WOOCOMMERCE.customers.pathV3
 
-        val response = requestBuilder.syncPostRequest(
-                restClient = this,
-                site = site,
-                url = url,
-                body = customer.toMap(),
-                clazz = CustomerDTO::class.java
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            body = customer.toMap(),
+            clazz = CustomerDTO::class.java
         )
 
-        return when (response) {
-            is JetpackSuccess -> WooPayload(response.data)
-            is JetpackError -> WooPayload(response.error.toWooError())
-        }
+        return response.toWooPayload()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
@@ -1,16 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.customer
 
-import android.content.Context
-import com.android.volley.RequestQueue
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.CustomerSorting.INCLUDE_ASC
@@ -20,24 +11,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.CustomerSortin
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.CustomerSorting.REGISTERED_DATE_ASC
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.CustomerSorting.REGISTERED_DATE_DESC
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.dto.CustomerDTO
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.network.utils.toMap
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
-class CustomerRestClient @Inject constructor(
-    appContext: Context,
-    private val requestBuilder: JetpackTunnelGsonRequestBuilder,
-    dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class CustomerRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     /**
      * Makes a GET call to `/wc/v3/customers/[remoteCustomerId]` to fetch a single customer
      *

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
@@ -84,10 +84,10 @@ class CustomerRestClient @Inject constructor(
         }
 
         val params = mutableMapOf(
-                "per_page" to pageSize.toString(),
-                "orderby" to orderBy,
-                "order" to sortOrder,
-                "offset" to offset.toString()
+            "per_page" to pageSize.toString(),
+            "orderby" to orderBy,
+            "order" to sortOrder,
+            "offset" to offset.toString()
         ).run {
             putIfNotEmpty("search" to searchQuery)
             putIfNotEmpty("email" to email)
@@ -103,18 +103,14 @@ class CustomerRestClient @Inject constructor(
             params["exclude"] = excludedCustomerIds.map { it }.joinToString()
         }
 
-        val response = requestBuilder.syncGetRequest(
-                restClient = this,
-                site = site,
-                url = url,
-                params = params,
-                Array<CustomerDTO>::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            params = params,
+            clazz = Array<CustomerDTO>::class.java
         )
 
-        return when (response) {
-            is JetpackSuccess -> WooPayload(response.data)
-            is JetpackError -> WooPayload(response.error.toWooError())
-        }
+        return response.toWooPayload()
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/data/WCDataRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/data/WCDataRestClient.kt
@@ -1,51 +1,24 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.data
 
-import android.content.Context
-import com.android.volley.RequestQueue
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
-class WCDataRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class WCDataRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun fetchCountries(
         site: SiteModel
     ): WooPayload<Array<CountryApiResponse>> {
         val url = WOOCOMMERCE.data.countries.pathV3
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                Array<CountryApiResponse>::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<CountryApiResponse>::class.java
         )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return response.toWooPayload()
     }
 
     data class CountryApiResponse(


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/8074
Closes https://github.com/woocommerce/woocommerce-android/issues/8075

This PR migrates `CustomerRestClient` and `WCDataRestClient` to use `WooNetwork` and support application passwords.

### Testing
While the focus should be on the code review itself to catch any errors during the migration (missing an argument or using the wrong HTTP method), we can test the basic features using the below steps:

##### WordPress.com login
1. Open the example app, then sign in using WordPress.com.
2. Click on Woo, then pick a site.
3. Click on Customers, then test some scenarios.
4. Go back, then click on Fetch countries, and confirm it fetches then prints the name of countries.

##### Site Credentials login
1. Open the example app, then sign in using site credentials (enter site address in the login dialog).
2. Repeat steps 2 -> 4 from above.
