### PR TITLE
Variation quantity rules data

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
@@ -23,6 +23,7 @@ class StripProductVariationMetaData @Inject internal constructor(private val gso
     companion object {
         val SUPPORTED_KEYS: Set<String> = buildSet {
             addAll(WCProductVariationModel.SubscriptionMetadataKeys.ALL_KEYS)
+            addAll(WCProductVariationModel.QuantityRulesMetadataKeys.ALL_KEYS)
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -170,4 +170,15 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
             SUBSCRIPTION_ONE_TIME_SHIPPING
         )
     }
+
+    object QuantityRulesMetadataKeys {
+        const val MINIMUM_ALLOWED_QUANTITY = "variation_minimum_allowed_quantity"
+        const val MAXIMUM_ALLOWED_QUANTITY = "variation_maximum_allowed_quantity"
+        const val GROUP_OF_QUANTITY = "variation_group_of_quantity"
+        val ALL_KEYS = setOf(
+            MINIMUM_ALLOWED_QUANTITY,
+            MAXIMUM_ALLOWED_QUANTITY,
+            GROUP_OF_QUANTITY
+        )
+    }
 }


### PR DESCRIPTION
Needed to close:  https://github.com/woocommerce/woocommerce-android/issues/8400

### Why
We are adding Min / Max Quantities read-only support to the Woo App

### Description
This small PR adds the `QuantityRulesMetadataKeys` to check for the QuantityRules metadata values from between the Variation's metadata values. It also adds the `QuantityRulesMetadataKeys` to the supported keys of `StripProductVaiationMetaData` to ensure these values are saved in the local database.

### Testing
It is better to test these changes along with the [woo PR](https://github.com/woocommerce/woocommerce-android/pull/8722)