### PR TITLE
Adding functions for JP plugin install endpoint

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/PluginAction.java
@@ -35,6 +35,8 @@ public enum PluginAction implements IAction {
     FETCH_SITE_PLUGIN,
     @Action(payloadType = InstallSitePluginPayload.class)
     INSTALL_SITE_PLUGIN,
+    @Action(payloadType = InstallSitePluginPayload.class)
+    INSTALL_JP_FOR_INDIVIDUAL_PLUGIN_SITE,
     @Action(payloadType = SearchPluginDirectoryPayload.class)
     SEARCH_PLUGIN_DIRECTORY,
     @Action(payloadType = UpdateSitePluginPayload.class)
@@ -53,6 +55,8 @@ public enum PluginAction implements IAction {
     FETCHED_SITE_PLUGIN,
     @Action(payloadType = InstalledSitePluginPayload.class)
     INSTALLED_SITE_PLUGIN,
+    @Action(payloadType = InstalledSitePluginPayload.class)
+    INSTALLED_JP_FOR_INDIVIDUAL_PLUGIN_SITE,
     @Action(payloadType = SearchedPluginDirectoryPayload.class)
     SEARCHED_PLUGIN_DIRECTORY,
     @Action(payloadType = UpdatedSitePluginPayload.class)


### PR DESCRIPTION
This PR adds 2 new actions to the PluginStore, namely
- INSTALL_JP_FOR_INDIVIDUAL_PLUGIN_SITE
- INSTALLED_JP_FOR_INDIVIDUAL_PLUGIN_SITE

It also add a installJetpackOnIndividualPluginSite method with a retry logic facility attempting to configure the JP plugin in case install detects the plugin is already installed (but not activated).

This PR has a companion PR [here](https://github.com/wordpress-mobile/WordPress-Android/pull/17980). You can use instructions there for testing purposes.

