### PR TITLE
[WP Individual JP Plugin] Save and retrieve filtered jetpack CP connected sites

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayoutCatego
 import org.wordpress.android.fluxc.network.rest.wpcom.site.PrivateAtomicCookie;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient;
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient;
+import org.wordpress.android.fluxc.persistence.JetpackCPConnectedSitesDao;
 import org.wordpress.android.fluxc.persistence.PostSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils;
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
@@ -52,6 +53,7 @@ import static org.wordpress.android.fluxc.site.SiteUtils.generateSiteWithZendesk
 import static org.wordpress.android.fluxc.site.SiteUtils.generateTestSite;
 import static org.wordpress.android.fluxc.site.SiteUtils.generateWPComSite;
 
+// TODO hthomas create new tests for the jetpack CP connected sites interactions
 @RunWith(RobolectricTestRunner.class)
 public class SiteStoreUnitTest {
     private PostSqlUtils mPostSqlUtils = new PostSqlUtils();
@@ -64,6 +66,7 @@ public class SiteStoreUnitTest {
             Mockito.mock(SiteWPAPIRestClient.class),
             Mockito.mock(PrivateAtomicCookie.class),
             mSiteSqlUtils,
+            Mockito.mock(JetpackCPConnectedSitesDao.class),
             CoroutineEngineUtilsKt.initCoroutineEngine()
     );
 

--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -53,7 +53,6 @@ import static org.wordpress.android.fluxc.site.SiteUtils.generateSiteWithZendesk
 import static org.wordpress.android.fluxc.site.SiteUtils.generateTestSite;
 import static org.wordpress.android.fluxc.site.SiteUtils.generateWPComSite;
 
-// TODO hthomas create new tests for the jetpack CP connected sites interactions
 @RunWith(RobolectricTestRunner.class)
 public class SiteStoreUnitTest {
     private PostSqlUtils mPostSqlUtils = new PostSqlUtils();

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -6,7 +6,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -48,7 +50,6 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 
-// TODO hthomas create new tests for the jetpack CP connected sites interactions
 @RunWith(MockitoJUnitRunner::class)
 class SiteStoreTest {
     @Mock lateinit var dispatcher: Dispatcher
@@ -165,6 +166,74 @@ class SiteStoreTest {
         inOrder.verify(siteSqlUtils).insertOrUpdateSite(siteA)
         inOrder.verify(siteSqlUtils).insertOrUpdateSite(siteB)
         inOrder.verify(siteSqlUtils).removeWPComRestSitesAbsentFromList(postSqlUtils, sitesModel.sites)
+    }
+
+    @Test
+    fun `fetchSites saves jetpack CP connected sites to DB`() = test {
+        val payload = FetchSitesPayload(listOf(WPCOM))
+        val sitesModel = SitesModel()
+        val siteA = SiteModel().apply {
+            siteId = 1
+            url = "http://A"
+            name = "A"
+            description = "A description"
+            setIsJetpackCPConnected(false)
+        }
+        val siteB = SiteModel().apply {
+            siteId = 2
+            url = "http://B"
+            name = "B"
+            description = "B description"
+            setIsJetpackCPConnected(false)
+        }
+        val siteC = SiteModel().apply {
+            siteId = 3
+            url = "http://C"
+            name = "C"
+            description = "C description"
+            activeJetpackConnectionPlugins = "jetpack-boost"
+            setIsJetpackCPConnected(true)
+        }
+        sitesModel.sites = listOf(siteA, siteB)
+        sitesModel.jetpackCPSites = listOf(siteC)
+        whenever(siteRestClient.fetchSites(payload.filters, false)).thenReturn(sitesModel)
+        whenever(siteSqlUtils.insertOrUpdateSite(siteA)).thenReturn(1)
+        whenever(siteSqlUtils.insertOrUpdateSite(siteB)).thenReturn(1)
+
+        siteStore.fetchSites(payload)
+
+        val inOrder = inOrder(jetpackCPConnectedSitesDao)
+        inOrder.verify(jetpackCPConnectedSitesDao).deleteAll()
+        inOrder.verify(jetpackCPConnectedSitesDao).insert(argWhere { it.size == 1 })
+    }
+
+    @Test
+    fun `fetchSites doesn't save jetpack CP connected sites to DB`() = test {
+        val payload = FetchSitesPayload(listOf(WPCOM))
+        val sitesModel = SitesModel()
+        val siteA = SiteModel().apply {
+            siteId = 1
+            url = "http://A"
+            name = "A"
+            description = "A description"
+            setIsJetpackCPConnected(false)
+        }
+        val siteB = SiteModel().apply {
+            siteId = 2
+            url = "http://B"
+            name = "B"
+            description = "B description"
+            setIsJetpackCPConnected(false)
+        }
+        sitesModel.sites = listOf(siteA, siteB)
+        whenever(siteRestClient.fetchSites(payload.filters, false)).thenReturn(sitesModel)
+        whenever(siteSqlUtils.insertOrUpdateSite(siteA)).thenReturn(1)
+        whenever(siteSqlUtils.insertOrUpdateSite(siteB)).thenReturn(1)
+
+        siteStore.fetchSites(payload)
+
+        verify(jetpackCPConnectedSitesDao, never()).deleteAll()
+        verify(jetpackCPConnectedSitesDao, never()).insert(argWhere { it.size == 1 })
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.PrivateAtomicCookie
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteRestClient.NewSiteResponsePayload
 import org.wordpress.android.fluxc.network.xmlrpc.site.SiteXMLRPCClient
+import org.wordpress.android.fluxc.persistence.JetpackCPConnectedSitesDao
 import org.wordpress.android.fluxc.persistence.PostSqlUtils
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
@@ -47,6 +48,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 
+// TODO hthomas create new tests for the jetpack CP connected sites interactions
 @RunWith(MockitoJUnitRunner::class)
 class SiteStoreTest {
     @Mock lateinit var dispatcher: Dispatcher
@@ -56,6 +58,7 @@ class SiteStoreTest {
     @Mock lateinit var siteWPAPIClient: SiteWPAPIRestClient
     @Mock lateinit var privateAtomicCookie: PrivateAtomicCookie
     @Mock lateinit var siteSqlUtils: SiteSqlUtils
+    @Mock lateinit var jetpackCPConnectedSitesDao: JetpackCPConnectedSitesDao
     @Mock lateinit var domainsSuccessResponse: Response.Success<DomainsResponse>
     @Mock lateinit var plansSuccessResponse: Response.Success<PlansResponse>
     @Mock lateinit var domainsErrorResponse: Response.Error<DomainsResponse>
@@ -72,6 +75,7 @@ class SiteStoreTest {
                 siteWPAPIClient,
                 privateAtomicCookie,
                 siteSqlUtils,
+                jetpackCPConnectedSitesDao,
                 initCoroutineEngine()
         )
     }

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/13.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/13.json
@@ -1,0 +1,672 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "ea143270b18bcf94049299a930db8dea",
+    "entities": [
+      {
+        "tableName": "BloggingReminders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `monday` INTEGER NOT NULL, `tuesday` INTEGER NOT NULL, `wednesday` INTEGER NOT NULL, `thursday` INTEGER NOT NULL, `friday` INTEGER NOT NULL, `saturday` INTEGER NOT NULL, `sunday` INTEGER NOT NULL, `hour` INTEGER NOT NULL, `minute` INTEGER NOT NULL, `isPromptRemindersOptedIn` INTEGER NOT NULL, `isPromptsCardOptedIn` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monday",
+            "columnName": "monday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tuesday",
+            "columnName": "tuesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wednesday",
+            "columnName": "wednesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thursday",
+            "columnName": "thursday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friday",
+            "columnName": "friday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saturday",
+            "columnName": "saturday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sunday",
+            "columnName": "sunday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hour",
+            "columnName": "hour",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minute",
+            "columnName": "minute",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPromptRemindersOptedIn",
+            "columnName": "isPromptRemindersOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPromptsCardOptedIn",
+            "columnName": "isPromptsCardOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOffers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `name` TEXT, `shortName` TEXT, `tagline` TEXT, `description` TEXT, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "shortName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_PlanOffers_internalPlanId",
+            "unique": true,
+            "columnNames": [
+              "internalPlanId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_PlanOffers_internalPlanId` ON `${TABLE_NAME}` (`internalPlanId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOfferIds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `productId` INTEGER NOT NULL, `internalPlanId` INTEGER NOT NULL, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PlanOfferFeatures",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `stringId` TEXT, `name` TEXT, `description` TEXT, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringId",
+            "columnName": "stringId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Comments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remoteCommentId` INTEGER NOT NULL, `remotePostId` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `remoteSiteId` INTEGER NOT NULL, `authorUrl` TEXT, `authorName` TEXT, `authorEmail` TEXT, `authorProfileImageUrl` TEXT, `authorId` INTEGER NOT NULL, `postTitle` TEXT, `status` TEXT, `datePublished` TEXT, `publishedTimestamp` INTEGER NOT NULL, `content` TEXT, `url` TEXT, `hasParent` INTEGER NOT NULL, `parentId` INTEGER NOT NULL, `iLike` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteCommentId",
+            "columnName": "remoteCommentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePostId",
+            "columnName": "remotePostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteSiteId",
+            "columnName": "remoteSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorUrl",
+            "columnName": "authorUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorEmail",
+            "columnName": "authorEmail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorProfileImageUrl",
+            "columnName": "authorProfileImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postTitle",
+            "columnName": "postTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "datePublished",
+            "columnName": "datePublished",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publishedTimestamp",
+            "columnName": "publishedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasParent",
+            "columnName": "hasParent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iLike",
+            "columnName": "iLike",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DashboardCards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteLocalId` INTEGER NOT NULL, `type` TEXT NOT NULL, `date` TEXT NOT NULL, `json` TEXT NOT NULL, PRIMARY KEY(`siteLocalId`, `type`))",
+        "fields": [
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "siteLocalId",
+            "type"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BloggingPrompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `siteLocalId` INTEGER NOT NULL, `text` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `date` TEXT NOT NULL, `isAnswered` INTEGER NOT NULL, `respondentsCount` INTEGER NOT NULL, `attribution` TEXT NOT NULL, `respondentsAvatars` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAnswered",
+            "columnName": "isAnswered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "respondentsCount",
+            "columnName": "respondentsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attribution",
+            "columnName": "attribution",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "respondentsAvatars",
+            "columnName": "respondentsAvatars",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "FeatureFlagConfigurations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "RemoteConfigurations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BlazeStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `isEligible` INTEGER NOT NULL, PRIMARY KEY(`siteId`))",
+        "fields": [
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEligible",
+            "columnName": "isEligible",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "siteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "JetpackCPConnectedSites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`remoteSiteId` INTEGER, `localSiteId` INTEGER NOT NULL, `url` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `activeJetpackConnectionPlugins` TEXT NOT NULL, PRIMARY KEY(`remoteSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "remoteSiteId",
+            "columnName": "remoteSiteId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeJetpackConnectionPlugins",
+            "columnName": "activeJetpackConnectionPlugins",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "remoteSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ea143270b18bcf94049299a930db8dea')"
+    ]
+  }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
@@ -37,7 +37,7 @@ public class SitesModel extends Payload<BaseNetworkError> {
     }
 
     public void setSites(List<SiteModel> sites) {
-        this.mSites = sites;
+        mSites = sites;
     }
 
     public void setJetpackCPSites(List<SiteModel> jetpackCPSites) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SitesModel.java
@@ -11,19 +11,36 @@ import java.util.List;
 public class SitesModel extends Payload<BaseNetworkError> {
     private List<SiteModel> mSites;
 
+    private List<SiteModel> mJetpackCPSites;
+
     public SitesModel() {
         mSites = new ArrayList<>();
+        mJetpackCPSites = new ArrayList<>();
     }
 
     public SitesModel(@NonNull List<SiteModel> sites) {
         mSites = sites;
+        mJetpackCPSites = new ArrayList<>();
+    }
+
+    public SitesModel(@NonNull List<SiteModel> sites, @NonNull List<SiteModel> jetpackCPSites) {
+        mSites = sites;
+        mJetpackCPSites = jetpackCPSites;
     }
 
     public List<SiteModel> getSites() {
         return mSites;
     }
 
+    public List<SiteModel> getJetpackCPSites() {
+        return mJetpackCPSites;
+    }
+
     public void setSites(List<SiteModel> sites) {
         this.mSites = sites;
+    }
+
+    public void setJetpackCPSites(List<SiteModel> jetpackCPSites) {
+        mJetpackCPSites = jetpackCPSites;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
@@ -6,6 +6,7 @@ import dagger.Provides
 import org.wordpress.android.fluxc.persistence.BloggingRemindersDao
 import org.wordpress.android.fluxc.persistence.PlanOffersDao
 import org.wordpress.android.fluxc.persistence.FeatureFlagConfigDao
+import org.wordpress.android.fluxc.persistence.JetpackCPConnectedSitesDao
 import org.wordpress.android.fluxc.persistence.RemoteConfigDao
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.buildDb
@@ -69,5 +70,13 @@ class DatabaseModule {
     @Provides
     fun provideBlazeStatusDao(wpAndroidDatabase: WPAndroidDatabase): BlazeStatusDao {
         return wpAndroidDatabase.blazeStatusDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideJetpackConnectedSitesDao(
+        wpAndroidDatabase: WPAndroidDatabase
+    ): JetpackCPConnectedSitesDao {
+        return wpAndroidDatabase.jetpackConnectedSitesDao()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
@@ -77,6 +77,6 @@ class DatabaseModule {
     fun provideJetpackConnectedSitesDao(
         wpAndroidDatabase: WPAndroidDatabase
     ): JetpackCPConnectedSitesDao {
-        return wpAndroidDatabase.jetpackConnectedSitesDao()
+        return wpAndroidDatabase.jetpackCPConnectedSitesDao()
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -138,8 +138,8 @@ class SiteRestClient @Inject constructor(
                 val jetpackCPSiteArray = mutableListOf<SiteModel>()
                 for (siteResponse in response.data.sites) {
                     val siteModel = siteResponseToSiteModel(siteResponse)
-                    // see https://github.com/wordpress-mobile/WordPress-Android/issues/15540#issuecomment-993752880
                     if (siteModel.isJetpackCPConnected) jetpackCPSiteArray.add(siteModel)
+                    // see https://github.com/wordpress-mobile/WordPress-Android/issues/15540#issuecomment-993752880
                     if (filterJetpackConnectedPackageSite && siteModel.isJetpackCPConnected) continue
                     siteArray.add(siteModel)
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -135,13 +135,15 @@ class SiteRestClient @Inject constructor(
         return when (response) {
             is Success -> {
                 val siteArray = mutableListOf<SiteModel>()
+                val jetpackCPSiteArray = mutableListOf<SiteModel>()
                 for (siteResponse in response.data.sites) {
                     val siteModel = siteResponseToSiteModel(siteResponse)
                     // see https://github.com/wordpress-mobile/WordPress-Android/issues/15540#issuecomment-993752880
+                    if (siteModel.isJetpackCPConnected) jetpackCPSiteArray.add(siteModel)
                     if (filterJetpackConnectedPackageSite && siteModel.isJetpackCPConnected) continue
                     siteArray.add(siteModel)
                 }
-                SitesModel(siteArray)
+                SitesModel(siteArray, jetpackCPSiteArray)
             }
             is Error -> {
                 val payload = SitesModel(emptyList())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/JetpackCPConnectedSitesDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/JetpackCPConnectedSitesDao.kt
@@ -33,7 +33,7 @@ interface JetpackCPConnectedSitesDao {
         val description: String,
         val activeJetpackConnectionPlugins: String,
     ) {
-        fun toJetpackCPConnectedSite() = JetpackCPConnectedSiteModel(
+        fun toJetpackCPConnectedSite(): JetpackCPConnectedSiteModel = JetpackCPConnectedSiteModel(
             remoteSiteId = remoteSiteId,
             localSiteId = localSiteId,
             url = url,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/JetpackCPConnectedSitesDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/JetpackCPConnectedSitesDao.kt
@@ -66,9 +66,9 @@ interface JetpackCPConnectedSitesDao {
                         remoteSiteId = remoteId().value,
                         localSiteId = localId().value,
                         url = url,
-                        name = name,
-                        description = description,
-                        activeJetpackConnectionPlugins = activeJetpackConnectionPlugins
+                        name = name.orEmpty(),
+                        description = description.orEmpty(),
+                        activeJetpackConnectionPlugins = activeJetpackConnectionPlugins.orEmpty()
                     )
                 }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/JetpackCPConnectedSitesDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/JetpackCPConnectedSitesDao.kt
@@ -1,0 +1,86 @@
+package org.wordpress.android.fluxc.persistence
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import org.wordpress.android.fluxc.model.SiteModel
+
+// TODO hthomas make everything suspend?
+@Dao
+interface JetpackCPConnectedSitesDao {
+    @Query("SELECT COUNT(*) FROM JetpackCPConnectedSites")
+    suspend fun getCount(): Int
+
+    @Query("SELECT * FROM JetpackCPConnectedSites")
+    suspend fun getAll(): List<JetpackCPConnectedSiteEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(sites: List<JetpackCPConnectedSiteEntity>)
+
+    @Query("DELETE FROM JetpackCPConnectedSites")
+    suspend fun deleteAll()
+
+    @Entity(
+        tableName = "JetpackCPConnectedSites",
+        primaryKeys = ["remoteSiteId"]
+    )
+    data class JetpackCPConnectedSiteEntity(
+        val remoteSiteId: Long? = null,
+        val localSiteId: Int,
+        val url: String,
+        val name: String,
+        val description: String,
+        val activeJetpackConnectionPlugins: String,
+    ) {
+        fun toJetpackCPConnectedSite() = JetpackCPConnectedSiteModel(
+            remoteSiteId = remoteSiteId,
+            localSiteId = localSiteId,
+            url = url,
+            name = name,
+            description = description,
+            activeJetpackConnectionPlugins = activeJetpackConnectionPlugins.split(","),
+        )
+
+        companion object {
+            fun from(
+                jetpackConnectedSite: JetpackCPConnectedSiteModel
+            ): JetpackCPConnectedSiteEntity = jetpackConnectedSite.run {
+                JetpackCPConnectedSiteEntity(
+                    remoteSiteId = remoteSiteId,
+                    localSiteId = localSiteId,
+                    url = url,
+                    name = name,
+                    description = description,
+                    activeJetpackConnectionPlugins = activeJetpackConnectionPlugins
+                        .joinToString(","),
+                )
+            }
+
+            fun from(
+                siteModel: SiteModel
+            ): JetpackCPConnectedSiteEntity? = siteModel
+                .takeIf { it.isJetpackCPConnected }
+                ?.run {
+                    JetpackCPConnectedSiteEntity(
+                        remoteSiteId = remoteId().value,
+                        localSiteId = localId().value,
+                        url = url,
+                        name = name,
+                        description = description,
+                        activeJetpackConnectionPlugins = activeJetpackConnectionPlugins
+                    )
+                }
+        }
+    }
+}
+
+data class JetpackCPConnectedSiteModel(
+    val remoteSiteId: Long? = null,
+    val localSiteId: Int,
+    val url: String,
+    val name: String,
+    val description: String,
+    val activeJetpackConnectionPlugins: List<String>,
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/JetpackCPConnectedSitesDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/JetpackCPConnectedSitesDao.kt
@@ -7,7 +7,6 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import org.wordpress.android.fluxc.model.SiteModel
 
-// TODO hthomas make everything suspend?
 @Dao
 interface JetpackCPConnectedSitesDao {
     @Query("SELECT COUNT(*) FROM JetpackCPConnectedSites")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
@@ -10,6 +10,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import org.wordpress.android.fluxc.persistence.BloggingRemindersDao.BloggingReminders
 import org.wordpress.android.fluxc.persistence.FeatureFlagConfigDao.FeatureFlag
+import org.wordpress.android.fluxc.persistence.JetpackCPConnectedSitesDao.JetpackCPConnectedSiteEntity
 import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOffer
 import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOfferFeature
 import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOfferId
@@ -25,7 +26,7 @@ import org.wordpress.android.fluxc.persistence.dashboard.CardsDao
 import org.wordpress.android.fluxc.persistence.dashboard.CardsDao.CardEntity
 
 @Database(
-        version = 12,
+        version = 13,
         entities = [
             BloggingReminders::class,
             PlanOffer::class,
@@ -36,10 +37,12 @@ import org.wordpress.android.fluxc.persistence.dashboard.CardsDao.CardEntity
             BloggingPromptEntity::class,
             FeatureFlag::class,
             RemoteConfig::class,
-            BlazeStatus::class
+            BlazeStatus::class,
+            JetpackCPConnectedSiteEntity::class,
         ],
         autoMigrations = [
-            AutoMigration(from = 11, to = 12)
+            AutoMigration(from = 11, to = 12),
+            AutoMigration(from = 12, to = 13)
         ]
 )
 @TypeConverters(
@@ -63,6 +66,8 @@ abstract class WPAndroidDatabase : RoomDatabase() {
     abstract fun remoteConfigDao(): RemoteConfigDao
 
     abstract fun blazeStatusDao(): BlazeStatusDao
+
+    abstract fun jetpackConnectedSitesDao(): JetpackCPConnectedSitesDao
 
     @Suppress("MemberVisibilityCanBePrivate")
     companion object {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
@@ -67,7 +67,7 @@ abstract class WPAndroidDatabase : RoomDatabase() {
 
     abstract fun blazeStatusDao(): BlazeStatusDao
 
-    abstract fun jetpackConnectedSitesDao(): JetpackCPConnectedSitesDao
+    abstract fun jetpackCPConnectedSitesDao(): JetpackCPConnectedSitesDao
 
     @Suppress("MemberVisibilityCanBePrivate")
     companion object {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1548,6 +1548,8 @@ open class SiteStore @Inject constructor(
                 siteInList?.let { fetchedSites.jetpackCPSites[i] = it }
             }
 
+            // clear all Jetpack CP connected sites and insert the new ones (to remove old stale sites)
+            jetpackCPConnectedSitesDao.deleteAll()
             jetpackCPConnectedSitesDao.insert(
                 fetchedSites.jetpackCPSites.mapNotNull(JetpackCPConnectedSiteEntity::from)
             )


### PR DESCRIPTION
Fixes #2678

Create a new DAO in Room for storing user sites that have Jetpack Connection Package connection as well as add methods to `SiteStore` to retrieve those sites, which will be needed for https://github.com/wordpress-mobile/WordPress-Android/issues/18114.

Mechanisms were added in place to make sure those sites are properly reset upon fetching the sites and logging out from the app.

Some unit tests were also added for those new public methods.