### PR TITLE
[Build] Remove Gradle Enterprise from Project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,3 +74,5 @@ ext {
 dependencies {
     detektPlugins sharedLibs.detekt.formatting
 }
+
+apply from: './config/gradle/gradle_build_scan.gradle'

--- a/config/gradle/gradle_build_cache.gradle
+++ b/config/gradle/gradle_build_cache.gradle
@@ -1,0 +1,12 @@
+
+// Only run build cache on CI builds.
+if (System.getenv('CI')) {
+    buildCache {
+        remote(HttpBuildCache) {
+            url = "http://10.0.2.215:5071/cache/"
+            allowUntrustedServer = true
+            allowInsecureProtocol = true
+            push = true
+        }
+    }
+}

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,0 +1,11 @@
+
+// Only run build scan on CI builds.
+if (System.getenv('CI')) {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+        tag 'CI'
+        publishAlways()
+        uploadInBackground = false
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -53,30 +53,6 @@ dependencyResolutionManagement {
     }
 }
 
-gradleEnterprise {
-    server = "https://gradle.a8c.com"
-    allowUntrustedServer = false
-    buildScan {
-        def disableGE = System.getenv("GRADLE_ENTERPRISE_ANALYTICS_DISABLE")
-        if (!(disableGE == "1" || disableGE == "true")) {
-            publishAlways()
-        }
-        capture {
-            taskInputFiles = true
-        }
-        uploadInBackground = System.getenv("CI") == null
-
-        if (!System.getenv().containsKey("CI")) {
-            // Obfuscate personal data unless it's a CI build
-            obfuscation {
-                username { username -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_USERNAME") ?: username }
-                hostname { hostname -> System.getenv("GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME") ?: hostname }
-                ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
-            }
-        }
-    }
-}
-
 rootProject.name = 'FluxC'
 
 include ':fluxc',

--- a/settings.gradle
+++ b/settings.gradle
@@ -60,3 +60,5 @@ include ':fluxc',
         ':plugins:woocommerce',
         ':example',
         ':tests:api'
+
+apply from: './config/gradle/gradle_build_cache.gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,7 +19,6 @@ pluginManagement {
 
 plugins {
     id 'com.gradle.enterprise' version '3.9'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.5'
 }
 
 def catalogVersion = "1.5.0"


### PR DESCRIPTION
### Description

Since `Gradle Enterprise (GE)` is shut down, at least temporarily (see `paaHJt-4Ap-p2`), this PR removes the existing `Gradle Enterprise` configuration as well (c1f7775831a42bf8865c193960c25d778a2418a1 + c60ba6c5d271211425e87f7abbd4da14a2ca354e).

Also, this PR adds back the previously removed custom Gradle related `buildCache` configuration on `CI` builds only (cb15e2fc1e04c93805819eb3927d2950f255f8b4), while also adding a custom Gradle related `buildScan` configuration, again, on `CI` builds only (07d8bd09624de1d3cd92dd087c2820723d85225a).

PS: I also chose not to bring back the `GRADLE_ENTERPRISE_ANALYTICS_DISABLE`, `GRADLE_ENTERPRISE_ANALYTICS_USERNAME`, and `GRADLE_ENTERPRISE_ANALYTICS_HOSTNAME` configuration that was added to `buildScan` afterwards (#2382). And this was done due to the fact that automatic build scan publishing is disabled for `LOCAL` builds anyway. As such, I don't think this kind of obfuscation is still necessary for when working without `Gradle Enterprise`. 🤔

### Testing instructions

- (`GE`): Verify `LOCAL` and `CI` builds no longer output the `A network error occurred.` error at the end of the build, related to it failing to connect to `Gradle Enterprise` since it has been shut down for day now.
- (`buildScan`): Verify `CI` builds are publishing the build scan at the end of the build, and create the corresponding build scan link.
- (`buildCache`): Verify `CI` builds are able to use the remote build cache. FYI: You can do that by looking at the build scan that is published on `CI` (looks for `Avoidance savings`, up to date and local/remote build cache savings).

⚠️ [Buildkite](https://buildkite.com/automattic/wordpress-fluxc-android/builds/2255#0186b7cf-a01e-442a-8b19-c52317f92809) -> [Build Scan](https://scans.gradle.com/s/4jnayqmfn34dy/performance/execution) -> `Performance` -> `Task execusion` 🤔

![image](https://user-images.githubusercontent.com/9729923/223178276-1035e422-bef7-4eaa-9264-a341a4a039e5.png)

FYI: About the ⚠️ 🤔 above I am actually not sure what is happening, but I am going to investigate it further tomorrow and see if I could figure this out.