### PR TITLE
Fix an unhandled exception

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainsResponse.kt
@@ -38,7 +38,7 @@ data class Domain(
     @SerializedName("current_user_can_manage")
     val currentUserCanManage: Boolean = false,
     @SerializedName("current_user_cannot_add_email_reason")
-    val currentUserCannotAddEmailReason: String? = null,
+    val currentUserCannotAddEmailReason: JsonElement? = null,
     @SerializedName("domain")
     val domain: String? = null,
     @SerializedName("domain_locking_available")


### PR DESCRIPTION
This PR fixes an unhandled exception that is thrown when the `current_user_cannot_add_email_reason` property is returned in a response. The problem is that the the type is wrong -- it's a complex Json object, not a string.

To test this requires a rather specific prerequisites: The response must contain a domain that has been registered by a different user than the one that makes the request. I could reliably reproduce the exception while working on a feature on Woo and this change fixes it. 

Since the property isn't used anywhere (I checked WPAndroid but I requested a review from @ravishanker to make sure I didn't miss anything) and the change actually makes the type more general, it should be safe to merge this.