### PR TITLE
Magic Link: allow clients to define custom values for the flow and source

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -226,11 +226,11 @@ public class Authenticator {
         params.put("scheme", scheme.toString());
 
         if (payload.flow != null) {
-            params.put("flow", payload.flow.toString());
+            params.put("flow", payload.flow.getName());
         }
 
         if (payload.source != null) {
-            params.put("source", payload.source.toString());
+            params.put("source", payload.source.getName());
         }
 
         if (payload.signupFlowName != null && !TextUtils.isEmpty(payload.signupFlowName)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -85,14 +85,14 @@ public class AccountStore extends Store {
 
     public static class AuthEmailPayload extends Payload<BaseNetworkError> {
         public AuthEmailPayloadScheme scheme;
-        public AuthEmailPayloadFlow flow;
-        public AuthEmailPayloadSource source;
+        public AuthEmailFlow flow;
+        public AuthEmailSource source;
         public String emailOrUsername;
         public String signupFlowName;
         public boolean isSignup;
 
-        public AuthEmailPayload(String emailOrUsername, boolean isSignup, AuthEmailPayloadFlow flow,
-                                AuthEmailPayloadSource source, AuthEmailPayloadScheme scheme) {
+        public AuthEmailPayload(String emailOrUsername, boolean isSignup, AuthEmailFlow flow,
+                                AuthEmailSource source, AuthEmailPayloadScheme scheme) {
             this.emailOrUsername = emailOrUsername;
             this.isSignup = isSignup;
             this.flow = flow;
@@ -123,34 +123,46 @@ public class AccountStore extends Store {
         }
     }
 
-    public enum AuthEmailPayloadFlow {
+    public interface AuthEmailFlow {
+        @NonNull
+        String getName();
+    }
+
+    public enum AuthEmailPayloadFlow implements AuthEmailFlow {
         JETPACK("jetpack");
 
-        private final String mString;
+        private final String mName;
 
-        AuthEmailPayloadFlow(final String s) {
-            mString = s;
+        AuthEmailPayloadFlow(final String name) {
+            mName = name;
         }
 
         @Override
-        public String toString() {
-            return mString;
+        @NonNull
+        public String getName() {
+            return mName;
         }
     }
 
-    public enum AuthEmailPayloadSource {
+    public interface AuthEmailSource {
+        @NonNull
+        String getName();
+    }
+
+    public enum AuthEmailPayloadSource implements AuthEmailSource {
         NOTIFICATIONS("notifications"),
         STATS("stats");
 
-        private final String mString;
+        private final String mName;
 
-        AuthEmailPayloadSource(final String s) {
-            mString = s;
+        AuthEmailPayloadSource(final String name) {
+            mName = name;
         }
 
         @Override
-        public String toString() {
-            return mString;
+        @NonNull
+        public String getName() {
+            return mName;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -101,8 +101,18 @@ public class AccountStore extends Store {
         }
 
         public AuthEmailPayload(String emailOrUsername, boolean isSignup, AuthEmailPayloadFlow flow,
-                                AuthEmailPayloadSource source) {
+                                AuthEmailPayloadSource source, AuthEmailPayloadScheme scheme) {
+            this(emailOrUsername, isSignup, (AuthEmailFlow) flow, (AuthEmailSource) source, scheme);
+        }
+
+        public AuthEmailPayload(String emailOrUsername, boolean isSignup, AuthEmailFlow flow,
+                                AuthEmailSource source) {
             this(emailOrUsername, isSignup, flow, source, null);
+        }
+
+        public AuthEmailPayload(String emailOrUsername, boolean isSignup, AuthEmailPayloadFlow flow,
+                                AuthEmailPayloadSource source) {
+            this(emailOrUsername, isSignup, (AuthEmailFlow) flow, (AuthEmailSource) source);
         }
     }
 


### PR DESCRIPTION
This PR is needed for https://github.com/woocommerce/woocommerce-android/issues/8427, check the discussion pe5sF9-1e3-p2 for why.

Although it was possible to add more values to the already defined enums `AuthEmailPayloadFlow`, I opted to convert it to an interface instead because I think that the other solution doesn't scale well, and would be confusing to have values that are not reusable with other clients, let me know what you think about this.

Since the existing enum types implement the new interfaces, and we kept the constructors that use them, the change shouldn't break anything in the Login library nor the WPAndroid app.

Check the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/8447 for testing instructions.