### PR TITLE
Update catalogVersion to 1.10.0

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.9.0"
+def catalogVersion = "1.10.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {


### PR DESCRIPTION
Updates `catalogVersion` to 1.10.0, which includes the latest Aztec library.

Changes for the 1.9.0 → 1.10.0 version of catalog:
- Updates Aztec lib to 1.6.4.

To test:
No need to test. The FluxC doesn't use any Aztec features. This PR aims just to keep the dependency catalog up-to-date.