### PR TITLE
Woo: Fetch site plans and domains

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/DomainsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/DomainsFragment.kt
@@ -1,0 +1,53 @@
+package org.wordpress.android.fluxc.example
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.fragment_domains.*
+import kotlinx.android.synthetic.main.fragment_plans.*
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
+import org.wordpress.android.fluxc.store.SiteStore
+import javax.inject.Inject
+
+class DomainsFragment : StoreSelectingFragment() {
+    @Inject internal lateinit var dispatcher: Dispatcher
+    @Inject internal lateinit var store: SiteStore
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+            inflater.inflate(R.layout.fragment_domains, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        fetch_domains.setOnClickListener {
+            selectedSite?.let { site ->
+                lifecycleScope.launch {
+                    val result = store.fetchSiteDomains(site)
+                    when {
+                        result.isError -> {
+                            prependToLog("Error fetching plans: ${result.error.type}")
+                        }
+                        else -> {
+                            val plans = result.domains
+                                ?.joinToString(separator = "\n") {
+                                    "${it.domain} (Renewal: ${it.autoRenewalDate}), primary: ${it.primaryDomain}"
+                                }
+                            prependToLog("Domains:\n$plans")
+                        }
+                    }
+                }
+            } ?: prependToLog("Select a site first")
+        }
+    }
+}

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -97,6 +97,7 @@ class MainFragment : Fragment() {
         experiments.setOnClickListener(getOnClickListener(ExperimentsFragment()))
         plugins.setOnClickListener(getOnClickListener(PluginsFragment()))
         plans.setOnClickListener(getOnClickListener(PlansFragment()))
+        domains.setOnClickListener(getOnClickListener(DomainsFragment()))
     }
 
     // Private methods

--- a/example/src/main/java/org/wordpress/android/fluxc/example/PlansFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/PlansFragment.kt
@@ -5,33 +5,39 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_plans.*
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
 import org.wordpress.android.fluxc.store.PlansStore
