### PR TITLE
Woo: Adopt start and end date parameters inside payload when valid

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -1251,7 +1251,7 @@ class WCStatsStoreTest {
         val plus12SiteDate = SiteModel().apply { timezone = "12" }.let {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
-            val startDate = DateUtils.formatDate("yyyy-MM-dd", Date())
+            val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
             wcStatsStore.fetchRevenueStats(payload)
 
@@ -1271,7 +1271,7 @@ class WCStatsStoreTest {
         val minus12SiteDate = SiteModel().apply { timezone = "-12" }.let {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
-            val startDate = DateUtils.formatDate("yyyy-MM-dd", Date())
+            val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
             wcStatsStore.fetchRevenueStats(payload)
 
@@ -1298,7 +1298,7 @@ class WCStatsStoreTest {
         val plus12SiteDate = SiteModel().apply { timezone = "12" }.let {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
-            val startDate = DateUtils.formatDate("yyyy-MM-dd", Date())
+            val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val endDate = DateUtils.formatDate("yyyy-MM-dd", Date())
 
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate, endDate)
@@ -1320,7 +1320,7 @@ class WCStatsStoreTest {
         val minus12SiteDate = SiteModel().apply { timezone = "-12" }.let {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
-            val startDate = DateUtils.formatDate("yyyy-MM-dd", Date())
+            val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
             wcStatsStore.fetchRevenueStats(payload)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -675,26 +675,19 @@ class WCStatsStore @Inject constructor(
     }
 
     suspend fun fetchRevenueStats(payload: FetchRevenueStatsPayload): OnWCRevenueStatsChanged {
-        val startDate = getStartDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.startDate)
-        val endDate = getEndDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.endDate)
-        return fetchRevenueStats(payload.site, payload.granularity, startDate, endDate, payload.forced)
-    }
+        val startDate = payload.startDate?.takeIf { it.isNotEmpty() }
+            ?: getStartDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.startDate)
+        val endDate = payload.endDate?.takeIf { it.isNotEmpty() }
+            ?: getEndDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.endDate)
 
-    suspend fun fetchRevenueStats(
-        site: SiteModel,
-        granularity: StatsGranularity,
-        startDate: String,
-        endDate: String,
-        forced: Boolean = false
-    ): OnWCRevenueStatsChanged {
         return coroutineEngine.withDefaultContext(API, this, "fetchRevenueStats") {
             val result = wcOrderStatsClient.fetchRevenueStats(
-                site = site,
-                granularity = granularity,
+                site = payload.site,
+                granularity = payload.granularity,
                 startDate = startDate,
                 endDate = endDate,
-                perPage = getPerPageQuantityForRevenueStatsGranularity(granularity),
-                forceRefresh = forced
+                perPage = getPerPageQuantityForRevenueStatsGranularity(payload.granularity),
+                forceRefresh = payload.forced
             )
 
             with(result) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -496,8 +496,8 @@ class WCStatsStore @Inject constructor(
 
     suspend fun fetchNewVisitorStats(payload: FetchNewVisitorStatsPayload): OnWCStatsChanged {
         val apiUnit = OrderStatsApiUnit.convertToVisitorsStatsApiUnit(payload.granularity)
-        val startDate = payload.startDate ?: getStartDate(payload.granularity)
-        val endDate = payload.endDate ?: getEndDate(payload.granularity, payload.site)
+        val startDate = payload.startDate?.takeIf { it.isNotEmpty() } ?: getStartDate(payload.granularity)
+        val endDate = payload.endDate?.takeIf { it.isNotEmpty() } ?: getEndDate(payload.granularity, payload.site)
         val quantity = getQuantityForOrderStatsApiUnit(payload.site, apiUnit, startDate, endDate)
         return coroutineEngine.withDefaultContext(T.API, this, "fetchNewVisitorStats") {
             val result = wcOrderStatsClient.fetchNewVisitorStats(


### PR DESCRIPTION
### ⚠️ Do not merge after your review, it should be merged alongside the main [Analytics Hub PR](https://github.com/woocommerce/woocommerce-android/pull/8112)

Changelog
==========
Introduces some changes to the Revenue and Visitors fetching to properly make use of the start and end date ranges when they're present in the Payload data.

How to Test
==========
1. These changes are better tested through the Woo app in this PR: https://github.com/woocommerce/woocommerce-android/pull/8195

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
