### PR TITLE
Urgent: Fix WP API root endpoint deserialization

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.discovery
 
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.network.Response
+import org.wordpress.android.fluxc.network.rest.JsonObjectOrEmptyArray
 
 class RootWPAPIRestResponse(
     val name: String? = null,
@@ -13,7 +14,7 @@ class RootWPAPIRestResponse(
 ) : Response {
     class Authentication(
         @SerializedName("application-passwords") val applicationPasswords: ApplicationPasswords? = null
-    ) {
+    ): JsonObjectOrEmptyArray() {
         class ApplicationPasswords(
             val endpoints: Endpoints?
         ) {


### PR DESCRIPTION
In the PR #2683, I added support for deserializing the `application-passwords` data in the `authentication` field, but in doing so, I accidentally removed the parent `JsonObjectOrEmptyArray` for the Authentication class, and this is causing a deserialization issue when the response is empty, which would block login for sites with empty `authentication` response.