### PR TITLE
[EditorTheme] Detect block-based themes (fixed)

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -19,10 +19,11 @@ const val MAP_KEY_ELEMENT_COLORS: String = "colors"
 const val MAP_KEY_ELEMENT_GRADIENTS: String = "gradients"
 const val MAP_KEY_ELEMENT_STYLES: String = "rawStyles"
 const val MAP_KEY_ELEMENT_FEATURES: String = "rawFeatures"
-const val MAP_KEY_IS_FSETHEME: String = "isFSETheme"
+const val MAP_KEY_IS_BLOCK_BASED_THEME: String = "isBlockBasedTheme"
 const val MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS: String = "galleryWithImageBlocks"
 const val MAP_KEY_QUOTE_BLOCK_V2: String = "quoteBlockV2"
 const val MAP_KEY_LIST_BLOCK_V2: String = "listBlockV2"
+const val MAP_KEY_HAS_BLOCK_TEMPLATES: String = "hasBlockTemplates"
 
 data class EditorTheme(
     @SerializedName("theme_supports") val themeSupport: EditorThemeSupport,
@@ -33,9 +34,10 @@ data class EditorTheme(
             themeSupport = EditorThemeSupport(
                     blockEditorSettings.colors,
                     blockEditorSettings.gradients,
+                    null,
                     blockEditorSettings.styles?.toString(),
                     blockEditorSettings.features?.toString(),
-                    blockEditorSettings.isFSETheme,
+                    blockEditorSettings.isBlockBasedTheme,
                     blockEditorSettings.galleryWithImageBlocks,
                     blockEditorSettings.quoteBlockV2,
                     blockEditorSettings.listBlockV2
@@ -51,10 +53,11 @@ data class EditorTheme(
         element.version = version
         element.rawStyles = themeSupport.rawStyles
         element.rawFeatures = themeSupport.rawFeatures
-        element.isFSETheme = themeSupport.isFSETheme
+        element.isBlockBasedTheme = themeSupport.isBlockBasedTheme
         element.galleryWithImageBlocks = themeSupport.galleryWithImageBlocks
         element.quoteBlockV2 = themeSupport.quoteBlockV2
         element.listBlockV2 = themeSupport.listBlockV2
+        element.hasBlockTemplates = themeSupport.hasBlockTemplates ?: false
 
         return element
     }
@@ -69,7 +72,7 @@ data class EditorTheme(
 }
 
 data class BlockEditorSettings(
-    @SerializedName("__unstableEnableFullSiteEditingBlocks") val isFSETheme: Boolean,
+    @SerializedName("__unstableIsBlockBasedTheme") val isBlockBasedTheme: Boolean,
     @SerializedName("__unstableGalleryWithImageBlocks") val galleryWithImageBlocks: Boolean,
     @SerializedName("__experimentalEnableQuoteBlockV2") val quoteBlockV2: Boolean,
     @SerializedName("__experimentalEnableListBlockV2") val listBlockV2: Boolean,
@@ -86,9 +89,11 @@ data class EditorThemeSupport(
     @JsonAdapter(EditorThemeElementListSerializer::class)
     @SerializedName("editor-gradient-presets")
     val gradients: List<EditorThemeElement>?,
+    @SerializedName("block-templates")
+    val hasBlockTemplates: Boolean?,
     val rawStyles: String?,
     val rawFeatures: String?,
-    val isFSETheme: Boolean,
+    val isBlockBasedTheme: Boolean,
     val galleryWithImageBlocks: Boolean,
     val quoteBlockV2: Boolean,
     val listBlockV2: Boolean
@@ -112,14 +117,17 @@ data class EditorThemeSupport(
             bundle.putString(MAP_KEY_ELEMENT_FEATURES, it)
         }
 
-        bundle.putBoolean(MAP_KEY_IS_FSETHEME, isFSETheme)
+        bundle.putBoolean(MAP_KEY_IS_BLOCK_BASED_THEME, isBlockBasedTheme)
         bundle.putBoolean(MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS, galleryWithImageBlocks)
         bundle.putBoolean(MAP_KEY_QUOTE_BLOCK_V2, quoteBlockV2)
         bundle.putBoolean(MAP_KEY_LIST_BLOCK_V2, listBlockV2)
+        bundle.putBoolean(MAP_KEY_HAS_BLOCK_TEMPLATES, hasBlockTemplates ?: false)
 
         return bundle
     }
+    fun isEditorThemeBlockBased(): Boolean = isBlockBasedTheme || (hasBlockTemplates ?: false)
 }
+
 
 data class EditorThemeElement(
     val name: String?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -89,10 +89,15 @@ class EditorThemeSqlUtils {
         @Column var version: String? = null
         @Column var rawStyles: String? = null
         @Column var rawFeatures: String? = null
-        @Column var isFSETheme: Boolean = false
-            @JvmName("isFSETheme")
+        @Column var hasBlockTemplates: Boolean = false
+            @JvmName("getHasBlockTemplates")
             get
-            @JvmName("setIsFSETheme")
+            @JvmName("setHasBlockTemplates")
+            set
+        @Column var isBlockBasedTheme: Boolean = false
+            @JvmName("isBlockBasedTheme")
+            get
+            @JvmName("setIsBlockBasedTheme")
             set
         @Column var galleryWithImageBlocks: Boolean = false
         @Column var quoteBlockV2: Boolean = false
@@ -121,9 +126,10 @@ class EditorThemeSqlUtils {
             val editorThemeSupport = EditorThemeSupport(
                     colors,
                     gradients,
+                    hasBlockTemplates,
                     rawStyles,
                     rawFeatures,
-                    isFSETheme,
+                    isBlockBasedTheme,
                     galleryWithImageBlocks,
                     quoteBlockV2,
                     listBlockV2

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 185
+        return 186
     }
 
     override fun getDbName(): String {
@@ -1905,6 +1905,10 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 184 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD SPECIAL_STOCK_STATUS TEXT")
+                }
+                185 -> migrate(version) {
+                    db.execSQL("ALTER TABLE EditorTheme RENAME COLUMN IS_FSETHEME TO IS_BLOCK_BASED_THEME ")
+                    db.execSQL("ALTER TABLE EditorTheme ADD HAS_BLOCK_TEMPLATES BOOLEAN")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -8,6 +8,7 @@ import android.preference.PreferenceManager
 import android.view.Gravity
 import android.widget.Toast
 import androidx.annotation.StringDef
+import com.wellsql.generated.EditorThemeTable
 import com.yarolegovich.wellsql.DefaultWellConfig
 import com.yarolegovich.wellsql.WellSql
 import com.yarolegovich.wellsql.WellTableManager
@@ -1907,8 +1908,40 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE WCProductModel ADD SPECIAL_STOCK_STATUS TEXT")
                 }
                 185 -> migrate(version) {
-                    db.execSQL("ALTER TABLE EditorTheme RENAME COLUMN IS_FSETHEME TO IS_BLOCK_BASED_THEME ")
-                    db.execSQL("ALTER TABLE EditorTheme ADD HAS_BLOCK_TEMPLATES BOOLEAN")
+                    // renaming tables is not supported by SQLite in some versions, so we need to:
+                    // 1. create a new table
+                    // 2. copy data from old table to new table, mapping to the new column names
+                    // 3. drop the old table
+                    // 4. rename the new table to the old table name
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS EditorTheme_new (" +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            "LOCAL_SITE_ID INTEGER," +
+                            "STYLESHEET TEXT," +
+                            "VERSION TEXT," +
+                            "RAW_STYLES TEXT," +
+                            "RAW_FEATURES TEXT," +
+                            "HAS_BLOCK_TEMPLATES INTEGER," +
+                            "IS_BLOCK_BASED_THEME INTEGER," +
+                            "GALLERY_WITH_IMAGE_BLOCKS INTEGER," +
+                            "QUOTE_BLOCK_V2 INTEGER," +
+                            "LIST_BLOCK_V2 INTEGER)"
+                    )
+
+                    db.execSQL(
+                        "INSERT INTO EditorTheme_new (" +
+                            "_id, LOCAL_SITE_ID, STYLESHEET, VERSION, RAW_STYLES, RAW_FEATURES, " +
+                            "HAS_BLOCK_TEMPLATES, IS_BLOCK_BASED_THEME, GALLERY_WITH_IMAGE_BLOCKS, " +
+                            "QUOTE_BLOCK_V2, LIST_BLOCK_V2) " +
+                            "SELECT " +
+                            "_id, LOCAL_SITE_ID, STYLESHEET, VERSION, RAW_STYLES, RAW_FEATURES, " +
+                            "0, IS_FSETHEME, GALLERY_WITH_IMAGE_BLOCKS, " +
+                            "QUOTE_BLOCK_V2, LIST_BLOCK_V2 " +
+                            "FROM EditorTheme"
+                    )
+
+                    db.execSQL("DROP TABLE EditorTheme")
+                    db.execSQL("ALTER TABLE EditorTheme_new RENAME TO EditorTheme")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EditorThemeStore.kt
@@ -63,6 +63,9 @@ class EditorThemeStore
         return editorThemeSqlUtils.getEditorThemeForSite(site)
     }
 
+    fun getIsBlockBasedTheme(site: SiteModel): Boolean =
+        getEditorThemeForSite(site)?.themeSupport?.isEditorThemeBlockBased() ?: false
+
     @Subscribe(threadMode = ThreadMode.ASYNC)
     override fun onAction(action: Action<*>) {
         val actionType = action.type as? EditorThemeAction ?: return


### PR DESCRIPTION
This PR reintroduces #2726, by reverting #2730 and fixing the crash mentioned there.

Here are the original PR details:

**Parent issue**: https://github.com/wordpress-mobile/WordPress-Android/issues/18368
**Parent PR**: https://github.com/wordpress-mobile/WordPress-Android/pull/18385

Thanks @mkevins for working on [the POC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/tree/try/support-block-based-themes) related to this issue. I've used much of your code 👍 

This PR introduces two new properties: `BlockEditorSettings#isBlockBasedTheme` and `BlockEditorSettings#hasBlockTemplates`. To detect if a Site's theme is block-based, the clients can call `EditorThemeStore#getIsBlockBasedTheme`.

For the crash fix (mentioned in #2730): instead of using `RENAME COLUMN`, which is not supported in all SQLite versions that ship with the various Android version, we are now creating a temporary table, moving and mapping the data to it, and then dropping the old table.