### PR TITLE
Application Passwords support without XMLRPC

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_AppComponent.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.release;
 
 import org.wordpress.android.fluxc.di.WCDatabaseModule;
 import org.wordpress.android.fluxc.example.di.AppConfigModule;
+import org.wordpress.android.fluxc.example.di.ApplicationPasswordsModule;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.DatabaseModule;
 import org.wordpress.android.fluxc.module.MockedToolsModule;
@@ -24,8 +25,7 @@ import dagger.Component;
         MockedToolsModule.class,
         DatabaseModule.class,
         WCDatabaseModule.class,
-        // TODO re-enable when we offer a way to fetch sites using the REST API
-        // ApplicationPasswordsModule.class
+        ApplicationPasswordsModule.class
 })
 public interface ReleaseStack_AppComponent {
     void inject(ReleaseStack_AccountTest test);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -808,7 +808,8 @@ public class MediaStore extends Store {
             mMediaRestClient.uploadMedia(payload.site, payload.media);
         } else if (payload.site.isJetpackCPConnected()) {
             mWPComV2MediaRestClient.uploadMedia(payload.site, payload.media);
-        } else if (mApplicationPasswordsConfiguration.isEnabled()) {
+        } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
+                   && mApplicationPasswordsConfiguration.isEnabled()) {
             mApplicationPasswordsMediaRestClient.uploadMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.uploadMedia(payload.site, payload.media);
@@ -831,7 +832,8 @@ public class MediaStore extends Store {
             mMediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
         } else if (payload.site.isJetpackCPConnected()) {
             mWPComV2MediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
-        } else if (mApplicationPasswordsConfiguration.isEnabled()) {
+        } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
+                   && mApplicationPasswordsConfiguration.isEnabled()) {
             mApplicationPasswordsMediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
         } else {
             mMediaXmlrpcClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
@@ -882,7 +884,8 @@ public class MediaStore extends Store {
             mMediaRestClient.cancelUpload(media);
         } else if (payload.site.isJetpackCPConnected()) {
             mWPComV2MediaRestClient.cancelUpload(media);
-        } else if (mApplicationPasswordsConfiguration.isEnabled()) {
+        } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
+                   && mApplicationPasswordsConfiguration.isEnabled()) {
             mApplicationPasswordsMediaRestClient.cancelUpload(media);
         } else {
             mMediaXmlrpcClient.cancelUpload(media);

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
@@ -17,6 +17,8 @@ import javax.inject.Singleton
  * passwords). This class allows this by supporting multiple networking implementations depending on the type of site:
  * - Jetpack Sites: the API call will use Jetpack Tunnel using [JetpackTunnelWPAPINetwork]
  * - Non-Jetpack Sites: the API call will use Application Passwords using [ApplicationPasswordsNetwork]
+ *
+ * The [SiteModel.ORIGIN_XMLRPC] support is kept for backward compatibility
  */
 @Singleton
 class WooNetwork @Inject constructor(
@@ -38,7 +40,7 @@ class WooNetwork @Inject constructor(
             SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executeGetGsonRequest(
                 site, path, clazz, params, enableCaching, cacheTimeToLive, forced, requestTimeout, retries
             ).toWPAPIResponse()
-            SiteModel.ORIGIN_XMLRPC -> applicationPasswordsNetwork.executeGetGsonRequest(
+            SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPAPI -> applicationPasswordsNetwork.executeGetGsonRequest(
                 site, path, clazz, params, enableCaching, cacheTimeToLive, forced, requestTimeout, retries
             )
             else -> error("Site with unsupported origin")
@@ -54,7 +56,9 @@ class WooNetwork @Inject constructor(
         return when (site.origin) {
             SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executePostGsonRequest(site, path, clazz, body)
                 .toWPAPIResponse()
-            SiteModel.ORIGIN_XMLRPC -> applicationPasswordsNetwork.executePostGsonRequest(site, path, clazz, body)
+            SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPAPI -> applicationPasswordsNetwork.executePostGsonRequest(
+                site, path, clazz, body
+            )
             else -> error("Site with unsupported origin")
         }
     }
@@ -68,7 +72,9 @@ class WooNetwork @Inject constructor(
         return when (site.origin) {
             SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executePutGsonRequest(site, path, clazz, body)
                 .toWPAPIResponse()
-            SiteModel.ORIGIN_XMLRPC -> applicationPasswordsNetwork.executePutGsonRequest(site, path, clazz, body)
+            SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPAPI -> applicationPasswordsNetwork.executePutGsonRequest(
+                site, path, clazz, body
+            )
             else -> error("Site with unsupported origin")
         }
     }
@@ -82,7 +88,9 @@ class WooNetwork @Inject constructor(
         return when (site.origin) {
             SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executeDeleteGsonRequest(site, path, clazz, params)
                 .toWPAPIResponse()
-            SiteModel.ORIGIN_XMLRPC -> applicationPasswordsNetwork.executeDeleteGsonRequest(site, path, clazz, params)
+            SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPAPI -> applicationPasswordsNetwork.executeDeleteGsonRequest(
+                site, path, clazz, params
+            )
             else -> error("Site with unsupported origin")
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -68,7 +68,7 @@ open class WooCommerceStore @Inject constructor(
     }
 
     private val SiteModel.needsAdditionalCheckForWooInstallation
-        get() = origin != SiteModel.ORIGIN_WPCOM_REST || isJetpackCPConnected
+        get() = origin == SiteModel.ORIGIN_XMLRPC || (origin == SiteModel.ORIGIN_WPCOM_REST && isJetpackCPConnected)
 
     override fun onRegister() = AppLog.d(T.API, "WooCommerceStore onRegister")
 


### PR DESCRIPTION
Part of #2648 

This PR builds on top of #2643, it adds the following changes:

1. Updates `WooNetwork` to work with the new SiteModel `origin`.
2. Update the logic for the WooCommerce installation check to be skipped for non `WPAPI_ORIGIN` sites.
3. Updates `MediaStore` to restrict Application Passwords rest client for the new origin.
4. Enables the Application Passwords connected tests.

#### Testing
1. Open the example app.
2. Sign in using site credentials (make sure to keep the XMLRPC option unchecked)
3. Click on Woo.
4. Select your site.
5. Do some testing, and confirm it works.