### PR TITLE
[JPAndroid] Dashboard cards: Add activity to endpoint handling

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
@@ -31,8 +31,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.activity.ActivityLogRestClient.ActivitiesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.ActivitiesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.CardsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.PageResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.PostResponse
@@ -316,9 +316,16 @@ class CardsRestClientTest {
     @Test
     fun `given activity unauthorized, when fetch cards triggered, then returns activity unauthorized card error`() =
         test {
-            val json = UnitTestUtils.getStringFromResourceFile(javaClass, DASHBOARD_CARDS_WITH_ERRORS_JSON)
+            val json = UnitTestUtils.getStringFromResourceFile(
+                javaClass,
+                DASHBOARD_CARDS_WITH_ERRORS_JSON
+            )
             val data = getCardsResponseFromJsonString(json)
-                .copy(activity = ActivitiesResponse(error = UNAUTHORIZED))
+                .copy(
+                    activity = ActivitiesResponse(
+                        error = UNAUTHORIZED, totalItems = null, summary = null, current = null
+                    )
+                )
             initFetchCards(data = data)
 
             val result = restClient.fetchCards(site, CARD_TYPES)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
@@ -367,7 +367,6 @@ class CardsRestClientTest {
         expected: CardsResponse,
         actual: CardsPayload<CardsResponse>
     ) {
-
         with(actual) {
             assertEquals(site, this@CardsRestClientTest.site)
             assertFalse(isError)

--- a/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
@@ -587,12 +587,18 @@ class CardsStoreTest {
         model?.filterIsInstance(ActivityCardModel::class.java)?.firstOrNull()?.error
 
     private fun getTodaysStatsErrorCardEntity(type: TodaysStatsCardErrorType) =
-            TODAY_STATS_WITH_ERROR_ENTITY.copy(
-                    json = CardsUtils.GSON.toJson(TodaysStatsCardModel(error = TodaysStatsCardError(type)))
-            )
+        TODAY_STATS_WITH_ERROR_ENTITY.copy(
+            json = CardsUtils.GSON.toJson(TodaysStatsCardModel(error = TodaysStatsCardError(type)))
+        )
 
     private fun getActivityErrorCardEntity() =
         ACTIVITY_WITH_ERROR_ENTITY.copy(
-            json = CardsUtils.GSON.toJson(ActivityCardModel(error = ActivityCardError(ActivityCardErrorType.UNAUTHORIZED)))
+            json = CardsUtils.GSON.toJson(
+                ActivityCardModel(
+                    error = ActivityCardError(
+                        ActivityCardErrorType.UNAUTHORIZED
+                    )
+                )
+            )
         )
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
@@ -19,8 +19,8 @@ import org.wordpress.android.fluxc.model.dashboard.CardModel.PagesCardModel.Page
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel.PostCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
+import org.wordpress.android.fluxc.network.rest.wpcom.activity.ActivityLogRestClient.ActivitiesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.ActivitiesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.CardsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.PageResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsRestClient.PostResponse

--- a/example/src/test/resources/wp/dashboard/cards.json
+++ b/example/src/test/resources/wp/dashboard/cards.json
@@ -1,9 +1,9 @@
 {
   "todays_stats": {
-      "views": 100,
-      "visitors": 30,
-      "likes": 50,
-      "comments": 10
+    "views": 100,
+    "visitors": 30,
+    "likes": 50,
+    "comments": 10
   },
   "posts": {
     "has_published": true,
@@ -50,5 +50,40 @@
       "status": "publish",
       "date": "2023-03-02 11:55:49"
     }
-  ]
+  ],
+  "activity": {
+    "summary": "response",
+    "totalItems": 1,
+    "current": {
+      "orderedItems": [
+        {
+          "summary": "activity",
+          "name": "name",
+          "actor": {
+            "type": "author",
+            "name": "John Smith",
+            "external_user_id": 10,
+            "wpcom_user_id": 15,
+            "icon": {
+              "type": "jpg",
+              "url": "dog.jpg",
+              "width": 100,
+              "height": 100
+            },
+            "role": "admin"
+          },
+          "type": "create a blog",
+          "generator": {
+            "jetpack_version": 10.3,
+            "blog_id": 123
+          },
+          "is_rewindable": false,
+          "rewind_id": "10.0",
+          "gridicon": "gridicon.jpg",
+          "status": "OK",
+          "activity_id": "activity123"
+        }
+      ]
+    }
+  }
 }

--- a/example/src/test/resources/wp/dashboard/cards_with_errors.json
+++ b/example/src/test/resources/wp/dashboard/cards_with_errors.json
@@ -4,5 +4,8 @@
   },
   "posts": {
     "error": "unauthorized"
+  },
+  "activity": {
+    "error": "unauthorized"
   }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.model.dashboard
 
+import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardError
 import java.util.Date
@@ -13,8 +14,14 @@ sealed class CardModel(
     ) {
         TODAYS_STATS(TodaysStatsCardModel::class.java, "todays_stats"),
         POSTS(PostsCardModel::class.java, "posts"),
-        PAGES(PagesCardModel::class.java, "pages")
+        PAGES(PagesCardModel::class.java, "pages"),
+        ACTIVITY(ActivityCardModel::class.java, "activity")
     }
+
+    data class ActivityCardModel(
+        val activities: List<ActivityLogModel> = emptyList(),
+        val error: Boolean? = false
+    )  : CardModel(Type.ACTIVITY)
 
     data class PagesCardModel(
         val pages: List<PageCardModel> = emptyList(),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.model.dashboard
 
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
+import org.wordpress.android.fluxc.store.dashboard.CardsStore.ActivityCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardError
 import java.util.Date
@@ -20,7 +21,7 @@ sealed class CardModel(
 
     data class ActivityCardModel(
         val activities: List<ActivityLogModel> = emptyList(),
-        val error: Boolean? = false
+        val error: ActivityCardError? = null
     )  : CardModel(Type.ACTIVITY)
 
     data class PagesCardModel(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -434,6 +434,7 @@ class ActivityLogRestClient @Inject constructor(
         val totalItems: Int?,
         val summary: String?,
         val current: Page?,
+        // This class is reused in CardsRestClient, the error field is not used for activity log
         val error: String? = null
     ) {
         class Page(val orderedItems: List<ActivityResponse>)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClient.kt
@@ -433,7 +433,8 @@ class ActivityLogRestClient @Inject constructor(
     class ActivitiesResponse(
         val totalItems: Int?,
         val summary: String?,
-        val current: Page?
+        val current: Page?,
+        val error: String? = null
     ) {
         class Page(val orderedItems: List<ActivityResponse>)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
@@ -196,15 +196,7 @@ fun ActivitiesResponse.toActivityCardModel(): ActivityCardModel {
 
     val activities = current?.orderedItems?.mapNotNull {
         when {
-            it.activity_id == null -> {
-                null
-            }
-            it.summary == null -> {
-                null
-            }
-            it.content?.text == null -> {
-                null
-            }
+            it.activity_id == null || it.summary == null || it.content?.text == null ||
             it.published == null -> {
                 null
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClient.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.activity.ActivityLogRestClient.ActivitiesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.ActivityCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.ActivityCardErrorType
@@ -31,8 +32,6 @@ import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardErrorType
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.TodaysStatsCardErrorType
-import org.wordpress.android.fluxc.tools.FormattableContent
-import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -164,106 +163,11 @@ class CardsRestClient @Inject constructor(
         )
     }
 
-    @Suppress("ConstructorParameterNaming")
-    class ActivitiesResponse(
-        val totalItems: Int? = null,
-        val summary: String? = null,
-        val current: Page? = null,
-        val error: String? = null
-    ) {
-        class Page(val orderedItems: List<ActivityResponse>)
-
-        data class ActivityResponse(
-            val summary: String?,
-            val content: FormattableContent?,
-            val name: String?,
-            val actor: Actor?,
-            val type: String?,
-            val published: Date?,
-            val generator: Generator?,
-            val is_rewindable: Boolean?,
-            val rewind_id: String?,
-            val gridicon: String?,
-            val status: String?,
-            val activity_id: String?
-        )
-
-        class Actor(
-            val type: String?,
-            val name: String?,
-            val external_user_id: Long?,
-            val wpcom_user_id: Long?,
-            val icon: Icon?,
-            val role: String?
-        )
-
-        class Icon(val type: String?, val url: String?, val width: Int?, val height: Int?)
-
-        class Generator(val jetpack_version: Float?, val blog_id: Long?)
-
-        fun toActivityCardModel(): ActivityCardModel {
-            val error = error?.let { toActivityCardError(it) }
-
-            val activities = current?.orderedItems?.mapNotNull {
-                when {
-                    it.activity_id == null -> {
-                        null
-                    }
-                    it.summary == null -> {
-                        null
-                    }
-                    it.content?.text == null -> {
-                        null
-                    }
-                    it.published == null -> {
-                        null
-                    }
-                    else -> {
-                        ActivityLogModel(
-                            activityID = it.activity_id,
-                            summary = it.summary,
-                            content = it.content,
-                            name = it.name,
-                            type = it.type,
-                            gridicon = it.gridicon,
-                            status = it.status,
-                            rewindable = it.is_rewindable,
-                            rewindID = it.rewind_id,
-                            published = it.published,
-                            actor = it.actor?.let { act ->
-                                ActivityLogModel.ActivityActor(
-                                    act.name,
-                                    act.type,
-                                    act.wpcom_user_id,
-                                    act.icon?.url,
-                                    act.role
-                                )
-                            }
-                        )
-                    }
-                }
-            }
-
-            return ActivityCardModel(
-                activities = activities ?: emptyList(),
-                error = error
-            )
-        }
-
-        private fun toActivityCardError(error: String): ActivityCardError {
-            val errorType = when (error) {
-                UNAUTHORIZED -> ActivityCardErrorType.UNAUTHORIZED
-                else -> ActivityCardErrorType.GENERIC_ERROR
-            }
-            return ActivityCardError(errorType, error)
-        }
-    }
-
     companion object {
         private const val CARDS = "cards"
         private const val JETPACK_DISCONNECTED = "jetpack_disconnected"
         private const val JETPACK_DISABLED = "jetpack_disabled"
-        private const val UNAUTHORIZED = "unauthorized"
+        const val UNAUTHORIZED = "unauthorized"
     }
 }
 
@@ -285,4 +189,60 @@ fun WPComGsonNetworkError.toCardsError(): CardsError {
         null -> CardsErrorType.GENERIC_ERROR
     }
     return CardsError(type, message)
+}
+
+fun ActivitiesResponse.toActivityCardModel(): ActivityCardModel {
+    val error = error?.let { toActivityCardError(it) }
+
+    val activities = current?.orderedItems?.mapNotNull {
+        when {
+            it.activity_id == null -> {
+                null
+            }
+            it.summary == null -> {
+                null
+            }
+            it.content?.text == null -> {
+                null
+            }
+            it.published == null -> {
+                null
+            }
+            else -> {
+                ActivityLogModel(
+                    activityID = it.activity_id,
+                    summary = it.summary,
+                    content = it.content,
+                    name = it.name,
+                    type = it.type,
+                    gridicon = it.gridicon,
+                    status = it.status,
+                    rewindable = it.is_rewindable,
+                    rewindID = it.rewind_id,
+                    published = it.published,
+                    actor = it.actor?.let { act ->
+                        ActivityLogModel.ActivityActor(
+                            act.name,
+                            act.type,
+                            act.wpcom_user_id,
+                            act.icon?.url,
+                            act.role
+                        )
+                    }
+                )
+            }
+        }
+    }
+
+    return ActivityCardModel(
+        activities = activities ?: emptyList(),
+        error = error
+    )
+}
+fun toActivityCardError(error: String): ActivityCardError {
+    val errorType = when (error) {
+        CardsRestClient.UNAUTHORIZED -> ActivityCardErrorType.UNAUTHORIZED
+        else -> ActivityCardErrorType.GENERIC_ERROR
+    }
+    return ActivityCardError(errorType, error)
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/dashboard/CardsStore.kt
@@ -110,6 +110,15 @@ class CardsStore @Inject constructor(
         val message: String? = null
     ) : OnChangedError
 
+    enum class ActivityCardErrorType {
+        UNAUTHORIZED,
+        GENERIC_ERROR
+    }
+    class ActivityCardError(
+        val type: ActivityCardErrorType,
+        val message: String? = null
+    ) : OnChangedError
+
     enum class CardsErrorType {
         GENERIC_ERROR,
         AUTHORIZATION_REQUIRED,


### PR DESCRIPTION
Parent Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/18207
Parent PR: In Progress

This PR updates the dashboard card endpoint to handle Activity Log data
Note: I had hoped to reuse `ActivityLogRestClient.ActivitiesResponse`, but the response from the dashboard cards includes an error, I thought it was best to create a copy and add the new response fields. I'm open to suggestions.
**Update**: After chatting with @RenanLukas, it was decided to move `error: String? = null ` to the existing `ActivitiesResponse` class and remove the copy from `CardsRestClient`. 

**Test**
- Do a code review
- Make sure the unit tests in `CardsRestClientTest.kt` and `CardsStoreTest.kt` pass
- Test the changes using the Parent PR