### PR TITLE
Feature/8260 fetch onboarding task

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.example.MainFragment
 import org.wordpress.android.fluxc.example.MediaFragment
 import org.wordpress.android.fluxc.example.NotificationsFragment
 import org.wordpress.android.fluxc.example.PlansFragment
+import org.wordpress.android.fluxc.example.PluginsFragment
 import org.wordpress.android.fluxc.example.PostsFragment
 import org.wordpress.android.fluxc.example.ReactNativeFragment
 import org.wordpress.android.fluxc.example.SignedOutActionsFragment
@@ -19,7 +20,6 @@ import org.wordpress.android.fluxc.example.SitesFragment
 import org.wordpress.android.fluxc.example.TaxonomiesFragment
 import org.wordpress.android.fluxc.example.ThemeFragment
 import org.wordpress.android.fluxc.example.UploadsFragment
-import org.wordpress.android.fluxc.example.PluginsFragment
 import org.wordpress.android.fluxc.example.ui.StoreSelectorDialog
 import org.wordpress.android.fluxc.example.ui.WooCommerceFragment
 import org.wordpress.android.fluxc.example.ui.coupons.WooCouponsFragment
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.example.ui.customer.search.WooCustomersSearch
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.helpsupport.WooHelpSupportFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
+import org.wordpress.android.fluxc.example.ui.onboarding.WooOnboardingFragment
 import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooAddonsTestFragment
