### PR TITLE
Enable account closure

### DIFF
--- a/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -20,6 +20,7 @@
 /me/send-verification-email/
 /me/social-login/connect/
 /me/username/
+/me/account/close/
 
 /me/transactions/supported-countries/
 /me/transactions/

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountClosure.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountClosure.kt
@@ -1,0 +1,43 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.account
+
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.network.Response
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.account.CloseAccountResult.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.account.CloseAccountResult.Failure
+import org.wordpress.android.fluxc.network.rest.wpcom.account.CloseAccountResult.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.account.CloseAccountResult.ErrorType
+
+/**
+ * Performs an HTTP POST call to v1.1 /me/account/close endpoint to close the user account.
+ */
+fun AccountRestClient.closeAccount(onResult: (CloseAccountResult) -> Unit) {
+    add(WPComGsonRequest.buildPostRequest(
+        WPCOMREST.me.account.close.urlV1_1,
+        null,
+        CloseAccountResponse::class.java,
+        { onResult(Success) },
+        { error ->
+            val errorType = ErrorType.values().firstOrNull { error.apiError == it.token } ?: ErrorType.UNKNOWN
+            onResult(Failure(error = Error(errorType, error.message)))
+        },
+
+    ))
+}
+
+class CloseAccountResponse: Response
+
+sealed class CloseAccountResult {
+    object Success: CloseAccountResult()
+    data class Failure(val error: Error): CloseAccountResult()
+    data class Error(val errorType: ErrorType, val message: String)
+    enum class ErrorType(val token: String? = null) {
+        UNAUTHORIZED("unauthorized"),
+        ATOMIC_SITE("atomic-site"),
+        CHARGEBACKED_SITE("chargebacked-site"),
+        ACTIVE_SUBSCRIPTIONS("active-subscriptions"),
+        ACTIVE_MEMBERSHIPS("active-memberships"),
+        INVALID_TOKEN("invalid_token"),
+        UNKNOWN,
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/18393

Related WordPress-Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18407

### Description

This PR adds support for the account closure API endpoint.