### PR TITLE
[Woo REST API] Allow Jetpack connection and user fetching using application passwords as alternative to cookie+nonce authentication.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -117,16 +117,7 @@ class JetpackWPAPIRestClient @Inject constructor(
             )
             return when (response) {
                 is Success<JetpackConnectionDataResponse> -> JetpackWPAPIPayload(
-                        response.data?.let {
-                            JetpackUser(
-                                    isConnected = it.currentUser.isConnected ?: false,
-                                    isMaster = it.currentUser.isMaster ?: false,
-                                    username = it.currentUser.username.orEmpty(),
-                                    wpcomEmail = it.currentUser.wpcomUser?.email.orEmpty(),
-                                    wpcomId = it.currentUser.wpcomUser?.id ?: 0L,
-                                    wpcomUsername = it.currentUser.wpcomUser?.login.orEmpty()
-                            )
-                        }
+                        response.data?.toJetpackUser()
                 )
 
                 is Error -> JetpackWPAPIPayload(response.error)
@@ -146,20 +137,22 @@ class JetpackWPAPIRestClient @Inject constructor(
 
         return when (response) {
             is Success<JetpackConnectionDataResponse> -> JetpackWPAPIPayload(
-                response.data?.let {
-                    JetpackUser(
-                        isConnected = it.currentUser.isConnected ?: false,
-                        isMaster = it.currentUser.isMaster ?: false,
-                        username = it.currentUser.username.orEmpty(),
-                        wpcomEmail = it.currentUser.wpcomUser?.email.orEmpty(),
-                        wpcomId = it.currentUser.wpcomUser?.id ?: 0L,
-                        wpcomUsername = it.currentUser.wpcomUser?.login.orEmpty()
-                    )
-                }
+                    response.data?.toJetpackUser()
             )
 
             is Error -> JetpackWPAPIPayload(response.error)
         }
+    }
+
+    private fun JetpackConnectionDataResponse.toJetpackUser(): JetpackUser {
+        return JetpackUser(
+            isConnected = currentUser.isConnected ?: false,
+            isMaster = currentUser.isMaster ?: false,
+            username = currentUser.username.orEmpty(),
+            wpcomEmail = currentUser.wpcomUser?.email.orEmpty(),
+            wpcomId = currentUser.wpcomUser?.id ?: 0L,
+            wpcomUsername = currentUser.wpcomUser?.login.orEmpty()
+        )
     }
 
     private fun SiteModel.buildUrl(path: String): String {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -200,11 +200,12 @@ class JetpackStore
 
     suspend fun fetchJetpackConnectionUrl(
         site: SiteModel,
-        autoRegisterSiteIfNeeded: Boolean = false
+        autoRegisterSiteIfNeeded: Boolean = false,
+        useApplicationPasswords: Boolean = false
     ): JetpackConnectionUrlResult {
         if (site.isUsingWpComRestApi) error("This function supports only self-hosted site using WPAPI")
         return coroutineEngine.withDefaultContext(T.API, this, "fetchJetpackConnectionUrl") {
-            val result = jetpackWPAPIRestClient.fetchJetpackConnectionUrl(site)
+            val result = jetpackWPAPIRestClient.fetchJetpackConnectionUrl(site, useApplicationPasswords)
 
             when {
                 result.isError -> JetpackConnectionUrlResult(
@@ -221,7 +222,7 @@ class JetpackStore
                 else -> {
                     val url = result.result.trim('"').replace("\\", "")
                     val connectionUri = URI.create(url)
-                    if (!autoRegisterSiteIfNeeded || connectionUri.host == JETPACK_DOMAIN) {
+                    if (!autoRegisterSiteIfNeeded || connectionUri.host == JETPACK_DOMAIN || useApplicationPasswords) {
                         JetpackConnectionUrlResult(url)
                     } else {
                         registerJetpackSite(url).fold(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -261,10 +261,10 @@ class JetpackStore
         val errorCode: Int? = null
     ) : OnChangedError
 
-    suspend fun fetchJetpackUser(site: SiteModel): JetpackUserResult {
+    suspend fun fetchJetpackUser(site: SiteModel, useApplicationPasswords: Boolean = false): JetpackUserResult {
         if (site.isUsingWpComRestApi) error("This function is not implemented yet for Jetpack tunnel")
         return coroutineEngine.withDefaultContext(T.API, this, "fetchJetpackUser") {
-            val result = jetpackWPAPIRestClient.fetchJetpackUser(site)
+            val result = jetpackWPAPIRestClient.fetchJetpackUser(site, useApplicationPasswords)
 
             when {
                 result.isError -> JetpackUserResult(


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-android/issues/8749 and https://github.com/woocommerce/woocommerce-android/pull/8802

In Woo Mobile, after adding REST API login flow, we're exploring the possibility of completely using webview to generate application passwords for logging in, without any native login component. In this situation, we won't have any site credentials anymore, so we can't do API calls that require cookie+nonce authentication.

Currently, for the Jetpack activation feature in REST API login flow, there are some API calls involved that still use the cookie+nonce authentication:

1. Call for `/jetpack/connection/url`
2. Call for `/jetpack/connection/data`

This PR adds the possibility in the `JetpackStore` and `JetpackWPAPIRestClient` to do the above calls using application passwords.

> **Note**
> Please note that not using cookie+nonce is only needed for REST API login flow. Fetching that uses cookie+nonce is still possible, to make sure [Jetpack installation in WPCom login flow](https://github.com/woocommerce/woocommerce-android/pull/7889) is still supported.

Lastly, registering a Jetpack site is not required during Jetpack activation in REST API login flow, so we make sure it's not done in the REST API case.

For testing instruction, please test using https://github.com/woocommerce/woocommerce-android/pull/8785