### PR TITLE
Add new endpoint for launching store

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/onboarding/WooOnboardingFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/onboarding/WooOnboardingFragment.kt
@@ -13,8 +13,6 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.store.OnboardingStore
 import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
@@ -55,16 +53,15 @@ internal class WooOnboardingFragment : StoreSelectingFragment() {
         btnLaunchSite.setOnClickListener {
             selectedSite?.let { site ->
                 lifecycleScope.launch {
-                    when (val result = siteStore.launchSite(site)) {
-                        is Error -> {
+                    val result = siteStore.launchSite(site)
+                    when {
+                        result.isError -> {
                             prependToLog(
                                 "Error launching site. Type:${result.error.type} \n " +
                                     "Message: ${result.error.message}"
                             )
                         }
-                        is Success -> {
-                            prependToLog("Site launched success")
-                        }
+                        else -> prependToLog("Site launched success")
                     }
                 }
             }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/onboarding/WooOnboardingFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/onboarding/WooOnboardingFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import kotlinx.android.synthetic.main.fragment_woo_onboarding.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -12,11 +13,15 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.example.R
 import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.store.OnboardingStore
+import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 
-class WooOnboardingFragment : StoreSelectingFragment() {
-    @Inject internal lateinit var onboardingStore: OnboardingStore
+internal class WooOnboardingFragment : StoreSelectingFragment() {
+    @Inject lateinit var onboardingStore: OnboardingStore
+    @Inject lateinit var siteStore: SiteStore
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
@@ -42,6 +47,24 @@ class WooOnboardingFragment : StoreSelectingFragment() {
                     }
                     result.model?.let {
                         prependToLog("Fetched data: $it")
+                    }
+                }
+            }
+        }
+
+        btnLaunchSite.setOnClickListener {
+            selectedSite?.let { site ->
+                lifecycleScope.launch {
+                    when (val result = siteStore.launchSite(site)) {
+                        is Error -> {
+                            prependToLog(
+                                "Error launching site. Type:${result.error.type} \n " +
+                                    "Message: ${result.error.message}"
+                            )
+                        }
+                        is Success -> {
+                            prependToLog("Site launched success")
+                        }
                     }
                 }
             }

--- a/example/src/main/res/layout/fragment_woo_onboarding.xml
+++ b/example/src/main/res/layout/fragment_woo_onboarding.xml
@@ -21,5 +21,13 @@
             android:enabled="false"
             android:text="Fetch onboarding tasks" />
 
+        <Button
+            android:id="@+id/btnLaunchSite"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Launch site" />
+
     </LinearLayout>
 </ScrollView>

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -36,6 +36,8 @@
 
 /sites/$site/blaze/status
 
+/sites/$site/launch
+
 /users/username/suggestions/
 
 /segments

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -276,6 +276,17 @@ class SiteRestClient @Inject constructor(
         }
     }
 
+    suspend fun launchSite(site: SiteModel) : Response<Unit>{
+        val url = WPCOMV2.sites.site(site.siteId).launch.url
+        return wpComGsonRequestBuilder.syncPostRequest(
+            restClient = this,
+            url = url,
+            params = mapOf(),
+            body = mapOf("site" to site.siteId),
+            Unit::class.java
+        )
+    }
+
     fun fetchSiteEditors(site: SiteModel) {
         val params = mutableMapOf<String, String>()
         val url = WPCOMV2.sites.site(site.siteId).gutenberg.url

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -73,11 +73,11 @@ import org.wordpress.android.fluxc.model.RoleModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.SitesModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.rest.wpapi.site.SiteWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordDeletionResult
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsManager
+import org.wordpress.android.fluxc.network.rest.wpapi.site.SiteWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
@@ -2046,6 +2046,20 @@ open class SiteStore @Inject constructor(
         return coroutineEngine.withDefaultContext(T.API, this, "Fetch domain price") {
             when (val response =
                 siteRestClient.fetchDomainPrice(domainName)) {
+                is Success -> {
+                    WPAPIResponse.Success(response.data)
+                }
+                is Error -> {
+                    WPAPIResponse.Error(WPAPINetworkError(response.error))
+                }
+            }
+        }
+    }
+
+    suspend fun launchSite(site: SiteModel): WPAPIResponse<Unit> {
+        return coroutineEngine.withDefaultContext(T.API, this, "Launch site") {
+            when (val response =
+                siteRestClient.launchSite(site)) {
                 is Success -> {
                     WPAPIResponse.Success(response.data)
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -746,7 +746,7 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    class LaunchSitePayload() : Payload<LaunchSiteError>() {
+    class OnSiteLaunched() : OnChanged<LaunchSiteError>() {
         constructor(error: LaunchSiteError) : this() {
             this.error = error
         }
@@ -2074,11 +2074,11 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    suspend fun launchSite(site: SiteModel): LaunchSitePayload {
+    suspend fun launchSite(site: SiteModel): OnSiteLaunched {
         return coroutineEngine.withDefaultContext(T.API, this, "Launch site") {
             when (val response =
                 siteRestClient.launchSite(site)) {
-                is Success -> LaunchSitePayload()
+                is Success -> OnSiteLaunched()
                 is Error -> {
                     val errorType = when (response.error.apiError) {
                         "unauthorized" -> LaunchSiteErrorType.UNAUTHORIZED
@@ -2086,7 +2086,7 @@ open class SiteStore @Inject constructor(
                         else -> LaunchSiteErrorType.GENERIC_ERROR
                     }
                     val error = LaunchSiteError(errorType, response.error.message)
-                    LaunchSitePayload(error)
+                    OnSiteLaunched(error)
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -107,7 +107,7 @@ import org.wordpress.android.fluxc.store.SiteStore.DeleteSiteErrorType.INVALID_S
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityErrorType.INVALID_DOMAIN_NAME
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesErrorType.INVALID_COUNTRY_CODE
 import org.wordpress.android.fluxc.store.SiteStore.ExportSiteErrorType.GENERIC_ERROR
-import org.wordpress.android.fluxc.store.SiteStore.LaunchStoreErrorType.ALREADY_LAUNCHED
+import org.wordpress.android.fluxc.store.SiteStore.LaunchSiteErrorType.ALREADY_LAUNCHED
 import org.wordpress.android.fluxc.store.SiteStore.PlansErrorType.NOT_AVAILABLE
 import org.wordpress.android.fluxc.store.SiteStore.SelfHostedErrorType.NOT_SET
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.DUPLICATE_SITE
@@ -746,18 +746,18 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    class LaunchStorePayload() : Payload<LaunchStoreError>() {
-        constructor(error: LaunchStoreError) : this() {
+    class LaunchSitePayload() : Payload<LaunchSiteError>() {
+        constructor(error: LaunchSiteError) : this() {
             this.error = error
         }
     }
 
-    data class LaunchStoreError internal constructor(
-        @JvmField val type: LaunchStoreErrorType?,
+    data class LaunchSiteError internal constructor(
+        @JvmField val type: LaunchSiteErrorType?,
         @JvmField val message: String
     ) : OnChangedError
 
-    enum class LaunchStoreErrorType {
+    enum class LaunchSiteErrorType {
         GENERIC_ERROR,
         ALREADY_LAUNCHED,
         UNAUTHORIZED
@@ -2074,19 +2074,19 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    suspend fun launchSite(site: SiteModel): LaunchStorePayload {
+    suspend fun launchSite(site: SiteModel): LaunchSitePayload {
         return coroutineEngine.withDefaultContext(T.API, this, "Launch site") {
             when (val response =
                 siteRestClient.launchSite(site)) {
-                is Success -> LaunchStorePayload()
+                is Success -> LaunchSitePayload()
                 is Error -> {
                     val errorType = when (response.error.apiError) {
-                        "unauthorized" -> LaunchStoreErrorType.UNAUTHORIZED
+                        "unauthorized" -> LaunchSiteErrorType.UNAUTHORIZED
                         "already-launched" -> ALREADY_LAUNCHED
-                        else -> LaunchStoreErrorType.GENERIC_ERROR
+                        else -> LaunchSiteErrorType.GENERIC_ERROR
                     }
-                    val error = LaunchStoreError(errorType, response.error.message)
-                    LaunchStorePayload(error)
+                    val error = LaunchSiteError(errorType, response.error.message)
+                    LaunchSitePayload(error)
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -107,6 +107,7 @@ import org.wordpress.android.fluxc.store.SiteStore.DeleteSiteErrorType.INVALID_S
 import org.wordpress.android.fluxc.store.SiteStore.DomainAvailabilityErrorType.INVALID_DOMAIN_NAME
 import org.wordpress.android.fluxc.store.SiteStore.DomainSupportedStatesErrorType.INVALID_COUNTRY_CODE
 import org.wordpress.android.fluxc.store.SiteStore.ExportSiteErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.SiteStore.LaunchStoreErrorType.ALREADY_LAUNCHED
 import org.wordpress.android.fluxc.store.SiteStore.PlansErrorType.NOT_AVAILABLE
 import org.wordpress.android.fluxc.store.SiteStore.SelfHostedErrorType.NOT_SET
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.DUPLICATE_SITE
@@ -743,6 +744,23 @@ open class SiteStore @Inject constructor(
         constructor(site: SiteModel, error: BaseNetworkError): this(site) {
             this.error = OnApplicationPasswordDeleteError(error)
         }
+    }
+
+    class LaunchStorePayload() : Payload<LaunchStoreError>() {
+        constructor(error: LaunchStoreError) : this() {
+            this.error = error
+        }
+    }
+
+    data class LaunchStoreError internal constructor(
+        @JvmField val type: LaunchStoreErrorType?,
+        @JvmField val message: String
+    ) : OnChangedError
+
+    enum class LaunchStoreErrorType {
+        GENERIC_ERROR,
+        ALREADY_LAUNCHED,
+        UNAUTHORIZED
     }
 
     class OnApplicationPasswordDeleteError(error: BaseNetworkError) : OnChangedError {
@@ -2056,15 +2074,19 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    suspend fun launchSite(site: SiteModel): WPAPIResponse<Unit> {
+    suspend fun launchSite(site: SiteModel): LaunchStorePayload {
         return coroutineEngine.withDefaultContext(T.API, this, "Launch site") {
             when (val response =
                 siteRestClient.launchSite(site)) {
-                is Success -> {
-                    WPAPIResponse.Success(response.data)
-                }
+                is Success -> LaunchStorePayload()
                 is Error -> {
-                    WPAPIResponse.Error(WPAPINetworkError(response.error))
+                    val errorType = when (response.error.apiError) {
+                        "unauthorized" -> LaunchStoreErrorType.UNAUTHORIZED
+                        "already-launched" -> ALREADY_LAUNCHED
+                        else -> LaunchStoreErrorType.GENERIC_ERROR
+                    }
+                    val error = LaunchStoreError(errorType, response.error.message)
+                    LaunchStorePayload(error)
                 }
             }
         }


### PR DESCRIPTION
Part of [#8425](https://github.com/woocommerce/woocommerce-android/issues/8425)

### Description 
Adds new endpoint to launch stores that are unpublished

### Testing 

1. Create a new WP.com site with `eCommerce` plan 
2. Run example app
3. Navigate to Woo/Store Onboarding/ Select your new site 
4. Click Launch Site
5. See the success log 
6. Click again 
7. Check "Site has already been launched..." error
