### PR TITLE
New API to handle flexible jitms

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JitmTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JitmTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.mocked
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.model.SiteModel
@@ -12,9 +13,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JitmRestClient
 import javax.inject.Inject
 
 class MockedStack_JitmTest : MockedStack_Base() {
-    @Inject internal lateinit var restClient: JitmRestClient
+    @Inject
+    internal lateinit var restClient: JitmRestClient
 
-    @Inject internal lateinit var interceptor: ResponseMockingInterceptor
+    @Inject
+    internal lateinit var interceptor: ResponseMockingInterceptor
 
     private val testSite = SiteModel().apply {
         origin = SiteModel.ORIGIN_WPCOM_REST
@@ -28,7 +31,7 @@ class MockedStack_JitmTest : MockedStack_Base() {
     }
 
     @Test
-    fun whenValidMessagePathPassedForJitmThenSuccessReturned() = runBlocking {
+    fun whenValidMessagePathPassedForJitmThenSuccessReturnedWithAssets() = runBlocking {
         interceptor.respondWith("jitm-fetch-success.json")
         val messagePath = "woomobile:my_store:admin_notices"
 
@@ -36,6 +39,20 @@ class MockedStack_JitmTest : MockedStack_Base() {
 
         assertFalse(result.isError)
         assertTrue(!result.result.isNullOrEmpty())
+        assertEquals("https://wordpress.com/bcg_image.png", result.result?.get(0)?.assets?.get("background_image_url"))
+        assertEquals("https://wordpress.com/badge_image.png", result.result?.get(0)?.assets?.get("badge_image_url"))
+    }
+
+    @Test
+    fun whenValidMessagePathPassedForJitmWithoutAssetsThenSuccessReturnedWithoutAssets() = runBlocking {
+        interceptor.respondWith("jitm-fetch-success_without_assets.json")
+        val messagePath = "woomobile:my_store:admin_notices"
+
+        val result = restClient.fetchJitmMessage(testSite, messagePath, "")
+
+        assertFalse(result.isError)
+        assertTrue(!result.result.isNullOrEmpty())
+        assertNull(result.result?.get(0)?.assets)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JitmTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_JitmTest.kt
@@ -13,11 +13,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm.JitmRestClient
 import javax.inject.Inject
 
 class MockedStack_JitmTest : MockedStack_Base() {
-    @Inject
-    internal lateinit var restClient: JitmRestClient
+    @Inject internal lateinit var restClient: JitmRestClient
 
-    @Inject
-    internal lateinit var interceptor: ResponseMockingInterceptor
+    @Inject internal lateinit var interceptor: ResponseMockingInterceptor
 
     private val testSite = SiteModel().apply {
         origin = SiteModel.ORIGIN_WPCOM_REST

--- a/example/src/androidTest/resources/jitm-fetch-success_without_assets.json
+++ b/example/src/androidTest/resources/jitm-fetch-success_without_assets.json
@@ -18,10 +18,6 @@
         "primary": true,
         "link": "https://woocommerce.com/products/hardware/US"
       },
-      "assets": {
-        "background_image_url": "https://wordpress.com/bcg_image.png",
-        "badge_image_url": "https://wordpress.com/badge_image.png"
-      },
       "template": "default",
       "ttl": 300,
       "id": "woomobile_ipp_barcode_users",

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jitm/JitmRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/jitm/JitmRestClientTest.kt
@@ -26,6 +26,7 @@ class JitmRestClientTest {
     }
 
     private fun provideJitmApiResponse(
+        template: String = "",
         content: JITMContent = provideJitmContent(),
         jitmCta: JITMCta = provideJitmCta(),
         timeToLive: Int = 0,
@@ -35,8 +36,10 @@ class JitmRestClientTest {
         maxDismissal: Int = 2,
         isDismissible: Boolean = false,
         url: String = "",
-        jitmStatsUrl: String = ""
+        jitmStatsUrl: String = "",
+        assets: Map<String, String>? = null
     ) = JITMApiResponse(
+        template = template,
         content = content,
         cta = jitmCta,
         timeToLive = timeToLive,
@@ -46,19 +49,22 @@ class JitmRestClientTest {
         maxDismissal = maxDismissal,
         isDismissible = isDismissible,
         url = url,
-        jitmStatsUrl = jitmStatsUrl
+        jitmStatsUrl = jitmStatsUrl,
+        assets = assets
     )
 
     private fun provideJitmContent(
         message: String = "",
         description: String = "",
         icon: String = "",
-        title: String = ""
+        title: String = "",
+        iconPath: String = ""
     ) = JITMContent(
         message = message,
         description = description,
         icon = icon,
-        title = title
+        title = title,
+        iconPath = iconPath,
     )
 
     private fun provideJitmCta(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JITMApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JITMApiResponse.kt
@@ -14,14 +14,13 @@ data class JITMApiResponse(
     @SerializedName("is_dismissible") val isDismissible: Boolean,
     @SerializedName("url") val url: String,
     @SerializedName("jitm_stats_url") val jitmStatsUrl: String,
+    @SerializedName("assets") val assets: Map<String, String>?,
 )
 
 data class JITMContent(
     @SerializedName("message") val message: String,
     @SerializedName("icon") val icon: String,
     @SerializedName("icon_path") val iconPath: String?,
-    @SerializedName("secondary_icon_path") val secondaryIconPath: String?,
-    @SerializedName("classes") val classes: String?,
     @SerializedName("description") val description: String,
     @SerializedName("title") val title: String,
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JITMApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/jitm/JITMApiResponse.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.jitm
 import com.google.gson.annotations.SerializedName
 
 data class JITMApiResponse(
+    @SerializedName("template") val template: String,
     @SerializedName("content") val content: JITMContent,
     @SerializedName("CTA") val cta: JITMCta,
     @SerializedName("ttl") val timeToLive: Int,
@@ -18,6 +19,9 @@ data class JITMApiResponse(
 data class JITMContent(
     @SerializedName("message") val message: String,
     @SerializedName("icon") val icon: String,
+    @SerializedName("icon_path") val iconPath: String?,
+    @SerializedName("secondary_icon_path") val secondaryIconPath: String?,
+    @SerializedName("classes") val classes: String?,
     @SerializedName("description") val description: String,
     @SerializedName("title") val title: String,
 )


### PR DESCRIPTION
Address changes to the API

```
{
  "template": "banner", // or modal. We default to banner
  "content": {
    "title": "Title of the JITM",
    "message": "Content of the JITM",
    "CTA": {
      "message": "CTA text",
      "link": "https://www.example.com"
    }
  },
  "assets": {
    "background_image_url": "https://wordpress.com/bcg_image.png",
    "badge_image_url": "https://wordpress.com/badge_image.png"
  }
}
```

pdfdoF-2xU-p2#comment-3767