### PR TITLE
Customer note for simple payments order

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.flow.FlowCollector
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.OrderEntity
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.order.FeeLine
@@ -133,11 +133,13 @@ class OrderUpdateStore @Inject internal constructor(
         site: SiteModel,
         amount: String,
         isTaxable: Boolean,
-        status: WCOrderStatusModel? = null
+        status: WCOrderStatusModel? = null,
+        customerNote: String? = null
     ): WooResult<OrderEntity> {
         val createOrderRequest = UpdateOrderRequest(
             status = status,
-            feeLines = generateSimplePaymentFeeLineList(amount, isTaxable)
+            feeLines = generateSimplePaymentFeeLineList(amount, isTaxable),
+            customerNote = customerNote
         )
         return createOrder(site, createOrderRequest)
     }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -417,6 +417,7 @@ class OrderUpdateStoreTest {
         // given
         val newOrder = initialOrder.copy(
                 status = SIMPLE_PAYMENT_ORDER_STATUS.statusKey,
+                customerNote = SIMPLE_PAYMENT_CUSTOMER_NOTE,
                 feeLines = OrderUpdateStore.generateSimplePaymentFeeLineJson(
                         SIMPLE_PAYMENT_AMOUNT,
                         SIMPLE_PAYMENT_IS_TAXABLE,
@@ -439,7 +440,8 @@ class OrderUpdateStoreTest {
             site,
             SIMPLE_PAYMENT_AMOUNT,
             SIMPLE_PAYMENT_IS_TAXABLE,
-            SIMPLE_PAYMENT_ORDER_STATUS
+            SIMPLE_PAYMENT_ORDER_STATUS,
+            SIMPLE_PAYMENT_CUSTOMER_NOTE,
         )
 
         // then
@@ -449,6 +451,7 @@ class OrderUpdateStoreTest {
         assertThat(result.model!!.getFeeLineList()[0].total).isEqualTo(SIMPLE_PAYMENT_AMOUNT)
         assertThat(result.model!!.getFeeLineList()[0].taxStatus!!.value).isEqualTo(SIMPLE_PAYMENT_TAX_STATUS)
         assertThat(result.model!!.status).isEqualTo(SIMPLE_PAYMENT_ORDER_STATUS.statusKey)
+        assertThat(result.model!!.customerNote).isEqualTo(SIMPLE_PAYMENT_CUSTOMER_NOTE)
     }
 
     @Test


### PR DESCRIPTION
Add API so simple payments order can be created with a customer note. We want to make it easier to recognise that the order was created during TTP test payment