### PR TITLE
Non negative Double deserializer

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -6,6 +6,7 @@ import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.network.utils.getString
+import org.wordpress.android.fluxc.utils.NonNegativeDoubleJsonDeserializer
 import org.wordpress.android.fluxc.utils.PrimitiveBooleanJsonDeserializer
 
 typealias ProductDto = ProductApiResponse
@@ -42,7 +43,8 @@ data class ProductApiResponse(
     val tax_status: String? = null,
     val tax_class: String? = null,
     val manage_stock: String? = null,
-    val stock_quantity:Double = 0.0,
+    @JsonAdapter(NonNegativeDoubleJsonDeserializer::class)
+    val stock_quantity:Double? = 0.0,
     val stock_status: String? = null,
     val date_on_sale_from: String? = null,
     val date_on_sale_to: String? = null,
@@ -130,7 +132,7 @@ data class ProductApiResponse(
                 it == "true" || it == "parent"
             } ?: false
 
-            stockQuantity = response.stock_quantity
+            stockQuantity = response.stock_quantity ?: 0.0
 
             stockStatus = response.stock_status ?: ""
             if (isBundledProduct && (response.bundle_stock_status in CoreProductStockStatus.ALL_VALUES).not()) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/NonNegativeDoubleJsonDeserializer.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/NonNegativeDoubleJsonDeserializer.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import java.lang.reflect.Type
+
+class NonNegativeDoubleJsonDeserializer : JsonDeserializer<Double?> {
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): Double? {
+        return try {
+            json?.asDouble?.let {
+                if (it >= 0) it else null
+            }
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/NonNegativeDoubleJsonDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/NonNegativeDoubleJsonDeserializerTest.kt
@@ -1,0 +1,81 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.JsonPrimitive
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+class NonNegativeDoubleJsonDeserializerTest {
+    private val sut = NonNegativeDoubleJsonDeserializer()
+
+    @Test
+    fun `when value is true then null value is returned`() {
+        val jsonElement = JsonPrimitive(true)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        Assertions.assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is a valid string number then the value is returned`() {
+        val value = 12345.0
+        val valueString = value.toString()
+        val jsonElement = JsonPrimitive(valueString)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        Assertions.assertThat(result).isEqualTo(value)
+    }
+
+    @Test
+    fun `when value is an invalid string number then the value is returned`() {
+        val jsonElement = JsonPrimitive("12345_test")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        Assertions.assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is less than 0 then null value is returned`() {
+        val value = -5.0
+        val jsonElement = JsonPrimitive(value)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        Assertions.assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is greater than 0 then the value is returned`() {
+        val value = 12345.0
+        val jsonElement = JsonPrimitive(value)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        Assertions.assertThat(result).isEqualTo(value)
+    }
+
+    @Test
+    fun `when value is different number format then the value is parsed to double and returned`() {
+        val value = 12345.0
+        val valueInt = value.toInt()
+        val jsonElement = JsonPrimitive(valueInt)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        Assertions.assertThat(result).isEqualTo(value)
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/PrimitiveBooleanJsonDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/PrimitiveBooleanJsonDeserializerTest.kt
@@ -1,11 +1,10 @@
-package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
+package org.wordpress.android.fluxc.utils
 
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.wordpress.android.fluxc.utils.PrimitiveBooleanJsonDeserializer
 
 class PrimitiveBooleanJsonDeserializerTest {
     private val sut = PrimitiveBooleanJsonDeserializer()


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/9157

### Description
This PR adds the new `NonNegativeDoubleJsonDeserializer` to use on expected double fields that could be modified by some extension returning a different type or an invalid value.

### Testing
Unit tests should cover all scenarios