### PR TITLE
[Blogging Prompts] Return list of prompts when calling fetchPrompts

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStoreTest.kt
@@ -191,7 +191,7 @@ class BloggingPromptsStoreTest {
     }
 
     @Test
-    fun `when fetch prompts triggered, then all prompt model are inserted into db`() = test {
+    fun `when fetch prompts triggered, then all prompt models are inserted into db`() = test {
         val payload = BloggingPromptsPayload(PROMPTS_RESPONSE)
         whenever(
             restClient.fetchPrompts(
@@ -207,7 +207,7 @@ class BloggingPromptsStoreTest {
     }
 
     @Test
-    fun `given cards response, when fetch cards gets triggered, then all prompt model are returned in the result`() =
+    fun `given cards response, when fetch cards gets triggered, then all prompt models are returned in the result`() =
         test {
             val payload = BloggingPromptsPayload(PROMPTS_RESPONSE)
             whenever(

--- a/example/src/test/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStoreTest.kt
@@ -207,7 +207,7 @@ class BloggingPromptsStoreTest {
     }
 
     @Test
-    fun `given cards response, when fetch cards gets triggered, then empty cards model is returned`() =
+    fun `given cards response, when fetch cards gets triggered, then all prompt model are returned in the result`() =
         test {
             val payload = BloggingPromptsPayload(PROMPTS_RESPONSE)
             whenever(
@@ -226,7 +226,7 @@ class BloggingPromptsStoreTest {
                 requestedPromptDate
             )
 
-            assertThat(result.model).isNull()
+            assertThat(result.model).isEqualTo(PROMPT_MODELS)
             assertThat(result.error).isNull()
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/bloggingprompts/BloggingPromptsStore.kt
@@ -84,8 +84,9 @@ class BloggingPromptsStore @Inject constructor(
         site: SiteModel,
         response: BloggingPromptsListResponse
     ): BloggingPromptsResult<List<BloggingPromptModel>> = try {
-        promptsDao.insertForSite(site.id, response.toBloggingPrompts())
-        BloggingPromptsResult()
+        val prompts = response.toBloggingPrompts()
+        promptsDao.insertForSite(site.id, prompts)
+        BloggingPromptsResult(prompts)
     } catch (e: Exception) {
         BloggingPromptsResult(BloggingPromptsError(GENERIC_ERROR))
     }


### PR DESCRIPTION
Fixes #2624 
WordPress-Android Dependent PR: https://github.com/wordpress-mobile/WordPress-Android/pull/17722

## Issue
This was found while developing the Prompts List screen in WordPress-Android (https://github.com/wordpress-mobile/WordPress-Android/issues/17125).

As explained in issue #2624, it seems like this method returns a list of the prompts that were fetched and inserted in the local database, based on the `fetchPrompts` return type, but it was always returning an empty successful result instead.

## Changes
This PR fixes the issue above by making sure the list of inserted prompts is also returned in the `model` field of the `BloggingPromptsResult`

## Test Instructions

Use PR https://github.com/wordpress-mobile/WordPress-Android/pull/17722 to test this change.

