### PR TITLE
Support core stock statuses

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
@@ -10,6 +10,7 @@ enum class CoreProductStockStatus(val value: String) {
 
     companion object {
         private val valueMap = values().associateBy(CoreProductStockStatus::value)
+        val ALL_VALUES = valueMap.keys
 
         /**
          * Convert the base value into the associated CoreProductStockStatus object

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -130,7 +130,7 @@ data class ProductApiResponse(
             stockQuantity = response.stock_quantity
 
             stockStatus = response.stock_status ?: ""
-            if (isBundledProduct && response.stock_status != response.bundle_stock_status) {
+            if (isBundledProduct && (response.bundle_stock_status in CoreProductStockStatus.ALL_VALUES).not()) {
                 specialStockStatus = response.bundle_stock_status ?: ""
             }
 


### PR DESCRIPTION
Close https://github.com/woocommerce/woocommerce-android/issues/8976

### Description
This PR goal is to match wp-admin behavior for bundled products when the product is on backorder status. Currently, we are using the  `bundle_stock_status` by default for bundled products, but this logic has a flaw. The bundled product field doesn't support the `backorder` stock status value, and this caused an inconsistency between what was displayed in the apps vs wp-admin. To solve this issue, we are now using the stock_status field for the cases when the bundle_stock_status is a core stock status.

### Testing instructions
My recommendation is to test this changes using this PR https://github.com/woocommerce/woocommerce-android/pull/8962 and composite builds
1. Create a Bundle product with backorder stock status
2. Open the product list screen
3. Check that the backorder stock status is displayed in the bundled product stock status description
4. Change one of the inner products in the bundle to out-of-stock
5. Open the product list screen
6. Check that the insufficient stock status is displayed in the bundled product stock status description