### PR TITLE
Application Passwords: Fix NPE errors

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
@@ -77,7 +77,14 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is JetpackSuccess<ApplicationPasswordDeleteResponse> -> {
-                ApplicationPasswordDeletionPayload(response.data!!.deleted)
+                response.data?.let {
+                    ApplicationPasswordDeletionPayload(it.deleted)
+                } ?: ApplicationPasswordDeletionPayload(
+                    BaseNetworkError(
+                        GenericErrorType.UNKNOWN,
+                        "Response is empty"
+                    )
+                )
             }
             is JetpackError<ApplicationPasswordDeleteResponse> -> {
                 ApplicationPasswordDeletionPayload(response.error)
@@ -105,7 +112,14 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is JetpackSuccess<UserApiResponse> -> {
-                UsernameFetchPayload(response.data!!.username)
+                response.data?.let {
+                    UsernameFetchPayload(it.username)
+                } ?: UsernameFetchPayload(
+                    BaseNetworkError(
+                        GenericErrorType.UNKNOWN,
+                        "Response is empty"
+                    )
+                )
             }
             is JetpackError<UserApiResponse> -> {
                 UsernameFetchPayload(response.error)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
@@ -82,7 +82,14 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
 
         return when (val response = payload.response) {
             is WPAPIResponse.Success<ApplicationPasswordDeleteResponse> -> {
-                ApplicationPasswordDeletionPayload(response.data!!.deleted)
+                response.data?.let {
+                    ApplicationPasswordDeletionPayload(it.deleted)
+                } ?: ApplicationPasswordDeletionPayload(
+                    BaseNetworkError(
+                        GenericErrorType.UNKNOWN,
+                        "Response is empty"
+                    )
+                )
             }
             is WPAPIResponse.Error<ApplicationPasswordDeleteResponse> -> {
                 ApplicationPasswordDeletionPayload(response.error)


### PR DESCRIPTION
This PR simply avoids using the double bang operator for reading the `data` property on success responses, as we found out that sometimes, the server would send an explicit `"data": null` (internal discussion p1671742442925879-slack-CGPNUU63E)

There is nothing to test, just code review.