### PR TITLE
Fix crash when Product call response error message is null

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1794,6 +1794,6 @@ class ProductRestClient @Inject constructor(
             "woocommerce_variation_invalid_image_id" -> ProductErrorType.INVALID_VARIATION_IMAGE_ID
             else -> ProductErrorType.fromString(wpAPINetworkError.errorCode.orEmpty())
         }
-        return ProductError(productErrorType, wpAPINetworkError.message)
+        return ProductError(productErrorType, wpAPINetworkError.message.orEmpty())
     }
 }


### PR DESCRIPTION
This is to fix issue https://github.com/woocommerce/woocommerce-android/issues/8823

Similar to a previous fix on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2703 , I still wasn't able to replicate how a null error message is possible, so unfortunately this fix comes with no unit test.