@@ -192,4 +193,7 @@ internal interface FragmentsModule {
 
     @ContributesAndroidInjector
     fun provideDomainsFragment(): DomainsFragment
+
+    @ContributesAndroidInjector
+    fun provideOnboardingFragment(): WooOnboardingFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.example.ui.customer.WooCustomersFragment
 import org.wordpress.android.fluxc.example.ui.gateways.WooGatewaysFragment
 import org.wordpress.android.fluxc.example.ui.helpsupport.WooHelpSupportFragment
 import org.wordpress.android.fluxc.example.ui.leaderboards.WooLeaderboardsFragment
+import org.wordpress.android.fluxc.example.ui.onboarding.WooOnboardingFragment
 import org.wordpress.android.fluxc.example.ui.orders.WooOrdersFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductAttributeFragment
 import org.wordpress.android.fluxc.example.ui.products.WooProductsFragment
@@ -43,7 +44,11 @@ class WooCommerceFragment : StoreSelectingFragment() {
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
         inflater.inflate(R.layout.fragment_woocommerce, container, false)
 
     @Suppress("LongMethod", "ComplexMethod")
@@ -97,8 +102,9 @@ class WooCommerceFragment : StoreSelectingFragment() {
                         prependToLog("Error fetching settings: ${it.type} - ${it.message}")
                     }
                     result.model?.let {
-                        prependToLog("Updated site settings for ${site.name}:\n" +
-                            it.toString()
+                        prependToLog(
+                            "Updated site settings for ${site.name}:\n" +
+                                it.toString()
                         )
                     }
                 }
@@ -222,6 +228,10 @@ class WooCommerceFragment : StoreSelectingFragment() {
             selectedSite?.let {
                 replaceFragment(WooHelpSupportFragment())
             } ?: showNoWCSitesToast()
+        }
+
+        store_onboarding.setOnClickListener {
+            replaceFragment(WooOnboardingFragment())
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/onboarding/WooOnboardingFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/onboarding/WooOnboardingFragment.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.fluxc.example.ui.onboarding
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.fragment_woo_onboarding.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
+import org.wordpress.android.fluxc.store.OnboardingStore
+import javax.inject.Inject
+
+class WooOnboardingFragment : StoreSelectingFragment() {
+    @Inject internal lateinit var onboardingStore: OnboardingStore
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
+        inflater.inflate(R.layout.fragment_woo_onboarding, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        btnFetchOnboardingTasks.setOnClickListener {
+            selectedSite?.let { site ->
+                coroutineScope.launch {
+                    val result = withContext(Dispatchers.Default) {
+                        onboardingStore.fetchOnboardingTasks(site)
+                    }
+
+                    result.error?.let {
+                        prependToLog("${it.type}: ${it.message}")
+                        return@launch
+                    }
+                    result.model?.let {
+                        prependToLog("Fetched data: $it")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/example/src/main/res/layout/fragment_woo_onboarding.xml
+++ b/example/src/main/res/layout/fragment_woo_onboarding.xml
@@ -1,0 +1,25 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    tools:context="org.wordpress.android.fluxc.example.ui.shippinglabels.WooShippingLabelFragment"
+    tools:ignore="HardcodedText">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp">
+
+        <Button
+            android:id="@+id/btnFetchOnboardingTasks"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Fetch onboarding tasks" />
+
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -141,5 +141,11 @@
             android:layout_height="wrap_content"
             android:text="Help &amp; Support" />
 
+        <Button
+            android:id="@+id/store_onboarding"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Store onboarding" />
+
     </LinearLayout>
 </ScrollView>

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -15,6 +15,8 @@ public class WCWPAPIEndpoint {
 
     private static final String WC_PREFIX_TELEMETRY = "wc-telemetry";
 
+    private static final String WC_PREFIX_ADMIN = "wc-admin";
+
     private final String mEndpoint;
 
     public WCWPAPIEndpoint(String endpoint) {
@@ -59,5 +61,9 @@ public class WCWPAPIEndpoint {
 
     public String getPathWcTelemetry() {
         return "/" + WC_PREFIX_TELEMETRY + mEndpoint;
+    }
+
+    public String getPathWcAdmin() {
+        return "/" + WC_PREFIX_ADMIN + mEndpoint;
     }
 }

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -94,3 +94,5 @@
 /admin/notes/<note_id>/action/<action_id>
 /admin/notes/delete/<note_id>
 /admin/notes/delete/all
+
+/onboarding/tasks

--- a/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -147,5 +147,3 @@
 /products
 
 /plans
-
-/wc-admin/onboarding/tasks

--- a/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -147,3 +147,5 @@
 /products
 
 /plans
+
+/wc-admin/onboarding/tasks

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingRestClient.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding
+
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.utils.toWooPayload
+import javax.inject.Inject
+
+class OnboardingRestClient @Inject constructor(
+    private val wooNetwork: WooNetwork
+) {
+    suspend fun fetchOnboardingTasks(site: SiteModel): WooPayload<OnboardingTasksResponse> {
+        val url = WPCOMREST.wc_admin.onboarding.tasks.endpoint
+        return wooNetwork.executeGetGsonRequest(
+            site,
+            url,
+            OnboardingTasksResponse::class.java
+        ).toWooPayload()
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingRestClient.kt
@@ -10,12 +10,12 @@ import javax.inject.Inject
 class OnboardingRestClient @Inject constructor(
     private val wooNetwork: WooNetwork
 ) {
-    suspend fun fetchOnboardingTasks(site: SiteModel): WooPayload<OnboardingTasksResponse> {
+    suspend fun fetchOnboardingTasks(site: SiteModel): WooPayload<Array<TaskGroupDto>> {
         val url = WPCOMREST.wc_admin.onboarding.tasks.endpoint
         return wooNetwork.executeGetGsonRequest(
             site,
             url,
-            OnboardingTasksResponse::class.java
+            Array<TaskGroupDto>::class.java
         ).toWooPayload()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingRestClient.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding
 
-import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
@@ -11,7 +11,7 @@ class OnboardingRestClient @Inject constructor(
     private val wooNetwork: WooNetwork
 ) {
     suspend fun fetchOnboardingTasks(site: SiteModel): WooPayload<Array<TaskGroupDto>> {
-        val url = WPCOMREST.wc_admin.onboarding.tasks.endpoint
+        val url = WOOCOMMERCE.onboarding.tasks.pathWcAdmin
         return wooNetwork.executeGetGsonRequest(
             site,
             url,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingTasksResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingTasksResponse.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding
+
+data class OnboardingTasksResponse(
+    val data: List<TaskGroupDto>
+)
+
+data class TaskGroupDto(
+    val id: String,
+    val title: String?,
+    val tasks: List<TaskDto>
+)
+
+data class TaskDto(
+    val id: String,
+    val isComplete: Boolean = false,
+    val isVisited: Boolean = false,
+    val isActioned: Boolean = false,
+    val actionUrl: String?
+)
+

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingTasksResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/onboarding/OnboardingTasksResponse.kt
@@ -1,12 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding
 
-data class OnboardingTasksResponse(
-    val data: List<TaskGroupDto>
-)
-
 data class TaskGroupDto(
     val id: String,
-    val title: String?,
     val tasks: List<TaskDto>
 )
 
@@ -15,6 +10,7 @@ data class TaskDto(
     val isComplete: Boolean = false,
     val isVisited: Boolean = false,
     val isActioned: Boolean = false,
+    val canView: Boolean = false,
     val actionUrl: String?
 )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
@@ -18,6 +18,7 @@ class OnboardingStore @Inject constructor(
     private companion object {
         const val ONBOARDING_TASKS_KEY = "setup"
     }
+
     suspend fun fetchOnboardingTasks(site: SiteModel): WooResult<List<TaskDto>> =
         coroutineEngine.withDefaultContext(API, this, "fetchOnboardingTasks") {
             val response = restClient.fetchOnboardingTasks(site)
@@ -25,11 +26,11 @@ class OnboardingStore @Inject constructor(
                 response.isError -> WooResult(response.error)
                 response.result != null -> WooResult(
                     response.result
-                        .firstOrNull { it.id == ONBOARDING_TASKS_KEY  }
+                        .firstOrNull { it.id == ONBOARDING_TASKS_KEY }
                         ?.tasks ?: emptyList()
                 )
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }
-
 }
+

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
@@ -15,12 +15,19 @@ class OnboardingStore @Inject constructor(
     private val restClient: OnboardingRestClient,
     private val coroutineEngine: CoroutineEngine,
 ) {
+    private companion object {
+        const val ONBOARDING_TASKS_KEY = "setup"
+    }
     suspend fun fetchOnboardingTasks(site: SiteModel): WooResult<List<TaskDto>> =
         coroutineEngine.withDefaultContext(API, this, "fetchOnboardingTasks") {
             val response = restClient.fetchOnboardingTasks(site)
             when {
                 response.isError -> WooResult(response.error)
-                response.result != null -> WooResult(emptyList())
+                response.result != null -> WooResult(
+                    response.result
+                        .firstOrNull { it.id == ONBOARDING_TASKS_KEY  }
+                        ?.tasks ?: emptyList()
+                )
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
@@ -10,7 +10,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding.TaskDto
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog.T.API
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class OnboardingStore @Inject constructor(
     private val restClient: OnboardingRestClient,
     private val coroutineEngine: CoroutineEngine,
@@ -33,4 +35,5 @@ class OnboardingStore @Inject constructor(
             }
         }
 }
+
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.fluxc.store
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding.OnboardingRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding.TaskDto
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog.T.API
+import javax.inject.Inject
+
+class OnboardingStore @Inject constructor(
+    private val restClient: OnboardingRestClient,
+    private val coroutineEngine: CoroutineEngine,
+) {
+    suspend fun fetchOnboardingTasks(site: SiteModel): WooResult<List<TaskDto>> =
+        coroutineEngine.withDefaultContext(API, this, "fetchOnboardingTasks") {
+            val response = restClient.fetchOnboardingTasks(site)
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> WooResult(emptyList())
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: [#8260 ](https://github.com/woocommerce/woocommerce-android/issues/8260)
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Fetch onboarding tasks from API. 

### Test 
1. Run FluxC Example app
2. Click on Woo option
3. Scroll down and click on Store Onboarding
4. Select a site 
5. Click Fetch onboarding task
6. See the fetched `TaskDto` data is displayed in the log output correctly. 

More in depth test will be done using WooCommerce app from [this PR ](https://github.com/woocommerce/woocommerce-android/pull/8359)