### PR TITLE
Save only used metadata

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.fluxc.model
+
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import javax.inject.Inject
+
+class StripProductVariationMetaData @Inject internal constructor(private val gson: Gson) {
+    operator fun invoke(metadata: String?): String? {
+        if (metadata == null) return null
+
+        val filteredMetadata = gson.fromJson(metadata, JsonArray::class.java)
+            .mapNotNull { it as? JsonObject }
+            .filter { jsonObject ->
+                val key = jsonObject[WCMetaData.KEY]?.asString ?: ""
+                key in SUPPORTED_KEYS
+            }
+            .filter { jsonObject ->
+                val value = jsonObject[WCMetaData.VALUE]?.asString ?: ""
+                value.isBlank().not()
+            }
+            .toList()
+
+        return if (filteredMetadata.isEmpty()) null else gson.toJson(filteredMetadata)
+    }
+
+    companion object {
+        val SUPPORTED_KEYS: Set<String> = buildSet {
+            addAll(WCProductVariationModel.SubscriptionMetadataKeys.ALL_KEYS)
+        }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
@@ -9,19 +9,15 @@ class StripProductVariationMetaData @Inject internal constructor(private val gso
     operator fun invoke(metadata: String?): String? {
         if (metadata == null) return null
 
-        val filteredMetadata = gson.fromJson(metadata, JsonArray::class.java)
+        return gson.fromJson(metadata, JsonArray::class.java)
             .mapNotNull { it as? JsonObject }
+            .asSequence()
             .filter { jsonObject ->
-                val key = jsonObject[WCMetaData.KEY]?.asString ?: ""
-                key in SUPPORTED_KEYS
-            }
-            .filter { jsonObject ->
-                val value = jsonObject[WCMetaData.VALUE]?.asString ?: ""
-                value.isBlank().not()
-            }
-            .toList()
-
-        return if (filteredMetadata.isEmpty()) null else gson.toJson(filteredMetadata)
+                jsonObject[WCMetaData.KEY]?.asString.orEmpty() in SUPPORTED_KEYS &&
+                    jsonObject[WCMetaData.VALUE]?.asString.orEmpty().isNotBlank()
+            }.toList()
+            .takeIf { it.isNotEmpty() }
+            ?.let { gson.toJson(it) }
     }
 
     companion object {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
@@ -3,9 +3,17 @@ package org.wordpress.android.fluxc.model
 import com.google.gson.annotations.SerializedName
 
 data class WCMetaData(
-    @SerializedName("id") val id: Long,
-    @SerializedName("key") val key: String?,
-    @SerializedName("value") val value: Any,
-    @SerializedName("display_key") val displayKey: String?,
-    @SerializedName("display_value") val displayValue: Any?
-)
+    @SerializedName(ID) val id: Long,
+    @SerializedName(KEY) val key: String?,
+    @SerializedName(VALUE) val value: Any,
+    @SerializedName(DISPLAY_KEY) val displayKey: String?,
+    @SerializedName(DISPLAY_VALUE) val displayValue: Any?
+){
+    companion object {
+        const val ID = "id"
+        const val KEY = "key"
+        const val VALUE = "value"
+        const val DISPLAY_KEY = "display_key"
+        const val DISPLAY_VALUE = "display_value"
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -149,4 +149,25 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
         val responseType = object : TypeToken<List<ProductVariantOption>>() {}.type
         return gson.fromJson(attributes, responseType) as? List<ProductVariantOption> ?: emptyList()
     }
+
+    object SubscriptionMetadataKeys {
+        const val SUBSCRIPTION_PRICE = "_subscription_price"
+        const val SUBSCRIPTION_PERIOD = "_subscription_period"
+        const val SUBSCRIPTION_PERIOD_INTERVAL = "_subscription_period_interval"
+        const val SUBSCRIPTION_LENGTH = "_subscription_length"
+        const val SUBSCRIPTION_SIGN_UP_FEE = "_subscription_sign_up_fee"
+        const val SUBSCRIPTION_TRIAL_PERIOD = "_subscription_trial_period"
+        const val SUBSCRIPTION_TRIAL_LENGTH = "_subscription_trial_length"
+        const val SUBSCRIPTION_ONE_TIME_SHIPPING = "_subscription_one_time_shipping"
+        val ALL_KEYS = setOf(
+            SUBSCRIPTION_PRICE,
+            SUBSCRIPTION_TRIAL_LENGTH,
+            SUBSCRIPTION_SIGN_UP_FEE,
+            SUBSCRIPTION_PERIOD,
+            SUBSCRIPTION_PERIOD_INTERVAL,
+            SUBSCRIPTION_LENGTH,
+            SUBSCRIPTION_TRIAL_PERIOD,
+            SUBSCRIPTION_ONE_TIME_SHIPPING
+        )
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.StripProductVariationMetaData
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
@@ -78,7 +79,8 @@ class ProductRestClient @Inject constructor(
     private val dispatcher: Dispatcher,
     private val wooNetwork: WooNetwork,
     private val wpComNetwork: WPComNetwork,
-    private val coroutineEngine: CoroutineEngine
+    private val coroutineEngine: CoroutineEngine,
+    private val stripProductVariationMetaData: StripProductVariationMetaData
 ) {
     /**
      * Makes a GET request to `/wp-json/wc/v3/products/shipping_classes/[remoteShippingClassId]`
@@ -337,6 +339,7 @@ class ProductRestClient @Inject constructor(
                         productData.asProductVariationModel().apply {
                             this.remoteProductId = remoteProductId
                             localSiteId = site.id
+                            metadata = stripProductVariationMetaData(metadata)
                         },
                         site
                     )
@@ -765,6 +768,7 @@ class ProductRestClient @Inject constructor(
                     it.asProductVariationModel().apply {
                         localSiteId = site.id
                         remoteProductId = productId
+                        metadata = stripProductVariationMetaData(metadata)
                     }
                 }.orEmpty()
 
@@ -827,6 +831,7 @@ class ProductRestClient @Inject constructor(
                     .apply {
                         localSiteId = site.id
                         remoteProductId = productId
+                        metadata = stripProductVariationMetaData(metadata)
                     }
             }
         }
@@ -911,6 +916,7 @@ class ProductRestClient @Inject constructor(
                     val newModel = it.asProductVariationModel().apply {
                         this.remoteProductId = remoteProductId
                         localSiteId = site.id
+                        metadata = stripProductVariationMetaData(metadata)
                     }
                     RemoteUpdateVariationPayload(site, newModel)
                 } ?: RemoteUpdateVariationPayload(

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -36,7 +36,7 @@ class ProductRestClientTest {
     private val wpComNetwork: WPComNetwork = mock()
 
     @Before fun setUp() {
-        sut = ProductRestClient(mock(), wooNetwork, wpComNetwork, initCoroutineEngine())
+        sut = ProductRestClient(mock(), wooNetwork, wpComNetwork, initCoroutineEngine(), mock())
     }
 
     @Test

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/StripProductVariationMetaDataTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/StripProductVariationMetaDataTest.kt
@@ -1,0 +1,177 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.model.StripProductVariationMetaData
+import org.wordpress.android.fluxc.model.WCMetaData
+
+class StripProductVariationMetaDataTest {
+    private val gson = Gson()
+    private val sut = StripProductVariationMetaData(gson)
+
+    @Test
+    fun `when metadata contains not supported keys, then NOT supported keys are stripped`() {
+        val result = sut.invoke(notOnlySupportedMetadata)
+        val jsonResult = gson.fromJson(result, JsonArray::class.java)
+
+        jsonResult.map { it as? JsonObject }.forEach { jsonObject ->
+            assertThat(jsonObject).isNotNull
+            assertThat(jsonObject?.get(WCMetaData.KEY)?.asString)
+                .isIn(StripProductVariationMetaData.SUPPORTED_KEYS)
+        }
+    }
+
+    @Test
+    fun `when metadata contains a supported key with a NULL value, then strip the supported key`() {
+        val supportedKey = StripProductVariationMetaData.SUPPORTED_KEYS.first()
+        val value: String? = null
+
+        val metadata = getOneItemMetadata(supportedKey, value)
+        val result = sut.invoke(metadata)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when metadata contains a supported key with a EMPTY value, then strip the supported key`() {
+        val supportedKey = StripProductVariationMetaData.SUPPORTED_KEYS.first()
+        val value = ""
+
+        val metadata = getOneItemMetadata(supportedKey, value)
+        val result = sut.invoke(metadata)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when metadata contains a supported key with a NOT EMPTY value, then value is kept`() {
+        val supportedKey = StripProductVariationMetaData.SUPPORTED_KEYS.first()
+        val value = "valid"
+
+        val metadata = getOneItemMetadata(supportedKey, value)
+        val result = sut.invoke(metadata)
+
+        val jsonResult = gson.fromJson(result, JsonArray::class.java)
+        val resultItem = jsonResult[0] as JsonObject
+        assertThat(result).isNotNull
+        assertThat(resultItem[WCMetaData.KEY].asString).isEqualTo(supportedKey)
+        assertThat(resultItem[WCMetaData.VALUE].asString).isEqualTo(value)
+    }
+
+    private fun getOneItemMetadata(itemKey: String, itemValue: String?): String {
+        val item = JsonObject().apply {
+            addProperty(WCMetaData.KEY, itemKey)
+            itemValue?.let {
+                addProperty(WCMetaData.VALUE, it)
+            } ?: add(WCMetaData.VALUE, null)
+        }
+        val jsonArray = JsonArray().apply {
+            add(item)
+        }
+
+        return gson.toJson(jsonArray)
+    }
+
+    private val notOnlySupportedMetadata = """
+        [
+          {
+            "id": 4464,
+            "key": "_subscription_period",
+            "value": "week"
+          },
+          {
+            "id": 4465,
+            "key": "_subscription_period_interval",
+            "value": "1"
+          },
+          {
+            "id": 4466,
+            "key": "_subscription_length",
+            "value": "0"
+          },
+          {
+            "id": 4467,
+            "key": "_subscription_trial_period",
+            "value": "month"
+          },
+          {
+            "id": 4674,
+            "key": "_not_supported_metadata",
+            "value": "product"
+          },
+          {
+            "id": 4678,
+            "key": "not_supported_metadata",
+            "value": "no"
+          },
+          {
+            "id": 4679,
+            "key": "variation_group_of_quantity",
+            "value": ""
+          },
+          {
+            "id": 4680,
+            "key": "variation_minimum_allowed_quantity",
+            "value": ""
+          },
+          {
+            "id": 4681,
+            "key": "variation_maximum_allowed_quantity",
+            "value": ""
+          },
+          {
+            "id": 4682,
+            "key": "variation_minmax_do_not_count",
+            "value": "no"
+          },
+          {
+            "id": 4683,
+            "key": "variation_minmax_cart_exclude",
+            "value": "no"
+          },
+          {
+            "id": 4684,
+            "key": "variation_minmax_category_group_of_exclude",
+            "value": "no"
+          },
+          {
+            "id": 4685,
+            "key": "_subscription_sign_up_fee",
+            "value": "0"
+          },
+          {
+            "id": 4686,
+            "key": "_subscription_price",
+            "value": "5"
+          },
+          {
+            "id": 4687,
+            "key": "_subscription_trial_length",
+            "value": "0"
+          },
+          {
+            "id": 4688,
+            "key": "_subscription_payment_sync_date",
+            "value": "0"
+          },
+          {
+            "id": 4726,
+            "key": "_wcpay_product_hash",
+            "value": "ece89db348e4ba7b4cfd7a0bd37dd178"
+          },
+          {
+            "id": 4727,
+            "key": "_wcpay_product_id_test",
+            "value": "prod_NEJorUIqZTYOjW"
+          },
+          {
+            "id": 8955,
+            "key": "_wc_gla_mc_status",
+            "value": "not_synced"
+          }
+        ]
+    """.trimIndent()
+}


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/8621

### Description
This PR strips the Product Variation Metadata before saving it on the database. This way, the product variation item saved gets smaller, and we can prevent memory issues.

### Testing instruction
Install the app from the [woo PR](https://github.com/woocommerce/woocommerce-android/pull/8622) and check that only the supported keys are saved in the database. You ca use the database inspector or FluxC