### PR TITLE
Support POST requests in React Native store

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
@@ -37,7 +37,7 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
             }
 
             // media queries with a context of 'view' do not require authentication
-            reactNativeStore.executeRequest(site, "wp/v2/media?context=view")
+            reactNativeStore.executeGetRequest(site, "wp/v2/media?context=view")
         }
 
         val assertionMessage = "Call unexpectedly failed with error: ${(response as? Error)?.error?.message}"
@@ -56,7 +56,7 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
             }
 
             // media queries with a context of 'edit' require authentication
-            reactNativeStore.executeRequest(siteWithCustomRestEndpoint, "wp/v2/media?context=edit")
+            reactNativeStore.executeGetRequest(siteWithCustomRestEndpoint, "wp/v2/media?context=edit")
         }
 
         val assertionMessage = "Call unexpectedly failed with error: ${(response as? Error)?.error?.message}"
@@ -78,13 +78,13 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
 
             // media queries with a context of 'edit' require authentication
             // this request will fail because of the self signed ssl certificate ("Invalid SSL certificate")
-            reactNativeStore.executeRequest(siteUsingSsl, "wp/v2/media?context=edit")
+            reactNativeStore.executeGetRequest(siteUsingSsl, "wp/v2/media?context=edit")
 
             // Add an exception for the last failure of certificate validation
             memorizingTrustManager.storeLastFailure()
 
             // Retry to run the same media query (media queries with a context of 'edit' require authentication)
-            reactNativeStore.executeRequest(siteUsingSsl, "wp/v2/media?context=edit")
+            reactNativeStore.executeGetRequest(siteUsingSsl, "wp/v2/media?context=edit")
         }
 
         memorizingTrustManager.clearLocalTrustStore()
@@ -103,7 +103,7 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
                 password = BuildConfig.TEST_WPORG_PASSWORD_SH_WPAPI_SIMPLE
             }
 
