### PR TITLE
Special stock status

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 184
+        return 185
     }
 
     override fun getDbName(): String {
@@ -1902,6 +1902,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 183 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD COMPOSITE_COMPONENTS TEXT")
+                }
+                184 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductModel ADD SPECIAL_STOCK_STATUS TEXT")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -112,6 +112,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var metadata = ""
     @Column var bundledItems = ""
     @Column var compositeComponents = ""
+    @Column var specialStockStatus = ""
 
     val attributeList: Array<ProductAttribute>
         get() = Gson().fromJson(attributes, Array<ProductAttribute>::class.java) ?: emptyArray()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -127,15 +127,11 @@ data class ProductApiResponse(
                 it == "true" || it == "parent"
             } ?: false
 
-            stockQuantity = if (isBundledProduct) {
-                response.bundle_stock_quantity?.toDoubleOrNull() ?: 0.0
-            } else {
-                response.stock_quantity
-            }
-            stockStatus = if (isBundledProduct) {
-                response.bundle_stock_status ?: ""
-            } else {
-                response.stock_status ?: ""
+            stockQuantity = response.stock_quantity
+
+            stockStatus = response.stock_status ?: ""
+            if (isBundledProduct && response.stock_status != response.bundle_stock_status) {
+                specialStockStatus = response.bundle_stock_status ?: ""
             }
 
             backorders = response.backorders ?: ""


### PR DESCRIPTION
Close https://github.com/woocommerce/woocommerce-android/issues/8961

### Why
We want to provide support for the insufficient stock status of Product Bundles

### Description
This PR adds the special stock status field to the local database. This new field will help in supporting extensions like the Bundle Products, which display extra stock statuses depending on their child's stock management settings/status.  