### PR TITLE
[EditorTheme] Detect block-based themes

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -125,7 +125,9 @@ data class EditorThemeSupport(
 
         return bundle
     }
+    fun isEditorThemeBlockBased(): Boolean = isBlockBasedTheme || (hasBlockTemplates ?: false)
 }
+
 
 data class EditorThemeElement(
     val name: String?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -57,6 +57,7 @@ data class EditorTheme(
         element.galleryWithImageBlocks = themeSupport.galleryWithImageBlocks
         element.quoteBlockV2 = themeSupport.quoteBlockV2
         element.listBlockV2 = themeSupport.listBlockV2
+        element.isBlockTemplates = themeSupport.isBlockTemplates ?: false
 
         return element
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -23,6 +23,7 @@ const val MAP_KEY_IS_BLOCK_BASED_THEME: String = "isBlockBasedTheme"
 const val MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS: String = "galleryWithImageBlocks"
 const val MAP_KEY_QUOTE_BLOCK_V2: String = "quoteBlockV2"
 const val MAP_KEY_LIST_BLOCK_V2: String = "listBlockV2"
+const val MAP_KEY_IS_BLOCK_TEMPLATES: String = "isBlockTemplates"
 
 data class EditorTheme(
     @SerializedName("theme_supports") val themeSupport: EditorThemeSupport,
@@ -33,6 +34,7 @@ data class EditorTheme(
             themeSupport = EditorThemeSupport(
                     blockEditorSettings.colors,
                     blockEditorSettings.gradients,
+                    null,
                     blockEditorSettings.styles?.toString(),
                     blockEditorSettings.features?.toString(),
                     blockEditorSettings.isBlockBasedTheme,
@@ -86,6 +88,8 @@ data class EditorThemeSupport(
     @JsonAdapter(EditorThemeElementListSerializer::class)
     @SerializedName("editor-gradient-presets")
     val gradients: List<EditorThemeElement>?,
+    @SerializedName("block-templates")
+    val isBlockTemplates: Boolean?,
     val rawStyles: String?,
     val rawFeatures: String?,
     val isBlockBasedTheme: Boolean,
@@ -116,6 +120,7 @@ data class EditorThemeSupport(
         bundle.putBoolean(MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS, galleryWithImageBlocks)
         bundle.putBoolean(MAP_KEY_QUOTE_BLOCK_V2, quoteBlockV2)
         bundle.putBoolean(MAP_KEY_LIST_BLOCK_V2, listBlockV2)
+        bundle.putBoolean(MAP_KEY_IS_BLOCK_TEMPLATES, isBlockTemplates ?: false)
 
         return bundle
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -23,7 +23,7 @@ const val MAP_KEY_IS_BLOCK_BASED_THEME: String = "isBlockBasedTheme"
 const val MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS: String = "galleryWithImageBlocks"
 const val MAP_KEY_QUOTE_BLOCK_V2: String = "quoteBlockV2"
 const val MAP_KEY_LIST_BLOCK_V2: String = "listBlockV2"
-const val MAP_KEY_IS_BLOCK_TEMPLATES: String = "isBlockTemplates"
+const val MAP_KEY_HAS_BLOCK_TEMPLATES: String = "hasBlockTemplates"
 
 data class EditorTheme(
     @SerializedName("theme_supports") val themeSupport: EditorThemeSupport,
@@ -57,7 +57,7 @@ data class EditorTheme(
         element.galleryWithImageBlocks = themeSupport.galleryWithImageBlocks
         element.quoteBlockV2 = themeSupport.quoteBlockV2
         element.listBlockV2 = themeSupport.listBlockV2
-        element.isBlockTemplates = themeSupport.isBlockTemplates ?: false
+        element.hasBlockTemplates = themeSupport.hasBlockTemplates ?: false
 
         return element
     }
@@ -90,7 +90,7 @@ data class EditorThemeSupport(
     @SerializedName("editor-gradient-presets")
     val gradients: List<EditorThemeElement>?,
     @SerializedName("block-templates")
-    val isBlockTemplates: Boolean?,
+    val hasBlockTemplates: Boolean?,
     val rawStyles: String?,
     val rawFeatures: String?,
     val isBlockBasedTheme: Boolean,
@@ -121,7 +121,7 @@ data class EditorThemeSupport(
         bundle.putBoolean(MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS, galleryWithImageBlocks)
         bundle.putBoolean(MAP_KEY_QUOTE_BLOCK_V2, quoteBlockV2)
         bundle.putBoolean(MAP_KEY_LIST_BLOCK_V2, listBlockV2)
-        bundle.putBoolean(MAP_KEY_IS_BLOCK_TEMPLATES, isBlockTemplates ?: false)
+        bundle.putBoolean(MAP_KEY_HAS_BLOCK_TEMPLATES, hasBlockTemplates ?: false)
 
         return bundle
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -19,7 +19,7 @@ const val MAP_KEY_ELEMENT_COLORS: String = "colors"
 const val MAP_KEY_ELEMENT_GRADIENTS: String = "gradients"
 const val MAP_KEY_ELEMENT_STYLES: String = "rawStyles"
 const val MAP_KEY_ELEMENT_FEATURES: String = "rawFeatures"
-const val MAP_KEY_IS_FSETHEME: String = "isFSETheme"
+const val MAP_KEY_IS_BLOCK_BASED_THEME: String = "isBlockBasedTheme"
 const val MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS: String = "galleryWithImageBlocks"
 const val MAP_KEY_QUOTE_BLOCK_V2: String = "quoteBlockV2"
 const val MAP_KEY_LIST_BLOCK_V2: String = "listBlockV2"
@@ -35,7 +35,7 @@ data class EditorTheme(
                     blockEditorSettings.gradients,
                     blockEditorSettings.styles?.toString(),
                     blockEditorSettings.features?.toString(),
-                    blockEditorSettings.isFSETheme,
+                    blockEditorSettings.isBlockBasedTheme,
                     blockEditorSettings.galleryWithImageBlocks,
                     blockEditorSettings.quoteBlockV2,
                     blockEditorSettings.listBlockV2
@@ -51,7 +51,7 @@ data class EditorTheme(
         element.version = version
         element.rawStyles = themeSupport.rawStyles
         element.rawFeatures = themeSupport.rawFeatures
-        element.isFSETheme = themeSupport.isFSETheme
+        element.isBlockBasedTheme = themeSupport.isBlockBasedTheme
         element.galleryWithImageBlocks = themeSupport.galleryWithImageBlocks
         element.quoteBlockV2 = themeSupport.quoteBlockV2
         element.listBlockV2 = themeSupport.listBlockV2
@@ -69,7 +69,7 @@ data class EditorTheme(
 }
 
 data class BlockEditorSettings(
-    @SerializedName("__unstableEnableFullSiteEditingBlocks") val isFSETheme: Boolean,
+    @SerializedName("__unstableIsBlockBasedTheme") val isBlockBasedTheme: Boolean,
     @SerializedName("__unstableGalleryWithImageBlocks") val galleryWithImageBlocks: Boolean,
     @SerializedName("__experimentalEnableQuoteBlockV2") val quoteBlockV2: Boolean,
     @SerializedName("__experimentalEnableListBlockV2") val listBlockV2: Boolean,
@@ -88,7 +88,7 @@ data class EditorThemeSupport(
     val gradients: List<EditorThemeElement>?,
     val rawStyles: String?,
     val rawFeatures: String?,
-    val isFSETheme: Boolean,
+    val isBlockBasedTheme: Boolean,
     val galleryWithImageBlocks: Boolean,
     val quoteBlockV2: Boolean,
     val listBlockV2: Boolean
@@ -112,7 +112,7 @@ data class EditorThemeSupport(
             bundle.putString(MAP_KEY_ELEMENT_FEATURES, it)
         }
 
-        bundle.putBoolean(MAP_KEY_IS_FSETHEME, isFSETheme)
+        bundle.putBoolean(MAP_KEY_IS_BLOCK_BASED_THEME, isBlockBasedTheme)
         bundle.putBoolean(MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS, galleryWithImageBlocks)
         bundle.putBoolean(MAP_KEY_QUOTE_BLOCK_V2, quoteBlockV2)
         bundle.putBoolean(MAP_KEY_LIST_BLOCK_V2, listBlockV2)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -89,6 +89,11 @@ class EditorThemeSqlUtils {
         @Column var version: String? = null
         @Column var rawStyles: String? = null
         @Column var rawFeatures: String? = null
+        @Column var isBlockTemplates: Boolean = false
+            @JvmName("isBlockTemplates")
+            get
+            @JvmName("setIsBlockTemplates")
+            set
         @Column var isBlockBasedTheme: Boolean = false
             @JvmName("isBlockBasedTheme")
             get
@@ -121,6 +126,7 @@ class EditorThemeSqlUtils {
             val editorThemeSupport = EditorThemeSupport(
                     colors,
                     gradients,
+                    isBlockTemplates,
                     rawStyles,
                     rawFeatures,
                     isBlockBasedTheme,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -89,10 +89,10 @@ class EditorThemeSqlUtils {
         @Column var version: String? = null
         @Column var rawStyles: String? = null
         @Column var rawFeatures: String? = null
-        @Column var isBlockTemplates: Boolean = false
-            @JvmName("isBlockTemplates")
+        @Column var hasBlockTemplates: Boolean = false
+            @JvmName("getHasBlockTemplates")
             get
-            @JvmName("setIsBlockTemplates")
+            @JvmName("setHasBlockTemplates")
             set
         @Column var isBlockBasedTheme: Boolean = false
             @JvmName("isBlockBasedTheme")
@@ -126,7 +126,7 @@ class EditorThemeSqlUtils {
             val editorThemeSupport = EditorThemeSupport(
                     colors,
                     gradients,
-                    isBlockTemplates,
+                    hasBlockTemplates,
                     rawStyles,
                     rawFeatures,
                     isBlockBasedTheme,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -89,10 +89,10 @@ class EditorThemeSqlUtils {
         @Column var version: String? = null
         @Column var rawStyles: String? = null
         @Column var rawFeatures: String? = null
-        @Column var isFSETheme: Boolean = false
-            @JvmName("isFSETheme")
+        @Column var isBlockBasedTheme: Boolean = false
+            @JvmName("isBlockBasedTheme")
             get
-            @JvmName("setIsFSETheme")
+            @JvmName("setIsBlockBasedTheme")
             set
         @Column var galleryWithImageBlocks: Boolean = false
         @Column var quoteBlockV2: Boolean = false
@@ -123,7 +123,7 @@ class EditorThemeSqlUtils {
                     gradients,
                     rawStyles,
                     rawFeatures,
-                    isFSETheme,
+                    isBlockBasedTheme,
                     galleryWithImageBlocks,
                     quoteBlockV2,
                     listBlockV2

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 185
+        return 186
     }
 
     override fun getDbName(): String {
@@ -1909,6 +1909,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 185 -> migrate(version) {
                     db.execSQL("ALTER TABLE EditorTheme RENAME COLUMN IS_FSETHEME TO IS_BLOCK_BASED_THEME ")
                     db.execSQL("ALTER TABLE EditorTheme ADD IS_BLOCK_TEMPLATES BOOLEAN")
+                }
             }
         }
         db.setTransactionSuccessful()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,11 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-<<<<<<< HEAD
         return 184
-=======
-        return 181
->>>>>>> 107b19ca2 (Rename FSE site settings flag to block based theme)
     }
 
     override fun getDbName(): String {
@@ -1909,6 +1905,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 184 -> migrate(version) {
                     db.execSQL("ALTER TABLE EditorTheme RENAME COLUMN IS_FSETHEME TO IS_BLOCK_BASED_THEME ")
+                    db.execSQL("ALTER TABLE EditorTheme ADD IS_BLOCK_TEMPLATES BOOLEAN")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1908,7 +1908,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 185 -> migrate(version) {
                     db.execSQL("ALTER TABLE EditorTheme RENAME COLUMN IS_FSETHEME TO IS_BLOCK_BASED_THEME ")
-                    db.execSQL("ALTER TABLE EditorTheme ADD IS_BLOCK_TEMPLATES BOOLEAN")
+                    db.execSQL("ALTER TABLE EditorTheme ADD HAS_BLOCK_TEMPLATES BOOLEAN")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,11 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
+<<<<<<< HEAD
         return 184
+=======
+        return 181
+>>>>>>> 107b19ca2 (Rename FSE site settings flag to block based theme)
     }
 
     override fun getDbName(): String {
@@ -1902,6 +1906,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 183 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD COMPOSITE_COMPONENTS TEXT")
+                }
+                184 -> migrate(version) {
+                    db.execSQL("ALTER TABLE EditorTheme RENAME COLUMN IS_FSETHEME TO IS_BLOCK_BASED_THEME ")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -63,6 +63,11 @@ class EditorThemeStore
         return editorThemeSqlUtils.getEditorThemeForSite(site)
     }
 
+    fun getIsBlockBasedTheme(site: SiteModel) =
+        getEditorThemeForSite(site)?.themeSupport?.let { themeSupport ->
+            themeSupport.isBlockBasedTheme || themeSupport.isBlockBasedTheme
+        }
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? EditorThemeAction ?: return

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -65,7 +65,7 @@ class EditorThemeStore
 
     fun getIsBlockBasedTheme(site: SiteModel) =
         getEditorThemeForSite(site)?.themeSupport?.let { themeSupport ->
-            themeSupport.isBlockBasedTheme || themeSupport.isBlockBasedTheme
+            themeSupport.isBlockBasedTheme || (themeSupport.isBlockTemplates ?: false)
         }
 
     @Subscribe(threadMode = ThreadMode.ASYNC)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -10,7 +10,6 @@ import org.wordpress.android.fluxc.action.EditorThemeAction.FETCH_EDITOR_THEME
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.BlockEditorSettings
 import org.wordpress.android.fluxc.model.EditorTheme
-import org.wordpress.android.fluxc.model.EditorThemeSupport
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
@@ -65,12 +64,7 @@ class EditorThemeStore
     }
 
     fun getIsBlockBasedTheme(site: SiteModel): Boolean =
-        getEditorThemeForSite(site)?.themeSupport?.let { editorThemeSupport ->
-            getIsBlockBasedTheme(editorThemeSupport)
-        } ?: false
-
-    fun getIsBlockBasedTheme(editorThemeSupport: EditorThemeSupport): Boolean =
-        editorThemeSupport.isBlockBasedTheme || (editorThemeSupport.hasBlockTemplates ?: false)
+        getEditorThemeForSite(site)?.themeSupport?.isEditorThemeBlockBased() ?: false
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.action.EditorThemeAction.FETCH_EDITOR_THEME
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.BlockEditorSettings
 import org.wordpress.android.fluxc.model.EditorTheme
+import org.wordpress.android.fluxc.model.EditorThemeSupport
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NOT_FOUND
@@ -63,10 +64,13 @@ class EditorThemeStore
         return editorThemeSqlUtils.getEditorThemeForSite(site)
     }
 
-    fun getIsBlockBasedTheme(site: SiteModel) =
-        getEditorThemeForSite(site)?.themeSupport?.let { themeSupport ->
-            themeSupport.isBlockBasedTheme || (themeSupport.isBlockTemplates ?: false)
-        }
+    fun getIsBlockBasedTheme(site: SiteModel): Boolean =
+        getEditorThemeForSite(site)?.themeSupport?.let { editorThemeSupport ->
+            getIsBlockBasedTheme(editorThemeSupport)
+        } ?: false
+
+    fun getIsBlockBasedTheme(editorThemeSupport: EditorThemeSupport): Boolean =
+        editorThemeSupport.isBlockBasedTheme || (editorThemeSupport.hasBlockTemplates ?: false)
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {


### PR DESCRIPTION
**Parent issue**: https://github.com/wordpress-mobile/WordPress-Android/issues/18368
**Parent PR**: https://github.com/wordpress-mobile/WordPress-Android/pull/18385

Thanks @mkevins for working on [the POC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/tree/try/support-block-based-themes) related to this issue. I've used much of your code 👍 

This PR introduces two new properties: `BlockEditorSettings#isBlockBasedTheme` and `BlockEditorSettings#hasBlockTemplates`. To detect if a Site's theme is block-based, the clients can call `EditorThemeStore#getIsBlockBasedTheme`.