### PR TITLE
WPAPI: Handle invalid nonce and cookies errors

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIAuthenticator.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIAuthenticator.kt
@@ -18,6 +18,7 @@ class WPAPIAuthenticator @Inject constructor(
     private val siteSqlUtils: SiteSqlUtils,
     private val currentTimeProvider: CurrentTimeProvider
 ) {
+    @Suppress("ComplexMethod")
     suspend fun <T : Payload<BaseNetworkError?>> makeAuthenticatedWPAPIRequest(
         site: SiteModel,
         fetchMethod: suspend (Nonce?) -> T


### PR DESCRIPTION
When attempting a Cookie Nonce authentication, if the password is change, the server will return a 403 error with the code: `rest_cookie_invalid_nonce`, this PR handles this error in the `WPApiAuthenticator` by making sure we clear the existing `nonce`, then retry getting a new one.

### Testing
Please check the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/8255