### PR TITLE
Execute WCProductVariationModel migration only for WooCommerce AddOn

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1894,7 +1894,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 180 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD APPLICATION_PASSWORDS_AUTHORIZE_URL TEXT")
                 }
-                181 -> migrate(version) {
+                181 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD METADATA TEXT")
                 }
             }


### PR DESCRIPTION
The WordPress and Jetpack apps are crashing when updating to the [current beta version (22.1)](https://github.com/wordpress-mobile/WordPress-Android/releases/tag/22.1-rc-1) from a previous version because the WellSQL migration tries to alter a table that does not exist in those apps: `WCProductVariationModel`.

This fix prevents the issue by replacing the `migrate` function with the specific `migrateAddOn(ADDON_WOOCOMMERCE, version)` for this version migration since this table is only added in that condition.

@oguzkocer I am pointing to a `release/2.23.1` branch that I just created since this fix needs to be on top of the version currently used by the frozen WPAndroid `release/22.1` branch, which is version `2.23.0` from FluxC. (ref p1680617034271059-slack-CC7L49W13 and paqN3M-l3-p2)

@atorresveiga and @wzieba I am adding you since the issue seems to have been introduced by [a PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2666) you are more familiar with, so I just want to I get at least one review from you to make sure everything is working as it should on your side as well. Thank you.