### PR TITLE
Add a way to get a FeatureFlag based on Key

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/FeatureFlagsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/FeatureFlagsStore.kt
@@ -48,7 +48,7 @@ class FeatureFlagsStore @Inject constructor(
 
     // This returns a list because there can be multiple values for a single key.
     // It will be the client's responsibility to decide which value to use.
-    fun getFeatureFlag(key: String): List<FeatureFlag> {
+    fun getFeatureFlagsByKey(key: String): List<FeatureFlag> {
         return featureFlagConfigDao.getFeatureFlag(key)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/FeatureFlagsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/mobile/FeatureFlagsStore.kt
@@ -46,6 +46,12 @@ class FeatureFlagsStore @Inject constructor(
         return featureFlagConfigDao.getFeatureFlagList()
     }
 
+    // This returns a list because there can be multiple values for a single key.
+    // It will be the client's responsibility to decide which value to use.
+    fun getFeatureFlag(key: String): List<FeatureFlag> {
+        return featureFlagConfigDao.getFeatureFlag(key)
+    }
+
     fun insertFeatureFlagValue(key: String, value: Boolean) {
         featureFlagConfigDao.insert(
                 FeatureFlag(


### PR DESCRIPTION
Related to work added in https://github.com/woocommerce/woocommerce-android/pull/9025

This PR is just to add a way to get a FeatureFlag based on a Key.

It's just a DB get so no specific testing is added here, but it's also good to test via the companion PR in  https://github.com/woocommerce/woocommerce-android/pull/9025