### PR TITLE
Support "coming soon" state. Allow clients to specify own site creation flow

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -202,7 +202,6 @@ class SiteRestClientTest {
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
         val findAvailableUrl = true
-        val isComingSoon = false
 
         val result = restClient.newSite(
             siteName,
@@ -213,7 +212,6 @@ class SiteRestClientTest {
             segmentId,
             siteDesign,
             findAvailableUrl,
-            isComingSoon,
             dryRun
         )
 
@@ -236,7 +234,6 @@ class SiteRestClientTest {
                                 "site_segment" to segmentId,
                                 "template" to siteDesign,
                                 "timezone_string" to timeZoneId,
-                                "wpcom_public_coming_soon" to "0"
                         )
                 )
         )
@@ -263,8 +260,6 @@ class SiteRestClientTest {
         val segmentId = 123L
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
-        val isComingSoon = false
-
 
         val result = restClient.newSite(
             siteName,
@@ -275,7 +270,6 @@ class SiteRestClientTest {
             segmentId,
             siteDesign,
             null,
-            isComingSoon,
             dryRun
         )
 
@@ -299,7 +293,6 @@ class SiteRestClientTest {
                     "template" to siteDesign,
                     "site_creation_flow" to "with-design-picker",
                     "timezone_string" to timeZoneId,
-                    "wpcom_public_coming_soon" to "0"
                 )
             )
         )
@@ -326,7 +319,6 @@ class SiteRestClientTest {
         val segmentId = 123L
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
-        val isComingSoon = false
 
         val result = restClient.newSite(
             siteName,
@@ -337,7 +329,6 @@ class SiteRestClientTest {
             segmentId,
             siteDesign,
             null,
-            isComingSoon,
             dryRun
         )
 
@@ -360,7 +351,6 @@ class SiteRestClientTest {
                     "template" to siteDesign,
                     "site_creation_flow" to "with-design-picker",
                     "timezone_string" to timeZoneId,
-                    "wpcom_public_coming_soon" to "0"
                 )
             )
         )
