### PR TITLE
Woo REST API: Migrate ProductAttributeRestClient

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -9,8 +9,9 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse
-import org.wordpress.android.fluxc.utils.handleResult
+import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -22,7 +23,8 @@ class ProductAttributeRestClient @Inject constructor(
     @Named("regular") requestQueue: RequestQueue,
     accessToken: AccessToken,
     userAgent: UserAgent,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
+    private val wooNetwork: WooNetwork
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
     suspend fun fetchProductFullAttributesList(
         site: SiteModel
@@ -84,42 +86,37 @@ class ProductAttributeRestClient @Inject constructor(
 
     private suspend inline fun <reified T : Any> String.request(
         site: SiteModel
-    ) = jetpackTunnelGsonRequestBuilder.syncGetRequest(
-            this@ProductAttributeRestClient,
-            site,
-            this,
-            emptyMap(),
-            T::class.java
-    ).handleResult()
+    ) = wooNetwork.executeGetGsonRequest(
+        site = site,
+        path = this,
+        clazz = T::class.java
+    ).toWooPayload()
 
     private suspend inline fun <reified T : Any> String.post(
         site: SiteModel,
         args: Map<String, String>
-    ) = jetpackTunnelGsonRequestBuilder.syncPostRequest(
-            this@ProductAttributeRestClient,
-            site,
-            this,
-            args,
-            T::class.java
-    ).handleResult()
+    ) = wooNetwork.executeGetGsonRequest(
+        site = site,
+        path = this,
+        clazz = T::class.java,
+        params = args
+    ).toWooPayload()
 
     private suspend inline fun <reified T : Any> String.put(
         site: SiteModel,
         args: Map<String, String>
-    ) = jetpackTunnelGsonRequestBuilder.syncPutRequest(
-            this@ProductAttributeRestClient,
-            site,
-            this,
-            args,
-            T::class.java
-    ).handleResult()
+    ) = wooNetwork.executePostGsonRequest(
+        site = site,
+        path = this,
+        clazz = T::class.java,
+        body = args
+    ).toWooPayload()
 
     private suspend inline fun <reified T : Any> String.delete(
         site: SiteModel
-    ) = jetpackTunnelGsonRequestBuilder.syncDeleteRequest(
-            this@ProductAttributeRestClient,
-            site,
-            this,
-            T::class.java
-    ).handleResult()
+    ) = wooNetwork.executeDeleteGsonRequest(
+        site = site,
+        path = this,
+        clazz = T::class.java
+    ).toWooPayload()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -1,31 +1,15 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes
 
-import android.content.Context
-import com.android.volley.RequestQueue
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.attributes.terms.AttributeTermApiResponse
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
-class ProductAttributeRestClient @Inject constructor(
-    appContext: Context?,
-    dispatcher: Dispatcher,
-    @Named("regular") requestQueue: RequestQueue,
-    accessToken: AccessToken,
-    userAgent: UserAgent,
-    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
-    private val wooNetwork: WooNetwork
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+class ProductAttributeRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun fetchProductFullAttributesList(
         site: SiteModel
     ) = WOOCOMMERCE.products.attributes.pathV3


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/8177

This PR migrates `ProductAttributeRestClient` to use `WooNetwork`. This class has a pretty interesting way to do the request, by the way.

### Testing
As this is a migration, please mostly check the code and ensure no functions are missed, and that the parameters and used HTTP methods are correct. Also ensure related tests still pass.