### PR TITLE
Nonce getting: Make username variable nullable so it doesn't crash when it's null.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -28,7 +28,7 @@ class NonceRestClient @Inject constructor(
     userAgent: UserAgent
 ) : BaseWPAPIRestClient(dispatcher, requestQueue, userAgent) {
     private val nonceMap: MutableMap<String, Nonce> = mutableMapOf()
-    fun getNonce(siteUrl: String, username: String): Nonce? = nonceMap[siteUrl]?.takeIf { it.username == username }
+    fun getNonce(siteUrl: String, username: String?): Nonce? = nonceMap[siteUrl]?.takeIf { it.username == username }
     fun getNonce(site: SiteModel): Nonce? = getNonce(site.url, site.username)
 
     /**


### PR DESCRIPTION
Fixes: #2736

Adds a null check to account for possibility of null `username` to prevent crash.