### PR TITLE
Fix crash when order error message during fetching is null

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -541,6 +541,21 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         assertEquals(payload.error.type, OrderErrorType.INVALID_RESPONSE)
     }
 
+    // Test for any order-related call that returns error with no message to ensure
+    // the app doesn't crash, by converting the null value to empty string.
+    @Test
+    fun testAnyOrderCallErrorWithNoMessage() = runBlocking {
+        val errorJson = JsonObject().apply {
+            addProperty("error", "some_error_message")
+        }
+        val remoteOrderId = 88L
+        interceptor.respondWithError(errorJson)
+        val response = orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
+
+        assertEquals(response.error.message, "")
+    }
+
+
     @Suppress("unused")
     @Subscribe
     fun onAction(action: Action<*>) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -541,21 +541,6 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         assertEquals(payload.error.type, OrderErrorType.INVALID_RESPONSE)
     }
 
-    // Test for any order-related call that returns error with no message to ensure
-    // the app doesn't crash, by converting the null value to empty string.
-    @Test
-    fun testAnyOrderCallErrorWithNoMessage() = runBlocking {
-        val errorJson = JsonObject().apply {
-            addProperty("error", "some_error_message")
-        }
-        val remoteOrderId = 88L
-        interceptor.respondWithError(errorJson)
-        val response = orderRestClient.fetchSingleOrder(siteModel, remoteOrderId)
-
-        assertEquals(response.error.message, "")
-    }
-
-
     @Suppress("unused")
     @Subscribe
     fun onAction(action: Action<*>) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -897,7 +897,7 @@ class OrderRestClient @Inject constructor(
             "rest_no_route" -> OrderErrorType.PLUGIN_NOT_ACTIVE
             else -> OrderErrorType.fromString(wpAPINetworkError.errorCode.orEmpty())
         }
-        return OrderError(orderErrorType, wpAPINetworkError.message)
+        return OrderError(orderErrorType, wpAPINetworkError.message.orEmpty())
     }
 
     private fun orderStatusResponseToOrderStatusModel(


### PR DESCRIPTION
This is to the FluxC part for issue https://github.com/woocommerce/woocommerce-android/issues/8729

Not sure how to test this since I'm not sure how to replicate an empty fetch error message, but probably OK to go without?