### PR TITLE
Provide WP database dependencies to Woo

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
+import org.wordpress.android.fluxc.module.DatabaseModule
 import org.wordpress.android.fluxc.persistence.TransactionExecutor
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.AddonsDao
@@ -11,7 +12,11 @@ import org.wordpress.android.fluxc.persistence.dao.CouponsDao
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import javax.inject.Singleton
 
-@Module
+@Module(
+    includes = [
+        DatabaseModule::class
+    ]
+)
 interface WCDatabaseModule {
     companion object {
         @Singleton @Provides fun provideDatabase(context: Context): WCAndroidDatabase {


### PR DESCRIPTION
Fixes lack of `JetpackCPConnectedSitesDao` that used in `SiteStore` in the Woo app