### PR TITLE
Site creation: Add the "coming soon" option

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -201,6 +201,7 @@ class SiteRestClientTest {
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
         val findAvailableUrl = true
+        val isComingSoon = false
 
         val result = restClient.newSite(
             siteName,
@@ -211,6 +212,7 @@ class SiteRestClientTest {
             segmentId,
             siteDesign,
             findAvailableUrl,
+            isComingSoon,
             dryRun
         )
 
@@ -259,6 +261,8 @@ class SiteRestClientTest {
         val segmentId = 123L
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
+        val isComingSoon = false
+
 
         val result = restClient.newSite(
             siteName,
@@ -269,6 +273,7 @@ class SiteRestClientTest {
             segmentId,
             siteDesign,
             null,
+            isComingSoon,
             dryRun
         )
 
@@ -318,6 +323,7 @@ class SiteRestClientTest {
         val segmentId = 123L
         val siteDesign = "design"
         val timeZoneId = "Europe/London"
+        val isComingSoon = false
 
         val result = restClient.newSite(
             siteName,
@@ -328,6 +334,7 @@ class SiteRestClientTest {
             segmentId,
             siteDesign,
             null,
+            isComingSoon,
             dryRun
         )
 
@@ -374,6 +381,7 @@ class SiteRestClientTest {
         val language = "CZ"
         val visibility = SiteVisibility.PRIVATE
         val timeZoneId = "Europe/London"
+        val isComingSoon = false
 
         val result = restClient.newSite(
             siteName,
@@ -384,6 +392,7 @@ class SiteRestClientTest {
             null,
             null,
             null,
+            isComingSoon,
             dryRun
         )
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -234,7 +234,8 @@ class SiteRestClientTest {
                         "options" to mapOf<String, Any>(
                                 "site_segment" to segmentId,
                                 "template" to siteDesign,
-                                "timezone_string" to timeZoneId
+                                "timezone_string" to timeZoneId,
+                                "wpcom_public_coming_soon" to "0"
                         )
                 )
         )
@@ -296,7 +297,8 @@ class SiteRestClientTest {
                     "site_segment" to segmentId,
                     "template" to siteDesign,
                     "site_creation_flow" to "with-design-picker",
-                    "timezone_string" to timeZoneId
+                    "timezone_string" to timeZoneId,
+                    "wpcom_public_coming_soon" to "0"
                 )
             )
         )
@@ -356,7 +358,8 @@ class SiteRestClientTest {
                     "site_segment" to segmentId,
                     "template" to siteDesign,
                     "site_creation_flow" to "with-design-picker",
-                    "timezone_string" to timeZoneId
+                    "timezone_string" to timeZoneId,
+                    "wpcom_public_coming_soon" to "0"
                 )
             )
         )
@@ -409,7 +412,10 @@ class SiteRestClientTest {
                         "validate" to "1",
                         "client_id" to appId,
                         "client_secret" to appSecret,
-                        "options" to mapOf<String, Any>("timezone_string" to timeZoneId)
+                        "options" to mapOf<String, Any>(
+                            "timezone_string" to timeZoneId,
+                            "wpcom_public_coming_soon" to "0"
+                        )
                 )
         )
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -196,7 +196,7 @@ class SiteStoreTest {
                         null,
                         null,
                         null,
-                        false,
+                        null,
                         payload.dryRun,
                 )
         ).thenReturn(response)
@@ -225,7 +225,7 @@ class SiteStoreTest {
                         null,
                         null,
                         null,
-                        false,
+                        null,
                         payload.dryRun
                 )
         ).thenReturn(response)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -196,6 +196,7 @@ class SiteStoreTest {
                         null,
                         null,
                         null,
+                        false,
                         payload.dryRun,
                 )
         ).thenReturn(response)
@@ -224,6 +225,7 @@ class SiteStoreTest {
                         null,
                         null,
                         null,
+                        false,
                         payload.dryRun
                 )
         ).thenReturn(response)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -190,6 +190,7 @@ class SiteRestClient @Inject constructor(
      * @param visibility The visibility of the site (public or private)
      * @param segmentId The segment that the site belongs to
      * @param siteDesign The design template of the site
+     * @param isComingSoon The "coming soon" flag, which hides the site content from the public
      * @param dryRun If set to true the call only validates the parameters passed
      *
      * The domain of the site is generated with the following logic:
@@ -214,7 +215,8 @@ class SiteRestClient @Inject constructor(
         segmentId: Long?,
         siteDesign: String?,
         findAvailableUrl: Boolean?,
-        dryRun: Boolean,
+        isComingSoon: Boolean?,
+        dryRun: Boolean
     ): NewSiteResponsePayload {
         val url = WPCOMREST.sites.new_.urlV1_1
         val body = mutableMapOf<String, Any>()
@@ -244,6 +246,9 @@ class SiteRestClient @Inject constructor(
         }
         if (timeZoneId != null) {
             options["timezone_string"] = timeZoneId
+        }
+        if (isComingSoon != null) {
+            options["wpcom_public_coming_soon"] = if (isComingSoon) "1" else "0"
         }
 
         // Add site options if available

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -176,6 +176,7 @@ open class SiteStore @Inject constructor(
      * @param segmentId The segment that the site belongs to
      * @param siteDesign The design template of the site
      * @param dryRun If set to true the call only validates the parameters passed
+     * @param isComingSoon The "coming soon" flag, which hides the site content from the public
      */
     data class NewSitePayload(
         @JvmField val siteName: String?,
@@ -187,6 +188,7 @@ open class SiteStore @Inject constructor(
         @JvmField val siteDesign: String? = null,
         @JvmField val dryRun: Boolean,
         @JvmField val findAvailableUrl: Boolean? = null,
+        @JvmField val isComingSoon: Boolean? = null,
     ) : Payload<BaseNetworkError>() {
         constructor(
             siteName: String?,
@@ -1616,6 +1618,7 @@ open class SiteStore @Inject constructor(
                 payload.segmentId,
                 payload.siteDesign,
                 payload.findAvailableUrl,
+                payload.isComingSoon,
                 payload.dryRun,
         )
         return handleCreateNewSiteCompleted(


### PR DESCRIPTION
This PR adds a "coming soon" flag optional parameter to the site creation request. 

To test this, please see the [associated Woo PR](https://github.com/woocommerce/woocommerce-android/pull/8582) that implements it for store creation.