### PR TITLE
Android 13 Migration: Update targetSdkVersion to 33

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ allprojects {
 ext {
     minSdkVersion = 24
     compileSdkVersion = 33
-    targetSdkVersion = 31
+    targetSdkVersion = 33
 }
 
 ext {

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,7 +48,7 @@ dependencyResolutionManagement {
             version("facebook-soloader", "0.9.0")
             version("kotlinx-coroutines", "1.3.9")
             version("wordpress-utils", "develop-eebc5d8e91a1d90190919f900f924b39c861a528")
-            version("robolectric", "10-e52d425f5c654c413c56c9c15f023d7458a17965")
+            version("robolectric", "4.9.2")
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.5.0"
+def catalogVersion = "1.6.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {
@@ -48,7 +48,6 @@ dependencyResolutionManagement {
             version("facebook-soloader", "0.9.0")
             version("kotlinx-coroutines", "1.3.9")
             version("wordpress-utils", "develop-eebc5d8e91a1d90190919f900f924b39c861a528")
-            version("robolectric", "4.9.2")
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,6 +48,7 @@ dependencyResolutionManagement {
             version("facebook-soloader", "0.9.0")
             version("kotlinx-coroutines", "1.3.9")
             version("wordpress-utils", "develop-eebc5d8e91a1d90190919f900f924b39c861a528")
+            version("robolectric", "10-e52d425f5c654c413c56c9c15f023d7458a17965")
         }
     }
 }


### PR DESCRIPTION
Update targetSdkVersion from 31 to 33 (Android 13)

_Internal project thread: pbArwn-5IN-p2_

To test

- Checkout this branch
- Use this branch through WP (uncomment locaFluxCPath in local-builds.gradle)
- Log out if already logged in
- Try out login and various flows
- Ensure, no issues or crashes

>**Note**
> - [x] This requires [update to Robolectric version from 4.7.3 5o 4.9](https://github.com/Automattic/android-dependency-catalog/pull/10)