### PR TITLE
IPP feedback survey bug fix

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderMappingConst.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.model.WCMetaData
 object OrderMappingConst {
     const val CHARGE_ID_KEY = "_charge_id"
     const val SHIPPING_PHONE_KEY = "_shipping_phone"
+    const val RECEIPT_URL_KEY = "receipt_url"
     /**
      * Verify if the Metadata key is not null or a internal store attribute
      * @return false if the `key` is null or starts with the `_` character

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.RECEIPT_URL_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.isDisplayableAttribute
 import javax.inject.Inject
@@ -23,7 +24,9 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                 metaData = gson.toJson(
                         fatModel.getMetaDataList()
                                 .filter {
-                                    it.key == CHARGE_ID_KEY || it.key == SHIPPING_PHONE_KEY
+                                    it.key == CHARGE_ID_KEY ||
+                                            it.key == SHIPPING_PHONE_KEY ||
+                                            it.key == RECEIPT_URL_KEY
                                 }
                 )
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_11_12
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_15_16
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_20_21
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_21_22
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_22_23
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
@@ -49,37 +50,37 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_8_9
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
 
 @Database(
-        version = 23,
-        entities = [
-            AddonEntity::class,
-            AddonOptionEntity::class,
-            CouponEntity::class,
-            CouponEmailEntity::class,
-            GlobalAddonGroupEntity::class,
-            OrderNoteEntity::class,
-            OrderEntity::class,
-            OrderMetaDataEntity::class,
-            InboxNoteEntity::class,
-            InboxNoteActionEntity::class,
-            TopPerformerProductEntity::class
-        ],
-        autoMigrations = [
-            AutoMigration(from = 12, to = 13),
-            AutoMigration(from = 13, to = 14, spec = AutoMigration13to14::class),
-            AutoMigration(from = 14, to = 15, spec = AutoMigration14to15::class),
-            AutoMigration(from = 16, to = 17, spec = AutoMigration16to17::class),
-            AutoMigration(from = 17, to = 18, spec = AutoMigration17to18::class),
-            AutoMigration(from = 18, to = 19, spec = AutoMigration18to19::class),
-            AutoMigration(from = 19, to = 20, spec = AutoMigration19to20::class)
-        ]
+    version = 23,
+    entities = [
+        AddonEntity::class,
+        AddonOptionEntity::class,
+        CouponEntity::class,
+        CouponEmailEntity::class,
+        GlobalAddonGroupEntity::class,
+        OrderNoteEntity::class,
+        OrderEntity::class,
+        OrderMetaDataEntity::class,
+        InboxNoteEntity::class,
+        InboxNoteActionEntity::class,
+        TopPerformerProductEntity::class
+    ],
+    autoMigrations = [
+        AutoMigration(from = 12, to = 13),
+        AutoMigration(from = 13, to = 14, spec = AutoMigration13to14::class),
+        AutoMigration(from = 14, to = 15, spec = AutoMigration14to15::class),
+        AutoMigration(from = 16, to = 17, spec = AutoMigration16to17::class),
+        AutoMigration(from = 17, to = 18, spec = AutoMigration17to18::class),
+        AutoMigration(from = 18, to = 19, spec = AutoMigration18to19::class),
+        AutoMigration(from = 19, to = 20, spec = AutoMigration19to20::class)
+    ]
 )
 @TypeConverters(
-        value = [
-            LocalIdConverter::class,
-            LongListConverter::class,
-            RemoteIdConverter::class,
-            BigDecimalConverter::class
-        ]
+    value = [
+        LocalIdConverter::class,
+        LongListConverter::class,
+        RemoteIdConverter::class,
+        BigDecimalConverter::class
+    ]
 )
 abstract class WCAndroidDatabase : RoomDatabase(), TransactionExecutor {
     abstract val addonsDao: AddonsDao
@@ -92,25 +93,26 @@ abstract class WCAndroidDatabase : RoomDatabase(), TransactionExecutor {
 
     companion object {
         fun buildDb(applicationContext: Context) = Room.databaseBuilder(
-                applicationContext,
-                WCAndroidDatabase::class.java,
-                "wc-android-database"
+            applicationContext,
+            WCAndroidDatabase::class.java,
+            "wc-android-database"
         ).allowMainThreadQueries()
-                .fallbackToDestructiveMigrationOnDowngrade()
-                .fallbackToDestructiveMigrationFrom(1, 2)
-                .addMigrations(MIGRATION_3_4)
-                .addMigrations(MIGRATION_4_5)
-                .addMigrations(MIGRATION_5_6)
-                .addMigrations(MIGRATION_6_7)
-                .addMigrations(MIGRATION_7_8)
-                .addMigrations(MIGRATION_8_9)
-                .addMigrations(MIGRATION_9_10)
-                .addMigrations(MIGRATION_10_11)
-                .addMigrations(MIGRATION_11_12)
-                .addMigrations(MIGRATION_15_16)
-                .addMigrations(MIGRATION_20_21)
-                .addMigrations(MIGRATION_21_22)
-                .build()
+            .fallbackToDestructiveMigrationOnDowngrade()
+            .fallbackToDestructiveMigrationFrom(1, 2)
+            .addMigrations(MIGRATION_3_4)
+            .addMigrations(MIGRATION_4_5)
+            .addMigrations(MIGRATION_5_6)
+            .addMigrations(MIGRATION_6_7)
+            .addMigrations(MIGRATION_7_8)
+            .addMigrations(MIGRATION_8_9)
+            .addMigrations(MIGRATION_9_10)
+            .addMigrations(MIGRATION_10_11)
+            .addMigrations(MIGRATION_11_12)
+            .addMigrations(MIGRATION_15_16)
+            .addMigrations(MIGRATION_20_21)
+            .addMigrations(MIGRATION_21_22)
+            .addMigrations(MIGRATION_22_23)
+            .build()
     }
 
     override suspend fun <R> executeInTransaction(block: suspend () -> R): R =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -49,7 +49,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_8_9
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
 
 @Database(
-        version = 22,
+        version = 23,
         entities = [
             AddonEntity::class,
             AddonOptionEntity::class,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -662,3 +662,74 @@ internal val MIGRATION_21_22 = Migration(21, 22) { database ->
     database.execSQL("CREATE INDEX IF NOT EXISTS `index_AddonEntity_globalGroupLocalId` ON `AddonEntity` (`globalGroupLocalId`)")
     database.execSQL("CREATE INDEX IF NOT EXISTS `index_InboxNoteActions_inboxNoteLocalId` ON `InboxNoteActions` (`inboxNoteLocalId`)")
 }
+
+internal val MIGRATION_22_23 = object : Migration(22, 23) {
+    @Suppress("LongMethod")
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.apply {
+            execSQL("DROP TABLE OrderEntity")
+            // language=RoomSql
+            execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS  `OrderEntity` (
+                  `localSiteId` INTEGER NOT NULL,
+                  `orderId` INTEGER NOT NULL,
+                  `number` TEXT NOT NULL,
+                  `status` TEXT NOT NULL,
+                  `currency` TEXT NOT NULL,
+                  `orderKey` TEXT NOT NULL,
+                  `dateCreated` TEXT NOT NULL,
+                  `dateModified` TEXT NOT NULL,
+                  `total` TEXT NOT NULL,
+                  `totalTax` TEXT NOT NULL,
+                  `shippingTotal` TEXT NOT NULL,
+                  `paymentMethod` TEXT NOT NULL,
+                  `paymentMethodTitle` TEXT NOT NULL,
+                  `datePaid` TEXT NOT NULL,
+                  `pricesIncludeTax` INTEGER NOT NULL,
+                  `customerNote` TEXT NOT NULL,
+                  `discountTotal` TEXT NOT NULL,
+                  `discountCodes` TEXT NOT NULL,
+                  `refundTotal` TEXT NOT NULL,
+                  `billingFirstName` TEXT NOT NULL,
+                  `billingLastName` TEXT NOT NULL,
+                  `billingCompany` TEXT NOT NULL,
+                  `billingAddress1` TEXT NOT NULL,
+                  `billingAddress2` TEXT NOT NULL,
+                  `billingCity` TEXT NOT NULL,
+                  `billingState` TEXT NOT NULL,
+                  `billingPostcode` TEXT NOT NULL,
+                  `billingCountry` TEXT NOT NULL,
+                  `billingEmail` TEXT NOT NULL,
+                  `billingPhone` TEXT NOT NULL,
+                  `shippingFirstName` TEXT NOT NULL,
+                  `shippingLastName` TEXT NOT NULL,
+                  `shippingCompany` TEXT NOT NULL,
+                  `shippingAddress1` TEXT NOT NULL,
+                  `shippingAddress2` TEXT NOT NULL,
+                  `shippingCity` TEXT NOT NULL,
+                  `shippingState` TEXT NOT NULL,
+                  `shippingPostcode` TEXT NOT NULL,
+                  `shippingCountry` TEXT NOT NULL,
+                  `shippingPhone` TEXT NOT NULL,
+                  `lineItems` TEXT NOT NULL,
+                  `shippingLines` TEXT NOT NULL,
+                  `feeLines` TEXT NOT NULL,
+                  `taxLines` TEXT NOT NULL,
+                  `metaData` TEXT NOT NULL,
+                  `paymentUrl` TEXT NOT NULL DEFAULT '',
+                  `isEditable` INTEGER NOT NULL DEFAULT 1,
+                  PRIMARY KEY(`localSiteId`, `orderId`)
+                )
+            """.trimIndent()
+            )
+            execSQL(
+                // language=RoomSql
+                """
+                    CREATE INDEX IF NOT EXISTS `index_OrderEntity_localSiteId_orderId` 
+                    ON `OrderEntity` (`localSiteId`, `orderId`);
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -663,6 +663,14 @@ internal val MIGRATION_21_22 = Migration(21, 22) { database ->
     database.execSQL("CREATE INDEX IF NOT EXISTS `index_InboxNoteActions_inboxNoteLocalId` ON `InboxNoteActions` (`inboxNoteLocalId`)")
 }
 
+/**
+ * We are storing "receipt_url" into the order metadata. The purpose of this migration
+ * is to recreate all of the orders freshly from the API so that the "receipt_url" will be stored
+ * in every orders metadata and not just on the newly created ones.
+ *
+ * We need the "receipt_url" metadata to identify whether the order is an IPP order or not. We
+ * use "receipt_url" along with the "paymentMethod" to identify the IPP order.
+ */
 internal val MIGRATION_22_23 = object : Migration(22, 23) {
     @Suppress("LongMethod")
     override fun migrate(database: SupportSQLiteDatabase) {

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.RECEIPT_URL_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
 import org.wordpress.android.fluxc.utils.json
 
@@ -196,6 +197,47 @@ internal class StripOrderTest {
         // then
         assertThat(fatModel.lineItems).contains(emptyAttributeValue)
         assertThat(strippedOrder.lineItems).contains(emptyAttributeValue)
+    }
+
+    @Test
+    fun `should filter meta data that contains "receipt_url" as key`() {
+        // given
+        val metaDataFromRemote = JsonArray().apply {
+            add(json {
+                "id" To "1"
+                "key" To redundantMemberKey
+            })
+            add(json {
+                "id" To "2"
+                "key" To CHARGE_ID_KEY
+            })
+            add(json {
+                "id" To "3"
+                "key" To SHIPPING_PHONE_KEY
+            })
+            add(json {
+                "id" To "3"
+                "key" To RECEIPT_URL_KEY
+            })
+        }.toString()
+        val fatModel = emptyOrder.copy(metaData = metaDataFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(fatModel.metaData).contains(
+            redundantMemberKey,
+            CHARGE_ID_KEY,
+            SHIPPING_PHONE_KEY,
+            RECEIPT_URL_KEY
+        )
+        assertThat(strippedOrder.metaData)
+            .contains(
+                CHARGE_ID_KEY,
+                SHIPPING_PHONE_KEY,
+                RECEIPT_URL_KEY
+            )
     }
 
     companion object {


### PR DESCRIPTION
### Please make sure to review the corresponding [WooCommerce PR](https://github.com/woocommerce/woocommerce-android/pull/8482) as soon as this PR gets merged. Or better yet, review the WooCommerce PR and get it ready before merging this one.

This PR contains fluxc changes to fix the [IPP survey feedback display logic bug](https://github.com/woocommerce/woocommerce-android/issues/8445). 

### Changes in this PR
1. Store "receipt_url" metadata into the metadata column in the Order database
2. Created a new database migration. The reason for this migration is explained as a comment in the `Migrations.kt` file