### PR TITLE
Declare gallery v2 field as optional

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_EditorThemeStoreTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_EditorThemeStoreTest.kt
@@ -63,7 +63,7 @@ class MockedStack_EditorThemeStoreTest : MockedStack_Base() {
         assertNotEmpty(cachedTheme)
 
         // Validate Bundle
-        val themeBundle = editorTheme!!.themeSupport.toBundle()
+        val themeBundle = editorTheme!!.themeSupport.toBundle(site)
         assertNotEmpty(themeBundle)
     }
 
@@ -83,7 +83,7 @@ class MockedStack_EditorThemeStoreTest : MockedStack_Base() {
         assertEmpty(cachedTheme)
 
         // Validate Bundle
-        val themeBundle = editorTheme!!.themeSupport.toBundle()
+        val themeBundle = editorTheme!!.themeSupport.toBundle(site)
         assertEmpty(themeBundle)
     }
 
@@ -135,7 +135,7 @@ class MockedStack_EditorThemeStoreTest : MockedStack_Base() {
         assertEmpty(cachedTheme)
 
         // Validate Bundle
-        val themeBundle = editorTheme!!.themeSupport.toBundle()
+        val themeBundle = editorTheme!!.themeSupport.toBundle(site)
         assertEmpty(themeBundle)
     }
 
@@ -155,7 +155,7 @@ class MockedStack_EditorThemeStoreTest : MockedStack_Base() {
         assertNotEmpty(cachedTheme)
 
         // Validate Bundle
-        val themeBundle = editorTheme!!.themeSupport.toBundle()
+        val themeBundle = editorTheme!!.themeSupport.toBundle(site)
         assertNotEmpty(themeBundle)
     }
 
@@ -177,7 +177,7 @@ class MockedStack_EditorThemeStoreTest : MockedStack_Base() {
         Assert.assertNotNull(cachedTheme?.themeSupport?.rawStyles)
 
         // Validate Bundle
-        val themeBundle = editorTheme!!.themeSupport.toBundle()
+        val themeBundle = editorTheme!!.themeSupport.toBundle(site)
         assertEmpty(themeBundle)
         val styles = themeBundle.getString("rawStyles")
         val features = themeBundle.getString("rawFeatures")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -11,7 +11,10 @@ import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.persistence.EditorThemeElementType
 import org.wordpress.android.fluxc.persistence.EditorThemeSqlUtils.EditorThemeBuilder
 import org.wordpress.android.fluxc.persistence.EditorThemeSqlUtils.EditorThemeElementBuilder
+import org.wordpress.android.util.VersionUtils
 import java.lang.reflect.Type
+
+private const val GALLERY_V2_WP_VERSION = "5.9"
 
 const val MAP_KEY_ELEMENT_DISPLAY_NAME: String = "name"
 const val MAP_KEY_ELEMENT_SLUG: String = "slug"
@@ -182,3 +185,6 @@ class EditorThemeElementListSerializer : JsonDeserializer<List<EditorThemeElemen
         }
     }
 }
+
+private val SiteModel.coreSupportsGalleryV2: Boolean
+    get() = VersionUtils.checkMinimalVersion(softwareVersion, GALLERY_V2_WP_VERSION)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -49,15 +49,15 @@ data class EditorTheme(
             version = null
     )
 
-    fun toBuilder(siteId: Int): EditorThemeBuilder {
+    fun toBuilder(site: SiteModel): EditorThemeBuilder {
         val element = EditorThemeBuilder()
-        element.localSiteId = siteId
+        element.localSiteId = site.id
         element.stylesheet = stylesheet
         element.version = version
         element.rawStyles = themeSupport.rawStyles
         element.rawFeatures = themeSupport.rawFeatures
         element.isBlockBasedTheme = themeSupport.isBlockBasedTheme
-        element.galleryWithImageBlocks = themeSupport.galleryWithImageBlocks
+        element.galleryWithImageBlocks = themeSupport.galleryWithImageBlocks ?: site.coreSupportsGalleryV2
         element.quoteBlockV2 = themeSupport.quoteBlockV2
         element.listBlockV2 = themeSupport.listBlockV2
         element.hasBlockTemplates = themeSupport.hasBlockTemplates ?: false
@@ -97,11 +97,11 @@ data class EditorThemeSupport(
     val rawStyles: String?,
     val rawFeatures: String?,
     val isBlockBasedTheme: Boolean,
-    val galleryWithImageBlocks: Boolean,
+    val galleryWithImageBlocks: Boolean?,
     val quoteBlockV2: Boolean,
     val listBlockV2: Boolean
 ) {
-    fun toBundle(): Bundle {
+    fun toBundle(site: SiteModel): Bundle {
         val bundle = Bundle()
 
         colors?.map { it.toBundle() }?.let {
@@ -121,7 +121,7 @@ data class EditorThemeSupport(
         }
 
         bundle.putBoolean(MAP_KEY_IS_BLOCK_BASED_THEME, isBlockBasedTheme)
-        bundle.putBoolean(MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS, galleryWithImageBlocks)
+        bundle.putBoolean(MAP_KEY_GALLERY_WITH_IMAGE_BLOCKS, galleryWithImageBlocks ?: site.coreSupportsGalleryV2)
         bundle.putBoolean(MAP_KEY_QUOTE_BLOCK_V2, quoteBlockV2)
         bundle.putBoolean(MAP_KEY_LIST_BLOCK_V2, listBlockV2)
         bundle.putBoolean(MAP_KEY_HAS_BLOCK_TEMPLATES, hasBlockTemplates ?: false)
@@ -130,7 +130,6 @@ data class EditorThemeSupport(
     }
     fun isEditorThemeBlockBased(): Boolean = isBlockBasedTheme || (hasBlockTemplates ?: false)
 }
-
 
 data class EditorThemeElement(
     val name: String?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EditorThemeSqlUtils.kt
@@ -65,7 +65,7 @@ class EditorThemeSqlUtils {
     }
 
     private fun makeEditorTheme(site: SiteModel, editorTheme: EditorTheme) {
-        val editorThemeBuilder = editorTheme.toBuilder(site.id)
+        val editorThemeBuilder = editorTheme.toBuilder(site)
         val items = (editorTheme.themeSupport.colors ?: emptyList()) +
                 (editorTheme.themeSupport.gradients ?: emptyList())
 


### PR DESCRIPTION
Related PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18519

Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/17712

### Description

This PR declares the `galleryWithImageBlocks` field to be optional, since it is sometimes omitted from the API response. In that case, this falls back to using the WordPress core version to determine whether v2 gallery support is enabled.