+import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 
-class PlansFragment : Fragment() {
+class PlansFragment : StoreSelectingFragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
-    @Inject internal lateinit var store: PlansStore
+    @Inject internal lateinit var plansStore: PlansStore
+    @Inject internal lateinit var siteStore: SiteStore
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
         super.onAttach(context)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-            inflater.inflate(R.layout.fragment_plans, container, false)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
+        inflater.inflate(R.layout.fragment_plans, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         fetch_plans.setOnClickListener {
             lifecycleScope.launch {
-                val plansResult = store.fetchPlans()
+                val plansResult = plansStore.fetchPlans()
                 when {
                     plansResult.isError -> {
                         prependToLog("Error fetching plans: ${plansResult.error}")
@@ -45,6 +51,28 @@ class PlansFragment : Fragment() {
                     }
                 }
             }
+        }
+
+        fetch_site_plan.setOnClickListener {
+            selectedSite?.let { site ->
+                lifecycleScope.launch {
+                    val plansResult = siteStore.fetchSitePlans(site)
+                    when {
+                        plansResult.isError -> {
+                            prependToLog("Error fetching site plan: ${plansResult.error.type}")
+                        }
+                        else -> {
+                            val plan = plansResult.plans?.firstOrNull { it.isCurrentPlan }
+                            if (plan != null) {
+                                prependToLog("Current site plan: ${plan.productName}" +
+                                    "; has domain credit: ${plan.hasDomainCredit}")
+                            } else {
+                               prependToLog("The site has no active plan")
+                            }
+                        }
+                    }
+                }
+            } ?: prependToLog("Select a site first")
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -4,6 +4,7 @@ import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import org.wordpress.android.fluxc.example.AccountFragment
 import org.wordpress.android.fluxc.example.CommentsFragment
+import org.wordpress.android.fluxc.example.DomainsFragment
 import org.wordpress.android.fluxc.example.EditorThemeFragment
 import org.wordpress.android.fluxc.example.ExperimentsFragment
 import org.wordpress.android.fluxc.example.MainFragment
@@ -188,4 +189,7 @@ internal interface FragmentsModule {
 
     @ContributesAndroidInjector
     fun providePlansFragment(): PlansFragment
+
+    @ContributesAndroidInjector
+    fun provideDomainsFragment(): DomainsFragment
 }

--- a/example/src/main/res/layout/fragment_domains.xml
+++ b/example/src/main/res/layout/fragment_domains.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    tools:context="org.wordpress.android.fluxc.example.DomainsFragment"
+    tools:ignore="HardcodedText">
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <Button
+            android:id="@+id/fetch_domains"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Fetch domains" />
+
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -151,6 +151,12 @@
                     android:layout_height="wrap_content"
                     android:text="Plans" />
 
+                <Button
+                    android:id="@+id/domains"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Domains" />
+
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>

--- a/example/src/main/res/layout/fragment_plans.xml
+++ b/example/src/main/res/layout/fragment_plans.xml
@@ -16,7 +16,13 @@
             android:id="@+id/fetch_plans"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Fetch plans" />
+            android:text="Fetch available plans" />
+
+        <Button
+            android:id="@+id/fetch_site_plan"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Fetch site plan" />
 
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -28,6 +28,8 @@ import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient
 import org.wordpress.android.fluxc.persistence.PostSqlUtils
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
+import org.wordpress.android.fluxc.store.SiteStore.FetchedDomainsPayload
+import org.wordpress.android.fluxc.store.SiteStore.FetchedPlansPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchedPostFormatsPayload
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteError
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType.SITE_NAME_INVALID
@@ -325,6 +327,7 @@ class SiteStoreTest {
         val onSiteDomainsFetched = siteStore.fetchSiteDomains(site)
 
         assertThat(onSiteDomainsFetched.error).isEqualTo(SiteError(GENERIC_ERROR, null))
+        assertThat(onSiteDomainsFetched).isEqualTo(FetchedDomainsPayload(site, onSiteDomainsFetched.domains))
     }
 
     @Test
@@ -339,6 +342,7 @@ class SiteStoreTest {
 
         assertThat(onSitePlansFetched.plans).isNotNull
         assertThat(onSitePlansFetched.error).isNull()
+        assertThat(onSitePlansFetched).isEqualTo(FetchedPlansPayload(site, onSitePlansFetched.plans))
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -756,6 +756,11 @@ class SiteRestClient @Inject constructor(
         return wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), DomainsResponse::class.java)
     }
 
+    suspend fun fetchSitePlans(site: SiteModel): Response<PlansResponse> {
+        val url = WPCOMREST.sites.site(site.siteId).plans.urlV1_3
+        return wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), PlansResponse::class.java)
+    }
+
     fun designatePrimaryDomain(site: SiteModel, domain: String) {
         val url = WPCOMREST.sites.site(site.siteId).domains.primary.urlV1_1
         val params = mutableMapOf<String, Any>()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -112,7 +112,6 @@ import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.SiteErrorUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import org.wordpress.android.util.AppLog.T.API
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Provider
@@ -1009,7 +1008,7 @@ open class SiteStore @Inject constructor(
     }
 
     override fun onRegister() {
-        AppLog.d(API, "SiteStore onRegister")
+        AppLog.d(T.API, "SiteStore onRegister")
     }
 
     /**
@@ -1668,7 +1667,7 @@ open class SiteStore @Inject constructor(
             if (currentModel == null) {
                 // this could happen when a site was added to the current account with another app, or on the web
                 AppLog.e(
-                    API,
+                    T.API,
                     "handleDesignatedMobileEditorForAllSites - The backend returned info for the " +
                         "following siteID $key but there is no site with that remote ID in SiteStore."
                 )


### PR DESCRIPTION
This is a subtask of woocommerce/woocommerce-android#8238. The PR mainly adds the UI to test the fetching of site domains and plans. It also adds a coroutine to fetch the plans and some unit tests. 

This will be used in the domain change feature.

**To test:**

_Domains_

1. Start the example app and sign in
2. Tap on the Domains button
3. Select a WP.com site
4. Tap on the Fetch site domains and verify the correct domains have been fetched & displayed
5. Select a non-WP.com site
6. Notice an error is shown

_Plans_

1. Tap on the Plans button
2. Select a site
3. Verify the correct active plan is shown, along with the flag for the store credit