### PR TITLE
Woo REST API: validate Application Passwords username before using it

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -44,7 +44,8 @@ internal class ApplicationPasswordsManager @Inject constructor(
             )
         )
         val existingPassword = applicationPasswordsStore.getCredentials(site.domainName)
-        if (existingPassword != null) {
+        if (existingPassword != null &&
+            (site.username == existingPassword.userName || site.isUsingWpComRestApi)) {
             return ApplicationPasswordCreationResult.Existing(existingPassword)
         }
 

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -23,6 +23,7 @@ class ApplicationPasswordManagerTests {
     private val siteDomain = "test-site.com"
     private val uuid = "uuid"
     private val testSite = SiteModel().apply {
+        username = "username"
         url = "http://$siteDomain"
     }
     private val testCredentials = ApplicationPasswordCredentials(


### PR DESCRIPTION
While working on the XMLRPC removal, I found a major bug with the way we store and retrieve the application passwords, but the fix is simple.
Let's start with the issue: during the logout, we delete the application password locally and remotely, but sometimes, we have some APIs in the queue, and when they get fired, they would trigger the creation of a new password, this is not really bad by itself, as the password is not harmful unless it's leaked, which won't happen. But the issue happens if we try to sign in later with a different username for the same site, the app will keep using the old password, as we don't check if it matches the correct username.

The fix is simple, when we find an existing password, we validate that it has the correct username before using it.

While the fix should work, and it's needed in all cases, we also need to start thinking about a way to cancel all pending network calls on logout.

Check the WCAndroid [PR](https://github.com/woocommerce/woocommerce-android/pull/8302) for testing steps.