### PR TITLE
Fix crash on sold items exceeding integer range

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.model
 
 import com.google.gson.Gson
 import com.google.gson.JsonParser
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.yarolegovich.wellsql.core.Identifiable
@@ -9,6 +10,7 @@ import com.yarolegovich.wellsql.core.annotation.Column
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey
 import com.yarolegovich.wellsql.core.annotation.Table
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
+import org.wordpress.android.fluxc.utils.NonNegativeIntJsonDeserializer
 
 @Table(addOn = WellSqlConfig.ADDON_WOOCOMMERCE)
 data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
@@ -63,6 +65,7 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
         val netRevenue: Double? = null
         @SerializedName("avg_order_value")
         val avgOrderValue: Double? = null
+        @JsonAdapter(NonNegativeIntJsonDeserializer::class)
         @SerializedName("num_items_sold")
         val itemsSold: Int? = null
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/NonNegativeIntJsonDeserializer.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/NonNegativeIntJsonDeserializer.kt
@@ -6,7 +6,6 @@ import com.google.gson.JsonElement
 import java.lang.reflect.Type
 
 class NonNegativeIntJsonDeserializer : JsonDeserializer<Int?> {
-
     override fun deserialize(
         json: JsonElement?,
         typeOfT: Type?,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/NonNegativeIntJsonDeserializer.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/NonNegativeIntJsonDeserializer.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import java.lang.reflect.Type
+
+class NonNegativeIntJsonDeserializer : JsonDeserializer<Int?> {
+
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): Int? {
+        return try {
+            json?.asInt?.let {
+                if (it >= 0) it else null
+            }
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/model/WCRevenueStatsModelTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/model/WCRevenueStatsModelTest.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.utils.json
+
+class WCRevenueStatsModelTest {
+
+    @Test
+    fun `should assign null value if number of sold items exceeds integer range`() {
+        val sut = WCRevenueStatsModel().apply {
+            total = json {
+                "num_items_sold" To "15032797007"
+            }.toString()
+        }
+
+        val total = sut.parseTotal()
+
+        assertThat(total?.itemsSold).isNull()
+    }
+
+    @Test
+    fun `should assign null value if number of sold items is negative`() {
+        val sut = WCRevenueStatsModel().apply {
+            total = json {
+                "num_items_sold" To "-123"
+            }.toString()
+        }
+
+        val total = sut.parseTotal()
+
+        assertThat(total?.itemsSold).isNull()
+    }
+
+    @Test
+    fun `should correctly parse value if number of sold items is within integer limits`() {
+        val sut = WCRevenueStatsModel().apply {
+            total = json {
+                "num_items_sold" To "123456"
+            }.toString()
+        }
+
+        val total = sut.parseTotal()
+
+        assertThat(total?.itemsSold).isEqualTo(123456)
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/model/WCRevenueStatsModelTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/model/WCRevenueStatsModelTest.kt
@@ -5,7 +5,6 @@ import org.junit.Test
 import org.wordpress.android.fluxc.utils.json
 
 class WCRevenueStatsModelTest {
-
     @Test
     fun `should assign null value if number of sold items exceeds integer range`() {
         val sut = WCRevenueStatsModel().apply {


### PR DESCRIPTION
## Description

This PR addresses https://github.com/woocommerce/woocommerce-android/issues/8825, by introducing a custom deserializer which will assign `null` value if API value exceeds integer limits or is negative. 

### Testing

I don't see a reasonable way to test this fix - I think unit tests are sufficient. When this PR is merged, I'll prepare a PR to update FluxC tag in the WooCommerce repository.