@@ -385,7 +375,6 @@ class SiteRestClientTest {
         val language = "CZ"
         val visibility = SiteVisibility.PRIVATE
         val timeZoneId = "Europe/London"
-        val isComingSoon = false
 
         val result = restClient.newSite(
             siteName,
@@ -396,7 +385,6 @@ class SiteRestClientTest {
             null,
             null,
             null,
-            isComingSoon,
             dryRun
         )
 
@@ -415,7 +403,6 @@ class SiteRestClientTest {
                         "client_secret" to appSecret,
                         "options" to mapOf<String, Any>(
                             "timezone_string" to timeZoneId,
-                            "wpcom_public_coming_soon" to "0"
                         )
                 )
         )

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteWPComRestResponse
 import org.wordpress.android.fluxc.store.SiteStore.PostFormatsErrorType
 import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
+import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.COMING_SOON
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import org.wordpress.android.fluxc.test
 import kotlin.test.assertNotNull
@@ -211,8 +212,7 @@ class SiteRestClientTest {
             segmentId,
             siteDesign,
             findAvailableUrl,
-            dryRun,
-            emptyMap()
+            dryRun
         )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
@@ -270,8 +270,7 @@ class SiteRestClientTest {
             segmentId,
             siteDesign,
             null,
-            dryRun,
-            emptyMap()
+            dryRun
         )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
@@ -330,8 +329,7 @@ class SiteRestClientTest {
             segmentId,
             siteDesign,
             null,
-            dryRun,
-            emptyMap()
+            dryRun
         )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
@@ -387,8 +385,7 @@ class SiteRestClientTest {
             null,
             null,
             null,
-            dryRun,
-            emptyMap()
+            dryRun
         )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
@@ -442,6 +439,25 @@ class SiteRestClientTest {
 
         assertNotNull(errorResponse.error)
         assertThat(errorResponse.error.type).isEqualTo(PostFormatsErrorType.GENERIC_ERROR)
+    }
+
+    @Test
+    fun `creates new site in coming soon state`() = test {
+        // given
+        whenever(appSecrets.appId).thenReturn("")
+        whenever(appSecrets.appSecret).thenReturn("")
+        initNewSiteResponse()
+
+        // when
+        restClient.newSite("", "", "", "", visibility = COMING_SOON, null, null, null, false)
+
+        // then
+        val body = bodyCaptor.lastValue
+        @Suppress("UNCHECKED_CAST")
+        val options = body["options"] as Map<String, String>
+
+        assertThat(body).containsEntry("public", "0")
+        assertThat(options).containsEntry("wpcom_public_coming_soon", "1")
     }
 
     private suspend fun initSiteResponse(

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -208,7 +208,8 @@ class SiteRestClientTest {
             visibility,
             segmentId,
             siteDesign,
-            dryRun
+            dryRun,
+            emptyMap()
         )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
@@ -264,7 +265,8 @@ class SiteRestClientTest {
             visibility,
             segmentId,
             siteDesign,
-            dryRun
+            dryRun,
+            emptyMap()
         )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
@@ -322,7 +324,8 @@ class SiteRestClientTest {
             visibility,
             segmentId,
             siteDesign,
-            dryRun
+            dryRun,
+            emptyMap()
         )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)
@@ -377,7 +380,8 @@ class SiteRestClientTest {
             visibility,
             null,
             null,
-            dryRun
+            dryRun,
+            emptyMap()
         )
 
         assertThat(result.newSiteRemoteId).isEqualTo(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -460,6 +460,37 @@ class SiteRestClientTest {
         assertThat(options).containsEntry("wpcom_public_coming_soon", "1")
     }
 
+    @Test
+    fun `creates new site with override site creation flow if specified`() = test {
+        // given
+        whenever(appSecrets.appId).thenReturn("")
+        whenever(appSecrets.appSecret).thenReturn("")
+        initNewSiteResponse()
+
+        val siteCreationFlow = "sample_creation_flow"
+
+        // when
+        restClient.newSite(
+            null,
+            "",
+            "",
+            "",
+            visibility = COMING_SOON,
+            null,
+            null,
+            null,
+            false,
+            siteCreationFlow = siteCreationFlow
+        )
+
+        // then
+        val body = bodyCaptor.lastValue
+        @Suppress("UNCHECKED_CAST")
+        val options = body["options"] as Map<String, String>
+
+        assertThat(options).containsEntry("site_creation_flow", siteCreationFlow)
+    }
+
     private suspend fun initSiteResponse(
         data: SiteWPComRestResponse? = null,
         error: WPComGsonNetworkError? = null

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -224,7 +224,6 @@ class SiteStoreTest {
                         null,
                         null,
                         null,
-                        null,
                         payload.dryRun
                 )
         ).thenReturn(response)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -196,8 +196,7 @@ class SiteStoreTest {
                         null,
                         null,
                         null,
-                        payload.dryRun,
-                        emptyMap()
+                        payload.dryRun
                 )
         ).thenReturn(response)
 
@@ -225,8 +224,7 @@ class SiteStoreTest {
                         null,
                         null,
                         null,
-                        payload.dryRun,
-                        payload.additionalOptions
+                        payload.dryRun
                 )
         ).thenReturn(response)
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -192,7 +192,8 @@ class SiteStoreTest {
                         payload.visibility,
                         null,
                         null,
-                        payload.dryRun
+                        payload.dryRun,
+                        payload.additionalOptions
                 )
         ).thenReturn(response)
 
@@ -218,7 +219,8 @@ class SiteStoreTest {
                         payload.visibility,
                         null,
                         null,
-                        payload.dryRun
+                        payload.dryRun,
+                        payload.additionalOptions
                 )
         ).thenReturn(response)
 

--- a/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -134,6 +134,8 @@
 
 /sites/$site/homepage
 
