### PR TITLE
Woo REST API: validate username on password deletion

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -43,8 +43,7 @@ internal class ApplicationPasswordsManager @Inject constructor(
             )
         )
         val existingPassword = applicationPasswordsStore.getCredentials(site)
-        if (existingPassword != null &&
-            (site.username == existingPassword.userName || site.isUsingWpComRestApi)) {
+        if (existingPassword != null) {
             return ApplicationPasswordCreationResult.Existing(existingPassword)
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -141,10 +141,11 @@ internal class ApplicationPasswordsManager @Inject constructor(
     suspend fun deleteApplicationCredentials(
         site: SiteModel
     ): ApplicationPasswordDeletionResult {
-        val uuid = applicationPasswordsStore.getUuid(site) ?: fetchApplicationPasswordUUID(site).let {
-            if (it.isError) return ApplicationPasswordDeletionResult.Failure(it.error)
-            it.uuid
-        }
+        val uuid = applicationPasswordsStore.getCredentials(site)?.uuid
+            ?: fetchApplicationPasswordUUID(site).let {
+                if (it.isError) return ApplicationPasswordDeletionResult.Failure(it.error)
+                it.uuid
+            }
 
         val payload = if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
             jetpackApplicationPasswordsRestClient.deleteApplicationPassword(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -109,10 +109,6 @@ internal class ApplicationPasswordsStore @Inject constructor(
         }
     }
 
-    fun getUuid(site: SiteModel): ApplicationPasswordUUID? {
-        return encryptedPreferences.getString(site.uuidPrefKey, null)
-    }
-
     private val SiteModel.domainName
         get() = UrlUtils.removeScheme(url).trim('/')
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -35,14 +35,15 @@ internal class ApplicationPasswordsStore @Inject constructor(
         val password = encryptedPreferences.getString(site.passwordPrefKey, null)
         val uuid = encryptedPreferences.getString(site.uuidPrefKey, null)
 
-        return if (username != null && password != null && uuid != null) {
-            ApplicationPasswordCredentials(
-                userName = username,
-                password = password,
-                uuid = uuid
-            )
-        } else {
-            null
+        return when {
+            !site.isUsingWpComRestApi && site.username != username -> null
+            username != null && password != null && uuid != null ->
+                ApplicationPasswordCredentials(
+                    userName = username,
+                    password = password,
+                    uuid = uuid
+                )
+            else -> null
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.UrlUtils
 import java.security.KeyStore
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,10 +30,10 @@ internal class ApplicationPasswordsStore @Inject constructor(
     }
 
     @Synchronized
-    fun getCredentials(host: String): ApplicationPasswordCredentials? {
-        val username = encryptedPreferences.getString(host.usernamePrefKey, null)
-        val password = encryptedPreferences.getString(host.passwordPrefKey, null)
-        val uuid = encryptedPreferences.getString(host.uuidPrefKey, null)
+    fun getCredentials(site: SiteModel): ApplicationPasswordCredentials? {
+        val username = encryptedPreferences.getString(site.usernamePrefKey, null)
+        val password = encryptedPreferences.getString(site.passwordPrefKey, null)
+        val uuid = encryptedPreferences.getString(site.uuidPrefKey, null)
 
         return if (username != null && password != null && uuid != null) {
             ApplicationPasswordCredentials(
@@ -45,20 +47,20 @@ internal class ApplicationPasswordsStore @Inject constructor(
     }
 
     @Synchronized
-    fun saveCredentials(host: String, credentials: ApplicationPasswordCredentials) {
+    fun saveCredentials(site: SiteModel, credentials: ApplicationPasswordCredentials) {
         encryptedPreferences.edit()
-            .putString(host.usernamePrefKey, credentials.userName)
-            .putString(host.passwordPrefKey, credentials.password)
-            .putString(host.uuidPrefKey, credentials.uuid)
+            .putString(site.usernamePrefKey, credentials.userName)
+            .putString(site.passwordPrefKey, credentials.password)
+            .putString(site.uuidPrefKey, credentials.uuid)
             .apply()
     }
 
     @Synchronized
-    fun deleteCredentials(host: String) {
+    fun deleteCredentials(site: SiteModel) {
         encryptedPreferences.edit()
-            .remove(host.usernamePrefKey)
-            .remove(host.passwordPrefKey)
-            .remove(host.uuidPrefKey)
+            .remove(site.usernamePrefKey)
+            .remove(site.passwordPrefKey)
+            .remove(site.uuidPrefKey)
             .apply()
     }
 
@@ -106,16 +108,19 @@ internal class ApplicationPasswordsStore @Inject constructor(
         }
     }
 
-    fun getUuid(host: String): ApplicationPasswordUUID? {
-        return encryptedPreferences.getString(host.uuidPrefKey, null)
+    fun getUuid(site: SiteModel): ApplicationPasswordUUID? {
+        return encryptedPreferences.getString(site.uuidPrefKey, null)
     }
 
-    private val String.usernamePrefKey
-        get() = "$USERNAME_PREFERENCE_KEY_PREFIX$this"
+    private val SiteModel.domainName
+        get() = UrlUtils.removeScheme(url).trim('/')
 
-    private val String.passwordPrefKey
-        get() = "$PASSWORD_PREFERENCE_KEY_PREFIX$this"
+    private val SiteModel.usernamePrefKey
+        get() = "$USERNAME_PREFERENCE_KEY_PREFIX$domainName"
 
-    private val String.uuidPrefKey
-        get() = "$UUID_PREFERENCE_KEY_PREFIX$this"
+    private val SiteModel.passwordPrefKey
+        get() = "$PASSWORD_PREFERENCE_KEY_PREFIX$domainName"
+
+    private val SiteModel.uuidPrefKey
+        get() = "$UUID_PREFERENCE_KEY_PREFIX$domainName"
 }

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -20,11 +20,10 @@ import kotlin.test.assertEquals
 @ExperimentalCoroutinesApi
 class ApplicationPasswordManagerTests {
     private val applicationName = "name"
-    private val siteDomain = "test-site.com"
     private val uuid = "uuid"
     private val testSite = SiteModel().apply {
         username = "username"
-        url = "http://$siteDomain"
+        url = "http://test-site.com"
     }
     private val testCredentials = ApplicationPasswordCredentials(
         userName = "username",
@@ -52,7 +51,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `given a local password exists, when we ask for a password, then return it`() = runBlockingTest {
-        whenever(applicationPasswordsStore.getCredentials(siteDomain)).thenReturn(testCredentials)
+        whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(testCredentials)
         val result = mApplicationPasswordsManager.getApplicationCredentials(
             testSite
         )
@@ -67,7 +66,7 @@ class ApplicationPasswordManagerTests {
                 origin = SiteModel.ORIGIN_WPCOM_REST
             }
 
-            whenever(applicationPasswordsStore.getCredentials(siteDomain)).thenReturn(null)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
             whenever(mJetpackApplicationPasswordsRestClient.fetchWPAdminUsername(site))
                 .thenReturn(UsernameFetchPayload(testCredentials.userName))
             whenever(
@@ -88,7 +87,7 @@ class ApplicationPasswordManagerTests {
             )
 
             assertEquals(ApplicationPasswordCreationResult.Created(testCredentials), result)
-            verify(applicationPasswordsStore).saveCredentials(siteDomain, testCredentials)
+            verify(applicationPasswordsStore).saveCredentials(testSite, testCredentials)
         }
 
     @Test
@@ -99,7 +98,7 @@ class ApplicationPasswordManagerTests {
                 username = testCredentials.userName
             }
 
-            whenever(applicationPasswordsStore.getCredentials(siteDomain)).thenReturn(null)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
             whenever(
                 mWpApiApplicationPasswordsRestClient.createApplicationPassword(
                     site,
@@ -128,7 +127,7 @@ class ApplicationPasswordManagerTests {
             }
             val networkError = BaseNetworkError(VolleyError(NetworkResponse(404, null, true, 0, emptyList())))
 
-            whenever(applicationPasswordsStore.getCredentials(siteDomain)).thenReturn(null)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
             whenever(mJetpackApplicationPasswordsRestClient.fetchWPAdminUsername(site))
                 .thenReturn(UsernameFetchPayload(testCredentials.userName))
             whenever(mJetpackApplicationPasswordsRestClient.createApplicationPassword(site, applicationName))
@@ -151,7 +150,7 @@ class ApplicationPasswordManagerTests {
                 apiError = "application_passwords_disabled"
             }
 
-            whenever(applicationPasswordsStore.getCredentials(siteDomain)).thenReturn(null)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
             whenever(mJetpackApplicationPasswordsRestClient.fetchWPAdminUsername(site))
                 .thenReturn(UsernameFetchPayload(testCredentials.userName))
             whenever(mJetpackApplicationPasswordsRestClient.createApplicationPassword(site, applicationName))
@@ -173,7 +172,7 @@ class ApplicationPasswordManagerTests {
             }
             val networkError = BaseNetworkError(VolleyError(NetworkResponse(404, null, true, 0, emptyList())))
 
-            whenever(applicationPasswordsStore.getCredentials(siteDomain)).thenReturn(null)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
             whenever(mWpApiApplicationPasswordsRestClient.createApplicationPassword(site, applicationName))
                 .thenReturn(ApplicationPasswordCreationPayload(networkError))
 
@@ -195,7 +194,7 @@ class ApplicationPasswordManagerTests {
                 apiError = "application_passwords_disabled"
             }
 
-            whenever(applicationPasswordsStore.getCredentials(siteDomain)).thenReturn(null)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
             whenever(mWpApiApplicationPasswordsRestClient.createApplicationPassword(site, applicationName))
                 .thenReturn(ApplicationPasswordCreationPayload(networkError))
 
@@ -213,7 +212,7 @@ class ApplicationPasswordManagerTests {
                 origin = SiteModel.ORIGIN_WPCOM_REST
             }
 
-            whenever(applicationPasswordsStore.getUuid(siteDomain)).thenReturn(uuid)
+            whenever(applicationPasswordsStore.getUuid(testSite)).thenReturn(uuid)
             whenever(mJetpackApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))
                 .thenReturn(ApplicationPasswordDeletionPayload(isDeleted = true))
 
@@ -232,7 +231,7 @@ class ApplicationPasswordManagerTests {
                 username = testCredentials.userName
             }
 
-            whenever(applicationPasswordsStore.getUuid(siteDomain)).thenReturn(uuid)
+            whenever(applicationPasswordsStore.getUuid(testSite)).thenReturn(uuid)
             whenever(mWpApiApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))
                 .thenReturn(ApplicationPasswordDeletionPayload(isDeleted = true))
 
@@ -251,7 +250,7 @@ class ApplicationPasswordManagerTests {
                 username = testCredentials.userName
             }
             val creationNetworkError = BaseNetworkError(VolleyError(NetworkResponse(409, null, true, 0, emptyList())))
-            whenever(applicationPasswordsStore.getCredentials(siteDomain)).thenReturn(null)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
             whenever(mWpApiApplicationPasswordsRestClient.createApplicationPassword(site, applicationName))
                 .thenReturn(ApplicationPasswordCreationPayload(creationNetworkError))
                 .thenReturn(ApplicationPasswordCreationPayload(testCredentials.password, testCredentials.uuid))
@@ -274,7 +273,7 @@ class ApplicationPasswordManagerTests {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
             }
-            whenever(applicationPasswordsStore.getUuid(siteDomain)).thenReturn(null)
+            whenever(applicationPasswordsStore.getUuid(testSite)).thenReturn(null)
             whenever(mWpApiApplicationPasswordsRestClient.fetchApplicationPasswordUUID(site, applicationName))
                 .thenReturn(ApplicationPasswordUUIDFetchPayload(uuid))
             whenever(mWpApiApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -212,7 +212,7 @@ class ApplicationPasswordManagerTests {
                 origin = SiteModel.ORIGIN_WPCOM_REST
             }
 
-            whenever(applicationPasswordsStore.getUuid(testSite)).thenReturn(uuid)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(testCredentials)
             whenever(mJetpackApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))
                 .thenReturn(ApplicationPasswordDeletionPayload(isDeleted = true))
 
@@ -231,7 +231,7 @@ class ApplicationPasswordManagerTests {
                 username = testCredentials.userName
             }
 
-            whenever(applicationPasswordsStore.getUuid(testSite)).thenReturn(uuid)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(testCredentials)
             whenever(mWpApiApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))
                 .thenReturn(ApplicationPasswordDeletionPayload(isDeleted = true))
 
@@ -273,7 +273,7 @@ class ApplicationPasswordManagerTests {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
             }
-            whenever(applicationPasswordsStore.getUuid(testSite)).thenReturn(null)
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
             whenever(mWpApiApplicationPasswordsRestClient.fetchApplicationPasswordUUID(site, applicationName))
                 .thenReturn(ApplicationPasswordUUIDFetchPayload(uuid))
             whenever(mWpApiApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))


### PR DESCRIPTION
This is a continuation of #2650, in the previous PR I missed the scenario of password deletion, which might still cause issues in some rare cases: if a password exists locally for a different account, when attempting to delete the password, we will be using the wrong UUID, and the request will fail.

Check the WCAndroid PR for testing steps https://github.com/woocommerce/woocommerce-android/pull/8306