### PR TITLE
Improve error handling of the Cookie+Nonce authentication

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -331,7 +331,7 @@ class MainFragment : Fragment() {
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onSiteChanged(event: OnSiteChanged) {
         if (event.isError) {
-            prependToLog("SiteChanged error: " + event.error?.type)
+            prependToLog("SiteChanged error: " + event.error)
             return
         }
         if (siteStore.hasSite()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
@@ -48,9 +47,7 @@ class SiteWPAPIRestClient @Inject constructor(
             password = payload.password
         ) { wpApiUrl, nonce ->
             if (nonce !is Available) {
-                val networkError = (nonce as? FailedRequest)?.networkError ?: WPAPINetworkError(
-                    BaseNetworkError(GenericErrorType.UNKNOWN)
-                )
+                val networkError = (nonce as? FailedRequest)?.networkError ?: BaseNetworkError(GenericErrorType.UNKNOWN)
 
                 return@makeAuthenticatedWPAPIRequest SiteModel().apply {
                     error = networkError

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -467,7 +467,8 @@ open class SiteStore @Inject constructor(
     data class SiteError @JvmOverloads constructor(
         @JvmField val type: SiteErrorType,
         @JvmField val message: String? = null,
-        @JvmField val selfHostedErrorType: SelfHostedErrorType = NOT_SET
+        @JvmField val selfHostedErrorType: SelfHostedErrorType = NOT_SET,
+        @JvmField val wpApiError: WPAPIError? = null
     ) : OnChangedError
 
     data class SiteEditorsError internal constructor(
@@ -918,6 +919,23 @@ open class SiteStore @Inject constructor(
         NOT_SET,
         XML_RPC_SERVICES_DISABLED,
         UNABLE_TO_READ_SITE
+    }
+
+    data class WPAPIError(
+        val errorType: WPAPIErrorType?,
+        val statusCode: Int?
+    )
+
+    enum class WPAPIErrorType {
+        CUSTOM_LOGIN_URL,
+        CUSTOM_ADMIN_URL;
+
+        companion object {
+            fun fromString(type: String?): WPAPIErrorType? {
+                return if (type.isNullOrEmpty()) null
+                else WPAPIErrorType.values().firstOrNull { it.name == type }
+            }
+        }
     }
 
     enum class DeleteSiteErrorType {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteErrorUtils.java
@@ -1,13 +1,17 @@
 package org.wordpress.android.fluxc.utils;
 
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError;
 import org.wordpress.android.fluxc.store.SiteStore.SelfHostedErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteError;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
+import org.wordpress.android.fluxc.store.SiteStore.WPAPIError;
+import org.wordpress.android.fluxc.store.SiteStore.WPAPIErrorType;
 
 public class SiteErrorUtils {
     public static SiteError genericToSiteError(BaseNetworkError error) {
         SiteErrorType errorType = SiteErrorType.GENERIC_ERROR;
+        WPAPIError wpapiError = null;
         if (error.isGeneric()) {
             switch (error.type) {
                 case INVALID_RESPONSE:
@@ -19,7 +23,17 @@ public class SiteErrorUtils {
             }
         }
 
-        SiteError siteError = new SiteError(errorType, error.message);
+        if (error instanceof WPAPINetworkError) {
+            String errorCode = ((WPAPINetworkError) error).getErrorCode();
+            wpapiError = new WPAPIError(
+                    WPAPIErrorType.Companion.fromString(errorCode),
+                    error.hasVolleyError() && error.volleyError.networkResponse != null
+                            ? error.volleyError.networkResponse.statusCode
+                            : 200 // volleyError will be missing when the request succeeds but the response is invalid
+            );
+        }
+
+        SiteError siteError = new SiteError(errorType, error.message, SelfHostedErrorType.NOT_SET, wpapiError);
 
         switch (error.xmlRpcErrorType) {
             case METHOD_NOT_ALLOWED:


### PR DESCRIPTION
This PR improves the error handling for the Cookie+Nonce authentication, the goal is to allow differentiating between the different causes of the issue:

1. If we receive a 200 from the wp-login.php URL, then we try to extract the error message from the received page, and then we return it with a status "NOT_AUTHENTICATED", and if the extraction fails, we consider the error as "INVALID_RESPONSE".
2. If we receive 404 from the wp-login.php, we report it as CUSTOM_LOGIN_URL
3. If we reveive 404 from wp-admin URL, we report it as CUSTOM_ADMIN_URL (this can't be reproduced, check p1678898799819319-slack-C046HDZL87J for more details.
4. If we receive other errors, we report them as GENERIC.

##### Testing
Check the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/8562