### PR TITLE
Add runtime media permissions to the example app

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -8,7 +8,12 @@
 
     <!-- Dangerous permissions, access must be requested at runtime.
          This is required for uploading media files. -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <application
         android:name=".ExampleApp"

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -87,58 +87,46 @@ public class MediaFragment extends Fragment {
                 (site, pos) -> mSite = site));
 
         mCancelButton = view.findViewById(R.id.cancel_upload);
-        mCancelButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (!isAdded()) {
-                    return;
-                }
-
-                if (mCurrentUpload == null) {
-                    mCancelButton.setEnabled(false);
-                    return;
-                }
-
-                cancelMediaUpload(mSite, mCurrentUpload);
+        mCancelButton.setOnClickListener(v -> {
+            if (!isAdded()) {
+                return;
             }
+
+            if (mCurrentUpload == null) {
+                mCancelButton.setEnabled(false);
+                return;
+            }
+
+            cancelMediaUpload(mSite, mCurrentUpload);
         });
 
-        view.findViewById(R.id.fetch_media_list).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                if (mSite == null) {
-                    prependToLog("Site is null, cannot request first media page.");
-                    return;
-                }
-                fetchMediaList(mSite);
+        view.findViewById(R.id.fetch_media_list).setOnClickListener(v -> {
+            if (mSite == null) {
+                prependToLog("Site is null, cannot request first media page.");
+                return;
             }
+            fetchMediaList(mSite);
         });
 
-        view.findViewById(R.id.fetch_specified_media).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                if (mSite == null) {
-                    prependToLog("Site is null, cannot request media.");
+        view.findViewById(R.id.fetch_specified_media).setOnClickListener(v -> {
+            if (mSite == null) {
+                prependToLog("Site is null, cannot request media.");
+                return;
+            }
+            ThreeEditTextDialog dialog = ThreeEditTextDialog.newInstance((text1, text2, text3) -> {
+                if (TextUtils.isEmpty(text1)) {
+                    prependToLog("You must specify media IDs to fetch.");
                     return;
                 }
-                ThreeEditTextDialog dialog = ThreeEditTextDialog.newInstance(new ThreeEditTextDialog.Listener() {
-                    @Override
-                    public void onClick(String text1, String text2, String text3) {
-                        if (TextUtils.isEmpty(text1)) {
-                            prependToLog("You must specify media IDs to fetch.");
-                            return;
-                        }
 
-                        String[] ids = text1.split(",");
-                        for (String id : ids) {
-                            MediaModel media = new MediaModel();
-                            media.setMediaId(Long.valueOf(id));
-                            fetchMedia(mSite, media);
-                        }
-                    }
-                }, "comma-separate media IDs", "", "");
-                dialog.show(getFragmentManager(), "media-ids-dialog");
-            }
+                String[] ids = text1.split(",");
+                for (String id : ids) {
+                    MediaModel media = new MediaModel();
+                    media.setMediaId(Long.valueOf(id));
+                    fetchMedia(mSite, media);
+                }
+            }, "comma-separate media IDs", "", "");
+            dialog.show(getFragmentManager(), "media-ids-dialog");
         });
 
         view.findViewById(R.id.upload_media).setOnClickListener(v -> {
@@ -158,22 +146,19 @@ public class MediaFragment extends Fragment {
             startActivityForResult(intent, RESULT_PICK_MEDIA);
         });
 
-        view.findViewById(R.id.delete_media).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                if (mSite == null) {
-                    prependToLog("Site is null, cannot request delete media.");
-                    return;
-                }
-
-                if (mMediaList.getCount() <= 0) {
-                    prependToLog("Please fetch media before attempting to delete.");
-                    return;
-                }
-
-                MediaModel media = (MediaModel) mMediaList.getSelectedItem();
-                deleteMedia(mSite, media);
+        view.findViewById(R.id.delete_media).setOnClickListener(v -> {
+            if (mSite == null) {
+                prependToLog("Site is null, cannot request delete media.");
+                return;
             }
+
+            if (mMediaList.getCount() <= 0) {
+                prependToLog("Please fetch media before attempting to delete.");
+                return;
+            }
+
+            MediaModel media = (MediaModel) mMediaList.getSelectedItem();
+            deleteMedia(mSite, media);
         });
 
         return view;

--- a/example/src/main/java/org/wordpress/android/fluxc/example/UploadsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/UploadsFragment.java
@@ -95,20 +95,17 @@ public class UploadsFragment extends Fragment {
         });
 
         mCancelButton = view.findViewById(R.id.cancel_upload);
-        mCancelButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (!isAdded()) {
-                    return;
-                }
-
-                if (mCurrentMediaUpload == null) {
-                    mCancelButton.setEnabled(false);
-                    return;
-                }
-
-                cancelMediaUpload(mSite, mCurrentMediaUpload);
+        mCancelButton.setOnClickListener(v -> {
+            if (!isAdded()) {
+                return;
             }
+
+            if (mCurrentMediaUpload == null) {
+                mCancelButton.setEnabled(false);
+                return;
+            }
+
+            cancelMediaUpload(mSite, mCurrentMediaUpload);
         });
 
         return view;
@@ -184,14 +181,15 @@ public class UploadsFragment extends Fragment {
                 if (event.media.getLocalPostId() > 0) {
                     PostModel associatedPost = mPostStore.getPostByLocalPostId(event.media.getLocalPostId());
                     if (mUploadStore.isPendingPost(associatedPost)) {
-                        // This media was attached to a post waiting to be uploaded (it's registered in the UploadStore)
+                        // This media was attached to a post waiting to be uploaded (it's registered in the
+                        // UploadStore)
                         String postContent = associatedPost.getContent();
                         // Replace image placeholder in post content with remote URL of uploaded image
                         associatedPost.setContent(postContent.replace("[image]", "<img src=\""
-                                + event.media.getUrl() + "\">"));
+                                                                                 + event.media.getUrl() + "\">"));
                         if (mUploadStore.getUploadingMediaForPost(associatedPost).isEmpty()) {
                             prependToLog("Post with localId=" + associatedPost.getId()
-                                    + " has no more pending media - uploading!");
+                                         + " has no more pending media - uploading!");
                             RemotePostPayload payload = new RemotePostPayload(associatedPost, mSite);
                             mDispatcher.dispatch(PostActionBuilder.newPushPostAction(payload));
                         }


### PR DESCRIPTION
The upload feature was broken. This PR adds runtime media permissions and fixes the upload feature.

Parent issue: https://github.com/wordpress-mobile/WordPress-Android/issues/17715

**To test:**
**Case 1:**
1. Launch the FluxC example app and sign in.
2. Tap UPLOADS.
3. Tap UPLOAD POST WITH LOCAL MEDIA.
4. Ensure the permission dialog appears.
5. Allow permission and add a photo.
6. Check log messages and ensure the photo is uploaded successfully.

**Case 2:**
1. Launch the FluxC example app and sign in.
2. Tap MEDIA.
3. Tap UPLOAD.
4. Ensure the permission dialog appears if the permission isn't granted.
5. Allow permission and add a photo.
6. Check log messages and ensure the photo is uploaded successfully.

> **Note**
> - After allowing the permission, you should tap the upload button again.
> - If you deny the permission, you should go to system settings to allow the permission. We don't show a message for this case since it's an example app.