-            reactNativeStore.executeRequest(site, "wp/v2/an-invalid-endpoint")
+            reactNativeStore.executeGetRequest(site, "wp/v2/an-invalid-endpoint")
         }
 
         val assertionMessage = "Call should have failed with a 404, instead response was $response"

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
@@ -29,14 +29,14 @@ class ReleaseStack_ReactNativeWPComRequestTest : ReleaseStack_WPComBase() {
     }
 
     private fun assertSuccessWithPath(path: String) {
-        val response = runBlocking { reactNativeStore.executeRequest(sSite, path) }
+        val response = runBlocking { reactNativeStore.executeGetRequest(sSite, path) }
         val failureMessage = "Call failed with error: ${(response as? Error)?.error}"
         assertTrue(failureMessage, response is Success)
     }
 
     @Test
     fun testWpComCall_fails() {
-        val response = runBlocking { reactNativeStore.executeRequest(sSite, "an-invalid-extension") }
+        val response = runBlocking { reactNativeStore.executeGetRequest(sSite, "an-invalid-extension") }
         val assertionMessage = "Call should have failed with a 404, instead response was $response"
         val actualStatusCode = (response as? Error)?.error?.volleyError?.networkResponse?.statusCode
         assertEquals(assertionMessage, 404, actualStatusCode)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
@@ -71,7 +71,7 @@ class ReactNativeFragment : Fragment() {
         val path = path_field.text.toString()
         prependToLog("Making request: $path")
         lifecycleScope.launch(Dispatchers.IO) {
-            val response = site?.let { reactNativeStore.executeRequest(it, path) }
+            val response = site?.let { reactNativeStore.executeGetRequest(it, path) }
             withContext(Dispatchers.Main) {
                 when (response) {
                     is Success -> {

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
@@ -89,7 +89,7 @@ class ReactNativeWPAPIRestClientTest {
                 true)
         ).thenReturn(expectedRestCallResponse)
 
-        val actual = subject.fetch(url, params, successHandler, errorHandler)
+        val actual = subject.getRequest(url, params, successHandler, errorHandler)
         assertEquals(expected, actual)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
@@ -93,7 +93,7 @@ class ReactNativeWPComRestClientTest {
                 true)
         ).thenReturn(expectedRestCallResponse)
 
-        val actual = subject.fetch(url, params, successHandler, errorHandler)
+        val actual = subject.getRequest(url, params, successHandler, errorHandler)
         assertEquals(expected, actual)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
@@ -98,7 +98,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(fetchUrl, nonce.value))
                 .thenReturn(callWithSuccess)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(callWithSuccess, actualResponse)
         assertEquals(restUrl, site.wpApiRestUrl, "site should be updated with rest endpoint used for successful call")
         inOrder(discoveryWPAPIRestClient, sitePersistenceMock, wpApiRestClient, nonceRestClient) {
@@ -118,7 +118,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(fetchUrl))
                 .thenReturn(initialResponseWithSuccess)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(initialResponseWithSuccess, actualResponse)
         verify(wpApiRestClient).fetch(fetchUrl)
         verify(sitePersistenceMock, never())(any()) // no wpApiRestUrl updates, so no persistence
@@ -141,7 +141,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(fetchUrl))
                 .thenReturn(initialResponseWithSuccess)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(initialResponseWithSuccess, actualResponse)
         assertEquals(restUrl, site.wpApiRestUrl, "site should be updated with rest endpoint used for successful call")
         inOrder(discoveryWPAPIRestClient, sitePersistenceMock, wpApiRestClient) {
@@ -167,7 +167,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(fetchUrl))
                 .thenReturn(successfulResponse)
 
-        val actualResponse = store.executeRequest(site, "$restPath?$queryKey=$queryValue")
+        val actualResponse = store.executeGetRequest(site, "$restPath?$queryKey=$queryValue")
         assertEquals(successfulResponse, actualResponse)
         assertEquals(
                 fallbackRestUrl, site.wpApiRestUrl,
@@ -203,7 +203,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(correctUrl))
                 .thenReturn(secondResponseWithSuccess)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(secondResponseWithSuccess, actualResponse)
         assertEquals(restUrl, site.wpApiRestUrl, "should save rest endpoint used for successful call")
         inOrder(discoveryWPAPIRestClient, sitePersistenceMock, wpApiRestClient) {
@@ -232,7 +232,7 @@ class ReactNativeStoreWPAPITest {
                 .thenReturn(responseWithNotFoundError)
 
         // 'not found' error does not lead to discovery call because we already did discovery
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(responseWithNotFoundError, actualResponse)
         assertNull(site.wpApiRestUrl, "should not update site wpApiRestEndpoint when call fails")
         inOrder(discoveryWPAPIRestClient, sitePersistenceMock, wpApiRestClient) {
@@ -250,7 +250,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(fetchUrl))
                 .thenReturn(responseWithUnknownError)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(responseWithUnknownError, actualResponse)
         verify(wpApiRestClient).fetch(fetchUrl)
     }
@@ -274,7 +274,7 @@ class ReactNativeStoreWPAPITest {
                 .thenReturn(initialResponseWithUnauthorizedError)
 
         // Already refreshed nonce, so just returns unauthorized error
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(initialResponseWithUnauthorizedError, actualResponse)
         inOrder(wpApiRestClient) {
             verify(wpApiRestClient).fetch(fetchUrl, nonce.value)
@@ -296,7 +296,7 @@ class ReactNativeStoreWPAPITest {
         whenever(nonceRestClient.getNonce(site))
                 .thenReturn(savedNonce)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(initialResponseWithUnauthorizedError, actualResponse)
         inOrder(wpApiRestClient, nonceRestClient) {
             verify(wpApiRestClient).fetch(fetchUrl, savedNonce.value)
@@ -325,7 +325,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(fetchUrl, updatedNonce.value))
                 .thenReturn(secondResponseWithSuccess)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(secondResponseWithSuccess, actualResponse)
         inOrder(wpApiRestClient, nonceRestClient) {
             verify(nonceRestClient).getNonce(site)
@@ -350,7 +350,7 @@ class ReactNativeStoreWPAPITest {
         whenever(nonceRestClient.getNonce(site))
                 .thenReturn(savedNonce, null)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(initialResponseWithUnauthorizedError, actualResponse)
         inOrder(wpApiRestClient, nonceRestClient) {
             verify(wpApiRestClient).fetch(fetchUrl, savedNonce.value)
@@ -370,7 +370,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(fetchUrl, null)) // passes null for nonce
                 .thenReturn(successResponse)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(successResponse, actualResponse)
         verify(wpApiRestClient).fetch(fetchUrl, null)
         verify(nonceRestClient, never()).requestNonce(any())
@@ -392,7 +392,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(fetchUrl, nonce.value)) // passes null for nonce
                 .thenReturn(successResponse)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(successResponse, actualResponse)
         inOrder(nonceRestClient, wpApiRestClient) {
             verify(nonceRestClient).requestNonce(site)
@@ -415,7 +415,7 @@ class ReactNativeStoreWPAPITest {
         whenever(wpApiRestClient.fetch(fetchUrl, nonce.value)) // passes null for nonce
                 .thenReturn(successResponse)
 
-        val actualResponse = store.executeRequest(site, restPathWithParams)
+        val actualResponse = store.executeGetRequest(site, restPathWithParams)
         assertEquals(successResponse, actualResponse)
         inOrder(wpApiRestClient, nonceRestClient) {
             verify(nonceRestClient).requestNonce(site)
@@ -449,13 +449,13 @@ class ReactNativeStoreWPAPITest {
                 uriParser
         )
 
-        val response = store.executeRequest(mock(), "")
+        val response = store.executeGetRequest(mock(), "")
         val errorType = (response as? Error)?.error?.type
         assertEquals(UNKNOWN, errorType)
     }
 
     private suspend fun ReactNativeWPAPIRestClient.fetch(url: String, nonce: String? = null) =
-            fetch(url, paramMap, ReactNativeFetchResponse::Success, ReactNativeFetchResponse::Error, nonce)
+            getRequest(url, paramMap, ReactNativeFetchResponse::Success, ReactNativeFetchResponse::Error, nonce)
 
     private fun errorResponse(statusCode: Int): ReactNativeFetchResponse = Error(mock()).apply {
         error.volleyError = VolleyError(NetworkResponse(statusCode, null, false, 0L, null))

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWpComTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWpComTest.kt
@@ -51,10 +51,10 @@ class ReactNativeStoreWpComTest {
         whenever(site.isUsingWpComRestApi).thenReturn(true)
 
         val expectedUrl = "https://public-api.wordpress.com/wp/v2/sites/${site.siteId}/media"
-        whenever(wpComRestClient.fetch(expectedUrl, mapOf("paramKey" to "paramValue"), ::Success, ::Error))
+        whenever(wpComRestClient.getRequest(expectedUrl, mapOf("paramKey" to "paramValue"), ::Success, ::Error))
                 .thenReturn(expectedResponse)
 
-        val actualResponse = store.executeRequest(site, "/wp/v2/media?paramKey=paramValue")
+        val actualResponse = store.executeGetRequest(site, "/wp/v2/media?paramKey=paramValue")
         assertEquals(expectedResponse, actualResponse)
     }
 
@@ -73,7 +73,7 @@ class ReactNativeStoreWpComTest {
                 initCoroutineEngine(),
                 uriParser = uriParser)
 
-        val response = store.executeRequest(mock(), "")
+        val response = store.executeGetRequest(mock(), "")
         val errorType = (response as? Error)?.error?.type
         assertEquals(UNKNOWN, errorType)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -21,7 +21,7 @@ class ReactNativeWPAPIRestClient @Inject constructor(
     @Named("custom-ssl") requestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
-    suspend fun fetch(
+    suspend fun getRequest(
         url: String,
         params: Map<String, String>,
         successHandler: (data: JsonElement?) -> ReactNativeFetchResponse,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -43,4 +43,24 @@ class ReactNativeWPAPIRestClient @Inject constructor(
             is Error -> errorHandler(response.error)
         }
     }
+
+    suspend fun postRequest(
+        url: String,
+        body: Map<String, String>,
+        successHandler: (data: JsonElement?) -> ReactNativeFetchResponse,
+        errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
+        nonce: String? = null,
+    ): ReactNativeFetchResponse {
+        val response =
+            wpApiGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                body,
+                JsonElement::class.java,
+                nonce = nonce)
+        return when (response) {
+            is Success -> successHandler(response.data)
+            is Error -> errorHandler(response.error)
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
@@ -25,7 +25,7 @@ class ReactNativeWPComRestClient @Inject constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    suspend fun fetch(
+    suspend fun getRequest(
         url: String,
         params: Map<String, String>,
         successHandler: (data: JsonElement) -> ReactNativeFetchResponse,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
@@ -39,4 +39,18 @@ class ReactNativeWPComRestClient @Inject constructor(
             is Error -> errorHandler(response.error)
         }
     }
+
+    suspend fun postRequest(
+        url: String,
+        body: Map<String, String>,
+        successHandler: (data: JsonElement) -> ReactNativeFetchResponse,
+        errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse
+    ): ReactNativeFetchResponse {
+        val response =
+            wpComGsonRequestBuilder.syncPostRequest(this, url, emptyMap(), body, JsonElement::class.java)
+        return when (response) {
+            is Success -> successHandler(response.data)
+            is Error -> errorHandler(response.error)
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -89,7 +89,7 @@ class EditorThemeStore
     }
 
     private suspend fun fetchEditorTheme(site: SiteModel, action: EditorThemeAction) {
-        val response = reactNativeStore.executeRequest(site, THEME_REQUEST_PATH, false)
+        val response = reactNativeStore.executeGetRequest(site, THEME_REQUEST_PATH, false)
 
         when (response) {
             is Success -> {
@@ -125,7 +125,7 @@ class EditorThemeStore
     }
 
     private suspend fun fetchEditorSettings(site: SiteModel, action: EditorThemeAction) {
-        val response = reactNativeStore.executeRequest(site, EDITOR_SETTINGS_REQUEST_PATH, false)
+        val response = reactNativeStore.executeGetRequest(site, EDITOR_SETTINGS_REQUEST_PATH, false)
 
         when (response) {
             is Success -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -61,12 +61,12 @@ class ReactNativeStore @VisibleForTesting constructor(
             Uri::parse
     )
 
-    suspend fun executeRequest(
+    suspend fun executeGetRequest(
         site: SiteModel,
         pathWithParams: String,
         enableCaching: Boolean = true
     ): ReactNativeFetchResponse =
-            coroutineEngine.withDefaultContext(AppLog.T.API, this, "executeRequest") {
+            coroutineEngine.withDefaultContext(AppLog.T.API, this, "executeGetRequest") {
                 return@withDefaultContext if (site.isUsingWpComRestApi) {
                     executeWPComRequest(site, pathWithParams, enableCaching)
                 } else {
@@ -81,7 +81,7 @@ class ReactNativeStore @VisibleForTesting constructor(
     ): ReactNativeFetchResponse {
         val (url, params) = parseUrlAndParamsForWPCom(path, site.siteId)
         return if (url != null) {
-            wpComRestClient.fetch(url, params, ::Success, ::Error, enableCaching)
+            wpComRestClient.getRequest(url, params, ::Success, ::Error, enableCaching)
         } else {
             urlParseError(path)
         }
@@ -186,7 +186,7 @@ class ReactNativeStore @VisibleForTesting constructor(
         nonce: String?,
         enableCaching: Boolean
     ): ReactNativeFetchResponse =
-            wpAPIRestClient.fetch(fullRestApiUrl, params, ::Success, ::Error, nonce, enableCaching)
+            wpAPIRestClient.getRequest(fullRestApiUrl, params, ::Success, ::Error, nonce, enableCaching)
 
     private fun parseUrlAndParamsForWPCom(
         pathWithParams: String,


### PR DESCRIPTION
This PR introduces the support for POST requests in the React Native store. With this change, the Gutenberg editor will be able to make POST requests.