### PR TITLE
Issue/8568 sort products by popularity business logic fluxc

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
@@ -34,6 +34,9 @@ abstract class OrdersDao {
             ?.let { insertOrUpdateOrder(it) }
     }
 
+    @Query("SELECT * FROM OrderEntity WHERE localSiteId = :localSiteId ORDER BY datePaid DESC")
+    abstract suspend fun getOrdersForSiteDesc(localSiteId: LocalId): List<OrderEntity>
+
     @Query("SELECT * FROM OrderEntity WHERE localSiteId = :localSiteId AND status IN (:status)")
     abstract suspend fun getOrdersForSite(localSiteId: LocalId, status: List<String>): List<OrderEntity>
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.OrderEntity
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 
 @Dao
 abstract class OrdersDao {
@@ -34,8 +35,11 @@ abstract class OrdersDao {
             ?.let { insertOrUpdateOrder(it) }
     }
 
-    @Query("SELECT * FROM OrderEntity WHERE localSiteId = :localSiteId ORDER BY datePaid DESC")
-    abstract suspend fun getOrdersForSiteDesc(localSiteId: LocalId): List<OrderEntity>
+    @Query("SELECT * FROM OrderEntity WHERE localSiteId = :localSiteId AND status IN (:status) ORDER BY datePaid DESC")
+    abstract suspend fun getPaidOrdersForSiteDesc(
+        localSiteId: LocalId,
+        status: List<String> = listOf(CoreOrderStatus.COMPLETED.value)
+    ): List<OrderEntity>
 
     @Query("SELECT * FROM OrderEntity WHERE localSiteId = :localSiteId AND status IN (:status)")
     abstract suspend fun getOrdersForSite(localSiteId: LocalId, status: List<String>): List<OrderEntity>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -361,7 +361,7 @@ class WCOrderStore @Inject constructor(
         ordersDao.getOrdersForSite(site.localId(), status = status.asList())
     }
 
-    suspend fun getOrdersForSiteDesc(siteModel: SiteModel) = ordersDao.getOrdersForSiteDesc(siteModel.localId())
+    suspend fun getPaidOrdersForSiteDesc(siteModel: SiteModel) = ordersDao.getPaidOrdersForSiteDesc(siteModel.localId())
 
     /**
      * Observe the changes to orders for a given [SiteModel]

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -361,6 +361,8 @@ class WCOrderStore @Inject constructor(
         ordersDao.getOrdersForSite(site.localId(), status = status.asList())
     }
 
+    suspend fun getOrdersForSiteDesc(siteModel: SiteModel) = ordersDao.getOrdersForSiteDesc(siteModel.localId())
+
     /**
      * Observe the changes to orders for a given [SiteModel]
      *


### PR DESCRIPTION
### Make sure to review [this ](https://github.com/woocommerce/woocommerce-android/pull/8652)WooCommerce PR before merging this one.
This PR adds methods to get paid orders sorted by date paid in descending order.
More context: pdfdoF-2ud-p2
Ticket: https://github.com/woocommerce/woocommerce-android/issues/8568

### Testing
Nothing to test. Just make sure the CI is happy.