### PR TITLE
Woo REST API: Migrate ShippingLabelRestClient

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -84,22 +84,13 @@ class ShippingLabelRestClient @Inject constructor(
                 "caption_csv" to "",
                 "json" to "true"
         )
-
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                params,
-                PrintShippingLabelApiResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = PrintShippingLabelApiResponse::class.java,
+            params = params
+        ).toWooPayload()
     }
 
     suspend fun checkShippingLabelCreationEligibility(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -234,21 +234,12 @@ class ShippingLabelRestClient @Inject constructor(
         labelIds: List<Long>
     ): WooPayload<ShippingLabelStatusApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).shippingLabels(labelIds.joinToString(separator = ",")).pathV1
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                ShippingLabelStatusApiResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = ShippingLabelStatusApiResponse::class.java
+        ).toWooPayload()
     }
 
     // Supports both creating custom package(s), or activating existing predefined package(s).

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -22,9 +22,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.network.utils.toMap
+import org.wordpress.android.fluxc.utils.toWooPayload
 import java.math.BigDecimal
 import java.util.Date
 import java.util.Locale
@@ -40,7 +42,8 @@ class ShippingLabelRestClient @Inject constructor(
     appContext: Context?,
     @Named("regular") requestQueue: RequestQueue,
     accessToken: AccessToken,
-    userAgent: UserAgent
+    userAgent: UserAgent,
+    private val wooNetwork: WooNetwork
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     suspend fun fetchShippingLabelsForOrder(
         orderId: Long,
@@ -48,21 +51,11 @@ class ShippingLabelRestClient @Inject constructor(
     ): WooPayload<ShippingLabelApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).pathV1
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                ShippingLabelApiResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = ShippingLabelApiResponse::class.java
+        ).toWooPayload()
     }
 
     suspend fun refundShippingLabelForOrder(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -65,21 +65,11 @@ class ShippingLabelRestClient @Inject constructor(
     ): WooPayload<ShippingLabelApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).shippingLabelId(remoteShippingLabelId).refund.pathV1
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                ShippingLabelApiResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = ShippingLabelApiResponse::class.java
+        ).toWooPayload()
     }
 
     suspend fun printShippingLabels(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -1,13 +1,10 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels
 
-import android.content.Context
-import com.android.volley.RequestQueue
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.shippinglabels.WCPackagesResult.CustomPackage
@@ -16,9 +13,6 @@ import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.Shi
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelModel.ShippingLabelPackage
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingLabelPackageData
 import org.wordpress.android.fluxc.model.shippinglabels.WCShippingPackageCustoms
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.utils.toMap
@@ -27,19 +21,11 @@ import java.math.BigDecimal
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.collections.toMap as asMap
 
 @Singleton
-class ShippingLabelRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    appContext: Context?,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun fetchShippingLabelsForOrder(
         orderId: Long,
         site: SiteModel

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -161,21 +161,12 @@ class ShippingLabelRestClient @Inject constructor(
     suspend fun updateAccountSettings(site: SiteModel, request: UpdateSettingsApiRequest): WooPayload<Boolean> {
         val url = WOOCOMMERCE.connect.account.settings.pathV1
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                this,
-                site,
-                url,
-                request.toMap(),
-                JsonObject::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data!!["success"].asBoolean)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = JsonObject::class.java,
+            body = request.toMap()
+        ).toWooPayload { it["success"].asBoolean }
     }
 
     @Suppress("LongParameterList")
@@ -198,21 +189,12 @@ class ShippingLabelRestClient @Inject constructor(
             }
         )
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                this,
-                site,
-                url,
-                params,
-                ShippingRatesApiResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = ShippingRatesApiResponse::class.java,
+            body = params
+        ).toWooPayload()
     }
 
     @Suppress("LongParameterList")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -84,7 +84,7 @@ class ShippingLabelRestClient @Inject constructor(
                 "caption_csv" to "",
                 "json" to "true"
         )
