### PR TITLE
Order creation - Search product by SKU (exact match) support

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -255,7 +255,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         val payload = lastAction!!.payload as RemoteSearchProductsPayload
         assertNull(payload.error)
         assertEquals(payload.searchQuery, searchQuery)
-        assertEquals(payload.skuSearchOptions.isSkuSearch, false)
+        assertEquals(payload.skuSearchOptions, WCProductStore.SkuSearchOptions.Disabled)
     }
 
     @Test
@@ -264,7 +264,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         productRestClient.searchProducts(
             site = siteModel,
             searchQuery = searchQuery,
-            skuSearchOptions = WCProductStore.SkuSearchOptions(isSkuSearch = true)
+            skuSearchOptions = WCProductStore.SkuSearchOptions.PartialMatch
         )
 
         countDownLatch = CountDownLatch(1)
@@ -274,7 +274,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         val payload = lastAction!!.payload as RemoteSearchProductsPayload
         assertNull(payload.error)
         assertEquals(payload.searchQuery, searchQuery)
-        assertEquals(payload.skuSearchOptions.isSkuSearch, true)
+        assertEquals(payload.skuSearchOptions, WCProductStore.SkuSearchOptions.PartialMatch)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -255,7 +255,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         val payload = lastAction!!.payload as RemoteSearchProductsPayload
         assertNull(payload.error)
         assertEquals(payload.searchQuery, searchQuery)
-        assertEquals(payload.isSkuSearch, false)
+        assertEquals(payload.skuSearchOptions.isSkuSearch, false)
     }
 
     @Test
@@ -264,7 +264,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         productRestClient.searchProducts(
             site = siteModel,
             searchQuery = searchQuery,
-            isSkuSearch = true
+            skuSearchOptions = WCProductStore.SkuSearchOptions(isSkuSearch = true)
         )
 
         countDownLatch = CountDownLatch(1)
@@ -274,7 +274,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         val payload = lastAction!!.payload as RemoteSearchProductsPayload
         assertNull(payload.error)
         assertEquals(payload.searchQuery, searchQuery)
