### PR TITLE
Better error mapping for create order endpoint

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobilepay/MobilePayRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobilepay/MobilePayRestClient.kt
@@ -82,15 +82,16 @@ class MobilePayRestClient @Inject constructor(
         GENERIC_ERROR,
         INVALID_RESPONSE,
         TIMEOUT,
+        NETWORK_ERROR
     }
 
     private fun WPComGsonRequest.WPComGsonNetworkError.toCreateOrderError() =
         when (type) {
             BaseRequest.GenericErrorType.TIMEOUT -> CreateOrderErrorType.TIMEOUT
             BaseRequest.GenericErrorType.NO_CONNECTION,
-            BaseRequest.GenericErrorType.SERVER_ERROR,
             BaseRequest.GenericErrorType.INVALID_SSL_CERTIFICATE,
-            BaseRequest.GenericErrorType.NETWORK_ERROR -> CreateOrderErrorType.API_ERROR
+            BaseRequest.GenericErrorType.NETWORK_ERROR -> CreateOrderErrorType.NETWORK_ERROR
+            BaseRequest.GenericErrorType.SERVER_ERROR -> CreateOrderErrorType.API_ERROR
             BaseRequest.GenericErrorType.PARSE_ERROR,
             BaseRequest.GenericErrorType.NOT_FOUND,
             BaseRequest.GenericErrorType.CENSORED,


### PR DESCRIPTION
Maps `NO_CONNECTION`, `INVALID_SSL_CERTIFICATE` and `NETWORK_ERROR` to `NETWORK_ERROR`, which is better representation than `API_ERROR`

@JorgeMucientes if this mapping makes sense to you, maybe use this change in your PR right away? E.g. to show network-related error in both cases - Timeout and Network_error, wdyt?