### PR TITLE
Merge 2.23.1 release to trunk

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1894,7 +1894,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 180 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD APPLICATION_PASSWORDS_AUTHORIZE_URL TEXT")
                 }
-                181 -> migrate(version) {
+                181 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD METADATA TEXT")
                 }
             }


### PR DESCRIPTION
This hotfix release was needed to fix some issues from 2.23.0 (see [release notes](https://github.com/wordpress-mobile/WordPress-FluxC-Android/releases/tag/2.23.1)).

We now just need to merge this branch back to `trunk` to sync the changes as mentioned in paqN3M-l3-p2