### PR TITLE
Support Vendor String in Domain Suggestions Payload

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_SiteTestWPCom.java
@@ -310,14 +310,14 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     @Test
     public void testWpcomSubdomainSuggestions() throws InterruptedException {
         String keywords = "awesomesubdomain";
-        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, true, true, false, 20, false);
+        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, true, true, false, 20, null);
         testSuggestDomains(payload, TestEvents.FETCHED_DOMAIN_SUGGESTIONS);
     }
 
     @Test
     public void testWpcomSubdomainDotBlogSuggestions() throws InterruptedException {
         String keywords = "awesomesubdomain";
-        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, true, true, true, 20, true);
+        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, true, true, true, 20, "dot");
         testSuggestDomains(payload, TestEvents.FETCHED_DOMAIN_SUGGESTIONS);
     }
 
@@ -334,7 +334,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
         // This query should return 0 results which returns a 400 error from the API. This test verifies that
         // we are converting it to a successful response.
         String keywords = "test";
-        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, true, true, false, 20, false);
+        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, true, true, false, 20, null);
         testSuggestDomains(payload, TestEvents.FETCHED_DOMAIN_SUGGESTIONS);
     }
 
@@ -342,7 +342,7 @@ public class ReleaseStack_SiteTestWPCom extends ReleaseStack_Base {
     public void testInvalidQueryDomainSuggestions() throws InterruptedException {
         // This query should return
         String keywords = ".";
-        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, true, true, false, 20, false);
+        SuggestDomainsPayload payload = new SuggestDomainsPayload(keywords, true, true, false, 20, null);
         testSuggestDomains(payload, TestEvents.DOMAIN_SUGGESTION_ERROR_INVALID_QUERY);
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SignedOutActionsFragment.java
@@ -185,7 +185,7 @@ public class SignedOutActionsFragment extends Fragment {
         alert.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 String keyword = editText.getText().toString();
-                SuggestDomainsPayload payload = new SuggestDomainsPayload(keyword, false, true, false, 5, false);
+                SuggestDomainsPayload payload = new SuggestDomainsPayload(keyword, false, true, false, 5, null);
                 mDispatcher.dispatch(SiteActionBuilder.newSuggestDomainsAction(payload));
             }
         });

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainSuggestionResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainSuggestionResponse.java
@@ -6,6 +6,7 @@ public class DomainSuggestionResponse implements Response {
     public String cost;
     public String domain_name;
     public boolean is_free;
+    public boolean is_premium;
     public boolean supports_privacy;
 
     public int product_id;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -457,17 +457,21 @@ class SiteRestClient @Inject constructor(
     @Suppress("LongParameterList")
     fun suggestDomains(
         query: String,
+        quantity: Int,
+        vendor: String?,
         onlyWordpressCom: Boolean?,
         includeWordpressCom: Boolean?,
         includeDotBlogSubdomain: Boolean?,
         segmentId: Long?,
-        quantity: Int,
-        includeVendorDot: Boolean,
         tlds: String?
     ) {
         val url = WPCOMREST.domains.suggestions.urlV1_1
         val params = mutableMapOf<String, String>()
         params["query"] = query
+        params["quantity"] = quantity.toString()
+        if (vendor != null) {
+            params["vendor"] = vendor
+        }
         if (onlyWordpressCom != null) {
             params["only_wordpressdotcom"] = onlyWordpressCom.toString() // CHECKSTYLE IGNORE
         }
@@ -482,10 +486,6 @@ class SiteRestClient @Inject constructor(
         }
         if (tlds != null) {
             params["tlds"] = tlds
-        }
-        params["quantity"] = quantity.toString()
-        if (includeVendorDot) {
-            params["vendor"] = "dot"
         }
         val request = WPComGsonRequest.buildGetRequest<List<DomainSuggestionResponse>>(url, params,
                 object : TypeToken<List<DomainSuggestionResponse>>() {}.type,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -301,14 +301,26 @@ open class SiteStore @Inject constructor(
 
     data class SuggestDomainsPayload(
         @JvmField val query: String,
+        @JvmField val quantity: Int,
+        @JvmField val vendor: String? = null,
         @JvmField val onlyWordpressCom: Boolean? = null,
         @JvmField val includeWordpressCom: Boolean? = null,
         @JvmField val includeDotBlogSubdomain: Boolean? = null,
         @JvmField val tlds: String? = null,
-        @JvmField val segmentId: Long? = null,
-        @JvmField val quantity: Int,
-        @JvmField val includeVendorDot: Boolean = false
+        @JvmField val segmentId: Long? = null
     ) : Payload<BaseNetworkError>() {
+        @Deprecated(
+            "Replace with primary constructor " +
+                "which accepts 'vendor = \"dot\"' instead of 'includeVendorDot = true' " +
+                "or 'vendor = null' instead of 'includeVendorDot = false'.",
+            replaceWith = ReplaceWith(expression = "SiteStore.SuggestDomainsPayload(" +
+                    "query = query, " +
+                    "onlyWordpressCom = onlyWordpressCom, " +
+                    "includeWordpressCom = includeWordpressCom, " +
+                    "includeDotBlogSubdomain = includeDotBlogSubdomain, " +
+                    "quantity = quantity, " +
+                    "vendor = null)")
+        )
         constructor(
             query: String,
             onlyWordpressCom: Boolean,
@@ -317,29 +329,39 @@ open class SiteStore @Inject constructor(
             quantity: Int,
             includeVendorDot: Boolean
         ) : this(
-                query = query,
-                onlyWordpressCom = onlyWordpressCom,
-                includeWordpressCom = includeWordpressCom,
-                includeDotBlogSubdomain = includeDotBlogSubdomain,
-                quantity = quantity,
-                includeVendorDot = includeVendorDot,
-                segmentId = null,
-                tlds = null
+            query = query,
+            quantity = quantity,
+            vendor = if (includeVendorDot) "dot" else null,
+            onlyWordpressCom = onlyWordpressCom,
+            includeWordpressCom = includeWordpressCom,
+            includeDotBlogSubdomain = includeDotBlogSubdomain,
+            tlds = null,
+            segmentId = null
         )
 
-        constructor(query: String, segmentId: Long?, quantity: Int, includeVendorDot: Boolean) : this(
-                query = query,
-                segmentId = segmentId,
-                quantity = quantity,
-                includeVendorDot = includeVendorDot,
-                tlds = null
+        constructor(
+            query: String,
+            onlyWordpressCom: Boolean,
+            includeWordpressCom: Boolean,
+            includeDotBlogSubdomain: Boolean,
+            quantity: Int,
+            vendor: String?,
+        ) : this(
+            query = query,
+            quantity = quantity,
+            vendor = vendor,
+            onlyWordpressCom = onlyWordpressCom,
+            includeWordpressCom = includeWordpressCom,
+            includeDotBlogSubdomain = includeDotBlogSubdomain,
+            tlds = null,
+            segmentId = null
         )
 
         constructor(query: String, quantity: Int, tlds: String?) : this(
-                query = query,
-                quantity = quantity,
-                tlds = tlds,
-                segmentId = null
+            query = query,
+            quantity = quantity,
+            tlds = tlds,
+            segmentId = null,
         )
     }
 
@@ -1765,9 +1787,14 @@ open class SiteStore @Inject constructor(
 
     private fun suggestDomains(payload: SuggestDomainsPayload) {
         siteRestClient.suggestDomains(
-                payload.query, payload.onlyWordpressCom, payload.includeWordpressCom,
-                payload.includeDotBlogSubdomain, payload.segmentId, payload.quantity, payload.includeVendorDot,
-                payload.tlds
+            payload.query,
+            payload.quantity,
+            payload.vendor,
+            payload.onlyWordpressCom,
+            payload.includeWordpressCom,
+            payload.includeDotBlogSubdomain,
+            payload.segmentId,
+            payload.tlds
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -303,14 +303,26 @@ open class SiteStore @Inject constructor(
 
     data class SuggestDomainsPayload(
         @JvmField val query: String,
+        @JvmField val quantity: Int,
+        @JvmField val vendor: String? = null,
         @JvmField val onlyWordpressCom: Boolean? = null,
         @JvmField val includeWordpressCom: Boolean? = null,
         @JvmField val includeDotBlogSubdomain: Boolean? = null,
         @JvmField val tlds: String? = null,
-        @JvmField val segmentId: Long? = null,
-        @JvmField val quantity: Int,
-        @JvmField val includeVendorDot: Boolean = false
+        @JvmField val segmentId: Long? = null
     ) : Payload<BaseNetworkError>() {
+        @Deprecated(
+            "Replace with primary constructor " +
+                "which accepts 'vendor = \"dot\"' instead of 'includeVendorDot = true' " +
+                "or 'vendor = null' instead of 'includeVendorDot = false'.",
+            replaceWith = ReplaceWith(expression = "SiteStore.SuggestDomainsPayload(" +
+                    "query = query, " +
+                    "onlyWordpressCom = onlyWordpressCom, " +
+                    "includeWordpressCom = includeWordpressCom, " +
+                    "includeDotBlogSubdomain = includeDotBlogSubdomain, " +
+                    "quantity = quantity, " +
+                    "vendor = null)")
+        )
         constructor(
             query: String,
             onlyWordpressCom: Boolean,
@@ -319,29 +331,39 @@ open class SiteStore @Inject constructor(
             quantity: Int,
             includeVendorDot: Boolean
         ) : this(
-                query = query,
-                onlyWordpressCom = onlyWordpressCom,
-                includeWordpressCom = includeWordpressCom,
-                includeDotBlogSubdomain = includeDotBlogSubdomain,
-                quantity = quantity,
-                includeVendorDot = includeVendorDot,
-                segmentId = null,
-                tlds = null
+            query = query,
+            quantity = quantity,
+            vendor = if (includeVendorDot) "dot" else null,
+            onlyWordpressCom = onlyWordpressCom,
+            includeWordpressCom = includeWordpressCom,
+            includeDotBlogSubdomain = includeDotBlogSubdomain,
+            tlds = null,
+            segmentId = null
         )
 
-        constructor(query: String, segmentId: Long?, quantity: Int, includeVendorDot: Boolean) : this(
-                query = query,
-                segmentId = segmentId,
-                quantity = quantity,
-                includeVendorDot = includeVendorDot,
-                tlds = null
+        constructor(
+            query: String,
+            onlyWordpressCom: Boolean,
+            includeWordpressCom: Boolean,
+            includeDotBlogSubdomain: Boolean,
+            quantity: Int,
+            vendor: String?,
+        ) : this(
+            query = query,
+            quantity = quantity,
+            vendor = vendor,
+            onlyWordpressCom = onlyWordpressCom,
+            includeWordpressCom = includeWordpressCom,
+            includeDotBlogSubdomain = includeDotBlogSubdomain,
+            tlds = null,
+            segmentId = null
         )
 
         constructor(query: String, quantity: Int, tlds: String?) : this(
-                query = query,
-                quantity = quantity,
-                tlds = tlds,
-                segmentId = null
+            query = query,
+            quantity = quantity,
+            tlds = tlds,
+            segmentId = null,
         )
     }
 
@@ -1767,9 +1789,14 @@ open class SiteStore @Inject constructor(
 
     private fun suggestDomains(payload: SuggestDomainsPayload) {
         siteRestClient.suggestDomains(
-                payload.query, payload.onlyWordpressCom, payload.includeWordpressCom,
-                payload.includeDotBlogSubdomain, payload.segmentId, payload.quantity, payload.includeVendorDot,
-                payload.tlds
+            payload.query,
+            payload.quantity,
+            payload.vendor,
+            payload.onlyWordpressCom,
+            payload.includeWordpressCom,
+            payload.includeDotBlogSubdomain,
+            payload.segmentId,
+            payload.tlds
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -313,13 +313,15 @@ open class SiteStore @Inject constructor(
             "Replace with primary constructor " +
                 "which accepts 'vendor = \"dot\"' instead of 'includeVendorDot = true' " +
                 "or 'vendor = null' instead of 'includeVendorDot = false'.",
-            replaceWith = ReplaceWith(expression = "SiteStore.SuggestDomainsPayload(" +
+            replaceWith = ReplaceWith(
+                expression = "SiteStore.SuggestDomainsPayload(" +
                     "query = query, " +
                     "onlyWordpressCom = onlyWordpressCom, " +
                     "includeWordpressCom = includeWordpressCom, " +
                     "includeDotBlogSubdomain = includeDotBlogSubdomain, " +
                     "quantity = quantity, " +
-                    "vendor = null)")
+                    "vendor = null)"
+            )
         )
         constructor(
             query: String,
@@ -334,9 +336,7 @@ open class SiteStore @Inject constructor(
             vendor = if (includeVendorDot) "dot" else null,
             onlyWordpressCom = onlyWordpressCom,
             includeWordpressCom = includeWordpressCom,
-            includeDotBlogSubdomain = includeDotBlogSubdomain,
-            tlds = null,
-            segmentId = null
+            includeDotBlogSubdomain = includeDotBlogSubdomain
         )
 
         constructor(
@@ -345,23 +345,21 @@ open class SiteStore @Inject constructor(
             includeWordpressCom: Boolean,
             includeDotBlogSubdomain: Boolean,
             quantity: Int,
-            vendor: String?,
+            vendor: String? = null,
         ) : this(
-            query = query,
-            quantity = quantity,
-            vendor = vendor,
-            onlyWordpressCom = onlyWordpressCom,
-            includeWordpressCom = includeWordpressCom,
-            includeDotBlogSubdomain = includeDotBlogSubdomain,
-            tlds = null,
-            segmentId = null
+            query,
+            quantity,
+            vendor,
+            onlyWordpressCom,
+            includeWordpressCom,
+            includeDotBlogSubdomain
         )
 
         constructor(query: String, quantity: Int, tlds: String?) : this(
-            query = query,
-            quantity = quantity,
-            tlds = tlds,
-            segmentId = null,
+            query,
+            quantity,
+            vendor = null, // Avoids error: "There's a cycle in the delegation calls chain"
+            tlds = tlds
         )
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -315,13 +315,15 @@ open class SiteStore @Inject constructor(
             "Replace with primary constructor " +
                 "which accepts 'vendor = \"dot\"' instead of 'includeVendorDot = true' " +
                 "or 'vendor = null' instead of 'includeVendorDot = false'.",
-            replaceWith = ReplaceWith(expression = "SiteStore.SuggestDomainsPayload(" +
+            replaceWith = ReplaceWith(
+                expression = "SiteStore.SuggestDomainsPayload(" +
                     "query = query, " +
                     "onlyWordpressCom = onlyWordpressCom, " +
                     "includeWordpressCom = includeWordpressCom, " +
                     "includeDotBlogSubdomain = includeDotBlogSubdomain, " +
                     "quantity = quantity, " +
-                    "vendor = null)")
+                    "vendor = null)"
+            )
         )
         constructor(
             query: String,
@@ -336,9 +338,7 @@ open class SiteStore @Inject constructor(
             vendor = if (includeVendorDot) "dot" else null,
             onlyWordpressCom = onlyWordpressCom,
             includeWordpressCom = includeWordpressCom,
-            includeDotBlogSubdomain = includeDotBlogSubdomain,
-            tlds = null,
-            segmentId = null
+            includeDotBlogSubdomain = includeDotBlogSubdomain
         )
 
         constructor(
@@ -347,23 +347,21 @@ open class SiteStore @Inject constructor(
             includeWordpressCom: Boolean,
             includeDotBlogSubdomain: Boolean,
             quantity: Int,
-            vendor: String?,
+            vendor: String? = null,
         ) : this(
-            query = query,
-            quantity = quantity,
-            vendor = vendor,
-            onlyWordpressCom = onlyWordpressCom,
-            includeWordpressCom = includeWordpressCom,
-            includeDotBlogSubdomain = includeDotBlogSubdomain,
-            tlds = null,
-            segmentId = null
+            query,
+            quantity,
+            vendor,
+            onlyWordpressCom,
+            includeWordpressCom,
+            includeDotBlogSubdomain
         )
 
         constructor(query: String, quantity: Int, tlds: String?) : this(
-            query = query,
-            quantity = quantity,
-            tlds = tlds,
-            segmentId = null,
+            query,
+            quantity,
+            vendor = null, // Avoids error: "There's a cycle in the delegation calls chain"
+            tlds = tlds
         )
     }
 


### PR DESCRIPTION
Resolves wordpress-mobile/WordPress-Android#17976
Integrated by wordpress-mobile/WordPress-Android#17977

This PR:
- ⊕ Adds support to pass a nullable `vendor` string to `SuggestDomainsPayload`
- ⊖ Removes `includeVendorDot` boolean from `SuggestDomainsPayload` primary constructor
- ⊕ Deprecates the `SuggestDomainsPayload` constructor accepting a non-nullable `includeVendorDot` boolean  
- ⊕ Reorders `SuggestDomainsPayload` parameters moving optionals (w/ default value) last

#### Compatibility Checks & Resolutions

- ✅ On [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android) merge:  
  - https://github.com/wordpress-mobile/WordPress-Android/pull/17977
- ✅ [woocommerce-android](https://github.com/woocommerce/woocommerce-android) uses the deprecated constructor
  > **Note** @wordpress-mobile/woo-android:
  > After this PR is merged you will get a build error if `woocommerce-android` is updated to use a newer FluxC version.
  > To fix it, you should be able to apply the `Replace with ...` suggestion in Android Studio (I tested this manually myself).
  > Once that's done and merged, ideally we'd remove the constructor from FluxC. I'm willing to open a PR for it if you ping me on the corresponding `woocommerce-android` PR.
- The other clients are not using `SuggestDomainPayload`:
  - [WordPress-Login-Flow-Android](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android)
  - [Automattic-Tracks-Android](https://github.com/Automattic/Automattic-Tracks-Android)
  - [WordPress-MediaPicker-Android](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android)

To Test:

- Test PR wordpress-mobile/WordPress-Android#17977

Optionally you could:
1. Update your local [`woocommerce-android`](https://github.com/woocommerce/woocommerce-android) clone on latest `trunk` to use the library version of this PR then:
2. Build the client app
3. **Verify** there's no build error. If there's is one **verify** it's saying:
```
'constructor SuggestDomainsPayload(String, Boolean, Boolean, Boolean, Int, Boolean)' is deprecated. Replace with primary constructor which accepts 'vendor = "dot"' instead of 'includeVendorDot = true' or 'vendor = null' instead of 'includeVendorDot = false'.
```

+ **Optionally** If you want to be be even more comprehensive, you could smoke test there's no regression in WordPress app on the `Site Creation` → `Choose a domain screen` screen. _Shouldn't be needed because the code changes are quite clear_.