### PR TITLE
Support finding an available url via site creation api

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/SitesFragment.java
@@ -176,6 +176,7 @@ public class SitesFragment extends Fragment {
                 defaultLanguage,
                 defaultTimeZoneId,
                 SiteVisibility.PUBLIC,
+                null,
                 true);
         mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload));
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -104,7 +104,7 @@ class SiteRestClientTest {
         )
         val errorResponse = restClient.fetchSite(site)
 
-        assertThat(errorResponse.error).isNotNull()
+        assertNotNull(errorResponse.error)
         assertThat(errorResponse.error.type).isEqualTo(GenericErrorType.NETWORK_ERROR)
         assertThat(errorResponse.error.message).isEqualTo(errorMessage)
     }
@@ -173,7 +173,7 @@ class SiteRestClientTest {
         )
         val errorResponse = restClient.fetchSites(listOf(), false)
 
-        assertThat(errorResponse.error).isNotNull()
+        assertNotNull(errorResponse.error)
         assertThat(errorResponse.error.type).isEqualTo(GenericErrorType.NETWORK_ERROR)
         assertThat(errorResponse.error.message).isEqualTo(errorMessage)
     }
@@ -199,6 +199,7 @@ class SiteRestClientTest {
         val segmentId = 123L
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
+        val findAvailableUrl = true
 
         val result = restClient.newSite(
             siteName,
@@ -208,6 +209,7 @@ class SiteRestClientTest {
             visibility,
             segmentId,
             siteDesign,
+            findAvailableUrl,
             dryRun
         )
 
@@ -223,6 +225,7 @@ class SiteRestClientTest {
                         "lang_id" to language,
                         "public" to "1",
                         "validate" to "0",
+                        "find_available_url" to findAvailableUrl.toString(),
                         "client_id" to appId,
                         "client_secret" to appSecret,
                         "options" to mapOf<String, Any>(
@@ -264,6 +267,7 @@ class SiteRestClientTest {
             visibility,
             segmentId,
             siteDesign,
+            null,
             dryRun
         )
 
@@ -322,6 +326,7 @@ class SiteRestClientTest {
             visibility,
             segmentId,
             siteDesign,
+            null,
             dryRun
         )
 
@@ -375,6 +380,7 @@ class SiteRestClientTest {
             language,
             timeZoneId,
             visibility,
+            null,
             null,
             null,
             dryRun

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import org.wordpress.android.fluxc.test
+import kotlin.test.assertNotNull
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteRestClientTest {
@@ -435,7 +436,7 @@ class SiteRestClientTest {
         )
         val errorResponse = restClient.fetchPostFormats(site)
 
-        assertThat(errorResponse.error).isNotNull()
+        assertNotNull(errorResponse.error)
         assertThat(errorResponse.error.type).isEqualTo(PostFormatsErrorType.GENERIC_ERROR)
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -469,7 +469,7 @@ class SiteRestClientTest {
     }
 
     private suspend fun <T> initGetResponse(
-        kclass: Class<T>,
+        clazz: Class<T>,
         data: T,
         error: WPComGsonNetworkError? = null
     ): Response<T> {
@@ -479,7 +479,7 @@ class SiteRestClientTest {
                         eq(restClient),
                         urlCaptor.capture(),
                         paramsCaptor.capture(),
-                        eq(kclass),
+                        eq(clazz),
                         any(),
                         any(),
                         any()
@@ -490,7 +490,7 @@ class SiteRestClientTest {
     }
 
     private suspend fun <T> initPostResponse(
-        kclass: Class<T>,
+        clazz: Class<T>,
         data: T,
         error: WPComGsonNetworkError? = null
     ): Response<T> {
@@ -501,7 +501,7 @@ class SiteRestClientTest {
                         urlCaptor.capture(),
                         paramsCaptor.capture(),
                         bodyCaptor.capture(),
-                        eq(kclass),
+                        eq(clazz),
                         anyOrNull(),
                         anyOrNull(),
                 )

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
+import kotlin.test.assertEquals
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteStoreTest {
@@ -180,19 +181,22 @@ class SiteStoreTest {
     @Test
     fun `creates a new site`() = test {
         val dryRun = false
-        val payload = NewSitePayload("New site", "CZ", "Europe/London", PUBLIC, dryRun)
+        val name = "New site"
+        val payload = NewSitePayload(name, null, "CZ", "Europe/London", PUBLIC, null, dryRun)
         val newSiteRemoteId: Long = 123
-        val response = NewSiteResponsePayload(newSiteRemoteId, dryRun = dryRun)
+        val url = "new.wp.com"
+        val response = NewSiteResponsePayload(newSiteRemoteId, siteUrl = url, dryRun)
         whenever(
                 siteRestClient.newSite(
-                        payload.siteName,
+                        name,
                         null,
                         payload.language,
                         payload.timeZoneId,
                         payload.visibility,
                         null,
                         null,
-                        payload.dryRun
+                        null,
+                        payload.dryRun,
                 )
         ).thenReturn(response)
 
@@ -200,6 +204,7 @@ class SiteStoreTest {
 
         assertThat(result.dryRun).isEqualTo(dryRun)
         assertThat(result.newSiteRemoteId).isEqualTo(newSiteRemoteId)
+        assertEquals(url, result.url)
     }
 
     @Test
@@ -216,6 +221,7 @@ class SiteStoreTest {
                         payload.language,
                         payload.timeZoneId,
                         payload.visibility,
+                        null,
                         null,
                         null,
                         payload.dryRun

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -213,7 +213,8 @@ class SiteRestClient @Inject constructor(
         visibility: SiteVisibility,
         segmentId: Long?,
         siteDesign: String?,
-        dryRun: Boolean
+        findAvailableUrl: Boolean?,
+        dryRun: Boolean,
     ): NewSiteResponsePayload {
         val url = WPCOMREST.sites.new_.urlV1_1
         val body = mutableMapOf<String, Any>()
@@ -224,6 +225,7 @@ class SiteRestClient @Inject constructor(
         body["validate"] = if (dryRun) "1" else "0"
         body["client_id"] = appSecrets.appId
         body["client_secret"] = appSecrets.appSecret
+        findAvailableUrl?.let { body["find_available_url"] = it.toString() }
 
         if (siteTitle != null) {
             body["blog_title"] = siteTitle

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -217,8 +217,9 @@ open class SiteStore @Inject constructor(
             language: String,
             timeZoneId: String,
             visibility: SiteVisibility,
+            findAvailableUrl: Boolean?,
             dryRun: Boolean
-        ) : this(siteName, siteTitle, language, timeZoneId, visibility, null, null, dryRun)
+        ) : this(siteName, siteTitle, language, timeZoneId, visibility, null, null, dryRun, findAvailableUrl)
     }
 
     data class FetchedPostFormatsPayload(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1596,7 +1596,8 @@ open class SiteStore @Inject constructor(
                 payload.visibility,
                 payload.segmentId,
                 payload.siteDesign,
-                payload.dryRun
+                payload.findAvailableUrl,
+                payload.dryRun,
         )
         return handleCreateNewSiteCompleted(
                 payload = result

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -185,7 +185,8 @@ open class SiteStore @Inject constructor(
         @JvmField val visibility: SiteVisibility,
         @JvmField val segmentId: Long? = null,
         @JvmField val siteDesign: String? = null,
-        @JvmField val dryRun: Boolean
+        @JvmField val dryRun: Boolean,
+        @JvmField val findAvailableUrl: Boolean? = null,
     ) : Payload<BaseNetworkError>() {
         constructor(
             siteName: String?,


### PR DESCRIPTION
Resolves wordpress-mobile/WordPress-Android#17905 (api side)

This PR:
- ★ Adds a backwards-compatible solution to pass `find_available_url` to the `sites/new` api

## To Test
- Test PR wordpress-mobile/WordPress-Android#18108