### PR TITLE
Revert "[EditorTheme] Detect block-based themes"

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -19,11 +19,10 @@ const val MAP_KEY_ELEMENT_COLORS: String = "colors"
 const val MAP_KEY_ELEMENT_GRADIENTS: String = "gradients"
 const val MAP_KEY_ELEMENT_STYLES: String = "rawStyles"
 const val MAP_KEY_ELEMENT_FEATURES: String = "rawFeatures"
-const val MAP_KEY_IS_BLOCK_BASED_THEME: String = "isBlockBasedTheme"
+const val MAP_KEY_IS_FSETHEME: String = "isFSETheme"
 const val MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS: String = "galleryWithImageBlocks"
 const val MAP_KEY_QUOTE_BLOCK_V2: String = "quoteBlockV2"
 const val MAP_KEY_LIST_BLOCK_V2: String = "listBlockV2"
-const val MAP_KEY_HAS_BLOCK_TEMPLATES: String = "hasBlockTemplates"
 
 data class EditorTheme(
     @SerializedName("theme_supports") val themeSupport: EditorThemeSupport,
@@ -34,10 +33,9 @@ data class EditorTheme(
             themeSupport = EditorThemeSupport(
                     blockEditorSettings.colors,
                     blockEditorSettings.gradients,
-                    null,
                     blockEditorSettings.styles?.toString(),
                     blockEditorSettings.features?.toString(),
-                    blockEditorSettings.isBlockBasedTheme,
+                    blockEditorSettings.isFSETheme,
                     blockEditorSettings.galleryWithImageBlocks,
                     blockEditorSettings.quoteBlockV2,
                     blockEditorSettings.listBlockV2
@@ -53,11 +51,10 @@ data class EditorTheme(
         element.version = version
         element.rawStyles = themeSupport.rawStyles
         element.rawFeatures = themeSupport.rawFeatures
-        element.isBlockBasedTheme = themeSupport.isBlockBasedTheme
+        element.isFSETheme = themeSupport.isFSETheme
         element.galleryWithImageBlocks = themeSupport.galleryWithImageBlocks
         element.quoteBlockV2 = themeSupport.quoteBlockV2
         element.listBlockV2 = themeSupport.listBlockV2
-        element.hasBlockTemplates = themeSupport.hasBlockTemplates ?: false
 
         return element
     }
@@ -72,7 +69,7 @@ data class EditorTheme(
 }
 
 data class BlockEditorSettings(
-    @SerializedName("__unstableIsBlockBasedTheme") val isBlockBasedTheme: Boolean,
+    @SerializedName("__unstableEnableFullSiteEditingBlocks") val isFSETheme: Boolean,
     @SerializedName("__unstableGalleryWithImageBlocks") val galleryWithImageBlocks: Boolean,
     @SerializedName("__experimentalEnableQuoteBlockV2") val quoteBlockV2: Boolean,
     @SerializedName("__experimentalEnableListBlockV2") val listBlockV2: Boolean,
@@ -89,11 +86,9 @@ data class EditorThemeSupport(
     @JsonAdapter(EditorThemeElementListSerializer::class)
     @SerializedName("editor-gradient-presets")
     val gradients: List<EditorThemeElement>?,
-    @SerializedName("block-templates")
-    val hasBlockTemplates: Boolean?,
     val rawStyles: String?,
     val rawFeatures: String?,
-    val isBlockBasedTheme: Boolean,
+    val isFSETheme: Boolean,
     val galleryWithImageBlocks: Boolean,
     val quoteBlockV2: Boolean,
     val listBlockV2: Boolean
@@ -117,17 +112,14 @@ data class EditorThemeSupport(
             bundle.putString(MAP_KEY_ELEMENT_FEATURES, it)
         }
 
-        bundle.putBoolean(MAP_KEY_IS_BLOCK_BASED_THEME, isBlockBasedTheme)
+        bundle.putBoolean(MAP_KEY_IS_FSETHEME, isFSETheme)
         bundle.putBoolean(MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS, galleryWithImageBlocks)
         bundle.putBoolean(MAP_KEY_QUOTE_BLOCK_V2, quoteBlockV2)
         bundle.putBoolean(MAP_KEY_LIST_BLOCK_V2, listBlockV2)
-        bundle.putBoolean(MAP_KEY_HAS_BLOCK_TEMPLATES, hasBlockTemplates ?: false)
 
         return bundle
     }
-    fun isEditorThemeBlockBased(): Boolean = isBlockBasedTheme || (hasBlockTemplates ?: false)
 }
-
 
 data class EditorThemeElement(
     val name: String?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -89,15 +89,10 @@ class EditorThemeSqlUtils {
         @Column var version: String? = null
         @Column var rawStyles: String? = null
         @Column var rawFeatures: String? = null
-        @Column var hasBlockTemplates: Boolean = false
-            @JvmName("getHasBlockTemplates")
+        @Column var isFSETheme: Boolean = false
+            @JvmName("isFSETheme")
             get
-            @JvmName("setHasBlockTemplates")
-            set
-        @Column var isBlockBasedTheme: Boolean = false
-            @JvmName("isBlockBasedTheme")
-            get
-            @JvmName("setIsBlockBasedTheme")
+            @JvmName("setIsFSETheme")
             set
         @Column var galleryWithImageBlocks: Boolean = false
         @Column var quoteBlockV2: Boolean = false
@@ -126,10 +121,9 @@ class EditorThemeSqlUtils {
             val editorThemeSupport = EditorThemeSupport(
                     colors,
                     gradients,
-                    hasBlockTemplates,
                     rawStyles,
                     rawFeatures,
-                    isBlockBasedTheme,
+                    isFSETheme,
                     galleryWithImageBlocks,
                     quoteBlockV2,
                     listBlockV2

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 186
+        return 185
     }
 
     override fun getDbName(): String {
@@ -1905,10 +1905,6 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 184 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD SPECIAL_STOCK_STATUS TEXT")
-                }
-                185 -> migrate(version) {
-                    db.execSQL("ALTER TABLE EditorTheme RENAME COLUMN IS_FSETHEME TO IS_BLOCK_BASED_THEME ")
-                    db.execSQL("ALTER TABLE EditorTheme ADD HAS_BLOCK_TEMPLATES BOOLEAN")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -63,9 +63,6 @@ class EditorThemeStore
         return editorThemeSqlUtils.getEditorThemeForSite(site)
     }
 
-    fun getIsBlockBasedTheme(site: SiteModel): Boolean =
-        getEditorThemeForSite(site)?.themeSupport?.isEditorThemeBlockBased() ?: false
-
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? EditorThemeAction ?: return


### PR DESCRIPTION
Revert https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2726

@thomashorta found out that the changes on FluxC introduced a SQLite statement (`RENAME COLUMN`) that is only supported in more recent SQLite versions (3.25+) which is only present on Android [API 30 and newer](https://developer.android.com/reference/android/database/sqlite/package-summary), so it causes a crash when updating in older APIs.