### PR TITLE
Keep parse error information

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -322,6 +322,7 @@ class WCProductStore @Inject constructor(
         // https://github.com/woocommerce/woocommerce/pull/27299
         INVALID_VARIATION_IMAGE_ID,
 
+        PARSE_ERROR,
         GENERIC_ERROR;
 
         companion object {


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/9145

### Why
When transforming API errors to Product errors, we lose the error information and track a GENERIC_ERROR with an empty message.

### Description
This PR solves the losing information issue by adding the new error type on ProductErrorType.PARSE_ERROR and combine the error message with the one contained in the volleyError field
Adding Unit tests represented added an extra level of complexity because of the use of the Legacy EventBus, which is why I did not unit test this code on this PR.

### Testing
I recommend testing this PR using composite builds with this PR

1. Using composite builds.
2. Apply this patch on this branch to force a parse error:

<details>
  <summary>Patch</summary>
  

  ```
Index: plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt	(revision da9d3ed717822d04ec6bf87234311ad793b99ab2)
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt	(date 1685479560323)
@@ -12,7 +12,7 @@
 data class ProductApiResponse(
     val id: Long? = null,
     val localSiteId: Int = 0,
-    val name: String? = null,
+    val name: Long? = null,
     val slug: String? = null,
     val permalink: String? = null,
     val date_created: String? = null,
@@ -84,7 +84,7 @@
         val isBundledProduct = response.type == CoreProductType.BUNDLE.value
         return WCProductModel().apply {
             remoteProductId = response.id ?: 0
-            name = response.name ?: ""
+            name = response.name.toString() ?: ""
             slug = response.slug ?: ""
             permalink = response.permalink ?: ""
 

  ```
</details>

3. Build the Woo app and open the Products list.
4. Check in the logs that we are tracking the full product error information on the `product_list_load_error` event, and that the `error_type` property value is `PARSE_ERROR`. 


### Image
 ```
🔵 Tracked: product_list_load_error, Properties: {"error_context":"ProductListRepository","error_description":"com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: For input string: \"16GB CompactFlash Card\"","error_type":"PARSE_ERROR","blog_id":214253715,"is_wpcom_store":true,"is_debug":true}
 ```