### PR TITLE
Renewal subscriptions support

### DIFF
--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -98,3 +98,4 @@
 /onboarding/tasks
 
 /subscriptions/
+/subscriptions/<id>/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
@@ -15,5 +15,11 @@ data class WCMetaData(
         const val VALUE = "value"
         const val DISPLAY_KEY = "display_key"
         const val DISPLAY_VALUE = "display_value"
+        val SUPPORTED_KEYS: Set<String> = buildSet {
+            add(SubscriptionMetadataKeys.SUBSCRIPTION_RENEWAL)
+        }
+    }
+    object SubscriptionMetadataKeys {
+        const val SUBSCRIPTION_RENEWAL = "_subscription_renewal"
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
@@ -27,7 +27,7 @@ class StripOrderMetaData @Inject internal constructor(private val gson: Gson) {
 
         return parseMetaDataJSON(orderDto.meta_data)
             ?.asSequence()
-            ?.filter { it.isDisplayableAttribute }
+            ?.filter { it.isDisplayableAttribute || it.key in WCMetaData.SUPPORTED_KEYS }
             ?.map { it.asOrderMetaDataEntity(orderDto.id, localSiteId) }
             ?.filter { it.value.isNotEmpty() && it.value.matches(jsonRegex).not() }
             ?.toList()


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/8658

### Description
This PR adds the changes needed to get the renewal orders subscriptions information. It adds a new endpoint to fetch the subscription information using the subscription id, and it also adds the `SUPPORTED_KEYS` set to save metadata keys needed by the app (in this case, the `_subscription_renewal` metadata).

### Testing
It is better to test this PR along with [the woo PR](https://github.com/woocommerce/woocommerce-android/pull/8659).
Check that the "_subscription_renewal" field is saved in the local database for renewal subscriptions.