### PR TITLE
Android 13 Migration: Update Utils version to 3.4.0

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -84,7 +84,7 @@ class NonceRestClient @Inject constructor(
                 } else {
                     val networkResponse = response.error.volleyError?.networkResponse
                     if (networkResponse?.statusCode?.isRedirect() == true) {
-                        requestNonce(networkResponse.headers["Location"] ?: redirectUrl, username)
+                        requestNonce(networkResponse.headers?.get("Location") ?: redirectUrl, username)
                     } else {
                         FailedRequest(
                             timeOfResponse = currentTimeProvider.currentDate().time,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -70,9 +70,9 @@ class JetpackWPAPIRestClient @Inject constructor(
                         return@RawRequest
                     }
 
-                    response.headers["Location"].let {
-                        if (!it.isNullOrEmpty()) {
-                            cont.resume(Result.success(response.headers["Location"]!!))
+                    response.headers?.get("Location")?.let {
+                        if (it.isNotEmpty()) {
+                            cont.resume(Result.success(it))
                         } else {
                             cont.resume(Result.failure(Exception("Location header missing")))
                         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -47,7 +47,7 @@ dependencyResolutionManagement {
             version("facebook-flipper", "0.51.0")
             version("facebook-soloader", "0.9.0")
             version("kotlinx-coroutines", "1.3.9")
-            version("wordpress-utils", "develop-eebc5d8e91a1d90190919f900f924b39c861a528")
+            version("wordpress-utils", "3.4.0")
         }
     }
 }


### PR DESCRIPTION
Updates Utils version from develop-eebc5d8e91a1d90190919f900f924b39c861a528 to 3.4.0 for Android 13

_Internal project thread: pbArwn-5IN-p2_

To test

- Checkout this branch
- Run example app
- Log out if already logged in
- Try out login and various flows on example app
- Ensure, no issues or crashes


