### PR TITLE
Woo REST API: some fixes

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import org.wordpress.android.util.AppLog
+import java.security.KeyStore
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -62,16 +63,29 @@ internal class ApplicationPasswordsStore @Inject constructor(
     }
 
     private fun initEncryptedPrefs(): SharedPreferences {
-        val masterKey = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        val keySpec = MasterKeys.AES256_GCM_SPEC
         val filename = "$applicationName-encrypted-prefs"
 
-        fun createPrefs() = EncryptedSharedPreferences.create(
-            filename,
-            masterKey,
-            context,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
+        fun createPrefs(): SharedPreferences {
+            val masterKey = MasterKeys.getOrCreate(keySpec)
+            return EncryptedSharedPreferences.create(
+                filename,
+                masterKey,
+                context,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        }
+
+        fun deletePrefs() {
+            context.deleteSharedPreferences(filename)
+            with(KeyStore.getInstance("AndroidKeyStore")) {
+                load(null)
+                if (containsAlias(keySpec.keystoreAlias)) {
+                    deleteEntry(keySpec.keystoreAlias)
+                }
+            }
+        }
 
         // The documentation recommends excluding the file from auto backup, but since the file
         // is defined in an internal library, adding to the backup rules and maintaining them won't
@@ -87,7 +101,7 @@ internal class ApplicationPasswordsStore @Inject constructor(
                 AppLog.T.MAIN,
                 "Can't decrypt encrypted preferences, delete it and create new one"
             )
-            context.deleteSharedPreferences(filename)
+            deletePrefs()
             createPrefs()
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -26,6 +26,7 @@ internal class ApplicationPasswordsStore @Inject constructor(
         initEncryptedPrefs()
     }
 
+    @Synchronized
     fun getCredentials(host: String): ApplicationPasswordCredentials? {
         val username = encryptedPreferences.getString(host.usernamePrefKey, null)
         val password = encryptedPreferences.getString(host.passwordPrefKey, null)
@@ -42,6 +43,7 @@ internal class ApplicationPasswordsStore @Inject constructor(
         }
     }
 
+    @Synchronized
     fun saveCredentials(host: String, credentials: ApplicationPasswordCredentials) {
         encryptedPreferences.edit()
             .putString(host.usernamePrefKey, credentials.userName)
@@ -50,6 +52,7 @@ internal class ApplicationPasswordsStore @Inject constructor(
             .apply()
     }
 
+    @Synchronized
     fun deleteCredentials(host: String) {
         encryptedPreferences.edit()
             .remove(host.usernamePrefKey)


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/8154
Closes: https://github.com/woocommerce/woocommerce-android/issues/8173

This PR fixes two issues:

### [Issue 1](https://github.com/woocommerce/woocommerce-android/issues/8154)
It fixes an issue with the usage of the `EncryptedSharedPreferences`, as explained in the code comments, the library's documentation states that to avoid issues with decryption, the file should be excluded from cloud backup. But since we can't really handle this easily as it's part of a library, I opted for a destructive approach if we can't decrypt the file.
But after the test done with Jetpack users, 3 users faced an issue still, it's about the unusability of the encryption key, as I couldn't reproduce the issue, I just tried to follow the different recommendations from this bug report https://github.com/google/tink/issues/535:
1. Make the code thread-safe: the init part was already thread-safe because of using `lazy`, so I just made the other functions of reading and writing synchronized.
2. Remove the key when deleting preferences, here I made a small improvement over the suggested solution in the issue by checking the existence of the key before attempting to delete it.

### [Issue 2](https://github.com/woocommerce/woocommerce-android/issues/8173)
By checking some logs of some crashes there, I noticed this happens on logout, and this made sense: a race condition might result in deleting the site after the network fetch and before reading it from the DB.
I tried to fix this by gracefully failing if the site doesn't exist in the DB instead of using the double bang operator.

### Testing
Since both bugs are not reproducible, I don't there is anything to test, except maybe confirming a non-regression by testing login using site credentials in the example app and testing some scenarios in the Woo section.