### PR TITLE
Support POST requests in React Native store

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPAPIRequestTest.kt
@@ -37,7 +37,7 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
             }
 
             // media queries with a context of 'view' do not require authentication
-            reactNativeStore.executeRequest(site, "wp/v2/media?context=view")
+            reactNativeStore.executeGetRequest(site, "wp/v2/media?context=view")
         }
 
         val assertionMessage = "Call unexpectedly failed with error: ${(response as? Error)?.error?.message}"
@@ -56,7 +56,7 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
             }
 
             // media queries with a context of 'edit' require authentication
-            reactNativeStore.executeRequest(siteWithCustomRestEndpoint, "wp/v2/media?context=edit")
+            reactNativeStore.executeGetRequest(siteWithCustomRestEndpoint, "wp/v2/media?context=edit")
         }
 
         val assertionMessage = "Call unexpectedly failed with error: ${(response as? Error)?.error?.message}"
@@ -78,13 +78,13 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
 
             // media queries with a context of 'edit' require authentication
             // this request will fail because of the self signed ssl certificate ("Invalid SSL certificate")
-            reactNativeStore.executeRequest(siteUsingSsl, "wp/v2/media?context=edit")
+            reactNativeStore.executeGetRequest(siteUsingSsl, "wp/v2/media?context=edit")
 
             // Add an exception for the last failure of certificate validation
             memorizingTrustManager.storeLastFailure()
 
             // Retry to run the same media query (media queries with a context of 'edit' require authentication)
-            reactNativeStore.executeRequest(siteUsingSsl, "wp/v2/media?context=edit")
+            reactNativeStore.executeGetRequest(siteUsingSsl, "wp/v2/media?context=edit")
         }
 
         memorizingTrustManager.clearLocalTrustStore()
@@ -103,7 +103,7 @@ class ReleaseStack_ReactNativeWPAPIRequestTest : ReleaseStack_Base() {
                 password = BuildConfig.TEST_WPORG_PASSWORD_SH_WPAPI_SIMPLE
             }
 
