### PR TITLE
Add allow combinations metadata key

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -558,10 +558,12 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         const val MINIMUM_ALLOWED_QUANTITY = "minimum_allowed_quantity"
         const val MAXIMUM_ALLOWED_QUANTITY = "maximum_allowed_quantity"
         const val GROUP_OF_QUANTITY = "group_of_quantity"
+        const val ALLOW_COMBINATION = "allow_combination"
         val ALL_KEYS = setOf(
             MINIMUM_ALLOWED_QUANTITY,
             MAXIMUM_ALLOWED_QUANTITY,
-            GROUP_OF_QUANTITY
+            GROUP_OF_QUANTITY,
+            ALLOW_COMBINATION
         )
     }
 }


### PR DESCRIPTION
### Why
We are adding Min / Max Quantities read-only support to the Woo App

Description
This small PR adds the `ALLOW_COMBINATION` key to be able to check for the setting value on the Woo app.

Testing
It is better to test these changes along with the [woo PR](https://github.com/woocommerce/woocommerce-android/pull/8777)