### PR TITLE
Expose formatted discount price of Products

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/products/Product.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/products/Product.kt
@@ -9,6 +9,8 @@ data class Product(
     val cost: Double? = 0.0,
     @SerializedName("sale_cost")
     val saleCost: Double? = 0.0,
+    @SerializedName("combined_sale_cost_display")
+    val combinedSaleCostDisplay: String? = "",
     @SerializedName("cost_display")
     val costDisplay: String? = "",
     @SerializedName("currency_code")


### PR DESCRIPTION
Resolves wordpress-mobile/WordPress-Android#17905 (partially)
Related: wordpress-mobile/WordPress-Android#18255

### This PR:
- ★ Exposes the `combined_sale_cost_display` string field from the `/products/` api to clients via `Product.combinedSaleCostDisplay`

> **Note**:
> This change allows clients to simply display the price formatted on the backend instead of having to implement client-side formatting.
> The same thing is already done for `DomainSuggestionResponse`, where we're using the `cost` string formatted by the api.

## To test
- Test PR wordpress-mobile/WordPress-Android#18255
