### PR TITLE
feat: bulk create variations

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -772,7 +772,11 @@ class WCProductStoreTest {
             )
 
             // when
-            productStore.createVariations(site, productId, emptyList())
+            productStore.createVariations(
+                site,
+                productId,
+                ProductTestUtils.generateSampleVariations(2, productId.value, site.id)
+            )
 
             // then
             val storedVariations = ProductSqlUtils.getVariationsForProduct(site, productId.value)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductVariationMapper.variantModelToProductJsonBody
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE
@@ -1029,6 +1030,24 @@ class ProductRestClient @Inject constructor(
                 ).toWooPayload()
             }
 
+    suspend fun createVariations(
+        site: SiteModel,
+        variations: List<Map<String, Any>>,
+        productId: RemoteId
+    ): WooPayload<BatchProductVariationsApiResponse> =
+        WOOCOMMERCE.products.id(productId.value).variations.batch.pathV3.let { url ->
+            val body = buildMap {
+                putIfNotNull("create" to variations)
+            }
+
+            wooNetwork.executePostGsonRequest(
+                site = site,
+                path = url,
+                clazz = BatchProductVariationsApiResponse::class.java,
+                body = body
+            ).toWooPayload()
+        }
+
     /**
      * Makes a POST request to `/wp-json/wc/v3/products` to create
      * a empty variation to a given variable product
@@ -1699,111 +1718,6 @@ class ProductRestClient @Inject constructor(
             }
         }
 
-        return body
-    }
-
-    /**
-     * Build json body of product items to be updated to the backend.
-     *
-     * This method checks if there is a cached version of the product stored locally.
-     * If not, it generates a new product model for the same product ID, with default fields
-     * and verifies that the [updatedVariationModel] has fields that are different from the default
-     * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any
-     * changes.
-     */
-    @Suppress("ForbiddenComment", "LongMethod", "ComplexMethod", "SwallowedException", "TooGenericExceptionCaught")
-    private fun variantModelToProductJsonBody(
-        variationModel: WCProductVariationModel?,
-        updatedVariationModel: WCProductVariationModel
-    ): HashMap<String, Any> {
-        val body = HashMap<String, Any>()
-
-        val storedVariationModel = variationModel ?: WCProductVariationModel().apply {
-            remoteProductId = updatedVariationModel.remoteProductId
-            remoteVariationId = updatedVariationModel.remoteVariationId
-        }
-        if (storedVariationModel.description != updatedVariationModel.description) {
-            body["description"] = updatedVariationModel.description
-        }
-        if (storedVariationModel.sku != updatedVariationModel.sku) {
-            body["sku"] = updatedVariationModel.sku
-        }
-        if (storedVariationModel.status != updatedVariationModel.status) {
-            body["status"] = updatedVariationModel.status
-        }
-        if (storedVariationModel.manageStock != updatedVariationModel.manageStock) {
-            body["manage_stock"] = updatedVariationModel.manageStock
-        }
-
-        // only allowed to change the following params if manageStock is enabled
-        if (updatedVariationModel.manageStock) {
-            if (storedVariationModel.stockQuantity != updatedVariationModel.stockQuantity) {
-                // Conversion/rounding down because core API only accepts Int value for stock quantity.
-                // On the app side, make sure it only allows whole decimal quantity when updating, so that
-                // there's no undesirable conversion effect.
-                body["stock_quantity"] = updatedVariationModel.stockQuantity.toInt()
-            }
-            if (storedVariationModel.backorders != updatedVariationModel.backorders) {
-                body["backorders"] = updatedVariationModel.backorders
-            }
-        }
-        if (storedVariationModel.stockStatus != updatedVariationModel.stockStatus) {
-            body["stock_status"] = updatedVariationModel.stockStatus
-        }
-        if (storedVariationModel.regularPrice != updatedVariationModel.regularPrice) {
-            body["regular_price"] = updatedVariationModel.regularPrice
-        }
-        if (storedVariationModel.salePrice != updatedVariationModel.salePrice) {
-            body["sale_price"] = updatedVariationModel.salePrice
-        }
-        if (storedVariationModel.dateOnSaleFromGmt != updatedVariationModel.dateOnSaleFromGmt) {
-            body["date_on_sale_from_gmt"] = updatedVariationModel.dateOnSaleFromGmt
-        }
-        if (storedVariationModel.dateOnSaleToGmt != updatedVariationModel.dateOnSaleToGmt) {
-            body["date_on_sale_to_gmt"] = updatedVariationModel.dateOnSaleToGmt
-        }
-        if (storedVariationModel.taxStatus != updatedVariationModel.taxStatus) {
-            body["tax_status"] = updatedVariationModel.taxStatus
-        }
-        if (storedVariationModel.taxClass != updatedVariationModel.taxClass) {
-            body["tax_class"] = updatedVariationModel.taxClass
-        }
-        if (storedVariationModel.weight != updatedVariationModel.weight) {
-            body["weight"] = updatedVariationModel.weight
-        }
-
-        val dimensionsBody = mutableMapOf<String, String>()
-        if (storedVariationModel.height != updatedVariationModel.height) {
-            dimensionsBody["height"] = updatedVariationModel.height
-        }
-        if (storedVariationModel.width != updatedVariationModel.width) {
-            dimensionsBody["width"] = updatedVariationModel.width
-        }
-        if (storedVariationModel.length != updatedVariationModel.length) {
-            dimensionsBody["length"] = updatedVariationModel.length
-        }
-        if (dimensionsBody.isNotEmpty()) {
-            body["dimensions"] = dimensionsBody
-        }
-        if (storedVariationModel.shippingClass != updatedVariationModel.shippingClass) {
-            body["shipping_class"] = updatedVariationModel.shippingClass
-        }
-        // TODO: Once removal is supported, we can remove the extra isNotBlank() condition
-        if (storedVariationModel.image != updatedVariationModel.image && updatedVariationModel.image.isNotBlank()) {
-            body["image"] = updatedVariationModel.getImageModel()?.toJson() ?: ""
-        }
-        if (storedVariationModel.menuOrder != updatedVariationModel.menuOrder) {
-            body["menu_order"] = updatedVariationModel.menuOrder
-        }
-        if (storedVariationModel.attributes != updatedVariationModel.attributes) {
-            JsonParser().apply {
-                body["attributes"] = try {
-                    parse(updatedVariationModel.attributes).asJsonArray
-                } catch (ex: Exception) {
-                    JsonArray()
-                }
-            }
-        }
         return body
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
@@ -1,0 +1,112 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonParser
+import org.wordpress.android.fluxc.model.WCProductVariationModel
+
+object ProductVariationMapper {
+    /**
+     * Build json body of product items to be updated to the backend.
+     *
+     * This method checks if there is a cached version of the product stored locally.
+     * If not, it generates a new product model for the same product ID, with default fields
+     * and verifies that the [updatedVariationModel] has fields that are different from the default
+     * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any
+     * changes.
+     */
+    @Suppress("ForbiddenComment", "LongMethod", "ComplexMethod", "SwallowedException", "TooGenericExceptionCaught")
+    fun variantModelToProductJsonBody(
+        variationModel: WCProductVariationModel?,
+        updatedVariationModel: WCProductVariationModel
+    ): HashMap<String, Any> {
+        val body = HashMap<String, Any>()
+
+        val storedVariationModel = variationModel ?: WCProductVariationModel().apply {
+            remoteProductId = updatedVariationModel.remoteProductId
+            remoteVariationId = updatedVariationModel.remoteVariationId
+        }
+        if (storedVariationModel.description != updatedVariationModel.description) {
+            body["description"] = updatedVariationModel.description
+        }
+        if (storedVariationModel.sku != updatedVariationModel.sku) {
+            body["sku"] = updatedVariationModel.sku
+        }
+        if (storedVariationModel.status != updatedVariationModel.status) {
+            body["status"] = updatedVariationModel.status
+        }
+        if (storedVariationModel.manageStock != updatedVariationModel.manageStock) {
+            body["manage_stock"] = updatedVariationModel.manageStock
+        }
+
+        // only allowed to change the following params if manageStock is enabled
+        if (updatedVariationModel.manageStock) {
+            if (storedVariationModel.stockQuantity != updatedVariationModel.stockQuantity) {
+                // Conversion/rounding down because core API only accepts Int value for stock quantity.
+                // On the app side, make sure it only allows whole decimal quantity when updating, so that
+                // there's no undesirable conversion effect.
+                body["stock_quantity"] = updatedVariationModel.stockQuantity.toInt()
+            }
+            if (storedVariationModel.backorders != updatedVariationModel.backorders) {
+                body["backorders"] = updatedVariationModel.backorders
+            }
+        }
+        if (storedVariationModel.stockStatus != updatedVariationModel.stockStatus) {
+            body["stock_status"] = updatedVariationModel.stockStatus
+        }
+        if (storedVariationModel.regularPrice != updatedVariationModel.regularPrice) {
+            body["regular_price"] = updatedVariationModel.regularPrice
+        }
+        if (storedVariationModel.salePrice != updatedVariationModel.salePrice) {
+            body["sale_price"] = updatedVariationModel.salePrice
+        }
+        if (storedVariationModel.dateOnSaleFromGmt != updatedVariationModel.dateOnSaleFromGmt) {
+            body["date_on_sale_from_gmt"] = updatedVariationModel.dateOnSaleFromGmt
+        }
+        if (storedVariationModel.dateOnSaleToGmt != updatedVariationModel.dateOnSaleToGmt) {
+            body["date_on_sale_to_gmt"] = updatedVariationModel.dateOnSaleToGmt
+        }
+        if (storedVariationModel.taxStatus != updatedVariationModel.taxStatus) {
+            body["tax_status"] = updatedVariationModel.taxStatus
+        }
+        if (storedVariationModel.taxClass != updatedVariationModel.taxClass) {
+            body["tax_class"] = updatedVariationModel.taxClass
+        }
+        if (storedVariationModel.weight != updatedVariationModel.weight) {
+            body["weight"] = updatedVariationModel.weight
+        }
+
+        val dimensionsBody = mutableMapOf<String, String>()
+        if (storedVariationModel.height != updatedVariationModel.height) {
+            dimensionsBody["height"] = updatedVariationModel.height
+        }
+        if (storedVariationModel.width != updatedVariationModel.width) {
+            dimensionsBody["width"] = updatedVariationModel.width
+        }
+        if (storedVariationModel.length != updatedVariationModel.length) {
+            dimensionsBody["length"] = updatedVariationModel.length
+        }
+        if (dimensionsBody.isNotEmpty()) {
+            body["dimensions"] = dimensionsBody
+        }
+        if (storedVariationModel.shippingClass != updatedVariationModel.shippingClass) {
+            body["shipping_class"] = updatedVariationModel.shippingClass
+        }
+        // TODO: Once removal is supported, we can remove the extra isNotBlank() condition
+        if (storedVariationModel.image != updatedVariationModel.image && updatedVariationModel.image.isNotBlank()) {
+            body["image"] = updatedVariationModel.getImageModel()?.toJson() ?: ""
+        }
+        if (storedVariationModel.menuOrder != updatedVariationModel.menuOrder) {
+            body["menu_order"] = updatedVariationModel.menuOrder
+        }
+        if (storedVariationModel.attributes != updatedVariationModel.attributes) {
+            JsonParser().apply {
+                body["attributes"] = try {
+                    parse(updatedVariationModel.attributes).asJsonArray
+                } catch (ex: Exception) {
+                    JsonArray()
+                }
+            }
+        }
+        return body
+    }
+}


### PR DESCRIPTION
### Description

This PR adds `WCProductStore#createVariations`, which allows for bulk creation of variations required by https://github.com/woocommerce/woocommerce-android/issues/8157

