### PR TITLE
Primitive boolean deserializer

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -2,9 +2,11 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.network.utils.getString
+import org.wordpress.android.fluxc.utils.PrimitiveBooleanJsonDeserializer
 
 typealias ProductDto = ProductApiResponse
 
@@ -29,6 +31,7 @@ data class ProductApiResponse(
     val sale_price: String? = null,
     val on_sale: Boolean = false,
     val total_sales: Long = 0L,
+    @JsonAdapter(PrimitiveBooleanJsonDeserializer::class)
     val purchasable: Boolean = false,
     val virtual: Boolean = false,
     val downloadable: Boolean = false,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/PrimitiveBooleanJsonDeserializer.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/PrimitiveBooleanJsonDeserializer.kt
@@ -1,0 +1,67 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
+import java.lang.reflect.Type
+
+@Suppress("SwallowedException")
+class PrimitiveBooleanJsonDeserializer : JsonDeserializer<Boolean?> {
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): Boolean? {
+        return try {
+            if (json == null || json.isJsonNull) return null
+            (json as? JsonPrimitive)?.let { jsonPrimitive ->
+                when {
+                    jsonPrimitive.isBoolean -> jsonPrimitive.asBoolean
+                    jsonPrimitive.isNumber -> tryIntToBoolean(jsonPrimitive)
+                    jsonPrimitive.isString -> tryStringToBoolean(jsonPrimitive)
+                    else -> null
+                }
+            }
+        } catch (e: IllegalStateException) {
+            null
+        } catch (e: ClassCastException) {
+            null
+        } catch (e: UnsupportedOperationException) {
+            null
+        }
+    }
+
+    private fun tryIntToBoolean(json: JsonElement?): Boolean? {
+        return try {
+            return when (json?.asInt) {
+                0 -> false
+                1 -> true
+                else -> null
+            }
+        } catch (e: IllegalStateException) {
+            null
+        } catch (e: ClassCastException) {
+            null
+        } catch (e: UnsupportedOperationException) {
+            null
+        }
+    }
+
+    private fun tryStringToBoolean(json: JsonElement?): Boolean? {
+        return try {
+            val stringValue = json?.asString?.replace(" ", "") ?: return null
+            stringValue.toBooleanStrictOrNull() ?: run {
+                val intValue = stringValue.toInt()
+                val intPrimitive = JsonPrimitive(intValue)
+                tryIntToBoolean(intPrimitive)
+            }
+        } catch (e: IllegalStateException) {
+            null
+        } catch (e: ClassCastException) {
+            null
+        } catch (e: UnsupportedOperationException) {
+            null
+        }
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/PrimitiveBooleanJsonDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/PrimitiveBooleanJsonDeserializerTest.kt
@@ -1,0 +1,165 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.utils.PrimitiveBooleanJsonDeserializer
+
+class PrimitiveBooleanJsonDeserializerTest {
+    private val sut = PrimitiveBooleanJsonDeserializer()
+
+    @Test
+    fun `when value is true then true value is returned`() {
+        val jsonElement = JsonPrimitive(true)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `when value is false then false value is returned`() {
+        val jsonElement = JsonPrimitive(false)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `when value is 0 then false value is returned`() {
+        val jsonElement = JsonPrimitive(0)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `when value is 1 then true value is returned`() {
+        val jsonElement = JsonPrimitive(1)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `when value is a number and is not 1 then false value is returned`() {
+        val jsonElement = JsonPrimitive(189)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is a string number and is 1 then true value is returned`() {
+        val jsonElement = JsonPrimitive("1")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `when value is a string number and is 0 then false value is returned`() {
+        val jsonElement = JsonPrimitive("0")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `when value is a string number and is 1 with spaces then true value is returned`() {
+        val jsonElement = JsonPrimitive("  1 ")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `when value is a string number and is 0 with spaces then false value is returned`() {
+        val jsonElement = JsonPrimitive(" 0  ")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `when value is a string boolean and is true then true value is returned`() {
+        val jsonElement = JsonPrimitive("true")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `when value is a string boolean and is false then false value is returned`() {
+        val jsonElement = JsonPrimitive("false")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `when value is a string boolean and is true with spaces then true value is returned`() {
+        val jsonElement = JsonPrimitive(" true  ")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `when value is a string boolean and is false with spaces then false value is returned`() {
+        val jsonElement = JsonPrimitive("  false ")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `when value is not valid then null is returned`() {
+        val jsonElement = JsonObject()
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isNull()
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/PrimitiveBooleanJsonDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/PrimitiveBooleanJsonDeserializerTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
+import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import org.assertj.core.api.Assertions.assertThat
@@ -155,6 +156,17 @@ class PrimitiveBooleanJsonDeserializerTest {
     @Test
     fun `when value is not valid then null is returned`() {
         val jsonElement = JsonObject()
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is null then null is returned`() {
+        val jsonElement = JsonNull.INSTANCE
         val result = sut.deserialize(
             json = jsonElement,
             typeOfT = null,

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/PrimitiveBooleanJsonDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/PrimitiveBooleanJsonDeserializerTest.kt
@@ -55,7 +55,7 @@ class PrimitiveBooleanJsonDeserializerTest {
     }
 
     @Test
-    fun `when value is a number and is not 1 then false value is returned`() {
+    fun `when value is a number and is not 1 then null value is returned`() {
         val jsonElement = JsonPrimitive(189)
         val result = sut.deserialize(
             json = jsonElement,


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/9153
Closes: https://github.com/woocommerce/woocommerce-android/issues/9154

### Description
Some extensions (YITH WooCommerce Gift Cards, for example) change the type of the purchasable field to be an integer resulting in a [JsonSyntaxException](https://a8c.sentry.io/issues/3923384523/events/fd2a9bacec4b41e3ba2501400d232210/?project=1459556&referrer=next-event) when trying to deserialize a boolean, but an integer value was received instead. This PR tries to solve this issue by introducing a more resilience deserializer that will try to recover from the error and deserialize the purchasable field from primitives values (Boolean, Int, String)

### Testing Instructions
Unit tests should cover all the different scenarios