### PR TITLE
Update catalogVersion to 1.9.0

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.7.0"
+def catalogVersion = "1.9.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {


### PR DESCRIPTION
Updates `catalogVersion` to 1.9.0, which includes the latest Utils library.

Changes for the 1.7.0 → 1.9.0 version of catalog:
- Reverts the Aztec lib version to the 1.6.3, so the Aztec lib won't be compatible with Android 13 such as `gutenberg-mobile`.
- Updates Utils libs to `3.6.0`.

To test:
No need to test. The FluxC was already working fine with Aztec 1.6.3. And Utils 3.6.0 introduces a new public function that doesn't affect FluxC.