### PR TITLE
Woo: Add domain vendor parameter

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -463,7 +463,8 @@ class SiteRestClient @Inject constructor(
         segmentId: Long?,
         quantity: Int,
         includeVendorDot: Boolean,
-        tlds: String?
+        tlds: String?,
+        vendor: String?
     ) {
         val url = WPCOMREST.domains.suggestions.urlV1_1
         val params = mutableMapOf<String, String>()
@@ -486,6 +487,8 @@ class SiteRestClient @Inject constructor(
         params["quantity"] = quantity.toString()
         if (includeVendorDot) {
             params["vendor"] = "dot"
+        } else if (vendor != null) {
+            params["vendor"] = vendor
         }
         val request = WPComGsonRequest.buildGetRequest<List<DomainSuggestionResponse>>(url, params,
                 object : TypeToken<List<DomainSuggestionResponse>>() {}.type,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -309,7 +309,8 @@ open class SiteStore @Inject constructor(
         @JvmField val tlds: String? = null,
         @JvmField val segmentId: Long? = null,
         @JvmField val quantity: Int,
-        @JvmField val includeVendorDot: Boolean = false
+        @JvmField val includeVendorDot: Boolean = false,
+        @JvmField val vendor: String? = null
     ) : Payload<BaseNetworkError>() {
         constructor(
             query: String,
@@ -317,7 +318,8 @@ open class SiteStore @Inject constructor(
             includeWordpressCom: Boolean,
             includeDotBlogSubdomain: Boolean,
             quantity: Int,
-            includeVendorDot: Boolean
+            includeVendorDot: Boolean,
+            vendor: String?
         ) : this(
                 query = query,
                 onlyWordpressCom = onlyWordpressCom,
@@ -1769,7 +1771,7 @@ open class SiteStore @Inject constructor(
         siteRestClient.suggestDomains(
                 payload.query, payload.onlyWordpressCom, payload.includeWordpressCom,
                 payload.includeDotBlogSubdomain, payload.segmentId, payload.quantity, payload.includeVendorDot,
-                payload.tlds
+                payload.tlds, payload.vendor
         )
     }
 


### PR DESCRIPTION
This PR adds an optional `vendor` parameter to the domain suggestion call in order to imitate the web domain suggestions, which also include premium domains. I've kept the `includeVendorDot` parameter as well in order to minimize conflicts with other apps and keep backwards compatibility.

**Note:** Please merge the #2652 first.