### PR TITLE
Send parse error info in orders

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -134,6 +134,19 @@ public abstract class BaseRequest<T> extends Request<T> {
         public boolean hasVolleyError() {
             return volleyError != null;
         }
+
+        public String getCombinedErrorMessage() {
+            String volleyErrorMessage = volleyError.getMessage();
+            if (volleyErrorMessage == null || volleyErrorMessage.isEmpty()) {
+                return message != null ? message : "";
+            } else {
+                if (message == null || message.isEmpty()) {
+                    return volleyErrorMessage;
+                } else {
+                    return message + " • " + volleyErrorMessage;
+                }
+            }
+        }
     }
 
     public enum GenericErrorType {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
 import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
+import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
@@ -892,13 +893,14 @@ class OrderRestClient @Inject constructor(
     }
 
     private fun wpAPINetworkErrorToOrderError(wpAPINetworkError: WPAPINetworkError): OrderError {
-        val orderErrorType = when (wpAPINetworkError.errorCode) {
-            "rest_invalid_param" -> OrderErrorType.INVALID_PARAM
-            "woocommerce_rest_shop_order_invalid_id" -> OrderErrorType.INVALID_ID
-            "rest_no_route" -> OrderErrorType.PLUGIN_NOT_ACTIVE
+        val orderErrorType = when {
+            wpAPINetworkError.errorCode == "rest_invalid_param" -> OrderErrorType.INVALID_PARAM
+            wpAPINetworkError.errorCode == "woocommerce_rest_shop_order_invalid_id" -> OrderErrorType.INVALID_ID
+            wpAPINetworkError.errorCode == "rest_no_route" -> OrderErrorType.PLUGIN_NOT_ACTIVE
+            wpAPINetworkError.type == BaseRequest.GenericErrorType.PARSE_ERROR -> OrderErrorType.PARSE_ERROR
             else -> OrderErrorType.fromString(wpAPINetworkError.errorCode.orEmpty())
         }
-        return OrderError(orderErrorType, wpAPINetworkError.message.orEmpty())
+        return OrderError(orderErrorType, wpAPINetworkError.combinedErrorMessage)
     }
 
     private fun orderStatusResponseToOrderStatusModel(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1793,11 +1793,7 @@ class ProductRestClient @Inject constructor(
             wpComError.type == PARSE_ERROR -> ProductErrorType.PARSE_ERROR
             else -> ProductErrorType.fromString(wpComError.apiError)
         }
-        val message = getCombineErrorMessage(
-            errorMessage = wpComError.message,
-            volleyErrorMessage = wpComError.volleyError.message
-        )
-        return ProductError(productErrorType, message)
+        return ProductError(productErrorType, wpComError.combinedErrorMessage)
     }
 
     private fun wpAPINetworkErrorToProductError(wpAPINetworkError: WPAPINetworkError): ProductError {
@@ -1816,22 +1812,6 @@ class ProductRestClient @Inject constructor(
             wpAPINetworkError.type == PARSE_ERROR -> ProductErrorType.PARSE_ERROR
             else -> ProductErrorType.fromString(wpAPINetworkError.errorCode.orEmpty())
         }
-        val message = getCombineErrorMessage(
-            errorMessage = wpAPINetworkError.message,
-            volleyErrorMessage = wpAPINetworkError.volleyError.message
-        )
-        return ProductError(productErrorType, message)
-    }
-
-    private fun getCombineErrorMessage(errorMessage:String?, volleyErrorMessage: String?): String {
-        return if (volleyErrorMessage.isNullOrEmpty()) {
-            errorMessage.orEmpty()
-        } else {
-            if (errorMessage.isNullOrEmpty()) {
-                volleyErrorMessage
-            } else {
-                "$errorMessage • $volleyErrorMessage"
-            }
-        }
+        return ProductError(productErrorType, wpAPINetworkError.combinedErrorMessage)
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -297,6 +297,7 @@ class WCOrderStore @Inject constructor(
         PLUGIN_NOT_ACTIVE,
         INVALID_RESPONSE,
         GENERIC_ERROR,
+        PARSE_ERROR,
         EMPTY_BILLING_EMAIL;
 
         companion object {


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/9146

### Why
When transforming API errors to Order errors, we lose the error information and send a GENERIC_ERROR with an empty message.

### Description
This PR solves the losing information issue by adding the new error type OrderErrorType.PARSE_ERROR and combine the error message with the one contained in the volleyError field

### Testing
I recommend testing this PR using composite builds with this Woo PR

1. Using composite builds.
2. Apply this patch on this branch to force a parse error:

<details>
  <summary>Patch</summary>
  
  ```
Index: plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt	(revision 8ddd1c8bd16c7bbe9a8d199aab1f333ae68a8566)
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt	(date 1685630863392)
@@ -41,7 +41,7 @@
 
     val billing: Billing? = null
     val coupon_lines: List<CouponLine>? = null
-    val currency: String? = null
+    val currency: Long? = null
     val order_key: String? = null
     val customer_note: String? = null
     val date_created_gmt: String? = null
Index: plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt	(revision 8ddd1c8bd16c7bbe9a8d199aab1f333ae68a8566)
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt	(date 1685630863396)
@@ -24,7 +24,7 @@
                     localSiteId = localSiteId,
                     number = this.number ?: (this.id ?: 0).toString(),
                     status = this.status ?: "",
-                    currency = this.currency ?: "",
+                    currency = this.currency.toString() ?: "",
                     orderKey = this.order_key ?: "",
                     dateCreated = convertDateToUTCString(this.date_created_gmt),
                     dateModified = convertDateToUTCString(this.date_modified_gmt),

  ```
</details>

3. Build the Woo app and open the Orders list.
4. Check in the logs that we are tracking the full product error information on the `order_list_load_error` event, and that the `error_type` property value is `PARSE_ERROR`. 


### Image
 ```
🔵 Tracked: order_list_load_error, Properties: {"error_context":"FetchOrdersRepository","error_description":"com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: For input string: \"USD\"","error_type":"PARSE_ERROR","blog_id":214253715,"is_wpcom_store":true,"is_debug":true}
 ```