### PR TITLE
Update catalogVersion to 1.7.0

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.6.0"
+def catalogVersion = "1.7.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {
@@ -47,7 +47,6 @@ dependencyResolutionManagement {
             version("facebook-flipper", "0.51.0")
             version("facebook-soloader", "0.9.0")
             version("kotlinx-coroutines", "1.3.9")
-            version("wordpress-utils", "3.4.0")
         }
     }
 }


### PR DESCRIPTION
Updates dependency catalogVersion to 1.7.0 that has Aztec, About-Automattic and Utils libs to latest


_Internal project thread: pbArwn-5IN-p2_

To test

- Checkout this branch
- Run example app
- Log out if already logged in
- Try out login and various flows on example app
- Ensure, no issues or crashes
