### PR TITLE
Woo REST API: Migrate OrderRestClient

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -45,6 +45,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     private var countDownLatch: CountDownLatch by notNull()
 
     private val siteModel = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
         id = 5
         siteId = 567
     }
@@ -170,7 +171,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     @Test
     fun testOrderListFetchError() {
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
-        orderRestClient.fetchOrders(SiteModel(), 0)
+        orderRestClient.fetchOrders(siteModel, 0)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -141,7 +141,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     @Test
     fun testSearchOrdersError() {
         interceptor.respondWithError("jetpack-tunnel-root-response-failure.json")
-        orderRestClient.searchOrders(SiteModel(), "", 0)
+        orderRestClient.searchOrders(siteModel, "", 0)
 
         countDownLatch = CountDownLatch(1)
         assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -598,7 +598,7 @@ class OrderRestClient @Inject constructor(
     ): WooPayload<OrderNoteEntity> {
         val url = WOOCOMMERCE.orders.id(orderId).notes.pathV3
 
-        val params = mutableMapOf(
+        val body = mutableMapOf(
             "note" to note,
             "customer_note" to isCustomerNote,
             "added_by_user" to true
@@ -608,7 +608,7 @@ class OrderRestClient @Inject constructor(
             site = site,
             path = url,
             clazz = OrderNoteApiResponse::class.java,
-            body = params
+            body = body
         )
 
         return when (response) {
@@ -683,7 +683,7 @@ class OrderRestClient @Inject constructor(
         isCustomProvider: Boolean
     ): AddOrderShipmentTrackingResponsePayload {
         val url = WOOCOMMERCE.orders.id(orderId).shipment_trackings.pathV2
-        val params = if (isCustomProvider) {
+        val body = if (isCustomProvider) {
             mutableMapOf(
                 "custom_tracking_provider" to tracking.trackingProvider,
                 "custom_tracking_link" to tracking.trackingLink
@@ -691,14 +691,14 @@ class OrderRestClient @Inject constructor(
         } else {
             mutableMapOf("tracking_provider" to tracking.trackingProvider)
         }
-        params["tracking_number"] = tracking.trackingNumber
-        params["date_shipped"] = tracking.dateShipped
+        body["tracking_number"] = tracking.trackingNumber
+        body["date_shipped"] = tracking.dateShipped
 
         val response = wooNetwork.executePostGsonRequest(
             site = site,
             path = url,
             clazz = OrderShipmentTrackingApiResponse::class.java,
-            body = params
+            body = body
         )
 
         return when (response) {
@@ -834,13 +834,13 @@ class OrderRestClient @Inject constructor(
         request: UpdateOrderRequest
     ): WooPayload<OrderEntity> {
         val url = WOOCOMMERCE.orders.pathV3
-        val params = request.toNetworkRequest()
+        val body = request.toNetworkRequest()
 
         val response = wooNetwork.executePostGsonRequest(
             site = site,
             path = url,
             clazz = OrderDto::class.java,
-            body = params
+            body = body
         )
 
         return when (response) {
@@ -865,13 +865,13 @@ class OrderRestClient @Inject constructor(
         request: UpdateOrderRequest
     ): WooPayload<OrderEntity> {
         val url = WOOCOMMERCE.orders.id(orderId).pathV3
-        val params = request.toNetworkRequest()
+        val body = request.toNetworkRequest()
 
         val response = wooNetwork.executePutGsonRequest(
             site = site,
             path = url,
             clazz = OrderDto::class.java,
-            body = params
+            body = body
         )
 
         return when (response) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -597,27 +597,27 @@ class OrderRestClient @Inject constructor(
                 "added_by_user" to true
         )
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                this,
-                site,
-                url,
-                params,
-                OrderNoteApiResponse::class.java
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = OrderNoteApiResponse::class.java,
+            body = params
         )
+
         return when (response) {
-            is JetpackSuccess -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let {
                     val newNote = it.toDataModel(site.remoteId(), RemoteId(orderId))
                     return WooPayload(newNote)
                 } ?: WooPayload(
-                        WooError(
-                                type = WooErrorType.GENERIC_ERROR,
-                                original = GenericErrorType.UNKNOWN,
-                                message = "Success response with empty data"
-                        )
+                    WooError(
+                        type = WooErrorType.GENERIC_ERROR,
+                        original = GenericErrorType.UNKNOWN,
+                        message = "Success response with empty data"
+                    )
                 )
             }
-            is JetpackError -> WooPayload(response.error.toWooError())
+            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -415,7 +415,7 @@ class OrderRestClient @Inject constructor(
                 )
             }
             is JetpackError -> {
-                var orderError = networkErrorToOrderError(response.error)
+                val orderError = networkErrorToOrderError(response.error)
                 FetchHasOrdersResponsePayload(
                         orderError,
                         site

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -17,8 +17,7 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
 import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
@@ -93,7 +92,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is Success -> {
+                is WPAPIResponse.Success -> {
                     val orderModels = response.data?.map { orderDto ->
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
@@ -104,7 +103,7 @@ class OrderRestClient @Inject constructor(
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
                 }
-                is Error -> {
+                is WPAPIResponse.Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrdersResponsePayload(orderError, site)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
@@ -158,7 +157,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is Success -> {
+                is WPAPIResponse.Success -> {
                     val orderSummaries = response.data?.map {
                         orderResponseToOrderSummaryModel(it).apply {
                             localSiteId = listDescriptor.site.id
@@ -176,7 +175,7 @@ class OrderRestClient @Inject constructor(
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderListAction(payload))
                 }
-                is Error -> {
+                is WPAPIResponse.Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrderListResponsePayload(
                         error = orderError,
@@ -215,7 +214,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is Success -> {
+                is WPAPIResponse.Success -> {
                     val orderModels = response.data?.map { orderDto ->
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
@@ -227,7 +226,7 @@ class OrderRestClient @Inject constructor(
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersByIdsAction(payload))
                 }
-                is Error -> {
+                is WPAPIResponse.Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrdersByIdsResponsePayload(
                         error = orderError, site = site, orderIds = orderIds
@@ -257,7 +256,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is Success -> {
+                is WPAPIResponse.Success -> {
                     val orderStatusOptions = response.data?.map {
                         orderStatusResponseToOrderStatusModel(it, site)
                     }.orEmpty()
@@ -267,7 +266,7 @@ class OrderRestClient @Inject constructor(
                         WCOrderActionBuilder.newFetchedOrderStatusOptionsAction(payload)
                     )
                 }
-                is Error -> {
+                is WPAPIResponse.Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrderStatusOptionsResponsePayload(orderError, site)
                     dispatcher.dispatch(
@@ -306,7 +305,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is Success -> {
+                is WPAPIResponse.Success -> {
                     val orderModels = response.data?.map { orderDto ->
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
@@ -323,7 +322,7 @@ class OrderRestClient @Inject constructor(
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newSearchedOrdersAction(payload))
                 }
-                is Error -> {
+                is WPAPIResponse.Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = SearchOrdersResponsePayload(orderError, site, searchQuery)
                     dispatcher.dispatch(WCOrderActionBuilder.newSearchedOrdersAction(payload))
@@ -349,7 +348,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is Success -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let { orderDto ->
                     val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     RemoteOrderPayload.Fetching(newModel, site)
@@ -362,7 +361,7 @@ class OrderRestClient @Inject constructor(
                     site
                 )
             }
-            is Error -> {
+            is WPAPIResponse.Error -> {
                 val orderError = wpAPINetworkErrorToOrderError(response.error)
                 RemoteOrderPayload.Fetching(
                     orderError,
@@ -397,7 +396,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is Success -> {
+                is WPAPIResponse.Success -> {
                     val total = response.data?.find { it.slug == filterByStatus }?.total
 
                     total?.let {
@@ -417,7 +416,7 @@ class OrderRestClient @Inject constructor(
                         )
                     }
                 }
-                is Error -> {
+                is WPAPIResponse.Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrdersCountResponsePayload(orderError, site, filterByStatus)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersCountAction(payload))
@@ -458,7 +457,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is Success -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let {
                     FetchHasOrdersResponsePayload(
                         site,
@@ -470,7 +469,7 @@ class OrderRestClient @Inject constructor(
                     site
                 )
             }
-            is Error -> {
+            is WPAPIResponse.Error -> {
                 val orderError = wpAPINetworkErrorToOrderError(response.error)
                 FetchHasOrdersResponsePayload(
                     orderError,
@@ -498,7 +497,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is Success -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let { orderDto ->
                     val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                         .first
@@ -512,7 +511,7 @@ class OrderRestClient @Inject constructor(
                     site
                 )
             }
-            is Error -> {
+            is WPAPIResponse.Error -> {
                 val orderError = wpAPINetworkErrorToOrderError(response.error)
                 RemoteOrderPayload.Updating(
                     orderError,
@@ -632,7 +631,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is Success -> {
+            is WPAPIResponse.Success -> {
                 val trackings = response.data?.map {
                     orderShipmentTrackingResponseToModel(it).apply {
                         localSiteId = site.id
@@ -642,7 +641,7 @@ class OrderRestClient @Inject constructor(
 
                 FetchOrderShipmentTrackingsResponsePayload(site, orderId, trackings)
             }
-            is Error -> {
+            is WPAPIResponse.Error -> {
                 val trackingsError = wpAPINetworkErrorToOrderError(response.error)
                 FetchOrderShipmentTrackingsResponsePayload(trackingsError, site, orderId)
             }
@@ -684,7 +683,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is Success -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let {
                     val trackingModel = orderShipmentTrackingResponseToModel(it).apply {
                         this.orderId = orderId
@@ -698,7 +697,7 @@ class OrderRestClient @Inject constructor(
                     tracking
                 )
             }
-            is Error -> {
+            is WPAPIResponse.Error -> {
                 val trackingsError = wpAPINetworkErrorToOrderError(response.error)
                 AddOrderShipmentTrackingResponsePayload(trackingsError, site, orderId, tracking)
             }
@@ -728,7 +727,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is Success -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let {
                     val model = orderShipmentTrackingResponseToModel(it).apply {
                         localSiteId = site.id
@@ -747,7 +746,7 @@ class OrderRestClient @Inject constructor(
                     tracking
                 )
             }
-            is Error -> DeleteOrderShipmentTrackingResponsePayload(
+            is WPAPIResponse.Error -> DeleteOrderShipmentTrackingResponsePayload(
                 wpAPINetworkErrorToOrderError(response.error),
                 site,
                 orderId,
@@ -779,7 +778,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is Success -> {
+            is WPAPIResponse.Success -> {
                 response.data?.let {
                     try {
                         val providers = jsonResponseToShipmentProviderList(site, it)
@@ -804,7 +803,7 @@ class OrderRestClient @Inject constructor(
                 )
             }
 
-            is Error -> {
+            is WPAPIResponse.Error -> {
                 val trackingError = wpAPINetworkErrorToOrderError(response.error)
                 FetchOrderShipmentProvidersResponsePayload(trackingError, site, order)
             }
@@ -865,8 +864,8 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is Success -> WooPayload(Unit)
-            is Error -> WooPayload(response.error.toWooError())
+            is WPAPIResponse.Success -> WooPayload(Unit)
+            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -24,7 +24,6 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
@@ -75,8 +74,8 @@ class OrderRestClient @Inject constructor(
     private val coroutineEngine: CoroutineEngine
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     /**
-     * Makes a GET call to `/wc/v3/orders` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * retrieving a list of orders for the given WooCommerce [SiteModel].
+     * Makes a GET call to `/wp-json/wc/v3/orders` retrieving a list of orders for the given
+     * WooCommerce [SiteModel].
      *
      * The number of orders fetched is defined in [WCOrderStore.NUM_ORDERS_PER_FETCH], and retrieving older
      * orders is done by passing an [offset].
@@ -132,8 +131,8 @@ class OrderRestClient @Inject constructor(
      * used to determine what orders should be fetched (either existing orders that have since changed or new
      * orders not yet downloaded).
      *
-     * Makes a GET call to `/wc/v3/orders` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * retrieving a list of orders for the given WooCommerce [SiteModel].
+     * Makes a GET call to `/wp-json/wc/v3/orders` retrieving a list of orders for the given
+     * WooCommerce [SiteModel].
      *
      * Dispatches a [WCOrderAction.FETCHED_ORDER_LIST] action with the resulting list of order summaries.
      *
@@ -206,7 +205,7 @@ class OrderRestClient @Inject constructor(
 
     /**
      * Requests orders from the API that match the provided list of [orderIds] by making a GET call to
-     * `/wc/v3/orders` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]).
+     * `/wp-json/wc/v3/orders`
      *
      * Dispatches a [WCOrderAction.FETCHED_ORDERS_BY_IDS] action with the resulting list of orders.
      *
@@ -255,8 +254,8 @@ class OrderRestClient @Inject constructor(
     }
 
     /**
-     * Makes a GET call to `/wc/v3/reports/orders/totals` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * retrieving a list of available order status options for the given WooCommerce [SiteModel].
+     * Makes a GET call to `/wp-json/wc/v3/reports/orders/totals` retrieving a list of available
+     * order status options for the given WooCommerce [SiteModel].
      *
      * Dispatches a [WCOrderAction.FETCHED_ORDER_STATUS_OPTIONS] action with the resulting list of order status labels.
      */
@@ -296,8 +295,8 @@ class OrderRestClient @Inject constructor(
     }
 
     /**
-     * Makes a GET call to `/wc/v3/orders` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * retrieving a list of orders for the given WooCommerce [SiteModel] matching [searchQuery]
+     * Makes a GET call to `/wp-json/wc/v3/orders` retrieving a list of orders for the given
+     * WooCommerce [SiteModel] matching [searchQuery]
      *
      * The number of orders fetched is defined in [WCOrderStore.NUM_ORDERS_PER_FETCH]
      *
@@ -350,7 +349,7 @@ class OrderRestClient @Inject constructor(
     }
 
     /**
-     * Makes a GET request to `/wc/v3/orders/{remoteOrderId}` to fetch a single order by the remoteOrderId.
+     * Makes a GET request to `/wp-json/wc/v3/orders/{remoteOrderId}` to fetch a single order by the remoteOrderId.
      *
      * @param [orderId] Unique server id of the order to fetch
      */
@@ -394,8 +393,8 @@ class OrderRestClient @Inject constructor(
     }
 
     /**
-     * Makes a GET call to `/wc/v3/reports/orders/totals` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * retrieving count of orders for the given WooCommerce [SiteModel], broken down by order status.
+     * Makes a GET call to `/wp-json/wc/v3/reports/orders/totals` retrieving count of orders for
+     * the given WooCommerce [SiteModel], broken down by order status.
      *
      * Dispatches a [WCOrderAction.FETCHED_ORDERS_COUNT] action with the resulting count.
      *
@@ -444,7 +443,7 @@ class OrderRestClient @Inject constructor(
     }
 
     /**
-     * Makes a GET request to `/wc/v3/orders` for a single order of a specific type (or any type) in order to
+     * Makes a GET request to `/wp-json/wc/v3/orders` for a single order of a specific type (or any type) in order to
      * determine if there are any orders in the store.
      *
      *
@@ -498,8 +497,7 @@ class OrderRestClient @Inject constructor(
     }
 
     /**
-     * Makes a PUT call to `/wc/v3/orders/<id>` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * updating the order.
+     * Makes a PUT call to `/wp-json/wc/v3/orders/<id>` updating the order.
      */
     private suspend fun updateOrder(
         orderToUpdate: OrderEntity,
@@ -576,8 +574,8 @@ class OrderRestClient @Inject constructor(
     )
 
     /**
-     * Makes a GET call to `/wc/v3/orders/<id>/notes` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * retrieving a list of notes for the given WooCommerce [SiteModel] and [OrderEntity].
+     * Makes a GET call to `/wp-json/wc/v3/orders/<id>/notes` retrieving a list of notes for the
+     * given WooCommerce [SiteModel] and [OrderEntity].
      */
     suspend fun fetchOrderNotes(
         orderId: Long,
@@ -604,8 +602,8 @@ class OrderRestClient @Inject constructor(
     }
 
     /**
-     * Makes a POST call to `/wc/v3/orders/<id>/notes` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
-     * saving the provide4d note for the given WooCommerce [SiteModel] and [OrderEntity].
+     * Makes a POST call to `/wp-json.wc/v3/orders/<id>/notes` saving the provided note for the
+     * given WooCommerce [SiteModel] and [OrderEntity].
      */
     suspend fun postOrderNote(
         orderId: Long,
@@ -646,8 +644,8 @@ class OrderRestClient @Inject constructor(
     }
 
     /**
-     * Makes a GET call to `/wc/v2/orders/<order_id>/shipment-trackings/` via the Jetpack tunnel
-     * (see [JetpackTunnelGsonRequest]), retrieving a list of shipment tracking objects for a single [OrderEntity].
+     * Makes a GET call to `/wp-json/wc/v2/orders/<order_id>/shipment-trackings/`, retrieving
+     * a list of shipment tracking objects for a single [OrderEntity].
      *
      * Note: This is not currently supported in v3, but will be in the short future.
      *
@@ -688,7 +686,7 @@ class OrderRestClient @Inject constructor(
     /**
      * Posts a new Order Shipment Tracking record to the API for an order.
      *
-     * Makes a POST call to save a Shipment Tracking record via the Jetpack tunnel (see [JetpackTunnelGsonRequest]).
+     * Makes a POST call to save a Shipment Tracking record.
      * The API calls for different fields depending on if the new record uses a custom provider or not, so this is
      * why there is an if-statement. Either way, the same standard [WCOrderShipmentTrackingModel] is returned.
      *
@@ -744,8 +742,8 @@ class OrderRestClient @Inject constructor(
     /**
      * Deletes a single shipment tracking record for an order.
      *
-     * Makes a POST call requesting a DELETE method on `/wc/v2/orders/<order_id>/shipment_trackings/<tracking_id>/`
-     * via the Jetpack tunnel (see [JetpackTunnelGsonRequest].
+     * Makes a POST call requesting a DELETE method on
+     * `/wp-json/wc/v2/orders/<order_id>/shipment_trackings/<tracking_id>/`
      *
      * Note this is currently not supported in v3, but will be in the future.
      */
@@ -795,8 +793,8 @@ class OrderRestClient @Inject constructor(
     /**
      * Fetches a list of shipment providers from the WooCommerce Shipment Tracking plugin.
      *
-     * Makes a GET call to `/wc/v2/orders/<order_id>/shipment-trackings/providers/` via the Jetpack tunnel
-     * (see [JetpackTunnelGsonRequest]), retrieving a list of shipment tracking provider objects. The `<order_id>`
+     * Makes a GET call to `/wp-json/wc/v2/orders/<order_id>/shipment-trackings/providers/`,
+     * retrieving a list of shipment tracking provider objects. The `<order_id>`
      * argument is only needed because it is a requirement of the plugins API even though this data is not directly
      * related to shipment providers.
      */

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -1,4 +1,5 @@
 @file:Suppress("DEPRECATION_ERROR")
+
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import android.content.Context
@@ -89,7 +90,8 @@ class OrderRestClient @Inject constructor(
     fun fetchOrders(site: SiteModel, offset: Int, filterByStatus: String? = null) {
         coroutineEngine.launch(T.API, this, "fetchOrders") {
             // If null, set the filter to the api default value of "any", which will not apply any order status filters.
-            val statusFilter = filterByStatus.takeUnless { it.isNullOrBlank() } ?: WCOrderStore.DEFAULT_ORDER_STATUS
+            val statusFilter = filterByStatus.takeUnless { it.isNullOrBlank() }
+                ?: WCOrderStore.DEFAULT_ORDER_STATUS
 
             val url = WOOCOMMERCE.orders.pathV3
             val params = mapOf(
@@ -114,7 +116,8 @@ class OrderRestClient @Inject constructor(
 
                     val canLoadMore = orderModels.size == WCOrderStore.NUM_ORDERS_PER_FETCH
                     val payload = FetchOrdersResponsePayload(
-                        site, orderModels, filterByStatus, offset > 0, canLoadMore)
+                        site, orderModels, filterByStatus, offset > 0, canLoadMore
+                    )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
                 }
                 is WPAPIResponse.Error -> {
@@ -140,7 +143,11 @@ class OrderRestClient @Inject constructor(
      * the optional parameters in effect.
      * @param offset Used to retrieve older orders
      */
-    fun fetchOrderListSummaries(listDescriptor: WCOrderListDescriptor, offset: Long, requestStartTime: Calendar) {
+    fun fetchOrderListSummaries(
+        listDescriptor: WCOrderListDescriptor,
+        offset: Long,
+        requestStartTime: Calendar
+    ) {
         coroutineEngine.launch(T.API, this, "fetchOrderListSummaries") {
             // If null, set the filter to the api default value of "any", which will not apply any order status filters.
             val statusFilter = listDescriptor.statusFilter.takeUnless { it.isNullOrBlank() }
@@ -214,7 +221,8 @@ class OrderRestClient @Inject constructor(
             val params = mapOf(
                 "per_page" to orderIds.size.toString(),
                 "include" to orderIds.map { it }.joinToString(),
-                "_fields" to ORDER_FIELDS)
+                "_fields" to ORDER_FIELDS
+            )
 
             val response = wooNetwork.executeGetGsonRequest(
                 site = site,
@@ -240,7 +248,8 @@ class OrderRestClient @Inject constructor(
                 is WPAPIResponse.Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrdersByIdsResponsePayload(
-                        error = orderError, site = site, orderIds = orderIds)
+                        error = orderError, site = site, orderIds = orderIds
+                    )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersByIdsAction(payload))
                 }
             }
@@ -315,7 +324,7 @@ class OrderRestClient @Inject constructor(
                 params = params
             )
 
-            when(response) {
+            when (response) {
                 is WPAPIResponse.Success -> {
                     val orderModels = response.data?.map { orderDto ->
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
@@ -358,7 +367,7 @@ class OrderRestClient @Inject constructor(
             params = params
         )
 
-       return when (response) {
+        return when (response) {
             is WPAPIResponse.Success -> {
                 response.data?.let { orderDto ->
                     val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
@@ -383,7 +392,7 @@ class OrderRestClient @Inject constructor(
                     site
                 )
             }
-       }
+        }
     }
 
     /**
@@ -443,20 +452,28 @@ class OrderRestClient @Inject constructor(
      *
      * @param [filterByStatus] Nullable. If not null, consider only orders with a matching order status.
      */
-    suspend fun fetchHasOrders(site: SiteModel, filterByStatus: String? = null): FetchHasOrdersResponsePayload {
-        val statusFilter = if (filterByStatus.isNullOrBlank()) { "any" } else { filterByStatus }
+    suspend fun fetchHasOrders(
+        site: SiteModel,
+        filterByStatus: String? = null
+    ): FetchHasOrdersResponsePayload {
+        val statusFilter = if (filterByStatus.isNullOrBlank()) {
+            "any"
+        } else {
+            filterByStatus
+        }
 
         val url = WOOCOMMERCE.orders.pathV3
         val params = mapOf(
-                "per_page" to "1",
-                "offset" to "0",
-                "status" to statusFilter)
+            "per_page" to "1",
+            "offset" to "0",
+            "status" to statusFilter
+        )
 
         val response = wooNetwork.executeGetGsonRequest(
-                site = site,
-                path = url,
-                clazz = Array<OrderDto>::class.java,
-                params = params
+            site = site,
+            path = url,
+            clazz = Array<OrderDto>::class.java,
+            params = params
         )
 
         return when (response) {
@@ -527,16 +544,28 @@ class OrderRestClient @Inject constructor(
     }
 
     suspend fun updateOrderStatus(orderToUpdate: OrderEntity, site: SiteModel, status: String) =
-            updateOrder(orderToUpdate, site, mapOf("status" to status))
+        updateOrder(orderToUpdate, site, mapOf("status" to status))
 
-    suspend fun updateCustomerOrderNote(orderToUpdate: OrderEntity, site: SiteModel, newNotes: String) =
-            updateOrder(orderToUpdate, site, mapOf("customer_note" to newNotes))
+    suspend fun updateCustomerOrderNote(
+        orderToUpdate: OrderEntity,
+        site: SiteModel,
+        newNotes: String
+    ) =
+        updateOrder(orderToUpdate, site, mapOf("customer_note" to newNotes))
 
-    suspend fun updateBillingAddress(orderToUpdate: OrderEntity, site: SiteModel, billing: Billing) =
-            updateOrder(orderToUpdate, site, mapOf("billing" to billing))
+    suspend fun updateBillingAddress(
+        orderToUpdate: OrderEntity,
+        site: SiteModel,
+        billing: Billing
+    ) =
+        updateOrder(orderToUpdate, site, mapOf("billing" to billing))
 
-    suspend fun updateShippingAddress(orderToUpdate: OrderEntity, site: SiteModel, shipping: Shipping) =
-            updateOrder(orderToUpdate, site, mapOf("shipping" to shipping))
+    suspend fun updateShippingAddress(
+        orderToUpdate: OrderEntity,
+        site: SiteModel,
+        shipping: Shipping
+    ) =
+        updateOrder(orderToUpdate, site, mapOf("shipping" to shipping))
 
     suspend fun updateBothOrderAddresses(
         orderToUpdate: OrderEntity,
@@ -544,8 +573,8 @@ class OrderRestClient @Inject constructor(
         shipping: Shipping,
         billing: Billing
     ) = updateOrder(
-            orderToUpdate, site,
-            mapOf("shipping" to shipping, "billing" to billing)
+        orderToUpdate, site,
+        mapOf("shipping" to shipping, "billing" to billing)
     )
 
     /**
@@ -589,9 +618,9 @@ class OrderRestClient @Inject constructor(
         val url = WOOCOMMERCE.orders.id(orderId).notes.pathV3
 
         val params = mutableMapOf(
-                "note" to note,
-                "customer_note" to isCustomerNote,
-                "added_by_user" to true
+            "note" to note,
+            "customer_note" to isCustomerNote,
+            "added_by_user" to true
         )
 
         val response = wooNetwork.executePostGsonRequest(
@@ -676,8 +705,9 @@ class OrderRestClient @Inject constructor(
         val url = WOOCOMMERCE.orders.id(orderId).shipment_trackings.pathV2
         val params = if (isCustomProvider) {
             mutableMapOf(
-                    "custom_tracking_provider" to tracking.trackingProvider,
-                    "custom_tracking_link" to tracking.trackingLink)
+                "custom_tracking_provider" to tracking.trackingProvider,
+                "custom_tracking_link" to tracking.trackingLink
+            )
         } else {
             mutableMapOf("tracking_provider" to tracking.trackingProvider)
         }
@@ -955,7 +985,7 @@ class OrderRestClient @Inject constructor(
     }
 
     private fun convertDateToUTCString(date: String?): String =
-            date?.let { DateUtils.formatGmtAsUtcDateString(it) } ?: "" // Store the date in UTC format
+        date?.let { DateUtils.formatGmtAsUtcDateString(it) } ?: "" // Store the date in UTC format
 
     private fun jsonResponseToShipmentProviderList(
         site: SiteModel,
@@ -963,60 +993,60 @@ class OrderRestClient @Inject constructor(
     ): List<WCOrderShipmentProviderModel> {
         val providers = mutableListOf<WCOrderShipmentProviderModel>()
         response.asJsonObject.entrySet()
-                .forEach { countryEntry: MutableEntry<String, JsonElement> ->
-                    countryEntry.value.asJsonObject.entrySet().map { carrierEntry ->
-                        carrierEntry?.let { carrier ->
-                            val provider = WCOrderShipmentProviderModel().apply {
-                                localSiteId = site.id
-                                this.country = countryEntry.key
-                                this.carrierName = carrier.key
-                                this.carrierLink = carrier.value.asString
-                            }
-                            providers.add(provider)
+            .forEach { countryEntry: MutableEntry<String, JsonElement> ->
+                countryEntry.value.asJsonObject.entrySet().map { carrierEntry ->
+                    carrierEntry?.let { carrier ->
+                        val provider = WCOrderShipmentProviderModel().apply {
+                            localSiteId = site.id
+                            this.country = countryEntry.key
+                            this.carrierName = carrier.key
+                            this.carrierLink = carrier.value.asString
                         }
+                        providers.add(provider)
                     }
                 }
+            }
 
         return providers
     }
 
     companion object {
         private val ORDER_FIELDS = arrayOf(
-                "billing",
-                "coupon_lines",
-                "currency",
-                "order_key",
-                "customer_note",
-                "date_created_gmt",
-                "date_modified_gmt",
-                "date_paid_gmt",
-                "discount_total",
-                "fee_lines",
-                "tax_lines",
-                "id",
-                "line_items",
-                "number",
-                "payment_method",
-                "payment_method_title",
-                "prices_include_tax",
-                "refunds",
-                "shipping",
-                "shipping_lines",
-                "shipping_total",
-                "status",
-                "total",
-                "total_tax",
-                "meta_data",
-                "payment_url",
-                "is_editable"
+            "billing",
+            "coupon_lines",
+            "currency",
+            "order_key",
+            "customer_note",
+            "date_created_gmt",
+            "date_modified_gmt",
+            "date_paid_gmt",
+            "discount_total",
+            "fee_lines",
+            "tax_lines",
+            "id",
+            "line_items",
+            "number",
+            "payment_method",
+            "payment_method_title",
+            "prices_include_tax",
+            "refunds",
+            "shipping",
+            "shipping_lines",
+            "shipping_total",
+            "status",
+            "total",
+            "total_tax",
+            "meta_data",
+            "payment_url",
+            "is_editable"
         ).joinToString(separator = ",")
 
         private val TRACKING_FIELDS = arrayOf(
-                "date_shipped",
-                "tracking_id",
-                "tracking_link",
-                "tracking_number",
-                "tracking_provider"
+            "date_shipped",
+            "tracking_id",
+            "tracking_link",
+            "tracking_number",
+            "tracking_provider"
         ).joinToString(separator = ",")
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -2,8 +2,6 @@
 
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
-import android.content.Context
-import com.android.volley.RequestQueue
 import com.google.gson.JsonElement
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction
@@ -19,12 +17,9 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
 import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
-import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
@@ -58,22 +53,17 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Calendar
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.collections.MutableMap.MutableEntry
 
-@Suppress("LargeClass")
+@Suppress("LargeClass", "TooManyFunctions")
 @Singleton
 class OrderRestClient @Inject constructor(
-    appContext: Context,
     private val dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
     private val orderDtoMapper: OrderDtoMapper,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
     private val wooNetwork: WooNetwork,
     private val coroutineEngine: CoroutineEngine
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+) {
     /**
      * Makes a GET call to `/wp-json/wc/v3/orders` retrieving a list of orders for the given
      * WooCommerce [SiteModel].

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -21,7 +21,8 @@ import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -106,7 +107,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is WPAPIResponse.Success -> {
+                is Success -> {
                     val orderModels = response.data?.map { orderDto ->
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
@@ -117,7 +118,7 @@ class OrderRestClient @Inject constructor(
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
                 }
-                is WPAPIResponse.Error -> {
+                is Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrdersResponsePayload(orderError, site)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersAction(payload))
@@ -171,7 +172,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is WPAPIResponse.Success -> {
+                is Success -> {
                     val orderSummaries = response.data?.map {
                         orderResponseToOrderSummaryModel(it).apply {
                             localSiteId = listDescriptor.site.id
@@ -190,7 +191,7 @@ class OrderRestClient @Inject constructor(
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderListAction(payload))
 
                 }
-                is WPAPIResponse.Error -> {
+                is Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrderListResponsePayload(
                         error = orderError,
@@ -229,7 +230,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is WPAPIResponse.Success -> {
+                is Success -> {
                     val orderModels = response.data?.map { orderDto ->
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
@@ -242,7 +243,7 @@ class OrderRestClient @Inject constructor(
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersByIdsAction(payload))
 
                 }
-                is WPAPIResponse.Error -> {
+                is Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrdersByIdsResponsePayload(
                         error = orderError, site = site, orderIds = orderIds
@@ -272,7 +273,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is WPAPIResponse.Success -> {
+                is Success -> {
                     val orderStatusOptions = response.data?.map {
                         orderStatusResponseToOrderStatusModel(it, site)
                     }.orEmpty()
@@ -283,7 +284,7 @@ class OrderRestClient @Inject constructor(
                     )
 
                 }
-                is WPAPIResponse.Error -> {
+                is Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrderStatusOptionsResponsePayload(orderError, site)
                     dispatcher.dispatch(
@@ -322,7 +323,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is WPAPIResponse.Success -> {
+                is Success -> {
                     val orderModels = response.data?.map { orderDto ->
                         orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     }.orEmpty()
@@ -339,7 +340,7 @@ class OrderRestClient @Inject constructor(
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newSearchedOrdersAction(payload))
                 }
-                is WPAPIResponse.Error -> {
+                is Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = SearchOrdersResponsePayload(orderError, site, searchQuery)
                     dispatcher.dispatch(WCOrderActionBuilder.newSearchedOrdersAction(payload))
@@ -365,7 +366,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 response.data?.let { orderDto ->
                     val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                     RemoteOrderPayload.Fetching(newModel, site)
@@ -378,7 +379,7 @@ class OrderRestClient @Inject constructor(
                     site
                 )
             }
-            is WPAPIResponse.Error -> {
+            is Error -> {
                 val orderError = wpAPINetworkErrorToOrderError(response.error)
                 RemoteOrderPayload.Fetching(
                     orderError,
@@ -413,7 +414,7 @@ class OrderRestClient @Inject constructor(
             )
 
             when (response) {
-                is WPAPIResponse.Success -> {
+                is Success -> {
                     val total = response.data?.find { it.slug == filterByStatus }?.total
 
                     total?.let {
@@ -433,7 +434,7 @@ class OrderRestClient @Inject constructor(
                         )
                     }
                 }
-                is WPAPIResponse.Error -> {
+                is Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrdersCountResponsePayload(orderError, site, filterByStatus)
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersCountAction(payload))
@@ -474,7 +475,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 response.data?.let {
                     FetchHasOrdersResponsePayload(
                         site,
@@ -486,7 +487,7 @@ class OrderRestClient @Inject constructor(
                     site
                 )
             }
-            is WPAPIResponse.Error -> {
+            is Error -> {
                 val orderError = wpAPINetworkErrorToOrderError(response.error)
                 FetchHasOrdersResponsePayload(
                     orderError,
@@ -514,7 +515,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 response.data?.let { orderDto ->
                     val newModel = orderDtoMapper.toDatabaseEntity(orderDto, site.localId())
                         .first
@@ -528,7 +529,7 @@ class OrderRestClient @Inject constructor(
                     site
                 )
             }
-            is WPAPIResponse.Error -> {
+            is Error -> {
                 val orderError = wpAPINetworkErrorToOrderError(response.error)
                 RemoteOrderPayload.Updating(
                     orderError,
@@ -590,14 +591,14 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 val noteModels = response.data?.map {
                     it.toDataModel(site.remoteId(), RemoteId(orderId))
                 }.orEmpty()
                 WooPayload(noteModels)
 
             }
-            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
+            is Error -> WooPayload(response.error.toWooError())
         }
     }
 
@@ -627,7 +628,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 response.data?.let {
                     val newNote = it.toDataModel(site.remoteId(), RemoteId(orderId))
                     return WooPayload(newNote)
@@ -639,7 +640,7 @@ class OrderRestClient @Inject constructor(
                     )
                 )
             }
-            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
+            is Error -> WooPayload(response.error.toWooError())
         }
     }
 
@@ -665,7 +666,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 val trackings = response.data?.map {
                     orderShipmentTrackingResponseToModel(it).apply {
                         localSiteId = site.id
@@ -675,7 +676,7 @@ class OrderRestClient @Inject constructor(
 
                 FetchOrderShipmentTrackingsResponsePayload(site, orderId, trackings)
             }
-            is WPAPIResponse.Error -> {
+            is Error -> {
                 val trackingsError = wpAPINetworkErrorToOrderError(response.error)
                 FetchOrderShipmentTrackingsResponsePayload(trackingsError, site, orderId)
 
@@ -718,7 +719,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 response.data?.let {
                     val trackingModel = orderShipmentTrackingResponseToModel(it).apply {
                         this.orderId = orderId
@@ -732,7 +733,7 @@ class OrderRestClient @Inject constructor(
                     tracking
                 )
             }
-            is WPAPIResponse.Error -> {
+            is Error -> {
                 val trackingsError = wpAPINetworkErrorToOrderError(response.error)
                 AddOrderShipmentTrackingResponsePayload(trackingsError, site, orderId, tracking)
             }
@@ -762,7 +763,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 response.data?.let {
                     val model = orderShipmentTrackingResponseToModel(it).apply {
                         localSiteId = site.id
@@ -781,7 +782,7 @@ class OrderRestClient @Inject constructor(
                     tracking
                 )
             }
-            is WPAPIResponse.Error -> DeleteOrderShipmentTrackingResponsePayload(
+            is Error -> DeleteOrderShipmentTrackingResponsePayload(
                 wpAPINetworkErrorToOrderError(response.error),
                 site,
                 orderId,
@@ -813,7 +814,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 response.data?.let {
                     try {
                         val providers = jsonResponseToShipmentProviderList(site, it)
@@ -838,7 +839,7 @@ class OrderRestClient @Inject constructor(
                 )
             }
 
-            is WPAPIResponse.Error -> {
+            is Error -> {
                 val trackingError = wpAPINetworkErrorToOrderError(response.error)
                 FetchOrderShipmentProvidersResponsePayload(trackingError, site, order)
             }
@@ -860,7 +861,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 response.data?.let { orderDto ->
                     WooPayload(orderDtoMapper.toDatabaseEntity(orderDto, site.localId()).first)
                 } ?: WooPayload(
@@ -871,7 +872,7 @@ class OrderRestClient @Inject constructor(
                     )
                 )
             }
-            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
+            is Error -> WooPayload(response.error.toWooError())
         }
     }
 
@@ -891,7 +892,7 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> {
+            is Success -> {
                 response.data?.let { orderDto ->
                     WooPayload(orderDtoMapper.toDatabaseEntity(orderDto, site.localId()).first)
                 } ?: WooPayload(
@@ -902,7 +903,7 @@ class OrderRestClient @Inject constructor(
                     )
                 )
             }
-            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
+            is Error -> WooPayload(response.error.toWooError())
         }
     }
 
@@ -921,8 +922,8 @@ class OrderRestClient @Inject constructor(
         )
 
         return when (response) {
-            is WPAPIResponse.Success -> WooPayload(Unit)
-            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
+            is Success -> WooPayload(Unit)
+            is Error -> WooPayload(response.error.toWooError())
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -635,16 +635,15 @@ class OrderRestClient @Inject constructor(
         val url = WOOCOMMERCE.orders.id(orderId).shipment_trackings.pathV2
         val params = mapOf("_fields" to TRACKING_FIELDS)
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                params,
-                Array<OrderShipmentTrackingApiResponse>::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<OrderShipmentTrackingApiResponse>::class.java,
+            params = params
         )
 
         return when (response) {
-            is JetpackSuccess -> {
+            is WPAPIResponse.Success -> {
                 val trackings = response.data?.map {
                     orderShipmentTrackingResponseToModel(it).apply {
                         localSiteId = site.id
@@ -654,9 +653,10 @@ class OrderRestClient @Inject constructor(
 
                 FetchOrderShipmentTrackingsResponsePayload(site, orderId, trackings)
             }
-            is JetpackError -> {
-                val trackingsError = networkErrorToOrderError(response.error)
+            is WPAPIResponse.Error -> {
+                val trackingsError = wpAPINetworkErrorToOrderError(response.error)
                 FetchOrderShipmentTrackingsResponsePayload(trackingsError, site, orderId)
+
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -560,21 +560,22 @@ class OrderRestClient @Inject constructor(
         site: SiteModel
     ): WooPayload<List<OrderNoteEntity>> {
         val url = WOOCOMMERCE.orders.id(orderId).notes.pathV3
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this,
-            site,
-            url,
-            mapOf(),
-            Array<OrderNoteApiResponse>::class.java
+
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<OrderNoteApiResponse>::class.java
         )
+
         return when (response) {
-            is JetpackSuccess -> {
+            is WPAPIResponse.Success -> {
                 val noteModels = response.data?.map {
                     it.toDataModel(site.remoteId(), RemoteId(orderId))
                 }.orEmpty()
                 WooPayload(noteModels)
+
             }
-            is JetpackError -> WooPayload(response.error.toWooError())
+            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -25,8 +25,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
@@ -889,17 +887,16 @@ class OrderRestClient @Inject constructor(
     ): WooPayload<Unit> {
         val url = WOOCOMMERCE.orders.id(orderId).pathV3
 
-        val response = jetpackTunnelGsonRequestBuilder.syncDeleteRequest(
-                restClient = this,
-                site = site,
-                url = url,
-                clazz = Unit::class.java,
-                params = mapOf("force" to trash.not().toString())
+        val response = wooNetwork.executeDeleteGsonRequest(
+            site = site,
+            path = url,
+            clazz = Unit::class.java,
+            params = mapOf("force" to trash.not().toString())
         )
 
         return when (response) {
-            is JetpackError -> WooPayload(response.error.toWooError())
-            is JetpackSuccess -> WooPayload(Unit)
+            is WPAPIResponse.Success -> WooPayload(Unit)
+            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunne
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Shipping
@@ -54,6 +55,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERR
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.INVALID_RESPONSE
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload
+import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.DateUtils
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.util.AppLog
@@ -73,7 +75,9 @@ class OrderRestClient @Inject constructor(
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
     private val orderDtoMapper: OrderDtoMapper,
     accessToken: AccessToken,
-    userAgent: UserAgent
+    userAgent: UserAgent,
+    private val wooNetwork: WooNetwork,
+    private val coroutineEngine: CoroutineEngine
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     /**
      * Makes a GET call to `/wc/v3/orders` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -828,25 +828,26 @@ class OrderRestClient @Inject constructor(
         val url = WOOCOMMERCE.orders.pathV3
         val params = request.toNetworkRequest()
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                this,
-                site,
-                url,
-                params,
-                OrderDto::class.java
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = OrderDto::class.java,
+            body = params
         )
 
         return when (response) {
-            is JetpackError -> WooPayload(response.error.toWooError())
-            is JetpackSuccess -> response.data?.let { orderDto ->
-                WooPayload(orderDtoMapper.toDatabaseEntity(orderDto, site.localId()).first)
-            } ?: WooPayload(
+            is WPAPIResponse.Success -> {
+                response.data?.let { orderDto ->
+                    WooPayload(orderDtoMapper.toDatabaseEntity(orderDto, site.localId()).first)
+                } ?: WooPayload(
                     error = WooError(
-                            type = WooErrorType.GENERIC_ERROR,
-                            original = GenericErrorType.UNKNOWN,
-                            message = "Success response with empty data"
+                        type = WooErrorType.GENERIC_ERROR,
+                        original = GenericErrorType.UNKNOWN,
+                        message = "Success response with empty data"
                     )
-            )
+                )
+            }
+            is WPAPIResponse.Error -> WooPayload(response.error.toWooError())
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -189,7 +189,6 @@ class OrderRestClient @Inject constructor(
                         requestStartTime = requestStartTime
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderListAction(payload))
-
                 }
                 is Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
@@ -241,7 +240,6 @@ class OrderRestClient @Inject constructor(
                         fetchedOrders = orderModels
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrdersByIdsAction(payload))
-
                 }
                 is Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
@@ -282,7 +280,6 @@ class OrderRestClient @Inject constructor(
                     dispatcher.dispatch(
                         WCOrderActionBuilder.newFetchedOrderStatusOptionsAction(payload)
                     )
-
                 }
                 is Error -> {
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
@@ -596,7 +593,6 @@ class OrderRestClient @Inject constructor(
                     it.toDataModel(site.remoteId(), RemoteId(orderId))
                 }.orEmpty()
                 WooPayload(noteModels)
-
             }
             is Error -> WooPayload(response.error.toWooError())
         }
@@ -679,7 +675,6 @@ class OrderRestClient @Inject constructor(
             is Error -> {
                 val trackingsError = wpAPINetworkErrorToOrderError(response.error)
                 FetchOrderShipmentTrackingsResponsePayload(trackingsError, site, orderId)
-
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
@@ -69,7 +68,6 @@ class OrderRestClient @Inject constructor(
     appContext: Context,
     private val dispatcher: Dispatcher,
     @Named("regular") requestQueue: RequestQueue,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
     private val orderDtoMapper: OrderDtoMapper,
     accessToken: AccessToken,
     userAgent: UserAgent,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -53,11 +53,9 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import java.util.Calendar
 import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.collections.MutableMap.MutableEntry
 
 @Suppress("LargeClass", "TooManyFunctions")
-@Singleton
 class OrderRestClient @Inject constructor(
     private val dispatcher: Dispatcher,
     private val orderDtoMapper: OrderDtoMapper,


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/8013

This PR migrates `OrderRestClient` to use `WooNetwork`.

### Testing
As this is a migration, please mostly check the code and ensure no functions are missed, and that the parameters and used HTTP methods are correct. Also ensure related tests still pass.

