### PR TITLE
Add gift cards to plugins enum

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -61,7 +61,6 @@ open class WooCommerceStore @Inject constructor(
         WOO_SHIPMENT_TRACKING("woocommerce-shipment-tracking/woocommerce-shipment-tracking"),
         WOO_SUBSCRIPTIONS("woocommerce-subscriptions/woocommerce-subscriptions"),
         WOO_GIFT_CARDS("woocommerce-gift-cards/woocommerce-gift-cards")
-
     }
 
     companion object {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -59,7 +59,9 @@ open class WooCommerceStore @Inject constructor(
         WOO_PAYMENTS("woocommerce-payments/woocommerce-payments"),
         WOO_STRIPE_GATEWAY("woocommerce-gateway-stripe/woocommerce-gateway-stripe"),
         WOO_SHIPMENT_TRACKING("woocommerce-shipment-tracking/woocommerce-shipment-tracking"),
-        WOO_SUBSCRIPTIONS("woocommerce-subscriptions/woocommerce-subscriptions")
+        WOO_SUBSCRIPTIONS("woocommerce-subscriptions/woocommerce-subscriptions"),
+        WOO_GIFT_CARDS("woocommerce-gift-cards/woocommerce-gift-cards")
+
     }
 
     companion object {


### PR DESCRIPTION
Needed to close https://github.com/woocommerce/woocommerce-android/issues/8398

### Why 
We are adding gift card read-only support to the Woo App
### Description
This small PR adds the `WOO_GIFT_CARDS` value to the WooPlugins enum. The Woo app needs this change to check for the availability of the plugin before requesting the plugin information. 