### PR TITLE
Save product variation metadata

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 180
+        return 181
     }
 
     override fun getDbName(): String {
@@ -1890,6 +1890,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 179 -> migrate(version) {
                     db.execSQL("ALTER TABLE AccountModel ADD TWO_STEP_ENABLED BOOLEAN")
+                }
+                180 -> migrate(version) {
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD METADATA TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -80,6 +80,8 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
 
     @Column var attributes = ""
 
+    @Column var metadata: String? = null
+
     override fun getId() = id
 
     override fun setId(id: Int) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -55,6 +55,7 @@ class ProductVariationApiResponse : Response {
     var dimensions: JsonElement? = null
     var attributes: JsonElement? = null
     var downloads: JsonElement? = null
+    var meta_data: JsonElement? = null
 
     @Suppress("ComplexMethod")
     fun asProductVariationModel() =
@@ -116,5 +117,6 @@ class ProductVariationApiResponse : Response {
             }
 
             image = response.image?.toString() ?: ""
+            metadata = response.meta_data?.toString()
         }
 }


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/8389

### Why 
We need to save the product variants metadata locally to be able to get the subscription details information from the subscription variants.

### Description 
This PR adds the metadata column to the WCProductVariationModel and uses the field to save the metadata of product variants locally

### Testing
Use the [woo PR](https://github.com/woocommerce/woocommerce-android/pull/8601) and check that the metadata value of product variants is saved locally