### PR TITLE
Add support for local product search

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -408,7 +408,7 @@ class ProductSqlUtilsTest {
     }
 
     @Test
-    fun testGetProductsForSiteWithFilterOptions() {
+    fun testGetProductsWithFilterOptions() {
         val productFilterOptions = mapOf(
                 ProductFilterOption.STOCK_STATUS to "instock",
                 ProductFilterOption.STATUS to "publish",
@@ -424,7 +424,7 @@ class ProductSqlUtilsTest {
         ProductSqlUtils.insertOrUpdateProduct(product3)
 
         val site = SiteModel().apply { id = product1.localSiteId }
-        val products = ProductSqlUtils.getProductsByFilterOptions(site, productFilterOptions)
+        val products = ProductSqlUtils.getProducts(site, productFilterOptions)
         assertEquals(2, products.size)
 
         // insert products with the same productId but for a different site
@@ -441,16 +441,16 @@ class ProductSqlUtilsTest {
         ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct3)
 
         // verify that the products for the first site is still 2
-        assertEquals(2, ProductSqlUtils.getProductsByFilterOptions(site, productFilterOptions).size)
+        assertEquals(2, ProductSqlUtils.getProducts(site, productFilterOptions).size)
 
         // verify that the products for the second site is 3
         val site2 = SiteModel().apply { id = differentSiteProduct1.localSiteId }
-        val differentSiteProducts = ProductSqlUtils.getProductsByFilterOptions(site2, productFilterOptions)
+        val differentSiteProducts = ProductSqlUtils.getProducts(site2, productFilterOptions)
         assertEquals(1, differentSiteProducts.size)
     }
 
     @Test
-    fun testGetProductsForSiteWithFilterOptionsAndSearchQuery() {
+    fun testGetProductsWithSearchQuery() {
         val product1 = ProductTestUtils.generateSampleProduct(40, name = "a", description = "1", shortDescription = "+")
         val product2 = ProductTestUtils.generateSampleProduct(41, name = "b", description = "2", shortDescription = "-")
         val product3 = ProductTestUtils
@@ -463,46 +463,46 @@ class ProductSqlUtilsTest {
         val site = SiteModel().apply { id = product1.localSiteId }
 
         // Test search in name
-        var products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "a")
+        var products = ProductSqlUtils.getProducts(site, emptyMap(), searchQuery = "a")
         // Products 1 and 3
         assertEquals(2, products.size)
 
-        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "b")
+        products = ProductSqlUtils.getProducts(site, emptyMap(), searchQuery = "b")
         // Products 2 and 3
         assertEquals(2, products.size)
 
         // Product 3
-        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "ab")
+        products = ProductSqlUtils.getProducts(site, emptyMap(), searchQuery = "ab")
         assertEquals(1, products.size)
 
         // Test search in description
-        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "1")
+        products = ProductSqlUtils.getProducts(site, emptyMap(), searchQuery = "1")
         // Products 1 and 3
         assertEquals(2, products.size)
 
-        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "2")
+        products = ProductSqlUtils.getProducts(site, emptyMap(), searchQuery = "2")
         // Products 2 and 3
         assertEquals(2, products.size)
 
-        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "12")
+        products = ProductSqlUtils.getProducts(site, emptyMap(), searchQuery = "12")
         // Product 3
         assertEquals(1, products.size)
 
         // Test search in short description
-        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "+")
+        products = ProductSqlUtils.getProducts(site, emptyMap(), searchQuery = "+")
         // Products 1 and 3
         assertEquals(2, products.size)
 
-        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "-")
+        products = ProductSqlUtils.getProducts(site, emptyMap(), searchQuery = "-")
         // Products 2 and 3
         assertEquals(2, products.size)
 
-        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "+-")
+        products = ProductSqlUtils.getProducts(site, emptyMap(), searchQuery = "+-")
         // Product 3
         assertEquals(1, products.size)
 
         // Test search with filter options
-        products = ProductSqlUtils.getProductsByFilterOptions(site, mapOf(ProductFilterOption.STOCK_STATUS to "instock"), searchQuery = "a")
+        products = ProductSqlUtils.getProducts(site, mapOf(ProductFilterOption.STOCK_STATUS to "instock"), searchQuery = "a")
         // Product 1
         assertEquals(1, products.size)
     }
