### PR TITLE
[Blogging Prompts] Add isPromptsCardOptedIn field to BloggingReminders entity

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/WPAndroidDatabaseMigrationTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/persistence/room/WPAndroidDatabaseMigrationTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.persistence.room
 
 import androidx.room.testing.MigrationTestHelper
-import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnit4
 import org.assertj.core.api.Assertions.assertThat
@@ -22,8 +21,7 @@ class WPAndroidDatabaseMigrationTest {
     @JvmField
     val helper: MigrationTestHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
-        WPAndroidDatabase::class.java.canonicalName,
-        FrameworkSQLiteOpenHelperFactory()
+        WPAndroidDatabase::class.java,
     )
 
     @Test
@@ -31,7 +29,8 @@ class WPAndroidDatabaseMigrationTest {
     fun migrate1To2() {
         helper.createDatabase(WP_DB_NAME, 1).apply {
             // populate BloggingReminders with some data
-            execSQL("""
+            execSQL(
+                """
                 INSERT INTO BloggingReminders 
                 (localSiteId, monday, tuesday, wednesday, thursday, friday, saturday, sunday) 
                 VALUES (1000,1, 1, 0, 0, 1, 0, 1) 
@@ -49,9 +48,9 @@ class WPAndroidDatabaseMigrationTest {
 
         assertThat(cursor.count).isEqualTo(1)
         cursor.moveToFirst()
-        assertThat(cursor.getInt(0)).isEqualTo(1000)
-        assertThat(cursor.getInt(2)).isEqualTo(1)
-        assertThat(cursor.getInt(4)).isEqualTo(0)
+        assertThat(cursor.getInt(cursor.getColumnIndex("localSiteId"))).isEqualTo(1000)
+        assertThat(cursor.getInt(cursor.getColumnIndex("tuesday"))).isEqualTo(1)
+        assertThat(cursor.getInt(cursor.getColumnIndex("thursday"))).isEqualTo(0)
         cursor.close()
         db.close()
     }
@@ -61,11 +60,13 @@ class WPAndroidDatabaseMigrationTest {
     fun migrate2To3() {
         helper.createDatabase(WP_DB_NAME, 2).apply {
             // populate BloggingReminders with some data
-            execSQL(""" 
+            execSQL(
+                """ 
                 INSERT INTO BloggingReminders 
                 (localSiteId, monday, tuesday, wednesday, thursday, friday, saturday, sunday) 
                 VALUES (1000,1, 1, 0, 0, 1, 0, 1) 
-            """)
+            """
+            )
             close()
         }
 
@@ -78,9 +79,9 @@ class WPAndroidDatabaseMigrationTest {
 
         assertThat(cursor.count).isEqualTo(1)
         cursor.moveToFirst()
-        assertThat(cursor.getInt(0)).isEqualTo(1000)
-        assertThat(cursor.getInt(2)).isEqualTo(1)
-        assertThat(cursor.getInt(4)).isEqualTo(0)
+        assertThat(cursor.getInt(cursor.getColumnIndex("localSiteId"))).isEqualTo(1000)
+        assertThat(cursor.getInt(cursor.getColumnIndex("tuesday"))).isEqualTo(1)
+        assertThat(cursor.getInt(cursor.getColumnIndex("thursday"))).isEqualTo(0)
         cursor.close()
         db.close()
     }
@@ -93,11 +94,13 @@ class WPAndroidDatabaseMigrationTest {
 
         helper.createDatabase(WP_DB_NAME, oldVersion).apply {
             // populate BloggingReminders with some data
-            execSQL(""" 
+            execSQL(
+                """ 
                 INSERT INTO BloggingReminders 
                 (localSiteId, monday, tuesday, wednesday, thursday, friday, saturday, sunday) 
                 VALUES (1000,1, 1, 0, 0, 1, 0, 1) 
-            """)
+            """
+            )
             close()
         }
 
@@ -109,11 +112,13 @@ class WPAndroidDatabaseMigrationTest {
 
         assertThat(cursor.count).isEqualTo(1)
         cursor.moveToFirst()
-        assertThat(cursor.getInt(0)).isEqualTo(1000)
-        assertThat(cursor.getInt(2)).isEqualTo(1)
-        assertThat(cursor.getInt(4)).isEqualTo(0)
-        assertThat(cursor.getInt(8)).isEqualTo(10)
-        assertThat(cursor.getInt(9)).isEqualTo(0)
+        assertThat(cursor.getInt(cursor.getColumnIndex("localSiteId"))).isEqualTo(1000)
+        assertThat(cursor.getInt(cursor.getColumnIndex("tuesday"))).isEqualTo(1)
+        assertThat(cursor.getInt(cursor.getColumnIndex("thursday"))).isEqualTo(0)
+        // also test existing entry has new field hour with correct default (10)
+        assertThat(cursor.getInt(cursor.getColumnIndex("hour"))).isEqualTo(10)
+        // also test existing entry has new field minute with correct default (0)
+        assertThat(cursor.getInt(cursor.getColumnIndex("minute"))).isEqualTo(0)
         cursor.close()
         db.close()
     }
@@ -126,11 +131,13 @@ class WPAndroidDatabaseMigrationTest {
 
         helper.createDatabase(WP_DB_NAME, oldVersion).apply {
             // populate BloggingReminders with some data
-            execSQL(""" 
+            execSQL(
+                """ 
                 INSERT INTO BloggingReminders 
                 (localSiteId, monday, tuesday, wednesday, thursday, friday, saturday, sunday, hour, minute) 
                 VALUES (1000,1, 1, 0, 0, 1, 0, 1, 10, 33) 
-            """)
+            """
+            )
             close()
         }
 
@@ -142,12 +149,52 @@ class WPAndroidDatabaseMigrationTest {
 
         assertThat(cursor.count).isEqualTo(1)
         cursor.moveToFirst()
-        assertThat(cursor.getInt(0)).isEqualTo(1000)
-        assertThat(cursor.getInt(2)).isEqualTo(1)
-        assertThat(cursor.getInt(4)).isEqualTo(0)
-        assertThat(cursor.getInt(8)).isEqualTo(10)
-        assertThat(cursor.getInt(9)).isEqualTo(33)
-        assertThat(cursor.getInt(10)).isEqualTo(0)
+        assertThat(cursor.getInt(cursor.getColumnIndex("localSiteId"))).isEqualTo(1000)
+        assertThat(cursor.getInt(cursor.getColumnIndex("tuesday"))).isEqualTo(1)
+        assertThat(cursor.getInt(cursor.getColumnIndex("thursday"))).isEqualTo(0)
+        assertThat(cursor.getInt(cursor.getColumnIndex("hour"))).isEqualTo(10)
+        assertThat(cursor.getInt(cursor.getColumnIndex("minute"))).isEqualTo(33)
+        // also test existing entry has new field isPromptRemindersOptedIn with correct default (0)
+        assertThat(cursor.getInt(cursor.getColumnIndex("isPromptRemindersOptedIn"))).isEqualTo(0)
+        cursor.close()
+        db.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate10to11() {
+        val oldVersion = 10
+        val newVersion = 11
+        helper.createDatabase(WP_DB_NAME, oldVersion).apply {
+            // populate BloggingReminders with some data
+            execSQL(
+                """ 
+                INSERT INTO BloggingReminders 
+                (localSiteId, monday, tuesday, wednesday, thursday, friday, saturday, sunday,
+                hour, minute, isPromptRemindersOptedIn) 
+                VALUES (1000,1, 1, 0, 0, 1, 0, 1, 10, 33, 0) 
+            """.trimIndent()
+            )
+            close()
+        }
+
+        // Re-open the database with the new version and provide migration to check against.
+        val db = helper.runMigrationsAndValidate(WP_DB_NAME, newVersion, true)
+
+        // Validate that the data was migrated properly.
+        val cursor = db.query("SELECT * FROM BloggingReminders")
+
+        assertThat(cursor.count).isEqualTo(1)
+        cursor.moveToFirst()
+        assertThat(cursor.getInt(cursor.getColumnIndex("localSiteId"))).isEqualTo(1000)
+        assertThat(cursor.getInt(cursor.getColumnIndex("tuesday"))).isEqualTo(1)
+        assertThat(cursor.getInt(cursor.getColumnIndex("thursday"))).isEqualTo(0)
+        assertThat(cursor.getInt(cursor.getColumnIndex("hour"))).isEqualTo(10)
+        assertThat(cursor.getInt(cursor.getColumnIndex("minute"))).isEqualTo(33)
+        assertThat(cursor.getInt(cursor.getColumnIndex("isPromptRemindersOptedIn"))).isEqualTo(0)
+        // also test existing entry has new field isPromptsCardOptedIn with correct default (1)
+        assertThat(cursor.getInt(cursor.getColumnIndex("isPromptsCardOptedIn"))).isEqualTo(1)
+
         cursor.close()
         db.close()
     }

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/11.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/11.json
@@ -1,0 +1,596 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "b2762448697f05a437512b9f25b43cb8",
+    "entities": [
+      {
+        "tableName": "BloggingReminders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `monday` INTEGER NOT NULL, `tuesday` INTEGER NOT NULL, `wednesday` INTEGER NOT NULL, `thursday` INTEGER NOT NULL, `friday` INTEGER NOT NULL, `saturday` INTEGER NOT NULL, `sunday` INTEGER NOT NULL, `hour` INTEGER NOT NULL, `minute` INTEGER NOT NULL, `isPromptRemindersOptedIn` INTEGER NOT NULL, `isPromptsCardOptedIn` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monday",
+            "columnName": "monday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tuesday",
+            "columnName": "tuesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wednesday",
+            "columnName": "wednesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thursday",
+            "columnName": "thursday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friday",
+            "columnName": "friday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saturday",
+            "columnName": "saturday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sunday",
+            "columnName": "sunday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hour",
+            "columnName": "hour",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minute",
+            "columnName": "minute",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPromptRemindersOptedIn",
+            "columnName": "isPromptRemindersOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPromptsCardOptedIn",
+            "columnName": "isPromptsCardOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOffers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `name` TEXT, `shortName` TEXT, `tagline` TEXT, `description` TEXT, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "shortName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_PlanOffers_internalPlanId",
+            "unique": true,
+            "columnNames": [
+              "internalPlanId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_PlanOffers_internalPlanId` ON `${TABLE_NAME}` (`internalPlanId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOfferIds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `productId` INTEGER NOT NULL, `internalPlanId` INTEGER NOT NULL, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PlanOfferFeatures",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `stringId` TEXT, `name` TEXT, `description` TEXT, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringId",
+            "columnName": "stringId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Comments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remoteCommentId` INTEGER NOT NULL, `remotePostId` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `remoteSiteId` INTEGER NOT NULL, `authorUrl` TEXT, `authorName` TEXT, `authorEmail` TEXT, `authorProfileImageUrl` TEXT, `authorId` INTEGER NOT NULL, `postTitle` TEXT, `status` TEXT, `datePublished` TEXT, `publishedTimestamp` INTEGER NOT NULL, `content` TEXT, `url` TEXT, `hasParent` INTEGER NOT NULL, `parentId` INTEGER NOT NULL, `iLike` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteCommentId",
+            "columnName": "remoteCommentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePostId",
+            "columnName": "remotePostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteSiteId",
+            "columnName": "remoteSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorUrl",
+            "columnName": "authorUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorEmail",
+            "columnName": "authorEmail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorProfileImageUrl",
+            "columnName": "authorProfileImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postTitle",
+            "columnName": "postTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "datePublished",
+            "columnName": "datePublished",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publishedTimestamp",
+            "columnName": "publishedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasParent",
+            "columnName": "hasParent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iLike",
+            "columnName": "iLike",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DashboardCards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteLocalId` INTEGER NOT NULL, `type` TEXT NOT NULL, `date` TEXT NOT NULL, `json` TEXT NOT NULL, PRIMARY KEY(`siteLocalId`, `type`))",
+        "fields": [
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "siteLocalId",
+            "type"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BloggingPrompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `siteLocalId` INTEGER NOT NULL, `text` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `date` TEXT NOT NULL, `isAnswered` INTEGER NOT NULL, `respondentsCount` INTEGER NOT NULL, `attribution` TEXT NOT NULL, `respondentsAvatars` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAnswered",
+            "columnName": "isAnswered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "respondentsCount",
+            "columnName": "respondentsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attribution",
+            "columnName": "attribution",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "respondentsAvatars",
+            "columnName": "respondentsAvatars",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "FeatureFlagConfigurations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "RemoteConfigurations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b2762448697f05a437512b9f25b43cb8')"
+    ]
+  }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/BloggingRemindersMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/BloggingRemindersMapper.kt
@@ -26,7 +26,8 @@ class BloggingRemindersMapper
                 sunday = enabledDays.contains(SUNDAY),
                 hour = this.hour,
                 minute = this.minute,
-                isPromptRemindersOptedIn = domainModel.isPromptIncluded
+                isPromptRemindersOptedIn = domainModel.isPromptIncluded,
+                isPromptsCardOptedIn = domainModel.isPromptsCardEnabled,
             )
         }
 
@@ -46,7 +47,8 @@ class BloggingRemindersMapper
                 },
                 hour = hour,
                 minute = minute,
-                isPromptIncluded = isPromptRemindersOptedIn
+                isPromptIncluded = isPromptRemindersOptedIn,
+                isPromptsCardEnabled = isPromptsCardOptedIn,
             )
         }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/BloggingRemindersModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/BloggingRemindersModel.kt
@@ -5,7 +5,8 @@ data class BloggingRemindersModel(
     val enabledDays: Set<Day> = setOf(),
     val hour: Int = 10,
     val minute: Int = 0,
-    val isPromptIncluded: Boolean = false
+    val isPromptIncluded: Boolean = false,
+    val isPromptsCardEnabled: Boolean = true,
 ) {
     enum class Day {
         MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/BloggingRemindersDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/BloggingRemindersDao.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.persistence
 
+import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Entity
 import androidx.room.Insert
@@ -35,6 +36,7 @@ interface BloggingRemindersDao {
         val sunday: Boolean = false,
         val hour: Int = 10,
         val minute: Int = 0,
-        val isPromptRemindersOptedIn: Boolean = false
+        val isPromptRemindersOptedIn: Boolean = false,
+        @ColumnInfo(defaultValue = "1") val isPromptsCardOptedIn: Boolean = true,
     )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.persistence
 
 import android.content.Context
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
@@ -8,10 +9,10 @@ import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import org.wordpress.android.fluxc.persistence.BloggingRemindersDao.BloggingReminders
+import org.wordpress.android.fluxc.persistence.FeatureFlagConfigDao.FeatureFlag
 import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOffer
 import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOfferFeature
 import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOfferId
-import org.wordpress.android.fluxc.persistence.FeatureFlagConfigDao.FeatureFlag
 import org.wordpress.android.fluxc.persistence.RemoteConfigDao.RemoteConfig
 import org.wordpress.android.fluxc.persistence.bloggingprompts.BloggingPromptsDao
 import org.wordpress.android.fluxc.persistence.bloggingprompts.BloggingPromptsDao.BloggingPromptEntity
@@ -22,7 +23,7 @@ import org.wordpress.android.fluxc.persistence.dashboard.CardsDao
 import org.wordpress.android.fluxc.persistence.dashboard.CardsDao.CardEntity
 
 @Database(
-        version = 10,
+        version = 11,
         entities = [
             BloggingReminders::class,
             PlanOffer::class,
@@ -33,6 +34,9 @@ import org.wordpress.android.fluxc.persistence.dashboard.CardsDao.CardEntity
             BloggingPromptEntity::class,
             FeatureFlag::class,
             RemoteConfig::class,
+        ],
+        autoMigrations = [
+            AutoMigration(from = 10, to = 11)
         ]
 )
 @TypeConverters(


### PR DESCRIPTION
Fixes #2644 
WordPress-Android Dependent PR: https://github.com/wordpress-mobile/WordPress-Android/pull/17857

## Issue 
As explained in #2644, the `BloggingRemindersStore` still doesn't use the backend to fetch remotely saved data, but in order to have the same model fields we are adding the `isPromptsCardOptedIn` to the local `BloggingReminders` room Entity.

This is also being done so we can move forward with improvements to allow the user to enable or disable the Blogging Prompts feature, which will be controlled by the new `isPromptsCardOptedIn` field (only locally for now).

## Changes
This new `isPromptsCardOptedIn` field was added to the `BloggingReminders` Entity and defaults to true. To make sure the new DB is compatible with existing data in the user's device, an auto-migration was added from version 10 to version 11 of the Room DB.

Added a test for the new Auto-migration from version 10 to 11.

## Test Instructions
Use PR **WIP** to test this change.