-        assertEquals(payload.isSkuSearch, true)
+        assertEquals(payload.skuSearchOptions.isSkuSearch, true)
     }
 
     @Test

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -231,7 +231,7 @@ class WooProductsFragment : StoreSelectingFragment() {
                     val payload = SearchProductsPayload(
                         site = site,
                         searchQuery = editText.text.toString(),
-                        isSkuSearch = true
+                        skuSearchOptions = WCProductStore.SkuSearchOptions(isSkuSearch = true)
                     )
                     dispatcher.dispatch(WCProductActionBuilder.newSearchProductsAction(payload))
                 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -231,7 +231,7 @@ class WooProductsFragment : StoreSelectingFragment() {
                     val payload = SearchProductsPayload(
                         site = site,
                         searchQuery = editText.text.toString(),
-                        skuSearchOptions = WCProductStore.SkuSearchOptions(isSkuSearch = true)
+                        skuSearchOptions = WCProductStore.SkuSearchOptions.PartialMatch
                     )
                     dispatcher.dispatch(WCProductActionBuilder.newSearchProductsAction(payload))
                 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -381,10 +381,7 @@ class ProductRestClient @Inject constructor(
         offset: Int = 0,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         searchQuery: String? = null,
-        skuSearchOptions: SkuSearchOptions = SkuSearchOptions(
-            isSkuSearch = false,
-            isExactSkuSearch = false
-        ),
+        skuSearchOptions: SkuSearchOptions = SkuSearchOptions.Disabled,
         includedProductIds: List<Long>? = null,
         filterOptions: Map<ProductFilterOption, String>? = null,
         excludedProductIds: List<Long>? = null
@@ -464,10 +461,7 @@ class ProductRestClient @Inject constructor(
     fun searchProducts(
         site: SiteModel,
         searchQuery: String,
-        skuSearchOptions: SkuSearchOptions = SkuSearchOptions(
-            isSkuSearch = false,
-            isExactSkuSearch = false
-        ),
+        skuSearchOptions: SkuSearchOptions = SkuSearchOptions.Disabled,
         pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         offset: Int = 0,
         sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
@@ -500,7 +494,7 @@ class ProductRestClient @Inject constructor(
         includedProductIds: List<Long>? = null,
         excludedProductIds: List<Long>? = null,
         searchQuery: String? = null,
-        skuSearchOptions: SkuSearchOptions = SkuSearchOptions(),
+        skuSearchOptions: SkuSearchOptions = SkuSearchOptions.Disabled,
         filterOptions: Map<ProductFilterOption, String>? = null
     ): WooPayload<List<WCProductModel>> {
         val params = buildProductParametersMap(
@@ -568,15 +562,17 @@ class ProductRestClient @Inject constructor(
         }
 
         if (searchQuery.isNullOrEmpty().not()) {
-            if (skuSearchOptions.isSkuSearch) {
-                if (skuSearchOptions.isExactSkuSearch) {
+            when (skuSearchOptions) {
+                SkuSearchOptions.Disabled -> {
+                    params["search"] = searchQuery!!
+                }
+                SkuSearchOptions.ExactSearch -> {
                     params["sku"] = searchQuery!! // full SKU match
-                } else {
+                }
+                SkuSearchOptions.PartialMatch -> {
                     params["sku"] = searchQuery!! // full SKU match
                     params["search_sku"] = searchQuery // partial SKU match, added in core v6.6
                 }
-            } else {
-                params["search"] = searchQuery!!
             }
         }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -380,7 +380,10 @@ class ProductRestClient @Inject constructor(
         offset: Int = 0,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         searchQuery: String? = null,
-        skuSearchOptions: WCProductStore.SkuSearchOptions,
+        skuSearchOptions: WCProductStore.SkuSearchOptions = WCProductStore.SkuSearchOptions(
+            isSkuSearch = false,
+            isExactSkuSearch = false
+        ),
         includedProductIds: List<Long>? = null,
         filterOptions: Map<ProductFilterOption, String>? = null,
         excludedProductIds: List<Long>? = null
@@ -460,7 +463,10 @@ class ProductRestClient @Inject constructor(
     fun searchProducts(
         site: SiteModel,
         searchQuery: String,
-        skuSearchOptions: WCProductStore.SkuSearchOptions,
+        skuSearchOptions: WCProductStore.SkuSearchOptions = WCProductStore.SkuSearchOptions(
+            isSkuSearch = false,
+            isExactSkuSearch = false
+        ),
         pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         offset: Int = 0,
         sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -380,7 +380,7 @@ class ProductRestClient @Inject constructor(
         offset: Int = 0,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         searchQuery: String? = null,
-        isSkuSearch: Boolean = false,
+        skuSearchOptions: WCProductStore.SkuSearchOptions,
         includedProductIds: List<Long>? = null,
         filterOptions: Map<ProductFilterOption, String>? = null,
         excludedProductIds: List<Long>? = null
@@ -392,7 +392,7 @@ class ProductRestClient @Inject constructor(
                 sortType = sortType,
                 offset = offset,
                 searchQuery = searchQuery,
-                isSkuSearch = isSkuSearch,
+                skuSearchOptions = skuSearchOptions,
                 includedProductIds = includedProductIds,
                 excludedProductIds = excludedProductIds,
                 filterOptions = filterOptions
@@ -428,7 +428,7 @@ class ProductRestClient @Inject constructor(
                         val payload = RemoteSearchProductsPayload(
                             site = site,
                             searchQuery = searchQuery,
-                            isSkuSearch = isSkuSearch,
+                            skuSearchOptions = skuSearchOptions,
                             products = productModels,
                             offset = offset,
                             loadedMore = loadedMore,
@@ -447,7 +447,7 @@ class ProductRestClient @Inject constructor(
                             error = productError,
                             site = site,
                             query = searchQuery,
-                            skuSearch = isSkuSearch,
+                            skuSearchOptions = skuSearchOptions,
                             filterOptions = filterOptions
                         )
                         dispatcher.dispatch(WCProductActionBuilder.newSearchedProductsAction(payload))
@@ -460,7 +460,7 @@ class ProductRestClient @Inject constructor(
     fun searchProducts(
         site: SiteModel,
         searchQuery: String,
-        isSkuSearch: Boolean = false,
+        skuSearchOptions: WCProductStore.SkuSearchOptions,
         pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         offset: Int = 0,
         sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
@@ -473,7 +473,7 @@ class ProductRestClient @Inject constructor(
             offset = offset,
             sortType = sorting,
             searchQuery = searchQuery,
-            isSkuSearch = isSkuSearch,
+            skuSearchOptions = skuSearchOptions,
             excludedProductIds = excludedProductIds,
             filterOptions = filterOptions
         )
@@ -493,7 +493,7 @@ class ProductRestClient @Inject constructor(
         includedProductIds: List<Long>? = null,
         excludedProductIds: List<Long>? = null,
         searchQuery: String? = null,
-        isSkuSearch: Boolean = false,
+        skuSearchOptions: WCProductStore.SkuSearchOptions = WCProductStore.SkuSearchOptions(),
         filterOptions: Map<ProductFilterOption, String>? = null
     ): WooPayload<List<WCProductModel>> {
         val params = buildProductParametersMap(
@@ -501,7 +501,7 @@ class ProductRestClient @Inject constructor(
             sortType = sortType,
             offset = offset,
             searchQuery = searchQuery,
-            isSkuSearch = isSkuSearch,
+            skuSearchOptions = skuSearchOptions,
             includedProductIds = includedProductIds,
             excludedProductIds = excludedProductIds,
             filterOptions = filterOptions
@@ -528,7 +528,7 @@ class ProductRestClient @Inject constructor(
         sortType: ProductSorting,
         offset: Int,
         searchQuery: String?,
-        isSkuSearch: Boolean,
+        skuSearchOptions: WCProductStore.SkuSearchOptions,
         includedProductIds: List<Long>? = null,
         excludedProductIds: List<Long>? = null,
         filterOptions: Map<ProductFilterOption, String>? = null
@@ -561,9 +561,13 @@ class ProductRestClient @Inject constructor(
         }
 
         if (searchQuery.isNullOrEmpty().not()) {
-            if (isSkuSearch) {
-                params["sku"] = searchQuery!! // full SKU match
-                params["search_sku"] = searchQuery // partial SKU match, added in core v6.6
+            if (skuSearchOptions.isSkuSearch) {
+                if (skuSearchOptions.isExactSkuSearch) {
+                    params["sku"] = searchQuery!! // full SKU match
+                } else {
+                    params["sku"] = searchQuery!! // full SKU match
+                    params["search_sku"] = searchQuery // partial SKU match, added in core v6.6
+                }
             } else {
                 params["search"] = searchQuery!!
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -67,6 +67,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateProductPaylo
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdateVariationPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteUpdatedProductPasswordPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteVariationPayload
+import org.wordpress.android.fluxc.store.WCProductStore.SkuSearchOptions
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.fluxc.utils.putIfNotNull
@@ -380,7 +381,7 @@ class ProductRestClient @Inject constructor(
         offset: Int = 0,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         searchQuery: String? = null,
-        skuSearchOptions: WCProductStore.SkuSearchOptions = WCProductStore.SkuSearchOptions(
+        skuSearchOptions: SkuSearchOptions = SkuSearchOptions(
             isSkuSearch = false,
             isExactSkuSearch = false
         ),
@@ -463,7 +464,7 @@ class ProductRestClient @Inject constructor(
     fun searchProducts(
         site: SiteModel,
         searchQuery: String,
-        skuSearchOptions: WCProductStore.SkuSearchOptions = WCProductStore.SkuSearchOptions(
+        skuSearchOptions: SkuSearchOptions = SkuSearchOptions(
             isSkuSearch = false,
             isExactSkuSearch = false
         ),
@@ -499,7 +500,7 @@ class ProductRestClient @Inject constructor(
         includedProductIds: List<Long>? = null,
         excludedProductIds: List<Long>? = null,
         searchQuery: String? = null,
-        skuSearchOptions: WCProductStore.SkuSearchOptions = WCProductStore.SkuSearchOptions(),
+        skuSearchOptions: SkuSearchOptions = SkuSearchOptions(),
         filterOptions: Map<ProductFilterOption, String>? = null
     ): WooPayload<List<WCProductModel>> {
         val params = buildProductParametersMap(
@@ -534,7 +535,7 @@ class ProductRestClient @Inject constructor(
         sortType: ProductSorting,
         offset: Int,
         searchQuery: String?,
-        skuSearchOptions: WCProductStore.SkuSearchOptions,
+        skuSearchOptions: SkuSearchOptions,
         includedProductIds: List<Long>? = null,
         excludedProductIds: List<Long>? = null,
         filterOptions: Map<ProductFilterOption, String>? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -85,6 +85,11 @@ class WCProductStore @Inject constructor(
         override fun toString() = name.toLowerCase(Locale.US)
     }
 
+    data class SkuSearchOptions(
+        val isSkuSearch: Boolean = false,
+        val isExactSkuSearch: Boolean = false,
+    )
+
     class FetchProductSkuAvailabilityPayload(
         var site: SiteModel,
         var sku: String
@@ -108,7 +113,7 @@ class WCProductStore @Inject constructor(
     class SearchProductsPayload(
         var site: SiteModel,
         var searchQuery: String,
-        var isSkuSearch: Boolean = false,
+        var skuSearchOptions: SkuSearchOptions,
         var pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         var offset: Int = 0,
         var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
@@ -432,7 +437,7 @@ class WCProductStore @Inject constructor(
     class RemoteSearchProductsPayload(
         var site: SiteModel,
         var searchQuery: String?,
-        var isSkuSearch: Boolean = false,
+        var skuSearchOptions: SkuSearchOptions,
         var products: List<WCProductModel> = emptyList(),
         var offset: Int = 0,
         var loadedMore: Boolean = false,
@@ -443,12 +448,12 @@ class WCProductStore @Inject constructor(
             error: ProductError,
             site: SiteModel,
             query: String?,
-            skuSearch: Boolean,
+            skuSearchOptions: SkuSearchOptions,
             filterOptions: Map<ProductFilterOption, String>?
         ) : this(
             site = site,
             searchQuery = query,
-            isSkuSearch = skuSearch,
+            skuSearchOptions = skuSearchOptions,
             filterOptions = filterOptions
         ) {
             this.error = error
@@ -750,7 +755,7 @@ class WCProductStore @Inject constructor(
      * returns the corresponding product from the database as a [WCProductModel].
      */
     fun getProductByRemoteId(site: SiteModel, remoteProductId: Long): WCProductModel? =
-            ProductSqlUtils.getProductByRemoteId(site, remoteProductId)
+        ProductSqlUtils.getProductByRemoteId(site, remoteProductId)
 
     /**
      * returns the corresponding variation from the database as a [WCProductVariationModel].
@@ -760,44 +765,44 @@ class WCProductStore @Inject constructor(
         remoteProductId: Long,
         remoteVariationId: Long
     ): WCProductVariationModel? =
-            ProductSqlUtils.getVariationByRemoteId(site, remoteProductId, remoteVariationId)
+        ProductSqlUtils.getVariationByRemoteId(site, remoteProductId, remoteVariationId)
 
     /**
      * returns true if the corresponding product exists in the database
      */
     fun geProductExistsByRemoteId(site: SiteModel, remoteProductId: Long) =
-            ProductSqlUtils.geProductExistsByRemoteId(site, remoteProductId)
+        ProductSqlUtils.geProductExistsByRemoteId(site, remoteProductId)
 
     /**
      * returns true if the product exists with this [sku] in the database
      */
     fun geProductExistsBySku(site: SiteModel, sku: String) =
-            ProductSqlUtils.getProductExistsBySku(site, sku)
+        ProductSqlUtils.getProductExistsBySku(site, sku)
 
     /**
      * returns a list of variations for a specific product in the database
      */
     fun getVariationsForProduct(site: SiteModel, remoteProductId: Long): List<WCProductVariationModel> =
-            ProductSqlUtils.getVariationsForProduct(site, remoteProductId)
+        ProductSqlUtils.getVariationsForProduct(site, remoteProductId)
 
     /**
      * returns a list of shipping classes for a specific site in the database
      */
     fun getShippingClassListForSite(site: SiteModel): List<WCProductShippingClassModel> =
-            ProductSqlUtils.getProductShippingClassListForSite(site.id)
+        ProductSqlUtils.getProductShippingClassListForSite(site.id)
 
     /**
      * returns the corresponding product shipping class from the database as a [WCProductShippingClassModel].
      */
     fun getShippingClassByRemoteId(site: SiteModel, remoteShippingClassId: Long): WCProductShippingClassModel? =
-            ProductSqlUtils.getProductShippingClassByRemoteId(remoteShippingClassId, site.id)
+        ProductSqlUtils.getProductShippingClassByRemoteId(remoteShippingClassId, site.id)
 
     /**
      * returns a list of [WCProductModel] for the give [SiteModel] and [remoteProductIds]
      * if it exists in the database
      */
     fun getProductsByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): List<WCProductModel> =
-            ProductSqlUtils.getProductsByRemoteIds(site, remoteProductIds)
+        ProductSqlUtils.getProductsByRemoteIds(site, remoteProductIds)
 
     /**
      * Returns a list of [WCProductModel] for the given [SiteModel], [filterOptions] and [searchQuery].
@@ -810,63 +815,63 @@ class WCProductStore @Inject constructor(
         excludedProductIds: List<Long>? = null,
         searchQuery: String? = null,
     ): List<WCProductModel> =
-            ProductSqlUtils.getProducts(site, filterOptions, sortType, excludedProductIds, searchQuery)
+        ProductSqlUtils.getProducts(site, filterOptions, sortType, excludedProductIds, searchQuery)
 
     fun getProductsForSite(site: SiteModel, sortType: ProductSorting = DEFAULT_PRODUCT_SORTING) =
-            ProductSqlUtils.getProductsForSite(site, sortType)
+        ProductSqlUtils.getProductsForSite(site, sortType)
 
     fun deleteProductsForSite(site: SiteModel) = ProductSqlUtils.deleteProductsForSite(site)
 
     fun getProductReviewsForSite(site: SiteModel): List<WCProductReviewModel> =
-            ProductSqlUtils.getProductReviewsForSite(site)
+        ProductSqlUtils.getProductReviewsForSite(site)
 
     fun getProductReviewsForProductAndSiteId(localSiteId: Int, remoteProductId: Long): List<WCProductReviewModel> =
-            ProductSqlUtils.getProductReviewsForProductAndSiteId(localSiteId, remoteProductId)
+        ProductSqlUtils.getProductReviewsForProductAndSiteId(localSiteId, remoteProductId)
 
     /**
      * returns the count of products for the given [SiteModel] and [remoteProductIds]
      * if it exists in the database
      */
     fun getProductCountByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): Int =
-            ProductSqlUtils.getProductCountByRemoteIds(site, remoteProductIds)
+        ProductSqlUtils.getProductCountByRemoteIds(site, remoteProductIds)
 
     /**
      * returns the count of virtual products for the given [SiteModel] and [remoteProductIds]
      * if it exists in the database
      */
     fun getVirtualProductCountByRemoteIds(site: SiteModel, remoteProductIds: List<Long>): Int =
-            ProductSqlUtils.getVirtualProductCountByRemoteIds(site, remoteProductIds)
+        ProductSqlUtils.getVirtualProductCountByRemoteIds(site, remoteProductIds)
 
     /**
      * returns a list of tags for a specific site in the database
      */
     fun getTagsForSite(site: SiteModel): List<WCProductTagModel> =
-            ProductSqlUtils.getProductTagsForSite(site.id)
+        ProductSqlUtils.getProductTagsForSite(site.id)
 
     fun getProductTagsByNames(site: SiteModel, tagNames: List<String>) =
-            ProductSqlUtils.getProductTagsByNames(site.id, tagNames)
+        ProductSqlUtils.getProductTagsByNames(site.id, tagNames)
 
     fun getProductTagByName(site: SiteModel, tagName: String) =
-            ProductSqlUtils.getProductTagByName(site.id, tagName)
+        ProductSqlUtils.getProductTagByName(site.id, tagName)
 
     fun getProductReviewByRemoteId(
         localSiteId: Int,
         remoteReviewId: Long
     ): WCProductReviewModel? = ProductSqlUtils
-            .getProductReviewByRemoteId(localSiteId, remoteReviewId)
+        .getProductReviewByRemoteId(localSiteId, remoteReviewId)
 
     fun deleteProductReviewsForSite(site: SiteModel) = ProductSqlUtils.deleteAllProductReviewsForSite(site)
 
     fun deleteAllProductReviews() = ProductSqlUtils.deleteAllProductReviews()
 
     fun deleteProductImage(site: SiteModel, remoteProductId: Long, remoteMediaId: Long) =
-            ProductSqlUtils.deleteProductImage(site, remoteProductId, remoteMediaId)
+        ProductSqlUtils.deleteProductImage(site, remoteProductId, remoteMediaId)
 
     fun getProductCategoriesForSite(site: SiteModel, sortType: ProductCategorySorting = DEFAULT_CATEGORY_SORTING) =
-            ProductSqlUtils.getProductCategoriesForSite(site, sortType)
+        ProductSqlUtils.getProductCategoriesForSite(site, sortType)
 
     fun getProductCategoryByRemoteId(site: SiteModel, remoteId: Long) =
-            ProductSqlUtils.getProductCategoryByRemoteId(site.id, remoteId)
+        ProductSqlUtils.getProductCategoryByRemoteId(site.id, remoteId)
 
     fun getProductCategoryByNameAndParentId(
         site: SiteModel,
@@ -979,16 +984,16 @@ class WCProductStore @Inject constructor(
         productId: Long,
         attributes: List<WCProductModel.ProductAttribute>
     ): WooResult<WCProductModel> =
-            coroutineEngine.withDefaultContext(API, this, "submitProductAttributes") {
-                wcProductRestClient.updateProductAttributes(site, productId, Gson().toJson(attributes))
-                    .asWooResult()
-                    .model?.asProductModel()
-                    ?.apply {
-                        localSiteId = site.id
-                        ProductSqlUtils.insertOrUpdateProduct(this)
-                    }
-                    ?.let { WooResult(it) }
-            } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
+        coroutineEngine.withDefaultContext(API, this, "submitProductAttributes") {
+            wcProductRestClient.updateProductAttributes(site, productId, Gson().toJson(attributes))
+                .asWooResult()
+                .model?.asProductModel()
+                ?.apply {
+                    localSiteId = site.id
+                    ProductSqlUtils.insertOrUpdateProduct(this)
+                }
+                ?.let { WooResult(it) }
+        } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
 
     suspend fun submitVariationAttributeChanges(
         site: SiteModel,
@@ -996,15 +1001,15 @@ class WCProductStore @Inject constructor(
         variationId: Long,
         attributes: List<WCProductModel.ProductAttribute>
     ): WooResult<WCProductVariationModel> =
-            coroutineEngine.withDefaultContext(API, this, "submitVariationAttributes") {
-                wcProductRestClient.updateVariationAttributes(site, productId, variationId, Gson().toJson(attributes))
-                    .asWooResult()
-                    .model?.asProductVariationModel()
-                    ?.apply {
-                        ProductSqlUtils.insertOrUpdateProductVariation(this)
-                    }
-                    ?.let { WooResult(it) }
-            } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
+        coroutineEngine.withDefaultContext(API, this, "submitVariationAttributes") {
+            wcProductRestClient.updateVariationAttributes(site, productId, variationId, Gson().toJson(attributes))
+                .asWooResult()
+                .model?.asProductVariationModel()
+                ?.apply {
+                    ProductSqlUtils.insertOrUpdateProductVariation(this)
+                }
+                ?.let { WooResult(it) }
+        } ?: WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
 
     suspend fun generateEmptyVariation(
         site: SiteModel,
@@ -1060,9 +1065,9 @@ class WCProductStore @Inject constructor(
                 coroutineEngine.launch(T.DB, this, "cacheProductAddons") {
                     val domainAddons = mapProductAddonsToDomain(result.product.addons)
                     addonsDao.cacheProductAddons(
-                            productRemoteId = result.product.remoteId,
-                            localSiteId = result.site.localId(),
-                            addons = domainAddons
+                        productRemoteId = result.product.remoteId,
+                        localSiteId = result.site.localId(),
+                        addons = domainAddons
                     )
                 }
 
@@ -1105,13 +1110,14 @@ class WCProductStore @Inject constructor(
     private fun fetchProducts(payload: FetchProductsPayload) {
         with(payload) {
             wcProductRestClient.fetchProducts(
-                    site = site,
-                    pageSize = pageSize,
-                    offset = offset,
-                    sortType = sorting,
-                    includedProductIds = remoteProductIds,
-                    filterOptions = filterOptions,
-                    excludedProductIds = excludedProductIds
+                site = site,
+                pageSize = pageSize,
+                offset = offset,
+                sortType = sorting,
+                includedProductIds = remoteProductIds,
+                filterOptions = filterOptions,
+                excludedProductIds = excludedProductIds,
+                skuSearchOptions = SkuSearchOptions()
             )
         }
     }
@@ -1143,7 +1149,7 @@ class WCProductStore @Inject constructor(
             wcProductRestClient.searchProducts(
                 site = site,
                 searchQuery = searchQuery,
-                isSkuSearch = isSkuSearch,
+                skuSearchOptions = skuSearchOptions,
                 pageSize = pageSize,
                 offset = offset,
                 sorting = sorting,
@@ -1156,8 +1162,8 @@ class WCProductStore @Inject constructor(
     suspend fun fetchProductVariations(payload: FetchProductVariationsPayload): OnProductChanged {
         return coroutineEngine.withDefaultContext(API, this, "fetchProductVariations") {
             val result = with(payload) {
-                    wcProductRestClient.fetchProductVariations(site, remoteProductId, pageSize, offset)
-                }
+                wcProductRestClient.fetchProductVariations(site, remoteProductId, pageSize, offset)
+            }
             return@withDefaultContext if (result.isError) {
                 OnProductChanged(0, payload.remoteProductId).also { it.error = result.error }
             } else {
@@ -1256,7 +1262,7 @@ class WCProductStore @Inject constructor(
     private fun fetchProductCategories(payloadProduct: FetchProductCategoriesPayload) {
         with(payloadProduct) {
             wcProductRestClient.fetchProductCategories(
-                    site, pageSize, offset, productCategorySorting
+                site, pageSize, offset, productCategorySorting
             )
         }
     }
@@ -1349,7 +1355,7 @@ class WCProductStore @Inject constructor(
      * @param payload Instance of [BatchGenerateVariationsPayload].
      */
     suspend fun batchGenerateVariations(payload: BatchGenerateVariationsPayload):
-        WooResult<BatchProductVariationsApiResponse> =
+            WooResult<BatchProductVariationsApiResponse> =
         coroutineEngine.withDefaultContext(API, this, "batchCreateVariations") {
             val createVariations = payload.variations.map {
                 buildMap { put("attributes", it) }
@@ -1385,7 +1391,7 @@ class WCProductStore @Inject constructor(
      * [BatchUpdateVariationsPayload.Builder] class.
      */
     suspend fun batchUpdateVariations(payload: BatchUpdateVariationsPayload):
-        WooResult<BatchProductVariationsApiResponse> =
+            WooResult<BatchProductVariationsApiResponse> =
         coroutineEngine.withDefaultContext(API, this, "batchUpdateVariations") {
             with(payload) {
                 val updateVariations: List<Map<String, Any>> = remoteVariationsIds.map { variationId ->
@@ -1490,7 +1496,7 @@ class WCProductStore @Inject constructor(
     suspend fun searchProducts(
         site: SiteModel,
         searchString: String,
-        isSkuSearch: Boolean = false,
+        skuSearchOptions: SkuSearchOptions = SkuSearchOptions(),
         offset: Int = 0,
         pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE
     ): WooResult<ProductSearchResult> {
@@ -1500,7 +1506,7 @@ class WCProductStore @Inject constructor(
                 offset = offset,
                 pageSize = pageSize,
                 searchQuery = searchString,
-                isSkuSearch = isSkuSearch
+                skuSearchOptions = skuSearchOptions
             )
             when {
                 response.isError -> WooResult(response.error)
@@ -1668,15 +1674,15 @@ class WCProductStore @Inject constructor(
 
     private fun mapProductAddonsToDomain(remoteAddons: Array<RemoteAddonDto>?): List<Addon> {
         return remoteAddons.orEmpty()
-                .toList()
-                .mapNotNull { remoteAddonDto ->
-                    try {
-                        RemoteAddonMapper.toDomain(remoteAddonDto)
-                    } catch (exception: MappingRemoteException) {
-                        logger.e(API, "Exception while parsing $remoteAddonDto: ${exception.message}")
-                        null
-                    }
+            .toList()
+            .mapNotNull { remoteAddonDto ->
+                try {
+                    RemoteAddonMapper.toDomain(remoteAddonDto)
+                } catch (exception: MappingRemoteException) {
+                    logger.e(API, "Exception while parsing $remoteAddonDto: ${exception.message}")
+                    null
                 }
+            }
     }
 
     private fun handleFetchProductSkuAvailabilityCompleted(payload: RemoteProductSkuAvailabilityPayload) {
@@ -1731,7 +1737,7 @@ class WCProductStore @Inject constructor(
             emitChange(
                 OnProductsSearched(
                     searchQuery = payload.searchQuery,
-                    isSkuSearch = payload.isSkuSearch
+                    isSkuSearch = payload.skuSearchOptions.isSkuSearch
                 )
             )
         } else {
@@ -1740,7 +1746,7 @@ class WCProductStore @Inject constructor(
                 emitChange(
                     OnProductsSearched(
                         searchQuery = payload.searchQuery,
-                        isSkuSearch = payload.isSkuSearch,
+                        isSkuSearch = payload.skuSearchOptions.isSkuSearch,
                         searchResults = payload.products,
                         canLoadMore = payload.canLoadMore
                     )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -84,11 +84,9 @@ class WCProductStore @Inject constructor(
 
         override fun toString() = name.toLowerCase(Locale.US)
     }
-
-    data class SkuSearchOptions(
-        val isSkuSearch: Boolean = false,
-        val isExactSkuSearch: Boolean = false,
-    )
+    enum class SkuSearchOptions {
+        Disabled, ExactSearch, PartialMatch
+    }
 
     class FetchProductSkuAvailabilityPayload(
         var site: SiteModel,
@@ -113,7 +111,7 @@ class WCProductStore @Inject constructor(
     class SearchProductsPayload(
         var site: SiteModel,
         var searchQuery: String,
-        var skuSearchOptions: SkuSearchOptions = SkuSearchOptions(isSkuSearch = false),
+        var skuSearchOptions: SkuSearchOptions = SkuSearchOptions.Disabled,
         var pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         var offset: Int = 0,
         var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,
@@ -682,7 +680,7 @@ class WCProductStore @Inject constructor(
 
     class OnProductsSearched(
         var searchQuery: String?,
-        var isSkuSearch: Boolean = false,
+        var isSkuSearch: SkuSearchOptions,
         var searchResults: List<WCProductModel> = emptyList(),
         var canLoadMore: Boolean = false
     ) : OnChanged<ProductError>()
@@ -1117,7 +1115,7 @@ class WCProductStore @Inject constructor(
                 includedProductIds = remoteProductIds,
                 filterOptions = filterOptions,
                 excludedProductIds = excludedProductIds,
-                skuSearchOptions = SkuSearchOptions()
+                skuSearchOptions = SkuSearchOptions.Disabled
             )
         }
     }
@@ -1496,7 +1494,7 @@ class WCProductStore @Inject constructor(
     suspend fun searchProducts(
         site: SiteModel,
         searchString: String,
-        skuSearchOptions: SkuSearchOptions = SkuSearchOptions(),
+        skuSearchOptions: SkuSearchOptions = SkuSearchOptions.Disabled,
         offset: Int = 0,
         pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE
     ): WooResult<ProductSearchResult> {
@@ -1737,7 +1735,7 @@ class WCProductStore @Inject constructor(
             emitChange(
                 OnProductsSearched(
                     searchQuery = payload.searchQuery,
-                    isSkuSearch = payload.skuSearchOptions.isSkuSearch
+                    isSkuSearch = payload.skuSearchOptions
                 )
             )
         } else {
@@ -1746,7 +1744,7 @@ class WCProductStore @Inject constructor(
                 emitChange(
                     OnProductsSearched(
                         searchQuery = payload.searchQuery,
-                        isSkuSearch = payload.skuSearchOptions.isSkuSearch,
+                        isSkuSearch = payload.skuSearchOptions,
                         searchResults = payload.products,
                         canLoadMore = payload.canLoadMore
                     )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -113,7 +113,7 @@ class WCProductStore @Inject constructor(
     class SearchProductsPayload(
         var site: SiteModel,
         var searchQuery: String,
-        var skuSearchOptions: SkuSearchOptions,
+        var skuSearchOptions: SkuSearchOptions = SkuSearchOptions(isSkuSearch = false),
         var pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
         var offset: Int = 0,
         var sorting: ProductSorting = DEFAULT_PRODUCT_SORTING,

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -134,7 +134,6 @@ class ProductRestClientTest {
             assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isEqualTo(
                 "test query"
             )
-            assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isNotNull
             assertThat(argumentCaptor.firstValue.getOrDefault("search_sku", null)).isNull()
         }
     }
@@ -163,10 +162,9 @@ class ProductRestClientTest {
                 retries = any()
             )
 
-            assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isEqualTo(
+            assertThat(argumentCaptor.firstValue.getOrDefault("search_sku", null)).isEqualTo(
                 "test query"
             )
-            assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isNotNull()
         }
     }
 

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -113,10 +113,7 @@ class ProductRestClientTest {
             sut.fetchProducts(
                 site = site,
                 searchQuery = "test query",
-                skuSearchOptions = WCProductStore.SkuSearchOptions(
-                    isExactSkuSearch = true,
-                    isSkuSearch = true
-                )
+                skuSearchOptions = WCProductStore.SkuSearchOptions.ExactSearch
             )
             val argumentCaptor = argumentCaptor<MutableMap<String, String>>()
             verify(wooNetwork).executeGetGsonRequest(
@@ -144,10 +141,7 @@ class ProductRestClientTest {
             sut.fetchProducts(
                 site = site,
                 searchQuery = "test query",
-                skuSearchOptions = WCProductStore.SkuSearchOptions(
-                    isExactSkuSearch = false,
-                    isSkuSearch = true
-                )
+                skuSearchOptions = WCProductStore.SkuSearchOptions.PartialMatch
             )
             val argumentCaptor = argumentCaptor<MutableMap<String, String>>()
             verify(wooNetwork).executeGetGsonRequest(

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -134,6 +134,38 @@ class ProductRestClientTest {
             assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isEqualTo(
                 "test query"
             )
+            assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isNotNull
+            assertThat(argumentCaptor.firstValue.getOrDefault("search_sku", null)).isNull()
+        }
+    }
+
+    @Test
+    fun `when fetch products called with partial sku search, then correct params is used for network call`() {
+        runBlockingTest {
+            sut.fetchProducts(
+                site = site,
+                searchQuery = "test query",
+                skuSearchOptions = WCProductStore.SkuSearchOptions(
+                    isExactSkuSearch = false,
+                    isSkuSearch = true
+                )
+            )
+            val argumentCaptor = argumentCaptor<MutableMap<String, String>>()
+            verify(wooNetwork).executeGetGsonRequest(
+                any(),
+                any(),
+                clazz = eq(Array<ProductApiResponse>::class.java),
+                params = argumentCaptor.capture(),
+                enableCaching = any(),
+                cacheTimeToLive = any(),
+                forced = any(),
+                requestTimeout = any(),
+                retries = any()
+            )
+
+            assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isEqualTo(
+                "test query"
+            )
             assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isNotNull()
         }
     }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.utils.initCoroutineEngine
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -104,6 +105,37 @@ class ProductRestClientTest {
             clazz = eq(BatchProductApiResponse::class.java),
             body = bodyCaptor.capture()
         )
+    }
+
+    @Test
+    fun `when fetch products called with exact sku search, then correct params is used for network call`() {
+        runBlockingTest {
+            sut.fetchProducts(
+                site = site,
+                searchQuery = "test query",
+                skuSearchOptions = WCProductStore.SkuSearchOptions(
+                    isExactSkuSearch = true,
+                    isSkuSearch = true
+                )
+            )
+            val argumentCaptor = argumentCaptor<MutableMap<String, String>>()
+            verify(wooNetwork).executeGetGsonRequest(
+                any(),
+                any(),
+                clazz = eq(Array<ProductApiResponse>::class.java),
+                params = argumentCaptor.capture(),
+                enableCaching = any(),
+                cacheTimeToLive = any(),
+                forced = any(),
+                requestTimeout = any(),
+                retries = any()
+            )
+
+            assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isEqualTo(
+                "test query"
+            )
+            assertThat(argumentCaptor.firstValue.getOrDefault("sku", null)).isNotNull()
+        }
     }
 
     private fun WCProductModel.withRegularPrice(newRegularPrice: String): WCProductModel =


### PR DESCRIPTION
**Note:** Please make sure to review and get the corresponding [WooCommerce PR](https://github.com/woocommerce/woocommerce-android/pull/9053) ready before merging this one.

This PR adds support for searching products by exact match SKU. This functionality is needed for the "Scanned and Deliver" project where we add the ability to add products by scanning the barcode.

