### PR TITLE
Add bundledBy field to LineItem

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -20,7 +20,9 @@ data class LineItem(
     val sku: String? = null,
     val price: String? = null, // The per-item price
     @SerializedName("meta_data")
-    val metaData: List<WCMetaData>? = null
+    val metaData: List<WCMetaData>? = null,
+    @SerializedName("bundled_by")
+    val bundledBy:String? = null
 ) {
     class Attribute(val key: String?, val value: String?)
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -22,7 +22,7 @@ data class LineItem(
     @SerializedName("meta_data")
     val metaData: List<WCMetaData>? = null,
     @SerializedName("bundled_by")
-    val bundledBy:String? = null
+    val bundledBy: String? = null
 ) {
     class Attribute(val key: String?, val value: String?)
 


### PR DESCRIPTION
### Why 
On the Eagle team, we are working on improving the experience for our users across our Canonical Extensions. One of these extensions is Bundled Products, and one of our tasks and ideas to improve the experience was to display the relationship between a bundled product and its products.

### Description 
This little PR adds the `bundledBy` field to the LineItem class. This field is required in the Woo app to group all internal products within its parent.

### Testing instruction
It is better to test this PR using the Woo PR