### PR TITLE
Process composite products

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 183
+        return 184
     }
 
     override fun getDbName(): String {
@@ -1899,6 +1899,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 182 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD BUNDLED_ITEMS TEXT")
+                }
+                183 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductModel ADD COMPOSITE_COMPONENTS TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductComponent.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductComponent.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.fluxc.model
+
+import com.google.gson.annotations.SerializedName
+
+data class WCProductComponent(
+    @SerializedName("id") val id: Long,
+    @SerializedName("title") val title: String,
+    @SerializedName("description") val description: String,
+    @SerializedName("query_type") val queryType: String,
+    @SerializedName("query_ids") val queryIds: List<Long>,
+    @SerializedName("default_option_id") val defaultOptionId: String,
+    @SerializedName("thumbnail_src") val thumbnailUrl: String?
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -111,6 +111,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var height = ""
     @Column var metadata = ""
     @Column var bundledItems = ""
+    @Column var compositeComponents = ""
 
     val attributeList: Array<ProductAttribute>
         get() = Gson().fromJson(attributes, Array<ProductAttribute>::class.java) ?: emptyArray()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -75,7 +75,8 @@ data class ProductApiResponse(
     val metadata: JsonArray? = null,
     val bundle_stock_quantity: String? = null,
     val bundle_stock_status: String? = null,
-    val bundled_items: JsonArray? = null
+    val bundled_items: JsonArray? = null,
+    val composite_components: JsonArray? = null
 ) {
     @Suppress("LongMethod", "ComplexMethod")
     fun asProductModel(): WCProductModel {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -169,6 +169,7 @@ data class ProductApiResponse(
             groupedProductIds = response.grouped_products?.toString() ?: ""
             metadata = response.metadata?.toString() ?: ""
             bundledItems = response.bundled_items?.toString() ?: ""
+            compositeComponents = response.composite_components?.toString() ?: ""
 
             response.dimensions?.asJsonObject?.let { json ->
                 length = json.getString("length") ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.onStart
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCBundledProduct
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
+import org.wordpress.android.fluxc.model.WCProductComponent
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
@@ -88,6 +89,14 @@ object ProductSqlUtils {
             .flowOn(Dispatchers.IO)
     }
 
+    fun getCompositeProducts(site: SiteModel, remoteProductId: Long): List<WCProductComponent> {
+        val productModel = getProductByRemoteId(site, remoteProductId)
+
+        return productModel?.let {
+            val responseType = object : TypeToken<List<WCProductComponent>>() {}.type
+            gson.fromJson(it.compositeComponents, responseType) as? List<WCProductComponent>
+        } ?: emptyList()
+    }
     private fun getBundledProducts(site: SiteModel, remoteProductId: Long): List<WCBundledProduct> {
         val productModel = WellSql.select(WCProductModel::class.java)
             .where().beginGroup()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.VariationAttributes
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
+import org.wordpress.android.fluxc.model.WCProductComponent
 import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
@@ -967,6 +968,10 @@ class WCProductStore @Inject constructor(
 
     suspend fun getBundledProductsCount(site: SiteModel, remoteProductId: Long): Int {
         return ProductSqlUtils.getBundledProductsCount(site, remoteProductId)
+    }
+
+    suspend fun getCompositeProducts(site: SiteModel, remoteProductId: Long): List<WCProductComponent> {
+        return ProductSqlUtils.getCompositeProducts(site, remoteProductId)
     }
 
     suspend fun submitProductAttributeChanges(


### PR DESCRIPTION
⚠️  Do not merge until [this PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2713) gets merged

Closes https://github.com/woocommerce/woocommerce-android/issues/8404

### Why
We are adding Composite Products read-only support to the Woo App.

### Description
This PR adds support to save composite components information locally. It does that by adding the new compositeComponents field to the WCProductModel table and exposing functions to get the compositeComponents information.

### Testing
It is better to test these changes along with the woo PR