### PR TITLE
add compositeParent field to LineItem

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -22,7 +22,9 @@ data class LineItem(
     @SerializedName("meta_data")
     val metaData: List<WCMetaData>? = null,
     @SerializedName("bundled_by")
-    val bundledBy: String? = null
+    val bundledBy: String? = null,
+    @SerializedName("composite_parent")
+    val compositeParent: String? = null
 ) {
     class Attribute(val key: String?, val value: String?)
 


### PR DESCRIPTION
Close: https://github.com/woocommerce/woocommerce-android/issues/8406 

### Why 
On the Eagle team, we are working on improving the experience for our users across our Canonical Extensions. One of these extensions is Composite Products, and one of our tasks and ideas to improve the experience was to display the relationship between a composite product and its components.

### Description 
This little PR adds the `compositeParent` field to the LineItem class. This field is required in the Woo app to group all components within its parent.

### Testing instruction
It is better to test this PR using the Woo PR