### PR TITLE
[wpandroid] Adds endpoint and DB layer for Blaze

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeRestClientTest.kt
@@ -1,0 +1,194 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.blaze
+
+import com.android.volley.RequestQueue
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.UnitTestUtils
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_AUTHENTICATED
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.TIMEOUT
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.test
+import kotlin.test.assertEquals
+
+@RunWith(MockitoJUnitRunner::class)
+class BlazeRestClientTest {
+    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var requestQueue: RequestQueue
+    @Mock private lateinit var accessToken: AccessToken
+    @Mock private lateinit var userAgent: UserAgent
+    @Mock private lateinit var site: SiteModel
+
+    private lateinit var urlCaptor: KArgumentCaptor<String>
+    private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
+    private lateinit var restClient: BlazeRestClient
+
+    private val siteId: Long = 12
+
+    private val successResponse = mapOf("approved" to true)
+
+    @Before
+    fun setUp() {
+        urlCaptor = argumentCaptor()
+        paramsCaptor = argumentCaptor()
+        restClient = BlazeRestClient(
+            wpComGsonRequestBuilder,
+            dispatcher,
+            null,
+            requestQueue,
+            accessToken,
+            userAgent
+        )
+        whenever(site.siteId).thenReturn(siteId)
+    }
+
+
+    @Test
+    fun `when blaze status is requested, then the correct url is built`() = test {
+        val json = UnitTestUtils.getStringFromResourceFile(javaClass, SUCCESS_JSON)
+        val response = getResponseFromJsonString(json)
+        initFetchBlazeStatus(data = response)
+
+        restClient.fetchBlazeStatus(site)
+
+        assertEquals(urlCaptor.firstValue,
+            "${API_SITE_PATH}/${site.siteId}/$API_AUTH_BLAZE_STATUS_PATH")
+    }
+
+    @Test
+    fun `given success call, when blaze status is requested, then correct response is returned`() = test {
+        val json = UnitTestUtils.getStringFromResourceFile(javaClass, SUCCESS_JSON)
+        initFetchBlazeStatus(data = getResponseFromJsonString(json))
+
+        val result = restClient.fetchBlazeStatus(site)
+        assertSuccess(successResponse, result)
+    }
+
+    @Test
+    fun `given timeout, when blaze status is requested, then return timeout error`() = test {
+        initFetchBlazeStatus(error = WPComGsonNetworkError(BaseNetworkError(TIMEOUT)))
+
+        val result = restClient.fetchBlazeStatus(site)
+
+        assertError(BlazeStatusErrorType.TIMEOUT, result)
+    }
+
+    @Test
+    fun `given network error, when blaze status is requested, then return api error`() = test {
+        initFetchBlazeStatus(error = WPComGsonNetworkError(BaseNetworkError(NETWORK_ERROR)))
+
+        val result = restClient.fetchBlazeStatus(site)
+
+        assertError(BlazeStatusErrorType.API_ERROR, result)
+    }
+
+    @Test
+    fun `given invalid response, when blaze status is requested, then return invalid response error`() = test {
+        initFetchBlazeStatus(error = WPComGsonNetworkError(BaseNetworkError(INVALID_RESPONSE)))
+
+        val result = restClient.fetchBlazeStatus(site)
+
+        assertError(BlazeStatusErrorType.INVALID_RESPONSE, result)
+    }
+
+    @Test
+    fun `given not authenticated, when blaze status is requested, then return auth required error`() = test {
+        initFetchBlazeStatus(error = WPComGsonNetworkError(BaseNetworkError(NOT_AUTHENTICATED)))
+
+        val result = restClient.fetchBlazeStatus(site)
+
+        assertError(BlazeStatusErrorType.AUTHORIZATION_REQUIRED, result)
+    }
+
+    @Test
+    fun `given unknown error, when blaze status is requested, then return generic error`() = test {
+        initFetchBlazeStatus(error = WPComGsonNetworkError(BaseNetworkError(UNKNOWN)))
+
+        val result = restClient.fetchBlazeStatus(site)
+
+        assertError(BlazeStatusErrorType.GENERIC_ERROR, result)
+    }
+
+
+    private suspend fun initFetchBlazeStatus(
+        data: Map<*, *>? = null,
+        error: WPComGsonNetworkError? = null
+    ) {
+        val nonNullData = data ?: mock()
+        val response = if (error != null) {
+            Response.Error(error)
+        } else {
+            Response.Success(nonNullData)
+        }
+
+        whenever(
+            wpComGsonRequestBuilder.syncGetRequest(
+                eq(restClient),
+                urlCaptor.capture(),
+                paramsCaptor.capture(),
+                eq(Map::class.java),
+                eq(false),
+                any(),
+                eq(false)
+            )
+        ).thenReturn(response)
+    }
+
+    @Suppress("SameParameterValue")
+    private fun assertSuccess(
+        expected: Map<String, Boolean>,
+        actual: BlazeStatusFetchedPayload
+    ) {
+        with(actual) {
+            Assert.assertFalse(isError)
+            Assert.assertEquals(BlazeStatusFetchedPayload(siteId, expected), this)
+        }
+    }
+
+    private fun assertError(
+        expected: BlazeStatusErrorType,
+        actual: BlazeStatusFetchedPayload
+    ) {
+        with(actual) {
+            Assert.assertTrue(isError)
+            Assert.assertEquals(expected, error.type)
+            Assert.assertEquals(null, error.message)
+        }
+    }
+
+    private fun getResponseFromJsonString(json: String): Map<String, Boolean> {
+        val responseType = object : TypeToken<Map<*, *>>() {}.type
+        return GsonBuilder()
+            .create().fromJson(json, responseType) as Map<String, Boolean>
+    }
+
+    companion object {
+        private const val API_BASE_PATH = "https://public-api.wordpress.com/wpcom/v2"
+        private const val API_SITE_PATH = "$API_BASE_PATH/sites"
+        private const val API_AUTH_BLAZE_STATUS_PATH = "blaze/status/"
+
+        private const val SUCCESS_JSON = "wp/blaze/blaze-status.json"
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/BlazeStatusDaoTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/BlazeStatusDaoTest.kt
@@ -1,0 +1,104 @@
+package org.wordpress.android.fluxc.persistence
+
+import androidx.room.Room
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.persistence.blaze.BlazeStatusDao
+import org.wordpress.android.fluxc.persistence.blaze.BlazeStatusDao.BlazeStatus
+import java.io.IOException
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class BlazeStatusDaoTest {
+    private lateinit var dao: BlazeStatusDao
+    private lateinit var db: WPAndroidDatabase
+
+    @Before
+    fun createDb() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        db = Room.inMemoryDatabaseBuilder(
+            context, WPAndroidDatabase::class.java
+        ).allowMainThreadQueries().build()
+        dao = db.blazeStatusDao()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun `when insert followed by update, then valid status is returned`(): Unit = runBlocking {
+        // when
+        var blazeStatus = generateBlazeStatus(isEligible = true)
+        dao.insert(blazeStatus)
+
+        // then
+        var observedStatus = dao.getBlazeStatus(defaultSiteId).first()
+        assertThat(observedStatus).isEqualTo(blazeStatus)
+
+        // when
+        blazeStatus = blazeStatus.copy(isEligible = false)
+        dao.insert(blazeStatus)
+
+        // then
+        observedStatus = dao.getBlazeStatus(defaultSiteId).first()
+        assertThat(observedStatus).isEqualTo(blazeStatus)
+    }
+
+    @Test
+    fun `when clear is requested, then all rows are deleted`(): Unit = runBlocking {
+        // when
+        val status1 = generateBlazeStatus(siteId = 1, isEligible = true)
+        dao.insert(status1)
+
+        val status2 = generateBlazeStatus(siteId = 2, isEligible = true)
+        dao.insert(status2)
+
+        val status3 = generateBlazeStatus(siteId = 3, isEligible = true)
+        dao.insert(status3)
+
+        // then
+       dao.clear()
+
+        // when
+        assertEmptyResult(dao.getBlazeStatus(1))
+        assertEmptyResult(dao.getBlazeStatus(2))
+        assertEmptyResult(dao.getBlazeStatus(3))
+    }
+
+    @Test
+    fun `given site not in the db, when request is made, empty list is returned`(): Unit = runBlocking {
+        // when
+        val emptyList = emptyList<BlazeStatus>()
+
+        // then
+        val observedStatus = dao.getBlazeStatus(defaultSiteId)
+
+        // when
+        assertThat(observedStatus).isEqualTo(emptyList)
+    }
+
+
+    private fun assertEmptyResult(blazeStatus: List<BlazeStatus>?) {
+        assertThat(blazeStatus).isNotNull
+        assertThat(blazeStatus).isEmpty()
+    }
+
+    private fun generateBlazeStatus(siteId: Long = defaultSiteId, isEligible: Boolean) = BlazeStatus(
+        siteId = siteId,
+        isEligible = isEligible
+    )
+
+    companion object {
+        private const val defaultSiteId = 1234L
+    }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeStoreTest.kt
@@ -1,0 +1,93 @@
+package org.wordpress.android.fluxc.store.blaze
+
+import junit.framework.TestCase.assertEquals
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeStatusError
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeStatusErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeStatusFetchedPayload
+import org.wordpress.android.fluxc.persistence.blaze.BlazeStatusDao
+import org.wordpress.android.fluxc.persistence.blaze.BlazeStatusDao.BlazeStatus
+import org.wordpress.android.fluxc.store.blaze.BlazeStore.BlazeStatusResult
+import org.wordpress.android.fluxc.test
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
+
+@RunWith(MockitoJUnitRunner::class)
+class BlazeStoreTest {
+    @Mock private lateinit var restClient: BlazeRestClient
+    @Mock private lateinit var dao: BlazeStatusDao
+    @Mock private lateinit var siteModel: SiteModel
+    private lateinit var store: BlazeStore
+
+    private val successResponse = mapOf("approved" to true)
+    private val statusResult = BlazeStatus(SITE_ID,true)
+    private val errorResponse = BlazeStatusError( type = GENERIC_ERROR)
+    private val errorResult = BlazeStatusError( type = GENERIC_ERROR)
+
+    @Before
+    fun setUp() {
+        store = BlazeStore(restClient, dao, initCoroutineEngine())
+        whenever(siteModel.siteId).thenReturn(SITE_ID)
+    }
+
+    @Test
+    fun `given success, when fetch blaze status is triggered, then status are inserted`() = test {
+        whenever(restClient.fetchBlazeStatus(any())).thenReturn(
+            BlazeStatusFetchedPayload(
+                SITE_ID,
+                successResponse
+            )
+        )
+
+        val response = store.fetchBlazeStatus(siteModel)
+
+        verify(dao).insert(statusResult)
+        assertThat(response.isEligible).isTrue
+    }
+
+    @Test
+    fun `given error, when fetch blaze status is triggered, then error result is returned`() =
+        test {
+            whenever(restClient.fetchBlazeStatus(any())).thenReturn(
+                BlazeStatusFetchedPayload(
+                    SITE_ID,
+                    errorResponse
+                )
+            )
+            val response = store.fetchBlazeStatus(siteModel)
+
+            verifyNoInteractions(dao)
+            assertThat(response.isEligible).isFalse
+            assertEquals(BlazeStatusResult(errorResult), response)
+        }
+
+    @Test
+    fun `given site not in db, when is eligible for blaze is triggered, then false is returned`() {
+        whenever(dao.getBlazeStatus(SITE_ID)).thenReturn(emptyList())
+
+        val result = store.isSiteEligibleForBlaze(SITE_ID)
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `when clear is requested, then the dao request is triggered`() {
+        store.clear()
+
+        verify(dao).clear()
+    }
+
+    companion object {
+        private const val SITE_ID = 1234L
+    }
+}

--- a/example/src/test/resources/wp/blaze/blaze-status.json
+++ b/example/src/test/resources/wp/blaze/blaze-status.json
@@ -1,0 +1,1 @@
+{ "approved": true}

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -34,6 +34,8 @@
 
 /sites/$site/blogging-prompts
 
+/sites/$site/blaze/status
+
 /users/username/suggestions/
 
 /segments

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/12.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/12.json
@@ -1,0 +1,622 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "94a7d9bef484b87bd1e9b29a7b956f5b",
+    "entities": [
+      {
+        "tableName": "BloggingReminders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `monday` INTEGER NOT NULL, `tuesday` INTEGER NOT NULL, `wednesday` INTEGER NOT NULL, `thursday` INTEGER NOT NULL, `friday` INTEGER NOT NULL, `saturday` INTEGER NOT NULL, `sunday` INTEGER NOT NULL, `hour` INTEGER NOT NULL, `minute` INTEGER NOT NULL, `isPromptRemindersOptedIn` INTEGER NOT NULL, `isPromptsCardOptedIn` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monday",
+            "columnName": "monday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tuesday",
+            "columnName": "tuesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wednesday",
+            "columnName": "wednesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thursday",
+            "columnName": "thursday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friday",
+            "columnName": "friday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saturday",
+            "columnName": "saturday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sunday",
+            "columnName": "sunday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hour",
+            "columnName": "hour",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minute",
+            "columnName": "minute",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPromptRemindersOptedIn",
+            "columnName": "isPromptRemindersOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPromptsCardOptedIn",
+            "columnName": "isPromptsCardOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOffers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `name` TEXT, `shortName` TEXT, `tagline` TEXT, `description` TEXT, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "shortName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_PlanOffers_internalPlanId",
+            "unique": true,
+            "columnNames": [
+              "internalPlanId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_PlanOffers_internalPlanId` ON `${TABLE_NAME}` (`internalPlanId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOfferIds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `productId` INTEGER NOT NULL, `internalPlanId` INTEGER NOT NULL, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PlanOfferFeatures",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `stringId` TEXT, `name` TEXT, `description` TEXT, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringId",
+            "columnName": "stringId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Comments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remoteCommentId` INTEGER NOT NULL, `remotePostId` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `remoteSiteId` INTEGER NOT NULL, `authorUrl` TEXT, `authorName` TEXT, `authorEmail` TEXT, `authorProfileImageUrl` TEXT, `authorId` INTEGER NOT NULL, `postTitle` TEXT, `status` TEXT, `datePublished` TEXT, `publishedTimestamp` INTEGER NOT NULL, `content` TEXT, `url` TEXT, `hasParent` INTEGER NOT NULL, `parentId` INTEGER NOT NULL, `iLike` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteCommentId",
+            "columnName": "remoteCommentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePostId",
+            "columnName": "remotePostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteSiteId",
+            "columnName": "remoteSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorUrl",
+            "columnName": "authorUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorEmail",
+            "columnName": "authorEmail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorProfileImageUrl",
+            "columnName": "authorProfileImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postTitle",
+            "columnName": "postTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "datePublished",
+            "columnName": "datePublished",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publishedTimestamp",
+            "columnName": "publishedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasParent",
+            "columnName": "hasParent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iLike",
+            "columnName": "iLike",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DashboardCards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteLocalId` INTEGER NOT NULL, `type` TEXT NOT NULL, `date` TEXT NOT NULL, `json` TEXT NOT NULL, PRIMARY KEY(`siteLocalId`, `type`))",
+        "fields": [
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "siteLocalId",
+            "type"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BloggingPrompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `siteLocalId` INTEGER NOT NULL, `text` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `date` TEXT NOT NULL, `isAnswered` INTEGER NOT NULL, `respondentsCount` INTEGER NOT NULL, `attribution` TEXT NOT NULL, `respondentsAvatars` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAnswered",
+            "columnName": "isAnswered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "respondentsCount",
+            "columnName": "respondentsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attribution",
+            "columnName": "attribution",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "respondentsAvatars",
+            "columnName": "respondentsAvatars",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "FeatureFlagConfigurations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "RemoteConfigurations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BlazeStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `isEligible` INTEGER NOT NULL, PRIMARY KEY(`siteId`))",
+        "fields": [
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEligible",
+            "columnName": "isEligible",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "siteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '94a7d9bef484b87bd1e9b29a7b956f5b')"
+    ]
+  }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.persistence.FeatureFlagConfigDao
 import org.wordpress.android.fluxc.persistence.RemoteConfigDao
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.buildDb
+import org.wordpress.android.fluxc.persistence.blaze.BlazeStatusDao
 import org.wordpress.android.fluxc.persistence.bloggingprompts.BloggingPromptsDao
 import org.wordpress.android.fluxc.persistence.comments.CommentsDao
 import org.wordpress.android.fluxc.persistence.dashboard.CardsDao
@@ -62,5 +63,11 @@ class DatabaseModule {
     @Provides
     fun provideRemoteConfigDao(wpAndroidDatabase: WPAndroidDatabase): RemoteConfigDao {
         return wpAndroidDatabase.remoteConfigDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideBlazeStatusDao(wpAndroidDatabase: WPAndroidDatabase): BlazeStatusDao {
+        return wpAndroidDatabase.blazeStatusDao()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeRestClient.kt
@@ -1,0 +1,89 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.blaze
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.Store.OnChangedError
+import javax.inject.Inject
+import javax.inject.Named
+
+class BlazeRestClient @Inject constructor(
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    dispatcher: Dispatcher,
+    appContext: Context?,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchBlazeStatus(site: SiteModel): BlazeStatusFetchedPayload {
+        val url = WPCOMV2.sites.site(site.siteId).blaze.status.url
+        val response = wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), Map::class.java)
+        return when (response) {
+            is Success -> buildBlazeStatusFetchedPayload(site, response.data)
+            is Error -> BlazeStatusFetchedPayload(site.siteId, response.error.toBlazeStatusError())
+        }
+    }
+
+    private fun buildBlazeStatusFetchedPayload(
+        site: SiteModel,
+        data: Map<*, *>?
+    ): BlazeStatusFetchedPayload {
+        return BlazeStatusFetchedPayload(site.siteId, data?.map { e ->
+            e.key.toString() to e.value.toString().toBoolean()
+        }?.toMap())
+    }
+}
+
+data class BlazeStatusFetchedPayload(
+    val siteId: Long,
+    val eligibility: Map<String, Boolean>? = null
+) : Payload<BlazeStatusError>() {
+    constructor(siteId: Long, error: BlazeStatusError) : this(siteId) {
+        this.error = error
+    }
+}
+
+class BlazeStatusError
+@JvmOverloads constructor(
+    val type: BlazeStatusErrorType,
+    val message: String? = null
+) : OnChangedError
+
+enum class BlazeStatusErrorType {
+    GENERIC_ERROR,
+    AUTHORIZATION_REQUIRED,
+    INVALID_RESPONSE,
+    API_ERROR,
+    TIMEOUT
+}
+
+fun WPComGsonNetworkError.toBlazeStatusError(): BlazeStatusError {
+    val type = when (type) {
+        GenericErrorType.TIMEOUT -> BlazeStatusErrorType.TIMEOUT
+        GenericErrorType.NO_CONNECTION,
+        GenericErrorType.SERVER_ERROR,
+        GenericErrorType.INVALID_SSL_CERTIFICATE,
+        GenericErrorType.NETWORK_ERROR -> BlazeStatusErrorType.API_ERROR
+        GenericErrorType.PARSE_ERROR,
+        GenericErrorType.NOT_FOUND,
+        GenericErrorType.CENSORED,
+        GenericErrorType.INVALID_RESPONSE -> BlazeStatusErrorType.INVALID_RESPONSE
+        GenericErrorType.HTTP_AUTH_ERROR,
+        GenericErrorType.AUTHORIZATION_REQUIRED,
+        GenericErrorType.NOT_AUTHENTICATED -> BlazeStatusErrorType.AUTHORIZATION_REQUIRED
+        GenericErrorType.UNKNOWN,
+        null -> BlazeStatusErrorType.GENERIC_ERROR
+    }
+    return BlazeStatusError(type, message)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeRestClient.kt
@@ -17,7 +17,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.Store.OnChangedError
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 
+@Singleton
 class BlazeRestClient @Inject constructor(
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
     dispatcher: Dispatcher,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
@@ -14,6 +14,8 @@ import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOffer
 import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOfferFeature
 import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOfferId
 import org.wordpress.android.fluxc.persistence.RemoteConfigDao.RemoteConfig
+import org.wordpress.android.fluxc.persistence.blaze.BlazeStatusDao
+import org.wordpress.android.fluxc.persistence.blaze.BlazeStatusDao.BlazeStatus
 import org.wordpress.android.fluxc.persistence.bloggingprompts.BloggingPromptsDao
 import org.wordpress.android.fluxc.persistence.bloggingprompts.BloggingPromptsDao.BloggingPromptEntity
 import org.wordpress.android.fluxc.persistence.comments.CommentsDao
@@ -23,7 +25,7 @@ import org.wordpress.android.fluxc.persistence.dashboard.CardsDao
 import org.wordpress.android.fluxc.persistence.dashboard.CardsDao.CardEntity
 
 @Database(
-        version = 11,
+        version = 12,
         entities = [
             BloggingReminders::class,
             PlanOffer::class,
@@ -34,9 +36,10 @@ import org.wordpress.android.fluxc.persistence.dashboard.CardsDao.CardEntity
             BloggingPromptEntity::class,
             FeatureFlag::class,
             RemoteConfig::class,
+            BlazeStatus::class
         ],
         autoMigrations = [
-            AutoMigration(from = 10, to = 11)
+            AutoMigration(from = 11, to = 12)
         ]
 )
 @TypeConverters(
@@ -58,6 +61,8 @@ abstract class WPAndroidDatabase : RoomDatabase() {
     abstract fun featureFlagConfigDao(): FeatureFlagConfigDao
 
     abstract fun remoteConfigDao(): RemoteConfigDao
+
+    abstract fun blazeStatusDao(): BlazeStatusDao
 
     @Suppress("MemberVisibilityCanBePrivate")
     companion object {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/blaze/BlazeStatusDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/blaze/BlazeStatusDao.kt
@@ -1,0 +1,42 @@
+package org.wordpress.android.fluxc.persistence.blaze
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Dao
+abstract class BlazeStatusDao {
+    @Transaction
+    @Query("SELECT * from BlazeStatus WHERE `siteId` = :siteId")
+    abstract fun getBlazeStatus(siteId: Long): List<BlazeStatus>
+
+    @Transaction
+    @Suppress("SpreadOperator")
+    open fun insert(siteId: Long, isEligible: Boolean) {
+        insert(
+            BlazeStatus(
+                siteId = siteId,
+                isEligible = isEligible
+            )
+        )
+    }
+
+    @Transaction
+    @Query("DELETE FROM BlazeStatus")
+    abstract fun clear()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insert(blazeStatus: BlazeStatus)
+
+    @Entity(
+        tableName = "BlazeStatus",
+        primaryKeys = ["siteId"]
+    )
+    data class BlazeStatus(
+        val siteId: Long,
+        val isEligible: Boolean
+    )
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/blaze/BlazeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/blaze/BlazeStore.kt
@@ -11,7 +11,9 @@ import org.wordpress.android.fluxc.store.Store
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class BlazeStore @Inject constructor(
     private val blazeRestClient: BlazeRestClient,
     private val blazeStatusDao: BlazeStatusDao,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/blaze/BlazeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/blaze/BlazeStore.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.fluxc.store.blaze
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeStatusError
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeStatusErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeStatusFetchedPayload
+import org.wordpress.android.fluxc.persistence.blaze.BlazeStatusDao
+import org.wordpress.android.fluxc.persistence.blaze.BlazeStatusDao.BlazeStatus
+import org.wordpress.android.fluxc.store.Store
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+
+class BlazeStore @Inject constructor(
+    private val blazeRestClient: BlazeRestClient,
+    private val blazeStatusDao: BlazeStatusDao,
+    private val coroutineEngine: CoroutineEngine
+) {
+    suspend fun fetchBlazeStatus(
+        site: SiteModel
+    ) = coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetch blaze status") {
+        val payload = blazeRestClient.fetchBlazeStatus(site)
+        storeBlazeStatus(site, payload)
+    }
+
+    private fun storeBlazeStatus(
+        site: SiteModel,
+        payload: BlazeStatusFetchedPayload
+    ): BlazeStatusResult {
+        return when {
+            payload.isError -> handlePayloadError(payload.error)
+            payload.eligibility != null -> handlePayloadSuccess(site, payload.eligibility)
+            else -> BlazeStatusResult(BlazeStatusError((INVALID_RESPONSE)))
+        }
+    }
+
+    private fun handlePayloadSuccess(site: SiteModel, eligibility: Map<String, Boolean>?): BlazeStatusResult {
+        val isEligible = eligibility?.get("approved")?.toString()?.toBoolean()?:false
+        insertBlazeStatusValue(site.siteId, isEligible)
+        return BlazeStatusResult(isEligible)
+    }
+
+    private fun handlePayloadError(error: BlazeStatusError): BlazeStatusResult {
+        return BlazeStatusResult(error)
+    }
+
+    private fun insertBlazeStatusValue(siteId: Long, value: Boolean) {
+        blazeStatusDao.insert(
+            BlazeStatus(
+                siteId = siteId,
+                isEligible = value
+            )
+        )
+    }
+
+    fun isSiteEligibleForBlaze(siteId: Long): Boolean {
+        return blazeStatusDao.getBlazeStatus(siteId).takeIf { it.isNotEmpty() }?.first()?.isEligible
+            ?: false
+    }
+
+    fun clear() {
+        blazeStatusDao.clear()
+    }
+
+    data class BlazeStatusResult(
+        val isEligible: Boolean = false
+    ) : Store.OnChanged<BlazeStatusError>() {
+        constructor(error: BlazeStatusError) : this() {
+            this.error = error
+        }
+    }
+}


### PR DESCRIPTION
Closes #2654 

This PR adds support for:
- Calling the blaze/status endpoint
- DB layer for storing approved site eligibility for blaze  

Would love a second set of 👀 on WPAndroidDatabase `autoMigrations` . I wasn't sure if I am correct in updating.

Related [WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/17944) (updates the fluxC version)

**To Test**
Run the included tests