@@ -520,7 +520,7 @@ class ProductSqlUtilsTest {
         ProductSqlUtils.insertOrUpdateProduct(product3)
 
         val site = SiteModel().apply { id = product1.localSiteId }
-        val products = ProductSqlUtils.getProductsByFilterOptions(
+        val products = ProductSqlUtils.getProducts(
                 site, filterOptions = emptyMap(), excludedProductIds = excludedProductIds
         )
         assertEquals(2, products.size)
@@ -541,13 +541,13 @@ class ProductSqlUtilsTest {
         ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct3)
 
         // verify that the products for the first site is still 2
-        assertEquals(2, ProductSqlUtils.getProductsByFilterOptions(
+        assertEquals(2, ProductSqlUtils.getProducts(
                 site, emptyMap(), excludedProductIds = excludedProductIds
         ).size)
 
         // verify that the products for the second site is also 2
         val site2 = SiteModel().apply { id = differentSiteProduct1.localSiteId }
-        val differentSiteProducts = ProductSqlUtils.getProductsByFilterOptions(
+        val differentSiteProducts = ProductSqlUtils.getProducts(
                 site2, emptyMap(), excludedProductIds = listOf(40, 41)
         )
         assertEquals(1, differentSiteProducts.size)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -450,6 +450,64 @@ class ProductSqlUtilsTest {
     }
 
     @Test
+    fun testGetProductsForSiteWithFilterOptionsAndSearchQuery() {
+        val product1 = ProductTestUtils.generateSampleProduct(40, name = "a", description = "1", shortDescription = "+")
+        val product2 = ProductTestUtils.generateSampleProduct(41, name = "b", description = "2", shortDescription = "-")
+        val product3 = ProductTestUtils
+                .generateSampleProduct(42, name = "xyz ab piu", description = "xyz 12 piu", shortDescription = "xyz +- piu", stockStatus = "onbackorder")
+
+        ProductSqlUtils.insertOrUpdateProduct(product1)
+        ProductSqlUtils.insertOrUpdateProduct(product2)
+        ProductSqlUtils.insertOrUpdateProduct(product3)
+
+        val site = SiteModel().apply { id = product1.localSiteId }
+
+        // Test search in name
+        var products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "a")
+        // Products 1 and 3
+        assertEquals(2, products.size)
+
+        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "b")
+        // Products 2 and 3
+        assertEquals(2, products.size)
+
+        // Product 3
+        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "ab")
+        assertEquals(1, products.size)
+
+        // Test search in description
+        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "1")
+        // Products 1 and 3
+        assertEquals(2, products.size)
+
+        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "2")
+        // Products 2 and 3
+        assertEquals(2, products.size)
+
+        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "12")
+        // Product 3
+        assertEquals(1, products.size)
+
+        // Test search in short description
+        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "+")
+        // Products 1 and 3
+        assertEquals(2, products.size)
+
+        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "-")
+        // Products 2 and 3
+        assertEquals(2, products.size)
+
+        products = ProductSqlUtils.getProductsByFilterOptions(site, emptyMap(), searchQuery = "+-")
+        // Product 3
+        assertEquals(1, products.size)
+
+        // Test search with filter options
+        products = ProductSqlUtils.getProductsByFilterOptions(site, mapOf(ProductFilterOption.STOCK_STATUS to "instock"), searchQuery = "a")
+        // Product 1
+        assertEquals(1, products.size)
+    }
+
+    @Test
     fun testGetProductsForSiteWithExcludedProductIds() {
         val excludedProductIds = listOf(40L)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductSqlUtilsTest.kt
@@ -451,10 +451,12 @@ class ProductSqlUtilsTest {
 
     @Test
     fun testGetProductsWithSearchQuery() {
-        val product1 = ProductTestUtils.generateSampleProduct(40, name = "a", description = "1", shortDescription = "+")
-        val product2 = ProductTestUtils.generateSampleProduct(41, name = "b", description = "2", shortDescription = "-")
-        val product3 = ProductTestUtils
-                .generateSampleProduct(42, name = "xyz ab piu", description = "xyz 12 piu", shortDescription = "xyz +- piu", stockStatus = "onbackorder")
+        val product1 = ProductTestUtils.generateSampleProduct(40, name = "a",
+                description = "1", shortDescription = "+")
+        val product2 = ProductTestUtils.generateSampleProduct(41, name = "b",
+                description = "2", shortDescription = "-")
+        val product3 = ProductTestUtils.generateSampleProduct(42, name = "xyz ab piu",
+                description = "xyz 12 piu", shortDescription = "xyz +- piu", stockStatus = "onbackorder")
 
         ProductSqlUtils.insertOrUpdateProduct(product1)
         ProductSqlUtils.insertOrUpdateProduct(product2)
@@ -502,7 +504,8 @@ class ProductSqlUtilsTest {
         assertEquals(1, products.size)
 
         // Test search with filter options
-        products = ProductSqlUtils.getProducts(site, mapOf(ProductFilterOption.STOCK_STATUS to "instock"), searchQuery = "a")
+        products = ProductSqlUtils.getProducts(site, mapOf(ProductFilterOption.STOCK_STATUS to "instock"),
+                searchQuery = "a")
         // Product 1
         assertEquals(1, products.size)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/ProductTestUtils.kt
@@ -24,7 +24,9 @@ object ProductTestUtils {
         stockStatus: String = CoreProductStockStatus.IN_STOCK.value,
         status: String = "publish",
         stockQuantity: Double = 0.0,
-        categories: String = ""
+        categories: String = "",
+        description: String = "",
+        shortDescription: String = "",
     ): WCProductModel {
         return WCProductModel().apply {
             remoteProductId = remoteId
@@ -36,6 +38,8 @@ object ProductTestUtils {
             this.status = status
             this.stockQuantity = stockQuantity
             this.categories = categories
+            this.description = description
+            this.shortDescription = shortDescription
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -206,7 +206,7 @@ class WCProductStoreTest {
     }
 
     @Test
-    fun testGetProductsByFilterOptions() {
+    fun testGetProductsWithFilterOptions() {
         val filterOptions = mapOf<ProductFilterOption, String>(
                 ProductFilterOption.TYPE to "simple",
                 ProductFilterOption.STOCK_STATUS to "instock",
@@ -230,7 +230,7 @@ class WCProductStoreTest {
         ProductSqlUtils.insertOrUpdateProduct(product4)
 
         val site = SiteModel().apply { id = product1.localSiteId }
-        val products = productStore.getProductsByFilterOptions(site, filterOptions)
+        val products = productStore.getProducts(site, filterOptions)
         assertEquals(1, products.size)
 
         // insert products with the same product options but for a different site
@@ -250,22 +250,22 @@ class WCProductStoreTest {
         ProductSqlUtils.insertOrUpdateProduct(differentSiteProduct4)
 
         // verify that the products for the first site is still 1
-        assertEquals(1, productStore.getProductsByFilterOptions(site, filterOptions).size)
+        assertEquals(1, productStore.getProducts(site, filterOptions).size)
 
         // verify that the products for the second site is 3
         val site2 = SiteModel().apply { id = differentSiteProduct1.localSiteId }
         val filterOptions2 = mapOf(ProductFilterOption.STATUS to "draft")
-        val differentSiteProducts = productStore.getProductsByFilterOptions(site2, filterOptions2)
+        val differentSiteProducts = productStore.getProducts(site2, filterOptions2)
         assertEquals(1, differentSiteProducts.size)
         assertEquals(differentSiteProduct2.status, differentSiteProducts[0].status)
 
         val filterOptions3 = mapOf(ProductFilterOption.STOCK_STATUS to "onbackorder")
-        val differentProductFilters = productStore.getProductsByFilterOptions(site2, filterOptions3)
+        val differentProductFilters = productStore.getProducts(site2, filterOptions3)
         assertEquals(1, differentProductFilters.size)
         assertEquals(differentSiteProduct3.stockStatus, differentProductFilters[0].stockStatus)
 
         val filterByCategory = mapOf(ProductFilterOption.CATEGORY to "1337")
-        val productsFilteredByCategory = productStore.getProductsByFilterOptions(site2, filterByCategory)
+        val productsFilteredByCategory = productStore.getProducts(site2, filterByCategory)
         assertEquals(1, productsFilteredByCategory.size)
         assertTrue(productsFilteredByCategory[0].categories.contains("1337"))
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -176,7 +176,8 @@ object ProductSqlUtils {
         site: SiteModel,
         filterOptions: Map<ProductFilterOption, String>,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
-        excludedProductIds: List<Long>? = null
+        excludedProductIds: List<Long>? = null,
+        searchQuery: String? = null,
     ): List<WCProductModel> {
         val queryBuilder = WellSql.select(WCProductModel::class.java)
                 .where().beginGroup()
@@ -196,6 +197,9 @@ object ProductSqlUtils {
             // [{"id":1377,"name":"Decor","slug":"decor"},{"id":1374,"name":"Hoodies","slug":"hoodies"}]
             val categoryFilter = "\"id\":${filterOptions[ProductFilterOption.CATEGORY]},"
             queryBuilder.contains(WCProductModelTable.CATEGORIES, categoryFilter)
+        }
+        if (searchQuery?.isNotEmpty() == true) {
+            queryBuilder.contains(WCProductModelTable.NAME, searchQuery)
         }
 
         excludedProductIds?.let {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -57,7 +57,7 @@ object ProductSqlUtils {
                 if (filterOptions.isEmpty()) {
                     getProductsForSite(site, sortType)
                 } else {
-                    getProductsByFilterOptions(site, filterOptions, sortType)
+                    getProducts(site, filterOptions, sortType)
                 }
             }
             .flowOn(Dispatchers.IO)
@@ -172,7 +172,7 @@ object ProductSqlUtils {
                 .count().toInt()
     }
 
-    fun getProductsByFilterOptions(
+    fun getProducts(
         site: SiteModel,
         filterOptions: Map<ProductFilterOption, String>,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -199,7 +199,14 @@ object ProductSqlUtils {
             queryBuilder.contains(WCProductModelTable.CATEGORIES, categoryFilter)
         }
         if (searchQuery?.isNotEmpty() == true) {
-            queryBuilder.contains(WCProductModelTable.NAME, searchQuery)
+            queryBuilder
+                    .beginGroup()
+                    .contains(WCProductModelTable.NAME, searchQuery)
+                    .or()
+                    .contains(WCProductModelTable.DESCRIPTION, searchQuery)
+                    .or()
+                    .contains(WCProductModelTable.SHORT_DESCRIPTION, searchQuery)
+                    .endGroup()
         }
 
         excludedProductIds?.let {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -807,9 +807,10 @@ class WCProductStore @Inject constructor(
         site: SiteModel,
         filterOptions: Map<ProductFilterOption, String>,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
-        excludedProductIds: List<Long>? = null
+        excludedProductIds: List<Long>? = null,
+        searchQuery: String? = null,
     ): List<WCProductModel> =
-            ProductSqlUtils.getProductsByFilterOptions(site, filterOptions, sortType, excludedProductIds)
+            ProductSqlUtils.getProductsByFilterOptions(site, filterOptions, sortType, excludedProductIds, searchQuery)
 
     fun getProductsForSite(site: SiteModel, sortType: ProductSorting = DEFAULT_PRODUCT_SORTING) =
             ProductSqlUtils.getProductsForSite(site, sortType)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -799,18 +799,17 @@ class WCProductStore @Inject constructor(
             ProductSqlUtils.getProductsByRemoteIds(site, remoteProductIds)
 
     /**
-     * returns a list of [WCProductModel] for the given [SiteModel] and [filterOptions]
-     * if it exists in the database. To filter by category, make sure the [filterOptions] value
-     * is the category ID in String.
+     * Returns a list of [WCProductModel] for the given [SiteModel], [filterOptions] and [searchQuery].
+     * To filter by category, make sure the [filterOptions] value is the category ID in String.
      */
-    fun getProductsByFilterOptions(
+    fun getProducts(
         site: SiteModel,
         filterOptions: Map<ProductFilterOption, String>,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         excludedProductIds: List<Long>? = null,
         searchQuery: String? = null,
     ): List<WCProductModel> =
-            ProductSqlUtils.getProductsByFilterOptions(site, filterOptions, sortType, excludedProductIds, searchQuery)
+            ProductSqlUtils.getProducts(site, filterOptions, sortType, excludedProductIds, searchQuery)
 
     fun getProductsForSite(site: SiteModel, sortType: ProductSorting = DEFAULT_PRODUCT_SORTING) =
             ProductSqlUtils.getProductsForSite(site, sortType)


### PR DESCRIPTION
This PR adds support for quering products by a searchQuery from the local database. It is used in [this PR in the woocommerce repo](https://github.com/woocommerce/woocommerce-android/pull/8391).

To Test:
[More on WCAndroid repo PR.](https://github.com/woocommerce/woocommerce-android/pull/8391)