### PR TITLE
Update a8c-ci-toolkit Buildkite plugin to new name and latest version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.11.0
+    - automattic/a8c-ci-toolkit#2.14.0
   # Common artifact paths used across steps
   - &artifact_paths
     - "**/build/test-results/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.14.0
+    - automattic/a8c-ci-toolkit#2.15.0
   # Common artifact paths used across steps
   - &artifact_paths
     - "**/build/test-results/**/*"


### PR DESCRIPTION
## What

- Update the `bash-cache` Buildkite plugin name to `a8c-ci-toolkit`
- Update the `a8c-ci-toolkit` plugin to version `2.15.0` 

## Testing

Ensure that CI is green and that all checks passed.