### PR TITLE
Product quantity rules data

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -553,4 +553,15 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         val storedFiles = getDownloadableFiles()
         return storedFiles == updatedFiles
     }
+
+    object QuantityRulesMetadataKeys {
+        const val MINIMUM_ALLOWED_QUANTITY = "minimum_allowed_quantity"
+        const val MAXIMUM_ALLOWED_QUANTITY = "maximum_allowed_quantity"
+        const val GROUP_OF_QUANTITY = "group_of_quantity"
+        val ALL_KEYS = setOf(
+            MINIMUM_ALLOWED_QUANTITY,
+            MAXIMUM_ALLOWED_QUANTITY,
+            GROUP_OF_QUANTITY
+        )
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -59,7 +59,8 @@ open class WooCommerceStore @Inject constructor(
         WOO_PAYMENTS("woocommerce-payments/woocommerce-payments"),
         WOO_STRIPE_GATEWAY("woocommerce-gateway-stripe/woocommerce-gateway-stripe"),
         WOO_SHIPMENT_TRACKING("woocommerce-shipment-tracking/woocommerce-shipment-tracking"),
-        WOO_SUBSCRIPTIONS("woocommerce-subscriptions/woocommerce-subscriptions")
+        WOO_SUBSCRIPTIONS("woocommerce-subscriptions/woocommerce-subscriptions"),
+        WOO_MIN_MAX_QUANTITIES("woocommerce-min-max-quantities/woocommerce-min-max-quantities")
     }
 
     companion object {


### PR DESCRIPTION
Needed to close:  https://github.com/woocommerce/woocommerce-android/issues/8400

### Why
We are adding Min / Max Quantities read-only support to the Woo App

### Description
This small PR adds the `WOO_MIN_MAX_QUANTITIES` value to the WooPlugins enum. The Woo app needs this change to check for the availability of the plugin before requesting the plugin information. 
It also adds the `QuantityRulesMetadataKeys` to check for the QuantityRules metadata values from between the Product's metadata values.

### Testing
It is better to test these changes along with [the woo PR](https://github.com/woocommerce/woocommerce-android/pull/8715)