### PR TITLE
Woo REST API: Migrate LeaderboardsRestClient and TrackerRestClient.

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsTestFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCLeaderboardsTestFixtures.kt
@@ -7,7 +7,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.Leaderboar
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
 
 object WCLeaderboardsTestFixtures {
-    val stubSite = SiteModel().apply { id = 321 }
+    val stubSite = SiteModel().apply {
+        id = 321
+        origin = SiteModel.ORIGIN_XMLRPC
+    }
 
     fun generateSampleProductList() = listOf(
             "wc/top-performer-product-1.json",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/leaderboards/LeaderboardsRestClient.kt
@@ -1,29 +1,15 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards
 
-import android.content.Context
-import com.android.volley.RequestQueue
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.utils.handleResult
+import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
-class LeaderboardsRestClient @Inject constructor(
-    appContext: Context?,
-    dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class LeaderboardsRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     @Suppress("LongParameterList")
     suspend fun fetchLeaderboards(
         site: SiteModel,
@@ -41,13 +27,14 @@ class LeaderboardsRestClient @Inject constructor(
 
         val parameters = createParameters(startDate, endDate, quantity, forceRefresh, interval)
 
-        return jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            restClient = this@LeaderboardsRestClient,
+        val response = wooNetwork.executeGetGsonRequest(
             site = site,
-            url = url,
-            params = parameters,
-            clazz = Array<LeaderboardsApiResponse>::class.java
-        ).handleResult()
+            path = url,
+            clazz = Array<LeaderboardsApiResponse>::class.java,
+            params = parameters
+        )
+
+        return response.toWooPayload()
     }
 
     @Suppress("LongParameterList")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerRestClient.kt
@@ -1,29 +1,15 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.tracker
 
-import android.content.Context
-import com.android.volley.RequestQueue
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
-internal class TrackerRestClient @Inject constructor(
-    appContext: Context,
-    dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+internal class TrackerRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun sendTelemetry(appVersion: String, site: SiteModel): WooPayload<Unit> {
         val url = WOOCOMMERCE.tracker.pathWcTelemetry
 


### PR DESCRIPTION
To close https://github.com/woocommerce/woocommerce-android/issues/8087 and https://github.com/woocommerce/woocommerce-android/issues/8088

This PR migrates `LeaderboardsRestClient` and `TrackerRestClient` to use `WooNetwork`.

## Testing
As this is a migration, please mostly check the code and ensure no functions are missed, and that the parameters and used HTTP methods are correct. Also ensure related tests still pass.