-            reactNativeStore.executeRequest(site, "wp/v2/an-invalid-endpoint")
+            reactNativeStore.executeGetRequest(site, "wp/v2/an-invalid-endpoint")
         }
 
         val assertionMessage = "Call should have failed with a 404, instead response was $response"

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ReactNativeWPComRequestTest.kt
@@ -29,14 +29,14 @@ class ReleaseStack_ReactNativeWPComRequestTest : ReleaseStack_WPComBase() {
     }
 
     private fun assertSuccessWithPath(path: String) {
-        val response = runBlocking { reactNativeStore.executeRequest(sSite, path) }
+        val response = runBlocking { reactNativeStore.executeGetRequest(sSite, path) }
         val failureMessage = "Call failed with error: ${(response as? Error)?.error}"
         assertTrue(failureMessage, response is Success)
     }
 
     @Test
     fun testWpComCall_fails() {
-        val response = runBlocking { reactNativeStore.executeRequest(sSite, "an-invalid-extension") }
+        val response = runBlocking { reactNativeStore.executeGetRequest(sSite, "an-invalid-extension") }
         val assertionMessage = "Call should have failed with a 404, instead response was $response"
         val actualStatusCode = (response as? Error)?.error?.volleyError?.networkResponse?.statusCode
         assertEquals(assertionMessage, 404, actualStatusCode)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
@@ -71,7 +71,7 @@ class ReactNativeFragment : Fragment() {
         val path = path_field.text.toString()
         prependToLog("Making request: $path")
         lifecycleScope.launch(Dispatchers.IO) {
-            val response = site?.let { reactNativeStore.executeRequest(it, path) }
+            val response = site?.let { reactNativeStore.executeGetRequest(it, path) }
             withContext(Dispatchers.Main) {
                 when (response) {
                     is Success -> {

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
@@ -28,6 +28,7 @@ class ReactNativeWPAPIRestClientTest {
 
     private val url = "a_url"
     private val params = mapOf("a_key" to "a_value")
+    private val body = mapOf("b_key" to "b_value")
 
     private lateinit var subject: ReactNativeWPAPIRestClient
 
@@ -75,6 +76,40 @@ class ReactNativeWPAPIRestClientTest {
         verifyGETRequest(successHandler, errorHandler, mockedRestCallResponse, expected)
     }
     
+    @Test
+    fun `POST request handles successful response`() = test {
+        val errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse = { _ ->
+            throw AssertionFailedError("errorHandler should not have been called")
+        }
+
+        val expected = mock<ReactNativeFetchResponse>()
+        val expectedJson = mock<JsonElement>()
+        val successHandler = { data: JsonElement? ->
+            if (data != expectedJson) fail("expected data was not passed to successHandler")
+            expected
+        }
+
+        val expectedRestCallResponse = Success(expectedJson)
+        verifyPOSTRequest(successHandler, errorHandler, expectedRestCallResponse, expected)
+    }
+
+    @Test
+    fun `POST request handles failure response`() = test {
+        val successHandler = { _: JsonElement? ->
+            throw AssertionFailedError("successHandler should not have been called")
+        }
+
+        val expected = mock<ReactNativeFetchResponse>()
+        val expectedBaseNetworkError = mock<WPAPINetworkError>()
+        val errorHandler = { error: BaseNetworkError ->
+            if (error != expectedBaseNetworkError) fail("expected error was not passed to errorHandler")
+            expected
+        }
+
+        val mockedRestCallResponse = Error<JsonElement>(expectedBaseNetworkError)
+        verifyPOSTRequest(successHandler, errorHandler, mockedRestCallResponse, expected)
+    }
+
     private suspend fun verifyGETRequest(
         successHandler: (JsonElement?) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
@@ -91,6 +126,23 @@ class ReactNativeWPAPIRestClientTest {
         ).thenReturn(expectedRestCallResponse)
 
         val actual = subject.getRequest(url, params, successHandler, errorHandler)
+        assertEquals(expected, actual)
+    }
+
+    private suspend fun verifyPOSTRequest(
+        successHandler: (JsonElement?) -> ReactNativeFetchResponse,
+        errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
+        expectedRestCallResponse: WPAPIResponse<JsonElement>,
+        expected: ReactNativeFetchResponse
+    ) {
+        whenever(wpApiGsonRequestBuilder.syncPostRequest(
+            subject,
+            url,
+            body,
+            JsonElement::class.java)
+        ).thenReturn(expectedRestCallResponse)
+
+        val actual = subject.postRequest(url, body, successHandler, errorHandler)
         assertEquals(expected, actual)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClientTest.kt
@@ -42,7 +42,7 @@ class ReactNativeWPAPIRestClientTest {
     }
 
     @Test
-    fun `fetch handles successful response`() = test {
+    fun `GET request handles successful response`() = test {
         val errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse = { _ ->
             throw AssertionFailedError("errorHandler should not have been called")
         }
@@ -55,11 +55,11 @@ class ReactNativeWPAPIRestClientTest {
         }
 
         val expectedRestCallResponse = Success(expectedJson)
-        verifyRestApi(successHandler, errorHandler, expectedRestCallResponse, expected)
+        verifyGETRequest(successHandler, errorHandler, expectedRestCallResponse, expected)
     }
 
     @Test
-    fun `fetch handles failure response`() = test {
+    fun `GET request handles failure response`() = test {
         val successHandler = { _: JsonElement? ->
             throw AssertionFailedError("successHandler should not have been called")
         }
@@ -72,9 +72,10 @@ class ReactNativeWPAPIRestClientTest {
         }
 
         val mockedRestCallResponse = Error<JsonElement>(expectedBaseNetworkError)
-        verifyRestApi(successHandler, errorHandler, mockedRestCallResponse, expected)
+        verifyGETRequest(successHandler, errorHandler, mockedRestCallResponse, expected)
     }
-    private suspend fun verifyRestApi(
+    
+    private suspend fun verifyGETRequest(
         successHandler: (JsonElement?) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
         expectedRestCallResponse: WPAPIResponse<JsonElement>,
@@ -89,7 +90,7 @@ class ReactNativeWPAPIRestClientTest {
                 true)
         ).thenReturn(expectedRestCallResponse)
 
-        val actual = subject.fetch(url, params, successHandler, errorHandler)
+        val actual = subject.getRequest(url, params, successHandler, errorHandler)
         assertEquals(expected, actual)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
@@ -46,7 +46,7 @@ class ReactNativeWPComRestClientTest {
     }
 
     @Test
-    fun `fetch handles successful response`() = test {
+    fun `GET request handles successful response`() = test {
         val errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse = { _ ->
             throw AssertionFailedError("errorHandler should not have been called")
         }
@@ -59,11 +59,11 @@ class ReactNativeWPComRestClientTest {
         }
 
         val expectedRestCallResponse = Success(expectedJson)
-        verifyRestApi(successHandler, errorHandler, expectedRestCallResponse, expected)
+        verifyGETRequest(successHandler, errorHandler, expectedRestCallResponse, expected)
     }
 
     @Test
-    fun `fetch handles failure response`() = test {
+    fun `GET request handles failure response`() = test {
         val successHandler = { _: JsonElement ->
             throw AssertionFailedError("successHandler should not have been called")
         }
@@ -76,10 +76,10 @@ class ReactNativeWPComRestClientTest {
         }
 
         val mockedRestCallResponse = Error<JsonElement>(expectedBaseNetworkError)
-        verifyRestApi(successHandler, errorHandler, mockedRestCallResponse, expected)
+        verifyGETRequest(successHandler, errorHandler, mockedRestCallResponse, expected)
     }
 
-    private suspend fun verifyRestApi(
+    private suspend fun verifyGETRequest(
         successHandler: (JsonElement) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
         expectedRestCallResponse: WPComGsonRequestBuilder.Response<JsonElement>,
@@ -93,7 +93,7 @@ class ReactNativeWPComRestClientTest {
                 true)
         ).thenReturn(expectedRestCallResponse)
 
-        val actual = subject.fetch(url, params, successHandler, errorHandler)
+        val actual = subject.getRequest(url, params, successHandler, errorHandler)
         assertEquals(expected, actual)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
@@ -31,6 +31,7 @@ class ReactNativeWPComRestClientTest {
 
     private val url = "a_url"
     val params = mapOf("a_key" to "a_value")
+    val body = mapOf("b_key" to "b_value")
 
     private lateinit var subject: ReactNativeWPComRestClient
 
@@ -79,6 +80,40 @@ class ReactNativeWPComRestClientTest {
         verifyGETRequest(successHandler, errorHandler, mockedRestCallResponse, expected)
     }
 
+    @Test
+    fun `POST request handles successful response`() = test {
+        val errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse = { _ ->
+            throw AssertionFailedError("errorHandler should not have been called")
+        }
+
+        val expected = mock<ReactNativeFetchResponse>()
+        val expectedJson = mock<JsonElement>()
+        val successHandler = { data: JsonElement ->
+            if (data != expectedJson) fail("expected data was not passed to successHandler")
+            expected
+        }
+
+        val expectedRestCallResponse = Success(expectedJson)
+        verifyPOSTRequest(successHandler, errorHandler, expectedRestCallResponse, expected)
+    }
+
+    @Test
+    fun `POST request handles failure response`() = test {
+        val successHandler = { _: JsonElement ->
+            throw AssertionFailedError("successHandler should not have been called")
+        }
+
+        val expected = mock<ReactNativeFetchResponse>()
+        val expectedBaseNetworkError = mock<WPComGsonNetworkError>()
+        val errorHandler = { error: BaseNetworkError ->
+            if (error != expectedBaseNetworkError) fail("expected error was not passed to errorHandler")
+            expected
+        }
+
+        val mockedRestCallResponse = Error<JsonElement>(expectedBaseNetworkError)
+        verifyPOSTRequest(successHandler, errorHandler, mockedRestCallResponse, expected)
+    }
+
     private suspend fun verifyGETRequest(
         successHandler: (JsonElement) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
@@ -94,6 +129,24 @@ class ReactNativeWPComRestClientTest {
         ).thenReturn(expectedRestCallResponse)
 
         val actual = subject.getRequest(url, params, successHandler, errorHandler)
+        assertEquals(expected, actual)
+    }
+
+    private suspend fun verifyPOSTRequest(
+        successHandler: (JsonElement) -> ReactNativeFetchResponse,
+        errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
+        expectedRestCallResponse: WPComGsonRequestBuilder.Response<JsonElement>,
+        expected: ReactNativeFetchResponse
+    ) {
+        whenever(wpComGsonRequestBuilder.syncPostRequest(
+            subject,
+            url,
+            params,
+            body,
+            JsonElement::class.java)
+        ).thenReturn(expectedRestCallResponse)
+
+        val actual = subject.postRequest(url, params, body, successHandler, errorHandler)
         assertEquals(expected, actual)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWpComTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWpComTest.kt
@@ -59,6 +59,22 @@ class ReactNativeStoreWpComTest {
     }
 
     @Test
+    fun `makes POST request to WPCOM`() = test {
+        val expectedResponse = mock<ReactNativeFetchResponse>()
+
+        val site = mock<SiteModel>()
+        whenever(site.siteId).thenReturn(123456L)
+        whenever(site.isUsingWpComRestApi).thenReturn(true)
+
+        val expectedUrl = "https://public-api.wordpress.com/wp/v2/sites/${site.siteId}/media/100"
+        whenever(wpComRestClient.postRequest(expectedUrl, mapOf("paramKey" to "paramValue"), mapOf("title" to "newTitle"), ::Success, ::Error))
+            .thenReturn(expectedResponse)
+
+        val actualResponse = store.executePostRequest(site, "/wp/v2/media/100?paramKey=paramValue", mapOf("title" to "newTitle"))
+        assertEquals(expectedResponse, actualResponse)
+    }
+
+    @Test
     fun `handles failure to parse path`() = test {
         val mockUri = mock<Uri>()
         assertNull(mockUri.path, "path must be null to represent failure to parse the path in this test")

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWpComTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWpComTest.kt
@@ -67,10 +67,17 @@ class ReactNativeStoreWpComTest {
         whenever(site.isUsingWpComRestApi).thenReturn(true)
 
         val expectedUrl = "https://public-api.wordpress.com/wp/v2/sites/${site.siteId}/media/100"
-        whenever(wpComRestClient.postRequest(expectedUrl, mapOf("paramKey" to "paramValue"), mapOf("title" to "newTitle"), ::Success, ::Error))
+        whenever(wpComRestClient.postRequest(
+            expectedUrl,
+            mapOf("paramKey" to "paramValue"),
+            mapOf("title" to "newTitle"),
+            ::Success, ::Error))
             .thenReturn(expectedResponse)
 
-        val actualResponse = store.executePostRequest(site, "/wp/v2/media/100?paramKey=paramValue", mapOf("title" to "newTitle"))
+        val actualResponse = store.executePostRequest(
+            site,
+            "/wp/v2/media/100?paramKey=paramValue",
+            mapOf("title" to "newTitle"))
         assertEquals(expectedResponse, actualResponse)
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWpComTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWpComTest.kt
@@ -51,10 +51,10 @@ class ReactNativeStoreWpComTest {
         whenever(site.isUsingWpComRestApi).thenReturn(true)
 
         val expectedUrl = "https://public-api.wordpress.com/wp/v2/sites/${site.siteId}/media"
-        whenever(wpComRestClient.fetch(expectedUrl, mapOf("paramKey" to "paramValue"), ::Success, ::Error))
+        whenever(wpComRestClient.getRequest(expectedUrl, mapOf("paramKey" to "paramValue"), ::Success, ::Error))
                 .thenReturn(expectedResponse)
 
-        val actualResponse = store.executeRequest(site, "/wp/v2/media?paramKey=paramValue")
+        val actualResponse = store.executeGetRequest(site, "/wp/v2/media?paramKey=paramValue")
         assertEquals(expectedResponse, actualResponse)
     }
 
@@ -73,7 +73,7 @@ class ReactNativeStoreWpComTest {
                 initCoroutineEngine(),
                 uriParser = uriParser)
 
-        val response = store.executeRequest(mock(), "")
+        val response = store.executeGetRequest(mock(), "")
         val errorType = (response as? Error)?.error?.type
         assertEquals(UNKNOWN, errorType)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIGsonRequestBuilder.kt
@@ -15,7 +15,7 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         restClient: BaseWPAPIRestClient,
         url: String,
         params: Map<String, String> = emptyMap(),
-        body: Map<String, String> = emptyMap(),
+        body: Map<String, Any> = emptyMap(),
         clazz: Class<T>,
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
@@ -27,7 +27,7 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         restClient: BaseWPAPIRestClient,
         url: String,
         params: Map<String, String> = emptyMap(),
-        body: Map<String, String> = emptyMap(),
+        body: Map<String, Any> = emptyMap(),
         type: Type,
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
@@ -39,7 +39,7 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
     suspend fun <T> syncPostRequest(
         restClient: BaseWPAPIRestClient,
         url: String,
-        body: Map<String, String> = emptyMap(),
+        body: Map<String, Any> = emptyMap(),
         clazz: Class<T>,
         nonce: String? = null
     ) = suspendCancellableCoroutine<WPAPIResponse<T>> { cont ->
@@ -49,7 +49,7 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
     suspend fun <T> syncPutRequest(
         restClient: BaseWPAPIRestClient,
         url: String,
-        body: Map<String, String> = emptyMap(),
+        body: Map<String, Any> = emptyMap(),
         clazz: Class<T>,
         nonce: String? = null
     ) = suspendCancellableCoroutine<WPAPIResponse<T>> { cont ->
@@ -59,7 +59,7 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
     suspend fun <T> syncDeleteRequest(
         restClient: BaseWPAPIRestClient,
         url: String,
-        body: Map<String, String> = emptyMap(),
+        body: Map<String, Any> = emptyMap(),
         clazz: Class<T>,
         nonce: String? = null
     ) = suspendCancellableCoroutine<WPAPIResponse<T>> { cont ->
@@ -71,7 +71,7 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         method: Int,
         url: String,
         params: Map<String, String>? = null,
-        body: Map<String, String> = emptyMap(),
+        body: Map<String, Any> = emptyMap(),
         clazz: Class<T>,
         cont: CancellableContinuation<WPAPIResponse<T>>,
         enableCaching: Boolean,
@@ -105,7 +105,7 @@ class WPAPIGsonRequestBuilder @Inject constructor() {
         method: Int,
         url: String,
         params: Map<String, String>?,
-        body: Map<String, String>,
+        body: Map<String, Any>,
         type: Type,
         cont: CancellableContinuation<WPAPIResponse<T>>,
         enableCaching: Boolean,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -46,7 +46,7 @@ class ReactNativeWPAPIRestClient @Inject constructor(
 
     suspend fun postRequest(
         url: String,
-        body: Map<String, String>,
+        body: Map<String, Any>,
         successHandler: (data: JsonElement?) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
         nonce: String? = null,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -21,7 +21,7 @@ class ReactNativeWPAPIRestClient @Inject constructor(
     @Named("custom-ssl") requestQueue: RequestQueue,
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
-    suspend fun fetch(
+    suspend fun getRequest(
         url: String,
         params: Map<String, String>,
         successHandler: (data: JsonElement?) -> ReactNativeFetchResponse,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/reactnative/ReactNativeWPAPIRestClient.kt
@@ -43,4 +43,24 @@ class ReactNativeWPAPIRestClient @Inject constructor(
             is Error -> errorHandler(response.error)
         }
     }
+
+    suspend fun postRequest(
+        url: String,
+        body: Map<String, String>,
+        successHandler: (data: JsonElement?) -> ReactNativeFetchResponse,
+        errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse,
+        nonce: String? = null,
+    ): ReactNativeFetchResponse {
+        val response =
+            wpApiGsonRequestBuilder.syncPostRequest(
+                this,
+                url,
+                body,
+                JsonElement::class.java,
+                nonce = nonce)
+        return when (response) {
+            is Success -> successHandler(response.data)
+            is Error -> errorHandler(response.error)
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
@@ -25,7 +25,7 @@ class ReactNativeWPComRestClient @Inject constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    suspend fun fetch(
+    suspend fun getRequest(
         url: String,
         params: Map<String, String>,
         successHandler: (data: JsonElement) -> ReactNativeFetchResponse,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
@@ -43,7 +43,7 @@ class ReactNativeWPComRestClient @Inject constructor(
     suspend fun postRequest(
         url: String,
         params: Map<String, String>,
-        body: Map<String, String>,
+        body: Map<String, Any>,
         successHandler: (data: JsonElement) -> ReactNativeFetchResponse,
         errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse
     ): ReactNativeFetchResponse {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClient.kt
@@ -39,4 +39,19 @@ class ReactNativeWPComRestClient @Inject constructor(
             is Error -> errorHandler(response.error)
         }
     }
+
+    suspend fun postRequest(
+        url: String,
+        params: Map<String, String>,
+        body: Map<String, String>,
+        successHandler: (data: JsonElement) -> ReactNativeFetchResponse,
+        errorHandler: (BaseNetworkError) -> ReactNativeFetchResponse
+    ): ReactNativeFetchResponse {
+        val response =
+            wpComGsonRequestBuilder.syncPostRequest(this, url, params, body, JsonElement::class.java)
+        return when (response) {
+            is Success -> successHandler(response.data)
+            is Error -> errorHandler(response.error)
+        }
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -89,7 +89,7 @@ class EditorThemeStore
     }
 
     private suspend fun fetchEditorTheme(site: SiteModel, action: EditorThemeAction) {
-        val response = reactNativeStore.executeRequest(site, THEME_REQUEST_PATH, false)
+        val response = reactNativeStore.executeGetRequest(site, THEME_REQUEST_PATH, false)
 
         when (response) {
             is Success -> {
@@ -125,7 +125,7 @@ class EditorThemeStore
     }
 
     private suspend fun fetchEditorSettings(site: SiteModel, action: EditorThemeAction) {
-        val response = reactNativeStore.executeRequest(site, EDITOR_SETTINGS_REQUEST_PATH, false)
+        val response = reactNativeStore.executeGetRequest(site, EDITOR_SETTINGS_REQUEST_PATH, false)
 
         when (response) {
             is Success -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -82,7 +82,7 @@ class ReactNativeStore @VisibleForTesting constructor(
     suspend fun executePostRequest(
         site: SiteModel,
         pathWithParams: String,
-        body: Map<String, String> = emptyMap(),
+        body: Map<String, Any> = emptyMap(),
     ): ReactNativeFetchResponse =
         coroutineEngine.withDefaultContext(AppLog.T.API, this, "executePostRequest") {
             return@withDefaultContext if (site.isUsingWpComRestApi) {
@@ -111,7 +111,7 @@ class ReactNativeStore @VisibleForTesting constructor(
     private suspend fun executeWPComPostRequest(
         site: SiteModel,
         path: String,
-        body: Map<String, String>,
+        body: Map<String, Any>,
     ): ReactNativeFetchResponse {
         val (url, params) = parseUrlAndParamsForWPCom(path, site.siteId)
         return if (url != null) {
@@ -141,7 +141,7 @@ class ReactNativeStore @VisibleForTesting constructor(
     private suspend fun executeWPAPIPostRequest(
         site: SiteModel,
         pathWithParams: String,
-        body: Map<String, String>,
+        body: Map<String, Any>,
     ): ReactNativeFetchResponse {
         val (path, params) = parsePathAndParams(pathWithParams)
         return if (path != null) {
@@ -165,7 +165,7 @@ class ReactNativeStore @VisibleForTesting constructor(
         path: String,
         method: RequestMethod,
         params: Map<String, String>,
-        body: Map<String, String>,
+        body: Map<String, Any>,
         enableCaching: Boolean
     ): ReactNativeFetchResponse {
         // Storing this in a variable to avoid a NPE that can occur if the site object is mutated
@@ -250,7 +250,7 @@ class ReactNativeStore @VisibleForTesting constructor(
 
     private suspend fun executePost(
         fullRestApiUrl: String,
-        body: Map<String, String>,
+        body: Map<String, Any>,
         nonce: String?
     ): ReactNativeFetchResponse =
         wpAPIRestClient.postRequest(fullRestApiUrl, body, ::Success, ::Error, nonce)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -61,12 +61,12 @@ class ReactNativeStore @VisibleForTesting constructor(
             Uri::parse
     )
 
-    suspend fun executeRequest(
+    suspend fun executeGetRequest(
         site: SiteModel,
         pathWithParams: String,
         enableCaching: Boolean = true
     ): ReactNativeFetchResponse =
-            coroutineEngine.withDefaultContext(AppLog.T.API, this, "executeRequest") {
+            coroutineEngine.withDefaultContext(AppLog.T.API, this, "executeGetRequest") {
                 return@withDefaultContext if (site.isUsingWpComRestApi) {
                     executeWPComRequest(site, pathWithParams, enableCaching)
                 } else {
@@ -81,7 +81,7 @@ class ReactNativeStore @VisibleForTesting constructor(
     ): ReactNativeFetchResponse {
         val (url, params) = parseUrlAndParamsForWPCom(path, site.siteId)
         return if (url != null) {
-            wpComRestClient.fetch(url, params, ::Success, ::Error, enableCaching)
+            wpComRestClient.getRequest(url, params, ::Success, ::Error, enableCaching)
         } else {
             urlParseError(path)
         }
@@ -186,7 +186,7 @@ class ReactNativeStore @VisibleForTesting constructor(
         nonce: String?,
         enableCaching: Boolean
     ): ReactNativeFetchResponse =
-            wpAPIRestClient.fetch(fullRestApiUrl, params, ::Success, ::Error, nonce, enableCaching)
+            wpAPIRestClient.getRequest(fullRestApiUrl, params, ::Success, ::Error, nonce, enableCaching)
 
     private fun parseUrlAndParamsForWPCom(
         pathWithParams: String,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ReactNativeStore.kt
@@ -159,7 +159,7 @@ class ReactNativeStore @VisibleForTesting constructor(
         return Error(error)
     }
 
-    @Suppress("ComplexMethod", "NestedBlockDepth")
+    @Suppress("ComplexMethod", "NestedBlockDepth", "LongParameterList")
     private suspend fun executeWPAPIRequest(
         site: SiteModel,
         path: String,


### PR DESCRIPTION
**Related PRs:**
* https://github.com/WordPress/gutenberg/pull/49371
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5596
* Android
    * https://github.com/wordpress-mobile/WordPress-Android/pull/18181
    * https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2691
* iOS
    * https://github.com/wordpress-mobile/WordPressKit-iOS/pull/589
    * https://github.com/wordpress-mobile/WordPress-iOS/pull/20428

This PR introduces the support for POST requests in the React Native store. With this change, the Gutenberg editor will be able to make POST requests.

The main changes of this PR are:
- https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2691/commits/737110e34409e22db4cff7d346829614f9f5de37: With the introduction of POST requests, I renamed the functions to differentiate GET and POST request functions in the React Native store.
- https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2691/commits/3122c6a9ca7183f17f1eabe7c576aff572a6e91b: Add request methods enum and update the GET functions to run only when the method passed is `GET`.
- https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2691/commits/69faa29afe2138126221674124ee18d7670a199d: Add functions to handle POST requests.
- https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2691/commits/0ccc8ed4880213826949c27ce7f4e2e39dcc08dc: Add unit tests for new POST request functions.
- https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2691/commits/677ed381c684aa0c368debfc4d25f015969d0687: Originally the `body` parameter passed in POST requests had type `Map<String, String>`. However, I noticed that the `GsonRequest` constructor accepts any object 
 for the `body` parameter not just `String`. In fact, it uses the type `Map<String, Object>`. This commit updates the types in `WPAPIGsonRequestBuilder` of that parameter, but since it's a Kotlin file, we use `Map<String, Any>`.
- https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2691/commits/267fce198b509e4db5ab1eab6cf97773dfeae988: Following the above commit, update the `body` type to `Map<String, Any>` in POST requests functions of React Native store.

**NOTE:** I haven't added tests against real sites (i.e. tests with file names `ReleaseStack_*`). I'm planning to do that in a separate PR.

### Testing Details

**The Gutenberg editor doesn't make POST requests yet**, hence this change can only be tested with a test PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18202.