+/sites/$site/ecommerce-trial/add/$plan_slug#String
+
 /users/new/
 /users/social/new
 /users/$emailOrUsername#String/auth-options

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -213,7 +213,8 @@ class SiteRestClient @Inject constructor(
         visibility: SiteVisibility,
         segmentId: Long?,
         siteDesign: String?,
-        dryRun: Boolean
+        dryRun: Boolean,
+        additionalOptions: Map<String, String>
     ): NewSiteResponsePayload {
         val url = WPCOMREST.sites.new_.urlV1_1
         val body = mutableMapOf<String, Any>()
@@ -243,6 +244,8 @@ class SiteRestClient @Inject constructor(
         if (timeZoneId != null) {
             options["timezone_string"] = timeZoneId
         }
+
+        options += additionalOptions
 
         // Add site options if available
         if (options.isNotEmpty()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -219,6 +219,7 @@ class SiteRestClient @Inject constructor(
         siteDesign: String?,
         findAvailableUrl: Boolean?,
         dryRun: Boolean,
+        siteCreationFlow: String? = null
     ): NewSiteResponsePayload {
         val url = WPCOMREST.sites.new_.urlV1_1
         val body = mutableMapOf<String, Any>()
@@ -250,6 +251,9 @@ class SiteRestClient @Inject constructor(
         }
         if (timeZoneId != null) {
             options["timezone_string"] = timeZoneId
+        }
+        if (siteCreationFlow != null) {
+            options["site_creation_flow"] = siteCreationFlow
         }
 
         // Add site options if available

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -176,7 +176,6 @@ open class SiteStore @Inject constructor(
      * @param segmentId The segment that the site belongs to
      * @param siteDesign The design template of the site
      * @param dryRun If set to true the call only validates the parameters passed
-     * @param isComingSoon The "coming soon" flag, which hides the site content from the public
      */
     data class NewSitePayload(
         @JvmField val siteName: String?,
@@ -1621,7 +1620,6 @@ open class SiteStore @Inject constructor(
                 payload.segmentId,
                 payload.siteDesign,
                 payload.findAvailableUrl,
-                payload.isComingSoon,
                 payload.dryRun,
                 payload.siteCreationFlow
         )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -186,7 +186,8 @@ open class SiteStore @Inject constructor(
         @JvmField val segmentId: Long? = null,
         @JvmField val siteDesign: String? = null,
         @JvmField val dryRun: Boolean,
-        @JvmField val findAvailableUrl: Boolean? = null
+        @JvmField val findAvailableUrl: Boolean? = null,
+        @JvmField val siteCreationFlow: String? = null
     ) : Payload<BaseNetworkError>() {
         constructor(
             siteName: String?,
@@ -1619,7 +1620,8 @@ open class SiteStore @Inject constructor(
                 payload.segmentId,
                 payload.siteDesign,
                 payload.findAvailableUrl,
-                payload.dryRun
+                payload.dryRun,
+                payload.siteCreationFlow
         )
         return handleCreateNewSiteCompleted(
                 payload = result

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -185,7 +185,8 @@ open class SiteStore @Inject constructor(
         @JvmField val visibility: SiteVisibility,
         @JvmField val segmentId: Long? = null,
         @JvmField val siteDesign: String? = null,
-        @JvmField val dryRun: Boolean
+        @JvmField val dryRun: Boolean,
+        @JvmField val additionalOptions: Map<String, String> = emptyMap()
     ) : Payload<BaseNetworkError>() {
         constructor(
             siteName: String?,
@@ -1595,7 +1596,8 @@ open class SiteStore @Inject constructor(
                 payload.visibility,
                 payload.segmentId,
                 payload.siteDesign,
-                payload.dryRun
+                payload.dryRun,
+                payload.additionalOptions
         )
         return handleCreateNewSiteCompleted(
                 payload = result

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -186,8 +186,7 @@ open class SiteStore @Inject constructor(
         @JvmField val segmentId: Long? = null,
         @JvmField val siteDesign: String? = null,
         @JvmField val dryRun: Boolean,
-        @JvmField val findAvailableUrl: Boolean? = null,
-        @JvmField val additionalOptions: Map<String, String> = emptyMap()
+        @JvmField val findAvailableUrl: Boolean? = null
     ) : Payload<BaseNetworkError>() {
         constructor(
             siteName: String?,
@@ -1054,7 +1053,10 @@ open class SiteStore @Inject constructor(
     }
 
     enum class SiteVisibility(private val mValue: Int) {
-        PRIVATE(-1), BLOCK_SEARCH_ENGINE(0), PUBLIC(1);
+        PRIVATE(-1),
+        BLOCK_SEARCH_ENGINE(0),
+        PUBLIC(1),
+        COMING_SOON(999);
 
         fun value(): Int {
             return mValue
@@ -1617,8 +1619,7 @@ open class SiteStore @Inject constructor(
                 payload.segmentId,
                 payload.siteDesign,
                 payload.findAvailableUrl,
-                payload.dryRun,
-                payload.additionalOptions
+                payload.dryRun
         )
         return handleCreateNewSiteCompleted(
                 payload = result


### PR DESCRIPTION
### Description

This PR adds 2 features to the site creation API

#### 1. Support of the "Coming Soon" state

For reference, please see https://github.com/woocommerce/woocommerce-android/pull/8582#pullrequestreview-1350254556

#### 2. Support specifying "site creation flow" by clients

It's needed for the Free Trial site creation (the flow will be "wooexpress"). 