### PR TITLE
Woo REST API: fix Woo detection for non-eligible users

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1341,12 +1341,15 @@ open class SiteStore @Inject constructor(
     }
 
     suspend fun fetchSite(site: SiteModel): OnSiteChanged {
-        val updatedSite = if (site.isUsingWpComRestApi) {
-            siteRestClient.fetchSite(site)
-        } else {
-            siteXMLRPCClient.fetchSite(site)
+        return coroutineEngine.withDefaultContext(T.API, this, "Fetch site") {
+            val updatedSite = if (site.isUsingWpComRestApi) {
+                siteRestClient.fetchSite(site)
+            } else {
+                siteXMLRPCClient.fetchSite(site)
+            }
+
+            updateSite(updatedSite)
         }
-        return updateSite(updatedSite)
     }
 
     suspend fun fetchSites(payload: FetchSitesPayload): OnSiteChanged {
@@ -1357,7 +1360,9 @@ open class SiteStore @Inject constructor(
     }
 
     suspend fun fetchSitesXmlRpc(payload: RefreshSitesXMLRPCPayload): OnSiteChanged {
-        return updateSites(siteXMLRPCClient.fetchSites(payload.url, payload.username, payload.password))
+        return coroutineEngine.withDefaultContext(T.API, this, "Fetch sites") {
+            updateSites(siteXMLRPCClient.fetchSites(payload.url, payload.username, payload.password))
+        }
     }
 
     @Suppress("ForbiddenComment", "SwallowedException")


### PR DESCRIPTION
When fetching a site using REST API or Jetpack CP, we use the endpoint `/wc/v3/settings` to infer if Woo is installed or not, and we were inferring a valid installation when we get a success, while 404 results in Woo missing, and other errors are reported as fetch errors.

When working on the User role check for the REST API project, I faced an issue as the API returns `403`. This PR adjusts the logic to handle the `403` status code too, and if we get it we can infer that Woo is installed, since this means that API  call reached the Woo API controller and resulted in the permission error.

For the second commit of the PR, check the comments below.

### Testing
Please check the WCAndroid [PR](https://github.com/woocommerce/woocommerce-android/pull/8156)
 