### PR TITLE
[Woo REST API] Prepare for Application Passwords' Web authorization

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -8,8 +8,10 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_main.*
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -23,6 +25,9 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.network.HTTPAuthManager
 import org.wordpress.android.fluxc.network.MemorizingTrustManager
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryError
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator.CookieNonceAuthenticationResult.Error
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator.CookieNonceAuthenticationResult.Success
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType
@@ -45,6 +50,7 @@ class MainFragment : Fragment() {
     @Inject internal lateinit var dispatcher: Dispatcher
     @Inject internal lateinit var httpAuthManager: HTTPAuthManager
     @Inject internal lateinit var memorizingTrustManager: MemorizingTrustManager
+    @Inject internal lateinit var cookieNonceAuthenticator: CookieNonceAuthenticator
 
     // Would be great to not have to keep this state, but it makes HTTPAuth and self signed SSL management easier
     private var selfHostedPayload: RefreshSitesXMLRPCPayload? = null
@@ -198,15 +204,20 @@ class MainFragment : Fragment() {
                 selfHostedPayload = RefreshSitesXMLRPCPayload(username, password, url)
                 dispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(url))
             }
-            else -> dispatcher.dispatch(
-                SiteActionBuilder.newFetchSiteWpApiAction(
-                    FetchWPAPISitePayload(
-                        url = url,
-                        username = username,
-                        password = password
-                    )
-                )
-            )
+            else -> lifecycleScope.launch {
+                cookieNonceAuthenticator.authenticate(url, username, password).let {
+                    when (it) {
+                        is Error -> prependToLog("Authentication error: ${it.type} - ${it.message}")
+                        Success -> SiteActionBuilder.newFetchSiteWpApiAction(
+                            FetchWPAPISitePayload(
+                                url = url,
+                                username = username,
+                                password = password
+                            )
+                        )
+                    }
+                }
+            }
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
@@ -77,7 +77,7 @@ class NonceRestClientTest {
             """
             <html>
               <head>
-                    <div id="login_error">	
+                    <div id="login_error">
                         <strong>Error:</strong> The password you entered for the username <strong>demo</strong> is incorrect. <a href="link/">Lost your password?</a><br>
                     </div>
               </head>

--- a/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.action.JetpackAction.ACTIVATE_STATS_MODULE
 import org.wordpress.android.fluxc.action.JetpackAction.INSTALL_JETPACK
 import org.wordpress.android.fluxc.generated.JetpackActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackRestClient
 import org.wordpress.android.fluxc.store.JetpackStore.ActivateStatsModuleError
@@ -37,7 +36,6 @@ import org.wordpress.android.fluxc.tools.initCoroutineEngine
 class JetpackStoreTest {
     @Mock private lateinit var jetpackRestClient: JetpackRestClient
     @Mock private lateinit var jetpackWPAPIRestClient: JetpackWPAPIRestClient
-    @Mock private lateinit var wpApiAuthenticator: WPAPIAuthenticator
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var siteStore: SiteStore
     @Mock private lateinit var site: SiteModel
@@ -50,7 +48,6 @@ class JetpackStoreTest {
             jetpackWPAPIRestClient,
             siteStore,
             initCoroutineEngine(),
-            wpApiAuthenticator,
             dispatcher
         )
         val siteId = 1

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
@@ -361,7 +361,11 @@ class ReactNativeStoreWPAPITest {
     @Test
     fun `nonce unavailable from recent request, so does not request nonce`() = test {
         // previous nonce faield, and was "recent"
-        val fourMinuteOldFailedNonceRequest = FailedRequest(currentTime - 4 * 60 * 1000, site.username)
+        val fourMinuteOldFailedNonceRequest = FailedRequest(
+            currentTime - 4 * 60 * 1000,
+            site.username,
+            Nonce.CookieNonceErrorType.GENERIC_ERROR
+        )
         initStore(fourMinuteOldFailedNonceRequest)
 
         // does not use nonce to make request because of recent unsuccessful attempt to refresh nonce
@@ -379,7 +383,11 @@ class ReactNativeStoreWPAPITest {
     @Test
     fun `nonce unavailable from older request, so requests nonce`() = test {
         // previous nonce request failed, but was not "recent"
-        val sixMinuteOldUnavailableNonce = FailedRequest(currentTime - 6 * 60 * 1000, site.username)
+        val sixMinuteOldUnavailableNonce = FailedRequest(
+            currentTime - 6 * 60 * 1000,
+            site.username,
+            Nonce.CookieNonceErrorType.GENERIC_ERROR
+        )
         initStore(sixMinuteOldUnavailableNonce)
 
         // refreshes nonce because latest attempt to refresh nonce was not recent

--- a/fluxc-processor/src/main/resources/wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-api-endpoints.txt
@@ -16,6 +16,7 @@
 /users/me/
 /users/me/application-passwords
 /users/me/application-passwords/<uuid>#String
+/users/me/application-passwords/introspect
 
 /plugins/
 /plugins/<name>#String

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -155,6 +155,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private boolean mIsBloggingReminderOnSunday;
     @Column private int mBloggingReminderHour;
     @Column private int mBloggingReminderMinute;
+    @Column private String mApplicationPasswordsAuthorizeUrl;
 
     @Override
     public int getId() {
@@ -947,5 +948,17 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setBloggingReminderMinute(int bloggingReminderMinute) {
         mBloggingReminderMinute = bloggingReminderMinute;
+    }
+
+    public String getApplicationPasswordsAuthorizeUrl() {
+        return mApplicationPasswordsAuthorizeUrl;
+    }
+
+    public void setApplicationPasswordsAuthorizeUrl(String applicationPasswordsAuthorizeUrl) {
+        mApplicationPasswordsAuthorizeUrl = applicationPasswordsAuthorizeUrl;
+    }
+
+    public boolean isApplicationPasswordsSupported() {
+        return mApplicationPasswordsAuthorizeUrl != null && !mApplicationPasswordsAuthorizeUrl.isEmpty();
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -46,9 +46,11 @@ public abstract class BaseRequest<T> extends Request<T> {
     public interface OnAuthFailedListener {
         void onAuthFailed(AuthenticateErrorPayload errorType);
     }
+
     public interface BaseErrorListener {
         void onErrorResponse(@NonNull BaseNetworkError error);
     }
+
     public interface OnParseErrorListener {
         void onParseError(OnUnexpectedError event);
     }
@@ -82,11 +84,13 @@ public abstract class BaseRequest<T> extends Request<T> {
             this.type = error;
             this.volleyError = volleyError;
         }
+
         public BaseNetworkError(@NonNull GenericErrorType error, @NonNull VolleyError volleyError) {
             this.message = "";
             this.type = error;
             this.volleyError = volleyError;
         }
+
         public BaseNetworkError(@NonNull GenericErrorType error,
                                 @NonNull VolleyError volleyError,
                                 @NonNull XmlRpcErrorType xmlRpcErrorType) {
@@ -95,31 +99,38 @@ public abstract class BaseRequest<T> extends Request<T> {
             this.volleyError = volleyError;
             this.xmlRpcErrorType = xmlRpcErrorType;
         }
+
         public BaseNetworkError(@NonNull VolleyError volleyError) {
             this.type = GenericErrorType.UNKNOWN;
             this.message = "";
             this.volleyError = volleyError;
         }
+
         public BaseNetworkError(@NonNull VolleyError volleyError, @NonNull XmlRpcErrorType xmlRpcErrorType) {
             this.type = GenericErrorType.UNKNOWN;
             this.message = "";
             this.volleyError = volleyError;
             this.xmlRpcErrorType = xmlRpcErrorType;
         }
+
         public BaseNetworkError(@NonNull GenericErrorType error) {
             this.type = error;
         }
+
         public BaseNetworkError(@NonNull GenericErrorType error, @NonNull String message) {
             this.type = error;
             this.message = message;
         }
+
         public BaseNetworkError(@NonNull GenericErrorType error, @NonNull XmlRpcErrorType xmlRpcErrorType) {
             this.type = error;
             this.xmlRpcErrorType = xmlRpcErrorType;
         }
+
         public boolean isGeneric() {
             return type != null;
         }
+
         public boolean hasVolleyError() {
             return volleyError != null;
         }
@@ -172,7 +183,9 @@ public abstract class BaseRequest<T> extends Request<T> {
     }
 
     public void addQueryParameters(Map<String, String> parameters) {
-        if (parameters == null) return;
+        if (parameters == null) {
+            return;
+        }
         Builder builder = mUri.buildUpon();
         for (String key : parameters.keySet()) {
             builder.appendQueryParameter(key, parameters.get(key));
@@ -183,7 +196,7 @@ public abstract class BaseRequest<T> extends Request<T> {
     /**
      * Enable caching for this request. The {@code timeToLive} param corresponds to the
      * {@code ttl} field in {@link Cache}.
-     *
+     * <p>
      * Disables soft expiry, which is when the cached result is returned, but a network request is also dispatched
      * to update the cache.
      *
@@ -197,7 +210,7 @@ public abstract class BaseRequest<T> extends Request<T> {
      * Enable caching for this request. The {@code timeToLive} and {@code softTimeToLive} params correspond to the
      * {@code ttl} and {@code softTtl} fields in {@link Cache}.
      *
-     * @param timeToLive the amount of time before the cache expires
+     * @param timeToLive     the amount of time before the cache expires
      * @param softTimeToLive the amount of time before the cache soft expires (the cached result is returned,
      *                       but a network request is also dispatched to update the cache)
      */
@@ -260,10 +273,10 @@ public abstract class BaseRequest<T> extends Request<T> {
 
     /**
      * Generate a cache entry for this request.
-     *
+     * <p>
      * If caching has been enabled through {@link BaseRequest#enableCaching(int, int)}, the expiry parameters that were
      * given are used to configure the cache entry.
-     *
+     * <p>
      * Otherwise, just generate a cache entry from the response's cache headers (default behaviour).
      */
     protected Cache.Entry createCacheEntry(NetworkResponse response) {
@@ -358,7 +371,10 @@ public abstract class BaseRequest<T> extends Request<T> {
 
     @Override
     public final void deliverError(VolleyError volleyError) {
-        AppLog.e(AppLog.T.API, "Volley error on " + getUrl(), volleyError);
+        Integer statusCode = volleyError.networkResponse != null ? volleyError.networkResponse.statusCode : null;
+        AppLog.e(AppLog.T.API,
+                "Volley error on " + getUrl() + (statusCode != null ? " Status Code: " + statusCode : ""),
+                volleyError);
         if (volleyError instanceof ParseError && mOnParseErrorListener != null) {
             OnUnexpectedError error = new OnUnexpectedError(volleyError, "API response parse error");
             error.addExtra(OnUnexpectedError.KEY_URL, getUrl());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
@@ -12,7 +12,7 @@ class RootWPAPIRestResponse(
     val authentication: Authentication? = null
 ) : Response {
     class Authentication(
-        @SerializedName("application-passwords") val applicationPasswords: ApplicationPasswords?
+        @SerializedName("application-passwords") val applicationPasswords: ApplicationPasswords? = null
     ) {
         class ApplicationPasswords(
             val endpoints: Endpoints?

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.discovery
 
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.network.Response
-import org.wordpress.android.fluxc.network.rest.JsonObjectOrEmptyArray
 
 class RootWPAPIRestResponse(
     val name: String? = null,
@@ -12,14 +11,15 @@ class RootWPAPIRestResponse(
     val namespaces: List<String>? = null,
     val authentication: Authentication? = null
 ) : Response {
-    class Authentication : JsonObjectOrEmptyArray() {
-        class Oauth1 {
-            var request: String? = null
-            var authorize: String? = null
-            var access: String? = null
-            var version: String? = null
+    class Authentication(
+        @SerializedName("application-passwords") val applicationPasswords: ApplicationPasswords?
+    ) {
+        class ApplicationPasswords(
+            val endpoints: Endpoints?
+        ) {
+            class Endpoints(
+                val authorization: String?
+            )
         }
-
-        var oauth1: Oauth1? = null
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticator.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticator.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
-class WPAPIAuthenticator @Inject constructor(
+class CookieNonceAuthenticator @Inject constructor(
     private val nonceRestClient: NonceRestClient,
     private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
     private val siteSqlUtils: SiteSqlUtils

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
@@ -9,8 +9,20 @@ sealed interface Nonce {
     data class FailedRequest(
         val timeOfResponse: Long,
         override val username: String,
+        val type: CookieNonceErrorType,
         val networkError: WPAPINetworkError? = null,
+        val errorMessage: String? = null,
     ) : Nonce
 
     data class Unknown(override val username: String) : Nonce
+
+    enum class CookieNonceErrorType {
+        NOT_AUTHENTICATED,
+        INVALID_RESPONSE,
+        CUSTOM_LOGIN_URL,
+        CUSTOM_ADMIN_URL,
+        INVALID_NONCE,
+        GENERIC_ERROR,
+        UNKNOWN
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpapi
 
-import androidx.core.text.HtmlCompat
 import com.android.volley.NoConnectionError
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
@@ -13,6 +12,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
+import org.wordpress.android.util.HtmlUtils
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -141,8 +141,7 @@ class NonceRestClient @Inject constructor(
 
         val errorHtml = loginErrorDiv.replace(urlRegex, "")
         // Strip HTML tags
-        return HtmlCompat.fromHtml(errorHtml, HtmlCompat.FROM_HTML_MODE_LEGACY)
-            .toString()
+        return HtmlUtils.fastStripHtml(errorHtml)
             .trim(' ', '\n')
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordCredentials.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordCredentials.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 
-internal data class ApplicationPasswordCredentials(
+data class ApplicationPasswordCredentials(
     val userName: String,
     val password: String,
     val uuid: ApplicationPasswordUUID

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordCredentials.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordCredentials.kt
@@ -3,5 +3,5 @@ package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 data class ApplicationPasswordCredentials(
     val userName: String,
     val password: String,
-    val uuid: ApplicationPasswordUUID
+    val uuid: ApplicationPasswordUUID? = null
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsConfiguration.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsConfiguration.kt
@@ -4,6 +4,11 @@ import org.wordpress.android.fluxc.module.ApplicationPasswordsClientId
 import java.util.Optional
 import javax.inject.Inject
 
+/**
+ * Note: the [ApplicationPasswordsClientId] is provided as [Optional] because we want to keep the feature optional and
+ * to not force the client apps to provide it. With this change, we will keep Dagger happy, and we move from a compile
+ * error to a runtime error if it's missing.
+ */
 internal data class ApplicationPasswordsConfiguration @Inject constructor(
     @ApplicationPasswordsClientId private val applicationNameOptional: Optional<String>
 ) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -36,7 +36,7 @@ internal class ApplicationPasswordsManager @Inject constructor(
      */
     private val SiteModel.supportsApplicationPasswordsGeneration
         get() = origin == SiteModel.ORIGIN_WPCOM_REST ||
-            (origin == SiteModel.ORIGIN_XMLRPC && !username.isNullOrEmpty() && !password.isNullOrEmpty())
+            (!username.isNullOrEmpty() && !password.isNullOrEmpty())
 
     @Suppress("ReturnCount")
     suspend fun getApplicationCredentials(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 import com.android.volley.NetworkResponse
 import com.android.volley.VolleyError
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.module.ApplicationPasswordsClientId
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
@@ -11,7 +10,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MAIN
-import java.util.Optional
 import javax.inject.Inject
 
 private const val UNAUTHORIZED = 401
@@ -19,11 +17,6 @@ private const val CONFLICT = 409
 private const val NOT_FOUND = 404
 private const val APPLICATION_PASSWORDS_DISABLED_ERROR_CODE = "application_passwords_disabled"
 
-/**
- * Note: the [ApplicationPasswordsClientId] is provided as [Optional] because we want to keep the feature optional and
- * to not force the client apps to provide it. With this change, we will keep Dagger happy, and we move from a compile
- * error to a runtime error if it's missing.
- */
 internal class ApplicationPasswordsManager @Inject constructor(
     private val applicationPasswordsStore: ApplicationPasswordsStore,
     private val jetpackApplicationPasswordsRestClient: JetpackApplicationPasswordsRestClient,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -38,7 +38,7 @@ class ApplicationPasswordsStore @Inject constructor(
 
         return when {
             !site.isUsingWpComRestApi && site.username != username -> null
-            username != null && password != null && uuid != null ->
+            username != null && password != null ->
                 ApplicationPasswordCredentials(
                     userName = username,
                     password = password,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -12,15 +12,17 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-internal class ApplicationPasswordsStore @Inject constructor(
-    private val context: Context,
-    private val configuration: ApplicationPasswordsConfiguration
+class ApplicationPasswordsStore @Inject constructor(
+    private val context: Context
 ) {
     companion object {
         private const val USERNAME_PREFERENCE_KEY_PREFIX = "username_"
         private const val PASSWORD_PREFERENCE_KEY_PREFIX = "app_password_"
         private const val UUID_PREFERENCE_KEY_PREFIX = "app_password_uuid_"
     }
+
+    @Inject
+    internal lateinit var configuration: ApplicationPasswordsConfiguration
 
     private val applicationName: String
         get() = configuration.applicationName
@@ -30,7 +32,7 @@ internal class ApplicationPasswordsStore @Inject constructor(
     }
 
     @Synchronized
-    fun getCredentials(site: SiteModel): ApplicationPasswordCredentials? {
+    internal fun getCredentials(site: SiteModel): ApplicationPasswordCredentials? {
         val username = encryptedPreferences.getString(site.usernamePrefKey, null)
         val password = encryptedPreferences.getString(site.passwordPrefKey, null)
         val uuid = encryptedPreferences.getString(site.uuidPrefKey, null)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -21,8 +21,7 @@ class ApplicationPasswordsStore @Inject constructor(
         private const val UUID_PREFERENCE_KEY_PREFIX = "app_password_uuid_"
     }
 
-    @Inject
-    internal lateinit var configuration: ApplicationPasswordsConfiguration
+    @Inject internal lateinit var configuration: ApplicationPasswordsConfiguration
 
     private val applicationName: String
         get() = configuration.applicationName

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
@@ -8,7 +8,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.util.AppLog
@@ -20,7 +20,7 @@ import javax.inject.Singleton
 @Singleton
 internal class WPApiApplicationPasswordsRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
-    private val wpApiAuthenticator: WPAPIAuthenticator,
+    private val wpApiAuthenticator: CookieNonceAuthenticator,
     dispatcher: Dispatcher,
     @Named("regular") requestQueue: RequestQueue,
     userAgent: UserAgent

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WPApiApplicationPasswordsRestClient.kt
@@ -1,6 +1,9 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 
+import com.android.volley.Request
 import com.android.volley.RequestQueue
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Credentials
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.SiteModel
@@ -9,21 +12,26 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
+import kotlin.coroutines.resume
 
 @Singleton
 internal class WPApiApplicationPasswordsRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     private val wpApiAuthenticator: CookieNonceAuthenticator,
-    dispatcher: Dispatcher,
+    private val applicationPasswordsStore: ApplicationPasswordsStore,
+    @Named("no-cookies") private val noCookieRequestQueue: RequestQueue,
     @Named("regular") requestQueue: RequestQueue,
-    userAgent: UserAgent
+    dispatcher: Dispatcher,
+    private val userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     suspend fun createApplicationPassword(
         site: SiteModel,
@@ -33,13 +41,13 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
         val path = WPAPI.users.me.application_passwords.urlV2
 
         val response = wpApiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
-                wpApiGsonRequestBuilder.syncPostRequest(
-                    restClient = this,
-                    url = site.buildUrl(path),
-                    body = mapOf("name" to applicationName),
-                    clazz = ApplicationPasswordCreationResponse::class.java,
-                    nonce = nonce.value
-                )
+            wpApiGsonRequestBuilder.syncPostRequest(
+                restClient = this,
+                url = site.buildUrl(path),
+                body = mapOf("name" to applicationName),
+                clazz = ApplicationPasswordCreationResponse::class.java,
+                nonce = nonce.value
+            )
         }
 
         return when (response) {
@@ -94,16 +102,16 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
         site: SiteModel,
         uuid: ApplicationPasswordUUID
     ): ApplicationPasswordDeletionPayload {
-        AppLog.d(T.MAIN, "Delete application password using Cookie Authentication")
+        AppLog.d(T.MAIN, "Delete application password")
 
-        val path = WPAPI.users.me.application_passwords.uuid(uuid).urlV2
-        val response = wpApiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
-            wpApiGsonRequestBuilder.syncDeleteRequest(
-                restClient = this,
-                url = site.buildUrl(path),
-                clazz = ApplicationPasswordDeleteResponse::class.java,
-                nonce = nonce.value
-            )
+        val applicationPasswordCredentials = applicationPasswordsStore.getCredentials(site)
+        val response = if (applicationPasswordCredentials != null) {
+            // If we have the credentials, attempt deleting the password using them
+            // This will allow deleting the password for sites authorized using the web flow where we don't have
+            // the user's credentials
+            deleteApplicationPasswordUsingBasicAuth(site, applicationPasswordCredentials)
+        } else {
+            deleteApplicationPasswordUsingCookieAuth(site, uuid)
         }
 
         return when (response) {
@@ -124,8 +132,46 @@ internal class WPApiApplicationPasswordsRestClient @Inject constructor(
         }
     }
 
+    private suspend fun deleteApplicationPasswordUsingBasicAuth(
+        site: SiteModel,
+        credentials: ApplicationPasswordCredentials
+    ) = suspendCancellableCoroutine<WPAPIResponse<ApplicationPasswordDeleteResponse>> { continuation ->
+        val path = WPAPI.users.me.application_passwords.uuid(credentials.uuid).urlV2
+
+        val request = WPAPIGsonRequest(
+            Request.Method.DELETE,
+            site.buildUrl(path),
+            emptyMap(),
+            emptyMap(),
+            ApplicationPasswordDeleteResponse::class.java,
+            /* listener = */ { continuation.resume(WPAPIResponse.Success(it)) },
+            /* errorListener = */ { continuation.resume(WPAPIResponse.Error(it)) }
+        )
+
+        request.addHeader("Authorization", Credentials.basic(credentials.userName, credentials.password))
+        request.setUserAgent(userAgent.userAgent)
+
+        noCookieRequestQueue.add(request)
+    }
+
+    private suspend fun deleteApplicationPasswordUsingCookieAuth(
+        site: SiteModel,
+        uuid: ApplicationPasswordUUID
+    ): WPAPIResponse<ApplicationPasswordDeleteResponse> {
+        val path = WPAPI.users.me.application_passwords.uuid(uuid).urlV2
+
+        return wpApiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+            wpApiGsonRequestBuilder.syncDeleteRequest(
+                restClient = this,
+                url = site.buildUrl(path),
+                clazz = ApplicationPasswordDeleteResponse::class.java,
+                nonce = nonce.value
+            )
+        }
+    }
+
     private fun SiteModel.buildUrl(path: String): String {
-        val baseUrl = wpApiRestUrl ?: "${url}/wp-json"
-        return "${baseUrl.trimEnd('/')}/${path.trimStart('/')}"
+        val baseUrl = wpApiRestUrl ?: url.slashJoin("/wp-json")
+        return baseUrl.slashJoin(path)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.RawRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIEncodedBodyRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
@@ -26,7 +26,7 @@ import kotlin.coroutines.resume
 class JetpackWPAPIRestClient @Inject constructor(
     private val wpApiEncodedBodyRequestBuilder: WPAPIEncodedBodyRequestBuilder,
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
-    private val wpapiAuthenticator: WPAPIAuthenticator,
+    private val cookieNonceAuthenticator: CookieNonceAuthenticator,
     dispatcher: Dispatcher,
     @Named("custom-ssl") requestQueue: RequestQueue,
     @Named("no-redirects") private val noRedirectsRequestQueue: RequestQueue,
@@ -38,7 +38,7 @@ class JetpackWPAPIRestClient @Inject constructor(
         val baseUrl = site.wpApiRestUrl ?: "${site.url}/wp-json"
         val url = "${baseUrl.trimEnd('/')}/${JPAPI.connection.url.pathV4.trimStart('/')}"
 
-        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+        val response = cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
             wpApiEncodedBodyRequestBuilder.syncGetRequest(
                 restClient = this,
                 url = url,
@@ -93,7 +93,7 @@ class JetpackWPAPIRestClient @Inject constructor(
     ): JetpackWPAPIPayload<JetpackUser> {
         val url = site.buildUrl(JPAPI.connection.data.pathV4)
 
-        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+        val response = cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
             wpApiGsonRequestBuilder.syncGetRequest(
                 restClient = this,
                 url = url,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.RawRequest
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIEncodedBodyRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
@@ -26,23 +26,25 @@ import kotlin.coroutines.resume
 class JetpackWPAPIRestClient @Inject constructor(
     private val wpApiEncodedBodyRequestBuilder: WPAPIEncodedBodyRequestBuilder,
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
+    private val wpapiAuthenticator: WPAPIAuthenticator,
     dispatcher: Dispatcher,
     @Named("custom-ssl") requestQueue: RequestQueue,
     @Named("no-redirects") private val noRedirectsRequestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     suspend fun fetchJetpackConnectionUrl(
-        site: SiteModel,
-        nonce: Nonce?
+        site: SiteModel
     ): JetpackWPAPIPayload<String> {
         val baseUrl = site.wpApiRestUrl ?: "${site.url}/wp-json"
         val url = "${baseUrl.trimEnd('/')}/${JPAPI.connection.url.pathV4.trimStart('/')}"
 
-        val response = wpApiEncodedBodyRequestBuilder.syncGetRequest(
-            restClient = this,
-            url = url,
-            nonce = nonce?.value
-        )
+        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+            wpApiEncodedBodyRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = url,
+                nonce = nonce.value
+            )
+        }
 
         return when (response) {
             is Success<String> -> JetpackWPAPIPayload(response.data)
@@ -87,17 +89,18 @@ class JetpackWPAPIRestClient @Inject constructor(
     }
 
     suspend fun fetchJetpackUser(
-        site: SiteModel,
-        nonce: Nonce?
+        site: SiteModel
     ): JetpackWPAPIPayload<JetpackUser> {
         val url = site.buildUrl(JPAPI.connection.data.pathV4)
 
-        val response = wpApiGsonRequestBuilder.syncGetRequest(
-            restClient = this,
-            url = url,
-            nonce = nonce?.value,
-            clazz = JetpackConnectionDataResponse::class.java
-        )
+        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+            wpApiGsonRequestBuilder.syncGetRequest(
+                restClient = this,
+                url = url,
+                nonce = nonce.value,
+                clazz = JetpackConnectionDataResponse::class.java
+            )
+        }
 
         return when (response) {
             is Success<JetpackConnectionDataResponse> -> JetpackWPAPIPayload(
@@ -112,6 +115,7 @@ class JetpackWPAPIRestClient @Inject constructor(
                     )
                 }
             )
+
             is Error -> JetpackWPAPIPayload(response.error)
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
@@ -7,7 +7,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
@@ -20,7 +20,7 @@ import javax.inject.Singleton
 @Singleton
 class PluginWPAPIRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
-    private val wpapiAuthenticator: WPAPIAuthenticator,
+    private val cookieNonceAuthenticator: CookieNonceAuthenticator,
     dispatcher: Dispatcher,
     @Named("custom-ssl") requestQueue: RequestQueue,
     userAgent: UserAgent
@@ -31,7 +31,7 @@ class PluginWPAPIRestClient @Inject constructor(
     ): WPApiPluginsPayload<List<SitePluginModel>> {
         val url = buildUrl(site)
         val type = object : TypeToken<List<PluginResponseModel>>() {}.type
-        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+        val response = cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
             wpApiGsonRequestBuilder.syncGetRequest<List<PluginResponseModel>>(
                 restClient = this,
                 url = url,
@@ -59,7 +59,7 @@ class PluginWPAPIRestClient @Inject constructor(
         pluginName: String
     ): WPApiPluginsPayload<SitePluginModel> {
         val url = buildUrl(site, pluginName)
-        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+        val response = cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
             wpApiGsonRequestBuilder.syncGetRequest(
                 restClient = this,
                 url = url,
@@ -75,7 +75,7 @@ class PluginWPAPIRestClient @Inject constructor(
         installedPluginSlug: String
     ): WPApiPluginsPayload<SitePluginModel> {
         val url = buildUrl(site)
-        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+        val response = cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
             wpApiGsonRequestBuilder.syncPostRequest(
                 restClient = this,
                 url = url,
@@ -93,7 +93,7 @@ class PluginWPAPIRestClient @Inject constructor(
         active: Boolean
     ): WPApiPluginsPayload<SitePluginModel> {
         val url = buildUrl(site, updatedPlugin)
-        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+        val response = cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
             wpApiGsonRequestBuilder.syncPutRequest(
                 restClient = this,
                 url = url,
@@ -110,7 +110,7 @@ class PluginWPAPIRestClient @Inject constructor(
         deletedPlugin: String
     ): WPApiPluginsPayload<SitePluginModel> {
         val url = buildUrl(site, deletedPlugin)
-        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+        val response = cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
             wpApiGsonRequestBuilder.syncDeleteRequest(
                 restClient = this,
                 url = url,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPAPIRestClient.kt
@@ -7,7 +7,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
@@ -20,25 +20,26 @@ import javax.inject.Singleton
 @Singleton
 class PluginWPAPIRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
+    private val wpapiAuthenticator: WPAPIAuthenticator,
     dispatcher: Dispatcher,
     @Named("custom-ssl") requestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     suspend fun fetchPlugins(
         site: SiteModel,
-        nonce: Nonce? = null,
         enableCaching: Boolean = true
     ): WPApiPluginsPayload<List<SitePluginModel>> {
         val url = buildUrl(site)
         val type = object : TypeToken<List<PluginResponseModel>>() {}.type
-        val response =
-                wpApiGsonRequestBuilder.syncGetRequest<List<PluginResponseModel>>(
-                        restClient = this,
-                        url = url,
-                        type = type,
-                        enableCaching = enableCaching,
-                        nonce = nonce?.value
-                )
+        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+            wpApiGsonRequestBuilder.syncGetRequest<List<PluginResponseModel>>(
+                restClient = this,
+                url = url,
+                type = type,
+                enableCaching = enableCaching,
+                nonce = nonce.value
+            )
+        }
         return when (response) {
             is Success -> {
                 val plugins = response.data?.map {
@@ -46,6 +47,7 @@ class PluginWPAPIRestClient @Inject constructor(
                 }
                 WPApiPluginsPayload(site, plugins)
             }
+
             is Error -> {
                 WPApiPluginsPayload(response.error)
             }
@@ -54,68 +56,68 @@ class PluginWPAPIRestClient @Inject constructor(
 
     suspend fun fetchPlugin(
         site: SiteModel,
-        nonce: Nonce?,
         pluginName: String
     ): WPApiPluginsPayload<SitePluginModel> {
         val url = buildUrl(site, pluginName)
-        val response =
+        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
             wpApiGsonRequestBuilder.syncGetRequest(
                 restClient = this,
                 url = url,
                 clazz = PluginResponseModel::class.java,
-                nonce = nonce?.value
+                nonce = nonce.value
             )
+        }
         return handleResponse(response, site)
     }
 
     suspend fun installPlugin(
         site: SiteModel,
-        nonce: Nonce? = null,
         installedPluginSlug: String
     ): WPApiPluginsPayload<SitePluginModel> {
         val url = buildUrl(site)
-        val response =
-                wpApiGsonRequestBuilder.syncPostRequest(
-                        restClient = this,
-                        url = url,
-                        body = mapOf("slug" to installedPluginSlug),
-                        clazz = PluginResponseModel::class.java,
-                        nonce = nonce?.value
-                )
+        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+            wpApiGsonRequestBuilder.syncPostRequest(
+                restClient = this,
+                url = url,
+                body = mapOf("slug" to installedPluginSlug),
+                clazz = PluginResponseModel::class.java,
+                nonce = nonce.value
+            )
+        }
         return handleResponse(response, site)
     }
 
     suspend fun updatePlugin(
         site: SiteModel,
-        nonce: Nonce? = null,
         updatedPlugin: String,
         active: Boolean
     ): WPApiPluginsPayload<SitePluginModel> {
         val url = buildUrl(site, updatedPlugin)
-        val response =
-                wpApiGsonRequestBuilder.syncPutRequest(
-                        restClient = this,
-                        url = url,
-                        body = mapOf("status" to if (active) "active" else "inactive"),
-                        clazz = PluginResponseModel::class.java,
-                        nonce = nonce?.value
-                )
+        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+            wpApiGsonRequestBuilder.syncPutRequest(
+                restClient = this,
+                url = url,
+                body = mapOf("status" to if (active) "active" else "inactive"),
+                clazz = PluginResponseModel::class.java,
+                nonce = nonce.value
+            )
+        }
         return handleResponse(response, site)
     }
 
     suspend fun deletePlugin(
         site: SiteModel,
-        nonce: Nonce? = null,
         deletedPlugin: String
     ): WPApiPluginsPayload<SitePluginModel> {
         val url = buildUrl(site, deletedPlugin)
-        val response =
-                wpApiGsonRequestBuilder.syncDeleteRequest(
-                        restClient = this,
-                        url = url,
-                        clazz = PluginResponseModel::class.java,
-                        nonce = nonce?.value
-                )
+        val response = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+            wpApiGsonRequestBuilder.syncDeleteRequest(
+                restClient = this,
+                url = url,
+                clazz = PluginResponseModel::class.java,
+                nonce = nonce.value
+            )
+        }
         return handleResponse(response, site)
     }
 
@@ -127,6 +129,7 @@ class PluginWPAPIRestClient @Inject constructor(
             val plugin = response.data?.toDomainModel(site.id)
             WPApiPluginsPayload(site, plugin)
         }
+
         is Error -> {
             WPApiPluginsPayload(response.error)
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -1,22 +1,19 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.site
 
 import com.android.volley.RequestQueue
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.discovery.DiscoveryUtils
+import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
 import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
-import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
+import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 import javax.inject.Named
@@ -24,8 +21,8 @@ import javax.inject.Singleton
 
 @Singleton
 class SiteWPAPIRestClient @Inject constructor(
-    private val cookieNonceAuthenticator: CookieNonceAuthenticator,
     private val wpapiGsonRequestBuilder: WPAPIGsonRequestBuilder,
+    private val discoveryWPAPIRestClient: DiscoveryWPAPIRestClient,
     dispatcher: Dispatcher,
     @Named("custom-ssl") requestQueue: RequestQueue,
     userAgent: UserAgent
@@ -42,28 +39,16 @@ class SiteWPAPIRestClient @Inject constructor(
         val cleanedUrl = UrlUtils.addUrlSchemeIfNeeded(payload.url, false).let { urlWithScheme ->
             DiscoveryUtils.stripKnownPaths(urlWithScheme)
         }
-        var discoveredWpApiUrl: String? = null
 
-        val result = cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(
-            siteUrl = cleanedUrl,
-            username = payload.username,
-            password = payload.password
-        ) { wpApiUrl, nonce ->
-            if (nonce !is Available) {
-                val networkError = (nonce as? FailedRequest)?.networkError ?: BaseNetworkError(GenericErrorType.UNKNOWN)
+        val discoveredWpApiUrl = discoverApiEndpoint(cleanedUrl)
+        val urlScheme = discoveredWpApiUrl.toHttpUrl().scheme
 
-                return@makeAuthenticatedWPAPIRequest Error(WPAPINetworkError(networkError))
-            }
-
-            discoveredWpApiUrl = wpApiUrl
-            wpapiGsonRequestBuilder.syncGetRequest(
-                restClient = this,
-                url = wpApiUrl,
-                clazz = RootWPAPIRestResponse::class.java,
-                params = mapOf("_fields" to FETCH_API_CALL_FIELDS),
-                nonce = nonce.value
-            )
-        }
+        val result = wpapiGsonRequestBuilder.syncGetRequest(
+            restClient = this,
+            url = discoveredWpApiUrl,
+            clazz = RootWPAPIRestResponse::class.java,
+            params = mapOf("_fields" to FETCH_API_CALL_FIELDS)
+        )
 
         return when (result) {
             is Success -> {
@@ -77,7 +62,7 @@ class SiteWPAPIRestClient @Inject constructor(
                         it.startsWith(WOO_API_NAMESPACE_PREFIX)
                     } ?: false
                     wpApiRestUrl = discoveredWpApiUrl
-                    this.url = response?.url ?: cleanedUrl
+                    this.url = response?.url ?: cleanedUrl.replaceBefore("://", urlScheme)
                     this.username = payload.username
                     this.password = payload.password
                 }
@@ -96,10 +81,17 @@ class SiteWPAPIRestClient @Inject constructor(
     ): SiteModel {
         return fetchWPAPISite(
             payload = FetchWPAPISitePayload(
+                url = site.url,
                 username = site.username,
                 password = site.password,
-                url = site.url
             )
         )
+    }
+
+    private fun discoverApiEndpoint(
+        url: String
+    ): String {
+        return discoveryWPAPIRestClient.discoverWPAPIBaseURL(url) // discover rest api endpoint
+            ?: url.slashJoin("wp-json/") // fallback to ".../wp-json/" if discovery fails
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -31,6 +31,7 @@ class SiteWPAPIRestClient @Inject constructor(
         private const val WOO_API_NAMESPACE_PREFIX = "wc/"
         private const val FETCH_API_CALL_FIELDS =
             "name,description,gmt_offset,url,authentication,namespaces"
+        private const val APPLICATION_PASSWORDS_URL_SUFFIX = "authorize-application.php"
     }
 
     suspend fun fetchWPAPISite(
@@ -61,6 +62,15 @@ class SiteWPAPIRestClient @Inject constructor(
                     hasWooCommerce = response?.namespaces?.any {
                         it.startsWith(WOO_API_NAMESPACE_PREFIX)
                     } ?: false
+
+                    applicationPasswordsAuthorizeUrl = response?.authentication?.applicationPasswords
+                        ?.endpoints?.authorization
+                    if (!applicationPasswordsAuthorizeUrl.isNullOrEmpty() &&
+                        applicationPasswordsAuthorizeUrl.contains(APPLICATION_PASSWORDS_URL_SUFFIX)) {
+                        // Infer the admin URL from the application passwords authorization URL
+                        adminUrl = applicationPasswordsAuthorizeUrl.substringBefore(APPLICATION_PASSWORDS_URL_SUFFIX)
+                    }
+
                     wpApiRestUrl = discoveredWpApiUrl
                     this.url = response?.url ?: cleanedUrl.replaceBefore("://", urlScheme)
                     this.username = payload.username

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Available
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIAuthenticator
+import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
@@ -24,7 +24,7 @@ import javax.inject.Singleton
 
 @Singleton
 class SiteWPAPIRestClient @Inject constructor(
-    private val wpapiAuthenticator: WPAPIAuthenticator,
+    private val cookieNonceAuthenticator: CookieNonceAuthenticator,
     private val wpapiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     dispatcher: Dispatcher,
     @Named("custom-ssl") requestQueue: RequestQueue,
@@ -44,7 +44,7 @@ class SiteWPAPIRestClient @Inject constructor(
         }
         var discoveredWpApiUrl: String? = null
 
-        val result = wpapiAuthenticator.makeAuthenticatedWPAPIRequest(
+        val result = cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(
             siteUrl = cleanedUrl,
             username = payload.username,
             password = payload.password

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 180
+        return 181
     }
 
     override fun getDbName(): String {
@@ -1890,6 +1890,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 179 -> migrate(version) {
                     db.execSQL("ALTER TABLE AccountModel ADD TWO_STEP_ENABLED BOOLEAN")
+                }
+                180 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD APPLICATION_PASSWORDS_AUTHORIZE_URL TEXT")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -469,8 +469,7 @@ open class SiteStore @Inject constructor(
     data class SiteError @JvmOverloads constructor(
         @JvmField val type: SiteErrorType,
         @JvmField val message: String? = null,
-        @JvmField val selfHostedErrorType: SelfHostedErrorType = NOT_SET,
-        @JvmField val wpApiError: WPAPIError? = null
+        @JvmField val selfHostedErrorType: SelfHostedErrorType = NOT_SET
     ) : OnChangedError
 
     data class SiteEditorsError internal constructor(
@@ -921,23 +920,6 @@ open class SiteStore @Inject constructor(
         NOT_SET,
         XML_RPC_SERVICES_DISABLED,
         UNABLE_TO_READ_SITE
-    }
-
-    data class WPAPIError(
-        val errorType: WPAPIErrorType?,
-        val statusCode: Int?
-    )
-
-    enum class WPAPIErrorType {
-        CUSTOM_LOGIN_URL,
-        CUSTOM_ADMIN_URL;
-
-        companion object {
-            fun fromString(type: String?): WPAPIErrorType? {
-                return if (type.isNullOrEmpty()) null
-                else WPAPIErrorType.values().firstOrNull { it.name == type }
-            }
-        }
     }
 
     enum class DeleteSiteErrorType {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -155,9 +155,9 @@ open class SiteStore @Inject constructor(
     ) : Payload<BaseNetworkError>()
 
     data class FetchWPAPISitePayload(
-        @JvmField val username: String = "",
-        @JvmField val password: String = "",
-        @JvmField val url: String = ""
+        val url: String,
+        val username: String? = null,
+        val password: String? = null,
     ) : Payload<BaseNetworkError>()
 
     data class FetchSitesPayload @JvmOverloads constructor(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/SiteErrorUtils.java
@@ -1,17 +1,13 @@
 package org.wordpress.android.fluxc.utils;
 
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError;
 import org.wordpress.android.fluxc.store.SiteStore.SelfHostedErrorType;
 import org.wordpress.android.fluxc.store.SiteStore.SiteError;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
-import org.wordpress.android.fluxc.store.SiteStore.WPAPIError;
-import org.wordpress.android.fluxc.store.SiteStore.WPAPIErrorType;
 
 public class SiteErrorUtils {
     public static SiteError genericToSiteError(BaseNetworkError error) {
         SiteErrorType errorType = SiteErrorType.GENERIC_ERROR;
-        WPAPIError wpapiError = null;
         if (error.isGeneric()) {
             switch (error.type) {
                 case INVALID_RESPONSE:
@@ -23,17 +19,7 @@ public class SiteErrorUtils {
             }
         }
 
-        if (error instanceof WPAPINetworkError) {
-            String errorCode = ((WPAPINetworkError) error).getErrorCode();
-            wpapiError = new WPAPIError(
-                    WPAPIErrorType.Companion.fromString(errorCode),
-                    error.hasVolleyError() && error.volleyError.networkResponse != null
-                            ? error.volleyError.networkResponse.statusCode
-                            : 200 // volleyError will be missing when the request succeeds but the response is invalid
-            );
-        }
-
-        SiteError siteError = new SiteError(errorType, error.message, SelfHostedErrorType.NOT_SET, wpapiError);
+        SiteError siteError = new SiteError(errorType, error.message, SelfHostedErrorType.NOT_SET);
 
         switch (error.xmlRpcErrorType) {
             case METHOD_NOT_ALLOWED:

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -96,6 +96,7 @@ class ApplicationPasswordManagerTests {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
+                password = "password"
             }
 
             whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
@@ -169,6 +170,7 @@ class ApplicationPasswordManagerTests {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
+                password = "password"
             }
             val networkError = BaseNetworkError(VolleyError(NetworkResponse(404, null, true, 0, emptyList())))
 
@@ -189,6 +191,7 @@ class ApplicationPasswordManagerTests {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
+                password = "password"
             }
             val networkError = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.SERVER_ERROR)).apply {
                 apiError = "application_passwords_disabled"
@@ -248,6 +251,7 @@ class ApplicationPasswordManagerTests {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
+                password = "password"
             }
             val creationNetworkError = BaseNetworkError(VolleyError(NetworkResponse(409, null, true, 0, emptyList())))
             whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -78,7 +78,7 @@ class ApplicationPasswordManagerTests {
                 .thenReturn(
                     ApplicationPasswordCreationPayload(
                         testCredentials.password,
-                        testCredentials.uuid
+                        testCredentials.uuid!!
                     )
                 )
 
@@ -109,7 +109,7 @@ class ApplicationPasswordManagerTests {
                 .thenReturn(
                     ApplicationPasswordCreationPayload(
                         testCredentials.password,
-                        testCredentials.uuid
+                        testCredentials.uuid!!
                     )
                 )
 
@@ -209,43 +209,6 @@ class ApplicationPasswordManagerTests {
         }
 
     @Test
-    fun `when password delete is requested for a jetpack site, then process it`() =
-        runBlockingTest {
-            val site = testSite.apply {
-                origin = SiteModel.ORIGIN_WPCOM_REST
-            }
-
-            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(testCredentials)
-            whenever(mJetpackApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))
-                .thenReturn(ApplicationPasswordDeletionPayload(isDeleted = true))
-
-            val result = mApplicationPasswordsManager.deleteApplicationCredentials(
-                testSite
-            )
-
-            assertEquals(ApplicationPasswordDeletionResult.Success, result)
-        }
-
-    @Test
-    fun `when password delete is requested for a non-jetpack site, then process it`() =
-        runBlockingTest {
-            val site = testSite.apply {
-                origin = SiteModel.ORIGIN_XMLRPC
-                username = testCredentials.userName
-            }
-
-            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(testCredentials)
-            whenever(mWpApiApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))
-                .thenReturn(ApplicationPasswordDeletionPayload(isDeleted = true))
-
-            val result = mApplicationPasswordsManager.deleteApplicationCredentials(
-                testSite
-            )
-
-            assertEquals(ApplicationPasswordDeletionResult.Success, result)
-        }
-
-    @Test
     fun `given a duplicate password already exists, when creating a new password, then delete the previous one`() =
         runBlockingTest {
             val site = testSite.apply {
@@ -257,7 +220,7 @@ class ApplicationPasswordManagerTests {
             whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
             whenever(mWpApiApplicationPasswordsRestClient.createApplicationPassword(site, applicationName))
                 .thenReturn(ApplicationPasswordCreationPayload(creationNetworkError))
-                .thenReturn(ApplicationPasswordCreationPayload(testCredentials.password, testCredentials.uuid))
+                .thenReturn(ApplicationPasswordCreationPayload(testCredentials.password, testCredentials.uuid!!))
             whenever(mWpApiApplicationPasswordsRestClient.fetchApplicationPasswordUUID(site, applicationName))
                 .thenReturn(ApplicationPasswordUUIDFetchPayload(uuid))
             whenever(mWpApiApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))
@@ -271,7 +234,7 @@ class ApplicationPasswordManagerTests {
         }
 
     @Test
-    fun `given uuid doesn't exist locally, when deleting a password, then fetch it`() =
+    fun `given application password doesn't exist locally, when deleting a password, then fetch the UUID`() =
         runBlockingTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
@@ -288,5 +251,22 @@ class ApplicationPasswordManagerTests {
             assertEquals(ApplicationPasswordDeletionResult.Success, result)
             verify(mWpApiApplicationPasswordsRestClient).fetchApplicationPasswordUUID(site, applicationName)
             verify(mWpApiApplicationPasswordsRestClient).deleteApplicationPassword(site, uuid)
+        }
+
+    @Test
+    fun `given application password exists locally, when deleting a password, then delete it using it itself`() =
+        runBlockingTest {
+            val site = testSite.apply {
+                origin = SiteModel.ORIGIN_XMLRPC
+                username = testCredentials.userName
+            }
+            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(testCredentials)
+            whenever(mWpApiApplicationPasswordsRestClient.deleteApplicationPassword(site, testCredentials))
+                .thenReturn(ApplicationPasswordDeletionPayload(isDeleted = true))
+
+            val result = mApplicationPasswordsManager.deleteApplicationCredentials(site)
+
+            assertEquals(ApplicationPasswordDeletionResult.Success, result)
+            verify(mWpApiApplicationPasswordsRestClient).deleteApplicationPassword(site, testCredentials)
         }
 }


### PR DESCRIPTION
This PR is needed to support the Web Authorization flow for the application passwords login, this flow differs from the other flow where the app would use the REST API to create the application password, instead the flow would be like this:
1. Fetches the REST root endpoint (`/wp-json/`), this will allow both checking if application passwords are enabled, and would give us the authorization URL.
2. Open the authorization URL.
3. The user will be asked to sign-in, then approve our connection.
4. When it's done, a redirection URL will be triggered, and it'll contain the created password.
5. Save the password to the `ApplicationPasswordsStore`, then proceed to finishing the signing.

This means that we'll have these two main changes to the rest of the flow:
1. We can't re-generate the password if it gets revoked.
2. For deleting the password, we need to use it itself for the authentication, as we don't have the site credentials.

To achieve the above, this PR has these changes:

1. Update the Application Passwords implementation to allow working with web authorization, and this includes the following changes:
    - Ability to save passwords directly by the clients 780f42d
    - Handle missing user credentials when attempting to regenerate the password 7501ab0
    - Handle deleting passwords using the Application Password itself 4682aa3
7. Update the WPApiAuthenticator class (called now `CookieNonceAuthenticator` for clarity) to work on network level, this is just an improvement to have a better code architecture ad815bd and d739927
8. Update the WPApi authentication to separate the login from the fetch, we need this since we need to fetch the site without authentication now 84fc30d
9. Handle fetching the Application Passwords authorization URL f2f60b9 and 548e889
10. Fix and Improve tests b449c4d and a2e0730

Reviewing each part separately will make the review easier.

The first part of WCAndroid changes to align with this PR is in https://github.com/woocommerce/woocommerce-android/issues/8598, then will add another PR to implement the Web Authorization.