### PR TITLE
Woo REST API: Migrate InPersonPaymentsRestClient and JitmRestClient

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JitmTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JitmTest.kt
@@ -16,6 +16,11 @@ class MockedStack_JitmTest : MockedStack_Base() {
 
     @Inject internal lateinit var interceptor: ResponseMockingInterceptor
 
+    private val testSite = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
+        siteId = 123L
+    }
+
     @Throws(Exception::class)
     override fun setUp() {
         super.setUp()
@@ -27,7 +32,7 @@ class MockedStack_JitmTest : MockedStack_Base() {
         interceptor.respondWith("jitm-fetch-success.json")
         val messagePath = "woomobile:my_store:admin_notices"
 
-        val result = restClient.fetchJitmMessage(SiteModel().apply { siteId = 123L }, messagePath, "")
+        val result = restClient.fetchJitmMessage(testSite, messagePath, "")
 
         assertFalse(result.isError)
         assertTrue(!result.result.isNullOrEmpty())
@@ -38,7 +43,7 @@ class MockedStack_JitmTest : MockedStack_Base() {
         interceptor.respondWith("jitm-fetch-success-empty.json")
         val messagePath = ""
 
-        val result = restClient.fetchJitmMessage(SiteModel().apply { siteId = 123L }, messagePath, "")
+        val result = restClient.fetchJitmMessage(testSite, messagePath, "")
 
         assertFalse(result.isError)
         assertTrue(result.result.isNullOrEmpty())
@@ -49,7 +54,7 @@ class MockedStack_JitmTest : MockedStack_Base() {
         interceptor.respondWithError("jitm-fetch-failure.json", 500)
         val messagePath = ""
 
-        val result = restClient.fetchJitmMessage(SiteModel().apply { siteId = 123L }, messagePath, "")
+        val result = restClient.fetchJitmMessage(testSite, messagePath, "")
 
         assertTrue(result.isError)
         assertEquals(API_ERROR, result.error.type)
@@ -60,7 +65,7 @@ class MockedStack_JitmTest : MockedStack_Base() {
         interceptor.respondWith("jitm-dismiss-success.json")
 
         val result = restClient.dismissJitmMessage(
-            SiteModel().apply { siteId = 123L },
+            testSite,
             jitmId = "123",
             featureClass = ""
         )
@@ -74,7 +79,7 @@ class MockedStack_JitmTest : MockedStack_Base() {
         interceptor.respondWithError("jitm-dismiss-failure.json", 500)
 
         val result = restClient.dismissJitmMessage(
-            SiteModel().apply { siteId = 123L },
+            testSite,
             jitmId = "123",
             featureClass = ""
         )

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
@@ -27,6 +27,11 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
     @Inject internal lateinit var interceptor: ResponseMockingInterceptor
 
+    private val testSite = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
+        siteId = 123L
+    }
+
     @Throws(Exception::class)
     override fun setUp() {
         super.setUp()
@@ -37,7 +42,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun givenSiteHasWCPayWhenFetchConnectionTokenInvokedThenTokenReturned() = runBlocking {
         interceptor.respondWith("wc-pay-fetch-connection-token-response-success.json")
 
-        val result = restClient.fetchConnectionToken(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.fetchConnectionToken(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.result?.token?.isNotEmpty() == true)
         assertTrue(result.result?.isTestMode == true)
@@ -49,7 +54,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
         val result = restClient.capturePayment(
             WOOCOMMERCE_PAYMENTS,
-            SiteModel().apply { siteId = 123L },
+            testSite,
             DUMMY_PAYMENT_ID,
             -10L
         )
@@ -64,7 +69,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
         val result = restClient.capturePayment(
             WOOCOMMERCE_PAYMENTS,
-            SiteModel().apply { siteId = 123L },
+            testSite,
             DUMMY_PAYMENT_ID,
             -10L
         )
@@ -78,7 +83,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
         val result = restClient.capturePayment(
             WOOCOMMERCE_PAYMENTS,
-            SiteModel().apply { siteId = 123L },
+            testSite,
             DUMMY_PAYMENT_ID,
             -10L
         )
@@ -92,7 +97,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
         val result = restClient.capturePayment(
             WOOCOMMERCE_PAYMENTS,
-            SiteModel().apply { siteId = 123L },
+            testSite,
             DUMMY_PAYMENT_ID,
             -10L
         )
@@ -106,7 +111,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
 
         val result = restClient.capturePayment(
             WOOCOMMERCE_PAYMENTS,
-            SiteModel().apply { siteId = 123L },
+            testSite,
             DUMMY_PAYMENT_ID,
             -10L
         )
@@ -118,7 +123,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenLoadAccountInvalidStatusThenFallbacksToUnknown() = runBlocking {
         interceptor.respondWith("wc-pay-load-account-response-new-status.json")
 
-        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.result?.status == WCPaymentAccountStatus.UNKNOWN)
     }
@@ -127,7 +132,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenLoadAccountEmptyStatusThenFallbackToNoAccount() = runBlocking {
         interceptor.respondWith("wc-pay-load-account-response-empty-status.json")
 
-        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.result?.status == WCPaymentAccountStatus.NO_ACCOUNT)
     }
@@ -136,7 +141,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenOverdueRequirementsThenCurrentDeadlineCorrectlyParsed() = runBlocking {
         interceptor.respondWith("wc-pay-load-account-response-current-deadline.json")
 
-        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.result?.currentDeadline == 1628258304L)
     }
@@ -145,7 +150,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenLoadAccountRestrictedSoonStatusThenRestrictedSoonStatusReturned() = runBlocking {
         interceptor.respondWith("wc-pay-load-account-response-restricted-soon-status.json")
 
-        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.result?.status == WCPaymentAccountStatus.RESTRICTED_SOON)
     }
@@ -154,7 +159,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenLoadAccountIsLiveThenIsLiveFlagIsTrue() = runBlocking {
         interceptor.respondWith("wc-pay-load-account-response-is-live-account.json")
 
-        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.result!!.isLive)
     }
@@ -163,7 +168,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenStatementeDescriptorNullThenFieldSetToNull() = runBlocking {
         interceptor.respondWith("stripe-extension-statement-descriptor-null.json")
 
-        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.loadAccount(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertNull(result.result!!.statementDescriptor)
     }
@@ -172,12 +177,12 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenGetStoreLocationForSiteErrorWithUrl() = runBlocking {
         interceptor.respondWithError("wc-pay-store-location-for-site-address-missing-with-url-error.json", 500)
 
-        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.isError)
         assertTrue(result.error?.type is MissingAddress)
         val expectedUrl = "https://myusernametestsite2020151673500.wpcomstaging.com/" +
-                "wp-admin/admin.php?page=wc-settings&tab=general"
+            "wp-admin/admin.php?page=wc-settings&tab=general"
         assertEquals(expectedUrl, (result.error?.type as MissingAddress).addressEditingUrl)
     }
 
@@ -185,7 +190,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenGetStoreLocationForSiteErrorWithEmptyUrl() = runBlocking {
         interceptor.respondWithError("wc-pay-store-location-for-site-address-missing-with-empty-url-error.json", 500)
 
-        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.isError)
         assertTrue(result.error?.type is GenericError)
@@ -195,7 +200,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenGetStoreLocationForSiteErrorWithoutUrl() = runBlocking {
         interceptor.respondWithError("wc-pay-store-location-for-site-address-missing-without-url-error.json", 500)
 
-        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.isError)
         assertTrue(result.error?.type is GenericError)
@@ -205,7 +210,7 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
     fun whenGetStoreLocationForSiteWithInvalidPostalCodeError() = runBlocking {
         interceptor.respondWithError("wc-pay-store-location-for-site-invalid-postal-code-error.json", 500)
 
-        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, SiteModel().apply { siteId = 123L })
+        val result = restClient.getStoreLocationForSite(WOOCOMMERCE_PAYMENTS, testSite)
 
         assertTrue(result.isError)
         assertTrue(result.error?.type is InvalidPostalCode)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jitm/JitmRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jitm/JitmRestClientTest.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.jitm
 
-import com.android.volley.RequestQueue
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -9,36 +8,21 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMContent
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JITMCta
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JitmRestClient
 
 class JitmRestClientTest {
-    private lateinit var jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder
-    private lateinit var requestQueue: RequestQueue
-    private lateinit var accessToken: AccessToken
-    private lateinit var userAgent: UserAgent
+    private val wooNetwork: WooNetwork = mock()
     private lateinit var jitmRestClient: JitmRestClient
 
     @Before
     fun setup() {
-        jetpackTunnelGsonRequestBuilder = mock()
-        requestQueue = mock()
-        accessToken = mock()
-        userAgent = mock()
-        jitmRestClient = JitmRestClient(
-            mock(),
-            jetpackTunnelGsonRequestBuilder,
-            mock(),
-            requestQueue,
-            accessToken,
-            userAgent
-        )
+        jitmRestClient = JitmRestClient(wooNetwork)
     }
 
     private fun provideJitmApiResponse(
@@ -90,18 +74,17 @@ class JitmRestClientTest {
         runBlocking {
             val site = SiteModel().apply { siteId = 1234 }
             whenever(
-                jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                    jitmRestClient,
-                    site,
-                    JPAPI.jitm.pathV4,
-                    mapOf(
+                wooNetwork.executeGetGsonRequest(
+                    site = site,
+                    path = JPAPI.jitm.pathV4,
+                    params = mapOf(
                         "message_path" to "",
                         "query" to "",
                     ),
-                    Array<JITMApiResponse>::class.java,
+                    clazz = Array<JITMApiResponse>::class.java,
                 )
             ).thenReturn(
-                JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess(
+                WPAPIResponse.Success(
                     arrayOf(provideJitmApiResponse())
                 )
             )
@@ -121,22 +104,21 @@ class JitmRestClientTest {
     fun `given error response, when fetch jitm, return error`() {
         val site = SiteModel().apply { siteId = 1234 }
         runBlocking {
-            val expectedError = mock<WPComGsonRequest.WPComGsonNetworkError>().apply {
+            val expectedError = mock<WPAPINetworkError>().apply {
                 type = mock()
             }
             whenever(
-                jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                    jitmRestClient,
-                    site,
-                    JPAPI.jitm.pathV4,
-                    mapOf(
+                wooNetwork.executeGetGsonRequest(
+                    site = site,
+                    path = JPAPI.jitm.pathV4,
+                    params = mapOf(
                         "message_path" to "",
                         "query" to "",
                     ),
-                    Array<JITMApiResponse>::class.java,
+                    clazz = Array<JITMApiResponse>::class.java,
                 )
             ).thenReturn(
-                JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError(expectedError)
+                WPAPIResponse.Error(expectedError)
             )
 
             val actualResponse = jitmRestClient.fetchJitmMessage(site, "", "")
@@ -151,18 +133,17 @@ class JitmRestClientTest {
         runBlocking {
             val site = SiteModel().apply { siteId = 1234 }
             whenever(
-                jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                    jitmRestClient,
-                    site,
-                    JPAPI.jitm.pathV4,
-                    mapOf(
+                wooNetwork.executePostGsonRequest(
+                    site = site,
+                    path = JPAPI.jitm.pathV4,
+                    body = mapOf(
                         "id" to "",
                         "feature_class" to ""
                     ),
-                    Any::class.java,
+                    clazz = Any::class.java,
                 )
             ).thenReturn(
-                JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess(
+                WPAPIResponse.Success(
                     arrayOf(provideJitmApiResponse())
                 )
             )
@@ -182,22 +163,21 @@ class JitmRestClientTest {
     fun `given error response, when dismiss jitm, return error`() {
         runBlocking {
             val site = SiteModel().apply { siteId = 1234 }
-            val expectedError = mock<WPComGsonRequest.WPComGsonNetworkError>().apply {
+            val expectedError = mock<WPAPINetworkError>().apply {
                 type = mock()
             }
             whenever(
-                jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                    jitmRestClient,
-                    site,
-                    JPAPI.jitm.pathV4,
-                    mapOf(
+                wooNetwork.executePostGsonRequest(
+                    site = site,
+                    path = JPAPI.jitm.pathV4,
+                    body = mapOf(
                         "id" to "",
                         "feature_class" to ""
                     ),
-                    Any::class.java,
+                    clazz = Any::class.java,
                 )
             ).thenReturn(
-                JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError(expectedError)
+                WPAPIResponse.Error(expectedError)
             )
 
             val actualResponse = jitmRestClient.dismissJitmMessage(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JitmRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JitmRestClient.kt
@@ -1,34 +1,16 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm
 
-import android.content.Context
-import com.android.volley.RequestQueue
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest
-import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
-class JitmRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class JitmRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun fetchJitmMessage(
         site: SiteModel,
         messagePath: String,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JitmRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JitmRestClient.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
@@ -55,22 +56,21 @@ class JitmRestClient @Inject constructor(
     ): WooPayload<Boolean> {
         val url = JPAPI.jitm.pathV4
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-            this,
-            site,
-            url,
-            mapOf(
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            body = mapOf(
                 "id" to jitmId,
                 "feature_class" to featureClass
             ),
-            Any::class.java
+            clazz = Any::class.java
         )
 
         return when (response) {
-            is JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess -> {
+            is WPAPIResponse.Success -> {
                 WooPayload(true)
             }
-            is JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError -> {
+            is WPAPIResponse.Error -> {
                 if (response.error.type == BaseRequest.GenericErrorType.NOT_FOUND) {
                     WooPayload(false)
                 } else {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -1,8 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.payments.inperson
 
-import android.content.Context
-import com.android.volley.RequestQueue
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentError
@@ -20,35 +17,17 @@ import org.wordpress.android.fluxc.model.payments.inperson.WCTerminalStoreLocati
 import org.wordpress.android.fluxc.model.payments.inperson.WCTerminalStoreLocationResult
 import org.wordpress.android.fluxc.model.payments.inperson.WCTerminalStoreLocationResult.StoreAddress
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
-import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.STRIPE
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
-class InPersonPaymentsRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class InPersonPaymentsRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun fetchConnectionToken(
         activePlugin: InPersonPaymentsPluginType,
         site: SiteModel
@@ -121,8 +100,8 @@ class InPersonPaymentsRestClient @Inject constructor(
         val response = wooNetwork.executeGetGsonRequest(
             site = site,
             path = url,
-                params = params,
-                clazz = WCPaymentAccountResult::class.java
+            params = params,
+            clazz = WCPaymentAccountResult::class.java
         )
 
         return response.toWooPayload()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -119,18 +119,14 @@ class InPersonPaymentsRestClient @Inject constructor(
         }
         val params = mapOf("_fields" to ACCOUNT_REQUESTED_FIELDS)
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                params,
-                WCPaymentAccountResult::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+                params = params,
+                clazz = WCPaymentAccountResult::class.java
         )
 
-        return when (response) {
-            is JetpackSuccess -> WooPayload(response.data)
-            is JetpackError -> WooPayload(response.error.toWooError())
-        }
+        return response.toWooPayload()
     }
 
     suspend fun getStoreLocationForSite(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -184,18 +184,13 @@ class InPersonPaymentsRestClient @Inject constructor(
             STRIPE -> WOOCOMMERCE.wc_stripe.charges.charge(chargeId).pathV3
         }
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                mapOf(),
-                WCPaymentChargeApiResult::class.java
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = WCPaymentChargeApiResult::class.java
         )
 
-        return when (response) {
-            is JetpackSuccess -> WooPayload(response.data)
-            is JetpackError -> WooPayload(response.error.toWooError())
-        }
+        return response.toWooPayload()
     }
 
     private fun mapToCapturePaymentError(error: WPAPINetworkError?, message: String): WCCapturePaymentError {


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/8093
Closes https://github.com/woocommerce/woocommerce-android/issues/8094

This PR migrates InPersonPaymentsRestClient and JitmRestClient to use WooNetwork.
Even though these features depend on having a valid Jetpack connection in the site, there is still a possibility that we will allow people to connect using their site credentials, so with this PR, we'll make the API available to use for the two types of authentications, which would allow things to work regardless of the product decision later.

#### Testing
Normally no testing is required, the code review is what's necessary to confirm that the migration didn't miss anything.
There are also mocked and connected tests to confirm there is no regression:
1. `ReleaseStack_InPersonPaymentsWCPayTest`
2. `ReleaseStack_InPersonPaymentsStripeExtensionTest`
3. `MockedStack_InPersonPaymentsTest`
4. `MockedStack_JitmTest`