-        
+
         return wooNetwork.executeGetGsonRequest(
             site = site,
             path = url,
@@ -106,21 +106,13 @@ class ShippingLabelRestClient @Inject constructor(
                 "can_create_payment_method" to canCreatePaymentMethod.toString(),
                 "can_create_customs_form" to canCreateCustomsForm.toString()
         )
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                params,
-                SLCreationEligibilityApiResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = SLCreationEligibilityApiResponse::class.java,
+            params = params
+        ).toWooPayload()
     }
 
     suspend fun verifyAddress(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -102,7 +102,7 @@ class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNet
         type: ShippingLabelAddress.Type
     ): WooPayload<VerifyAddressResponse> {
         val url = WOOCOMMERCE.connect.normalize_address.pathV1
-        val params = mapOf(
+        val body = mapOf(
                 "address" to address.toMap(),
                 "type" to type.name.toLowerCase(Locale.ROOT)
         )
@@ -111,7 +111,7 @@ class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNet
             site = site,
             path = url,
             clazz = VerifyAddressResponse::class.java,
-            body = params
+            body = body
         ).toWooPayload()
     }
 
@@ -161,7 +161,7 @@ class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNet
     ): WooPayload<ShippingRatesApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).rates.pathV1
 
-        val params = mapOf(
+        val body = mapOf(
             "origin" to origin.toMap(),
             "destination" to destination.toMap(),
             "packages" to packages.map { labelPackage ->
@@ -174,7 +174,7 @@ class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNet
             site = site,
             path = url,
             clazz = ShippingRatesApiResponse::class.java,
-            body = params
+            body = body
         ).toWooPayload()
     }
 
@@ -190,7 +190,7 @@ class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNet
     ): WooPayload<ShippingLabelStatusApiResponse> {
         val url = WOOCOMMERCE.connect.label.order(orderId).pathV1
 
-        val params = mapOf(
+        val body = mapOf(
                 "async" to true,
                 "origin" to origin,
                 "destination" to destination,
@@ -205,7 +205,7 @@ class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNet
             site = site,
             path = url,
             clazz = ShippingLabelStatusApiResponse::class.java,
-            body = params
+            body = body
         ).toWooPayload()
     }
 
@@ -275,7 +275,7 @@ class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNet
                             .map { it.id } // Grab all found package id(s)
                 }.asMap() // Convert list of Map to Map
 
-        val params = mapOf(
+        val body = mapOf(
                 "custom" to mappedCustomPackages,
                 "predefined" to predefinedParam
         )
@@ -284,7 +284,7 @@ class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNet
             site = site,
             path = url,
             clazz = JsonObject::class.java,
-            body = params
+            body = body
         ).toWooPayload { it["success"].asBoolean }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -139,21 +139,11 @@ class ShippingLabelRestClient @Inject constructor(
     ): WooPayload<GetPackageTypesResponse> {
         val url = WOOCOMMERCE.connect.packages.pathV1
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                GetPackageTypesResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = GetPackageTypesResponse::class.java
+        ).toWooPayload()
     }
 
     suspend fun getAccountSettings(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -220,21 +220,12 @@ class ShippingLabelRestClient @Inject constructor(
                 "email_receipt" to emailReceipts
         )
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                this,
-                site,
-                url,
-                params,
-                ShippingLabelStatusApiResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = ShippingLabelStatusApiResponse::class.java,
+            body = params
+        ).toWooPayload()
     }
 
     suspend fun fetchShippingLabelsStatus(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -126,21 +126,12 @@ class ShippingLabelRestClient @Inject constructor(
                 "type" to type.name.toLowerCase(Locale.ROOT)
         )
 
-        val response = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-                this,
-                site,
-                url,
-                params,
-                VerifyAddressResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = VerifyAddressResponse::class.java,
+            body = params
+        ).toWooPayload()
     }
 
     suspend fun getPackageTypes(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -151,21 +151,11 @@ class ShippingLabelRestClient @Inject constructor(
     ): WooPayload<AccountSettingsApiResponse> {
         val url = WOOCOMMERCE.connect.account.settings.pathV1
 
-        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-                this,
-                site,
-                url,
-                emptyMap(),
-                AccountSettingsApiResponse::class.java
-        )
-        return when (response) {
-            is JetpackSuccess -> {
-                WooPayload(response.data)
-            }
-            is JetpackError -> {
-                WooPayload(response.error.toWooError())
-            }
-        }
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = AccountSettingsApiResponse::class.java
+        ).toWooPayload()
     }
 
     suspend fun updateAccountSettings(site: SiteModel, request: UpdateSettingsApiRequest): WooPayload<Boolean> {


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/8085

This PR migrates `ShippingLabelRestClient` to use `WooNetwork`.

Testing
As this is a migration, please mostly check the code and ensure no functions are missed, and that the parameters and used HTTP methods are correct. Also ensure related tests still pass.