### PR TITLE
Woo REST API: handle UUID fetching when deleting a password

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ApplicationPasswordsLogger.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ApplicationPasswordsLogger.kt
@@ -42,9 +42,25 @@ class ApplicationPasswordsLogger @Inject constructor(
             })
     }
 
-    override fun onNewPasswordCreated() {
+    override fun onNewPasswordCreated(isPasswordRegenerated: Boolean) {
         invokeOnUiThread {
-            prependToLog("A new WordPress Application Password was created")
+            val message = if (isPasswordRegenerated) {
+                "A new WordPress Application Password was regenerated"
+            } else {
+                "An Application Password was created"
+            }
+            prependToLog(message)
+        }
+    }
+
+    override fun onPasswordGenerationFailed(networkError: WPAPINetworkError) {
+        invokeOnUiThread {
+            prependToLog(
+                "Application Password generation failed:" +
+                    "Error message: ${networkError.message}\n" +
+                    "Cause: ${networkError.errorCode} \n" +
+                    "Status Code: ${networkError.volleyError?.networkResponse?.statusCode}"
+            )
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordCredentials.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordCredentials.kt
@@ -3,5 +3,5 @@ package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 internal data class ApplicationPasswordCredentials(
     val userName: String,
     val password: String,
-    val uuid: String
+    val uuid: ApplicationPasswordUUID
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordUUID.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordUUID.kt
@@ -1,0 +1,3 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
+
+internal typealias ApplicationPasswordUUID = String

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 import com.google.gson.annotations.SerializedName
 
 internal data class ApplicationPasswordCreationResponse(
-    @SerializedName("uuid") val uuid: String,
+    @SerializedName("uuid") val uuid: ApplicationPasswordUUID,
     @SerializedName("name") val name: String,
     @SerializedName("password") val password: String
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
@@ -8,6 +8,11 @@ internal data class ApplicationPasswordCreationResponse(
     @SerializedName("password") val password: String
 )
 
+internal data class ApplicationPasswordsFetchResponse(
+    @SerializedName("uuid") val uuid: ApplicationPasswordUUID,
+    @SerializedName("name") val name: String
+)
+
 internal data class ApplicationPasswordDeleteResponse(
     @SerializedName("deleted") val deleted: Boolean
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsListener.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsListener.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 
 interface ApplicationPasswordsListener {
-    fun onNewPasswordCreated() {}
+    fun onNewPasswordCreated(isPasswordRegenerated: Boolean) {}
+    fun onPasswordGenerationFailed(networkError: WPAPINetworkError) {}
     fun onFeatureUnavailable(siteModel: SiteModel, networkError: WPAPINetworkError) {}
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -35,7 +35,7 @@ class ApplicationPasswordsNetwork @Inject constructor(
     // We can't use construction injection for this variable, as its class is internal
     @Inject internal lateinit var mApplicationPasswordsManager: ApplicationPasswordsManager
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "ComplexMethod")
     suspend fun <T> executeGsonRequest(
         site: SiteModel,
         method: HttpMethod,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -47,7 +47,8 @@ class ApplicationPasswordsNetwork @Inject constructor(
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
         forced: Boolean = false,
         requestTimeout: Int = BaseRequest.DEFAULT_REQUEST_TIMEOUT,
-        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES
+        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES,
+        isRegeneratingApplicationPassword: Boolean = false
     ): WPAPIResponse<T> {
         fun buildRequest(
             continuation: Continuation<WPAPIResponse<T>>,
@@ -87,12 +88,16 @@ class ApplicationPasswordsNetwork @Inject constructor(
             is ApplicationPasswordCreationResult.Existing -> credentialsResult.credentials
             is ApplicationPasswordCreationResult.Created -> {
                 if (listener.isPresent) {
-                    listener.get().onNewPasswordCreated()
+                    listener.get().onNewPasswordCreated(isRegeneratingApplicationPassword)
                 }
                 credentialsResult.credentials
             }
-            is ApplicationPasswordCreationResult.Failure ->
+            is ApplicationPasswordCreationResult.Failure -> {
+                if (listener.isPresent) {
+                    listener.get().onPasswordGenerationFailed(credentialsResult.error.toWPAPINetworkError())
+                }
                 return WPAPIResponse.Error(credentialsResult.error.toWPAPINetworkError())
+            }
             is ApplicationPasswordCreationResult.NotSupported -> {
                 val networkError = credentialsResult.originalError.toWPAPINetworkError()
                 if (listener.isPresent) {
@@ -123,7 +128,7 @@ class ApplicationPasswordsNetwork @Inject constructor(
                     " Delete the saved one then retry"
             )
             mApplicationPasswordsManager.deleteLocalApplicationPassword(site)
-            executeGsonRequest(site, method, path, clazz, params, body)
+            executeGsonRequest(site, method, path, clazz, params, body, isRegeneratingApplicationPassword = true)
         } else {
             response
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsPayloads.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsPayloads.kt
@@ -12,6 +12,14 @@ internal data class ApplicationPasswordCreationPayload(
     }
 }
 
+internal data class ApplicationPasswordUUIDFetchPayload(
+    val uuid: ApplicationPasswordUUID
+) : Payload<BaseNetworkError>() {
+    constructor(error: BaseNetworkError) : this("") {
+        this.error = error
+    }
+}
+
 internal data class ApplicationPasswordDeletionPayload(
     val isDeleted: Boolean
 ) : Payload<BaseNetworkError>() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -89,7 +89,7 @@ internal class ApplicationPasswordsStore @Inject constructor(
         }
     }
 
-    fun getUuid(host: String): String? {
+    fun getUuid(host: String): ApplicationPasswordUUID? {
         return encryptedPreferences.getString(host.uuidPrefKey, null)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
@@ -62,7 +62,7 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
 
     suspend fun deleteApplicationPassword(
         site: SiteModel,
-        uuid: String
+        uuid: ApplicationPasswordUUID
     ): ApplicationPasswordDeletionPayload {
         AppLog.d(T.MAIN, "Delete application password using Jetpack Tunnel")
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
@@ -60,6 +60,35 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
         }
     }
 
+    suspend fun fetchApplicationPasswordUUID(
+        site: SiteModel,
+        applicationName: String
+    ) : ApplicationPasswordUUIDFetchPayload {
+        AppLog.d(T.MAIN, "Fetch application password UUID using Jetpack Tunnel")
+        val url = WPAPI.users.me.application_passwords.urlV2
+        val response = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+            restClient = this,
+            site = site,
+            url = url,
+            params = emptyMap(),
+            clazz = Array<ApplicationPasswordCreationResponse>::class.java
+        )
+
+        return when (response) {
+            is JetpackSuccess -> {
+                response.data?.firstOrNull { it.name == applicationName }?.let {
+                    ApplicationPasswordUUIDFetchPayload(it.uuid)
+                } ?: ApplicationPasswordUUIDFetchPayload(
+                    BaseNetworkError(
+                        GenericErrorType.UNKNOWN,
+                        "UUID for application password $applicationName was not found"
+                    )
+                )
+            }
+            is JetpackError -> ApplicationPasswordUUIDFetchPayload(response.error)
+        }
+    }
+
     suspend fun deleteApplicationPassword(
         site: SiteModel,
         uuid: ApplicationPasswordUUID

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
@@ -63,7 +63,7 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
 
     suspend fun deleteApplicationPassword(
         site: SiteModel,
-        uuid: String
+        uuid: ApplicationPasswordUUID
     ): ApplicationPasswordDeletionPayload {
         AppLog.d(T.MAIN, "Delete application password using Cookie Authentication")
 

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
@@ -127,7 +127,21 @@ class ApplicationPasswordsNetworkTests {
 
             network.executeGsonRequest(testSite, HttpMethod.GET, "path", TestResponse::class.java)
 
-            verify(listener).onNewPasswordCreated()
+            verify(listener).onNewPasswordCreated(isPasswordRegenerated = false)
+        }
+
+    @Test
+    fun `given a revoked local password, when a new password is created, then notify listener`() =
+        runBlockingTest {
+            whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
+                .thenReturn(ApplicationPasswordCreationResult.Existing(testCredentials))
+                .thenReturn(ApplicationPasswordCreationResult.Created(testCredentials))
+            val networkError = VolleyError(NetworkResponse(401, byteArrayOf(), true, 0, emptyList()))
+            givenErrorResponse(networkError)
+
+            network.executeGsonRequest(testSite, HttpMethod.GET, "path", TestResponse::class.java)
+
+            verify(listener).onNewPasswordCreated(isPasswordRegenerated = true)
         }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Closes #2637 

⚠️ Please don't merge until the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/8213 is merged.

After fixing #2632, the logic to handle duplicate application passwords stopped working, because when it happens, we will be missing the required UUID to delete the previous password.

With this PR, when we don't find a local UUID, we will attempt to fetch the password UUID from the site, then attempt the download.

#### Testing
1. Open the app, then sign in using site credentials.
2. Open the Woo tab, this will trigger a request using Application Passwords, which would generate a new password.
3. Go to the device settings, then clear the app's data.
4. Re-open the app.
5. Click on the Woo tab.
6. Confirm a new password was successfully created.
7. Optionally: you can also confirm using Flipper that a request to fetch the UUID was sent before the `DELETE` one.