### PR TITLE
Allow updating specific fields when updating media details

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -93,7 +93,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     private boolean mDeleted;
 
     // Default fields to update upon request
-    private String[] fieldsToUpdate = {"parent_id", "title", "description", "caption", "alt"};
+    private String[] mFieldsToUpdate = {"parent_id", "title", "description", "caption", "alt"};
 
     @Override
     public boolean equals(Object other) {
@@ -331,11 +331,11 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     }
 
     public String[] getFieldsToUpdate() {
-        return fieldsToUpdate;
+        return mFieldsToUpdate;
     }
 
     public void setFieldsToUpdate(String[] fieldsToUpdate) {
-        this.fieldsToUpdate = fieldsToUpdate;
+        this.mFieldsToUpdate = fieldsToUpdate;
     }
 
     //

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -365,7 +365,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     //
     // Legacy methods
     //
-    
+
     public boolean isVideo() {
         return MediaUtils.isVideoMimeType(getMimeType());
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -104,16 +104,16 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         CAPTION("caption"),
         ALT("alt");
 
-        private String fieldName;
+        private String mFieldName;
 
         // Constructor
         MediaFields(String fieldName) {
-            this.fieldName = fieldName;
+            this.mFieldName = fieldName;
         }
 
         // Getter
         public String getFieldName() {
-            return this.fieldName;
+            return this.mFieldName;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -365,6 +365,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     //
     // Legacy methods
     //
+    
     public boolean isVideo() {
         return MediaUtils.isVideoMimeType(getMimeType());
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -92,8 +92,32 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     // Set to true on a successful response to delete via WP.com REST API, not stored locally
     private boolean mDeleted;
 
-    // Default fields to update upon request
-    private String[] mFieldsToUpdate = {"parent_id", "title", "description", "caption", "alt"};
+    /**
+     * Enum representing various media fields with their default field names.
+     * The default values can be changed by modifying the string parameter
+     * passed to the enum constructor.
+     */
+    public enum MediaFields {
+        PARENT_ID("parent_id"),
+        TITLE("title"),
+        DESCRIPTION("description"),
+        CAPTION("caption"),
+        ALT("alt");
+
+        private String fieldName;
+
+        // Constructor
+        MediaFields(String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        // Getter
+        public String getFieldName() {
+            return this.fieldName;
+        }
+    }
+
+    private MediaFields[] mFieldsToUpdate = MediaFields.values();
 
     @Override
     public boolean equals(Object other) {
@@ -330,18 +354,17 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         mUploadState = uploadState.toString();
     }
 
-    public String[] getFieldsToUpdate() {
+    public MediaFields[] getFieldsToUpdate() {
         return mFieldsToUpdate;
     }
 
-    public void setFieldsToUpdate(String[] fieldsToUpdate) {
+    public void setFieldsToUpdate(MediaFields[] fieldsToUpdate) {
         this.mFieldsToUpdate = fieldsToUpdate;
     }
 
     //
     // Legacy methods
     //
-
     public boolean isVideo() {
         return MediaUtils.isVideoMimeType(getMimeType());
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -92,6 +92,9 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     // Set to true on a successful response to delete via WP.com REST API, not stored locally
     private boolean mDeleted;
 
+    // Default fields to update upon request
+    private String[] fieldsToUpdate = {"parent_id", "title", "description", "caption", "alt"};
+
     @Override
     public boolean equals(Object other) {
         if (this == other) return true;
@@ -325,6 +328,14 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
 
     public void setUploadState(MediaUploadState uploadState) {
         mUploadState = uploadState.toString();
+    }
+
+    public String[] getFieldsToUpdate() {
+        return fieldsToUpdate;
+    }
+
+    public void setFieldsToUpdate(String[] fieldsToUpdate) {
+        this.fieldsToUpdate = fieldsToUpdate;
     }
 
     //

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -47,7 +47,6 @@ import org.wordpress.android.util.StringUtils;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -47,6 +47,7 @@ import org.wordpress.android.util.StringUtils;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -621,21 +622,37 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     private Map<String, Object> getEditRequestParams(final MediaModel media) {
         if (media == null) return null;
 
+        String[] fieldsToUpdate = media.getFieldsToUpdate();
+
         final Map<String, Object> params = new HashMap<>();
-        if (media.getPostId() > 0) {
-            params.put("parent_id", String.valueOf(media.getPostId()));
-        }
-        if (!TextUtils.isEmpty(media.getTitle())) {
-            params.put("title", media.getTitle());
-        }
-        if (!TextUtils.isEmpty(media.getDescription())) {
-            params.put("description", media.getDescription());
-        }
-        if (!TextUtils.isEmpty(media.getCaption())) {
-            params.put("caption", media.getCaption());
-        }
-        if (!TextUtils.isEmpty(media.getAlt())) {
-            params.put("alt", media.getAlt());
+        for (String field : fieldsToUpdate) {
+            switch (field) {
+                case "parent_id":
+                    if (media.getPostId() > 0) {
+                        params.put("parent_id", String.valueOf(media.getPostId()));
+                    }
+                    break;
+                case "title":
+                    if (!TextUtils.isEmpty(media.getTitle())) {
+                        params.put("title", media.getTitle());
+                    }
+                    break;
+                case "description":
+                    if (!TextUtils.isEmpty(media.getDescription())) {
+                        params.put("description", media.getDescription());
+                    }
+                    break;
+                case "caption":
+                    if (!TextUtils.isEmpty(media.getCaption())) {
+                        params.put("caption", media.getCaption());
+                    }
+                    break;
+                case "alt":
+                    if (!TextUtils.isEmpty(media.getAlt())) {
+                        params.put("alt", media.getAlt());
+                    }
+                    break;
+            }
         }
         return params;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.UploadActionBuilder;
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.MediaModel.MediaFields;
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.StockMediaModel;
@@ -621,34 +622,34 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     private Map<String, Object> getEditRequestParams(final MediaModel media) {
         if (media == null) return null;
 
-        String[] fieldsToUpdate = media.getFieldsToUpdate();
+        MediaFields[] fieldsToUpdate = media.getFieldsToUpdate();
 
         final Map<String, Object> params = new HashMap<>();
-        for (String field : fieldsToUpdate) {
+        for (MediaFields field : fieldsToUpdate) {
             switch (field) {
-                case "parent_id":
+                case PARENT_ID:
                     if (media.getPostId() > 0) {
-                        params.put("parent_id", String.valueOf(media.getPostId()));
+                        params.put(MediaFields.PARENT_ID.getFieldName(), String.valueOf(media.getPostId()));
                     }
                     break;
-                case "title":
+                case TITLE:
                     if (!TextUtils.isEmpty(media.getTitle())) {
-                        params.put("title", media.getTitle());
+                        params.put(MediaFields.TITLE.getFieldName(), media.getTitle());
                     }
                     break;
-                case "description":
+                case DESCRIPTION:
                     if (!TextUtils.isEmpty(media.getDescription())) {
-                        params.put("description", media.getDescription());
+                        params.put(MediaFields.DESCRIPTION.getFieldName(), media.getDescription());
                     }
                     break;
-                case "caption":
+                case CAPTION:
                     if (!TextUtils.isEmpty(media.getCaption())) {
-                        params.put("caption", media.getCaption());
+                        params.put(MediaFields.CAPTION.getFieldName(), media.getCaption());
                     }
                     break;
-                case "alt":
+                case ALT:
                     if (!TextUtils.isEmpty(media.getAlt())) {
-                        params.put("alt", media.getAlt());
+                        params.put(MediaFields.ALT.getFieldName(), media.getAlt());
                     }
                     break;
             }


### PR DESCRIPTION
# Related PRs

* `Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/18327

# Description

At the moment, when a request is made to edit a media item, its `title`, `description`, `caption`, `alt`, and `parent_id` fields are all updated ([reference](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/5805ef65e9cebb0153c38ebf98a8f6fab646648c/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java#L615-L641)).

With this PR and the related [FluxC PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/20606), the logic is updated to allow us to specify the fields that we want to update. The reason for this change is to avoid updating more fields than necessary when saving a post and updating the unattached media items (i.e. only update the field postID).

Further background and reasoning behind making this change can be found in https://github.com/wordpress-mobile/gutenberg-mobile/issues/5697, which describes a bug in the VideoPress block that's caused by the title being set for unattached items. The iOS equivalent to this change can be found at https://github.com/wordpress-mobile/WordPress-iOS/pull/20606.

# Testing

Please refer to [the Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/18327) for the central place, with the most up-to-date testing instructions.