### PR TITLE
Wrong id format

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -1,9 +1,12 @@
 package org.wordpress.android.fluxc.model.order
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.model.WCMetaData
+import org.wordpress.android.fluxc.utils.JsonElementToLongSerializerDeserializer
 
 data class LineItem(
+    @JsonAdapter(JsonElementToLongSerializerDeserializer::class)
     val id: Long? = null,
     val name: String? = null,
     @SerializedName("parent_name")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/JsonElementToLongSerializerDeserializer.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/JsonElementToLongSerializerDeserializer.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import java.lang.Exception
+import java.lang.reflect.Type
+
+class JsonElementToLongSerializerDeserializer : JsonSerializer<Long?>, JsonDeserializer<Long?> {
+    override fun serialize(
+        src: Long?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?
+    ): JsonElement {
+        return src?.let { JsonPrimitive(it) } ?: JsonNull.INSTANCE
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): Long? {
+        return try {
+            json?.asLong
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToLongSerializerDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToLongSerializerDeserializerTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.utils
 
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonPrimitive
+import com.google.gson.annotations.JsonAdapter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -67,5 +68,8 @@ class JsonElementToLongSerializerDeserializerTest {
         assertThat(deserialized.value).isEqualTo(value)
     }
 
-    data class TestData(val value: Long)
+    data class TestData(
+        @JsonAdapter(JsonElementToLongSerializerDeserializer::class)
+        val value: Long
+    )
 }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToLongSerializerDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToLongSerializerDeserializerTest.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.utils
 
-import com.google.gson.GsonBuilder
+import com.google.gson.Gson
 import com.google.gson.JsonPrimitive
 import com.google.gson.annotations.JsonAdapter
 import org.assertj.core.api.Assertions.assertThat
@@ -59,9 +59,7 @@ class JsonElementToLongSerializerDeserializerTest {
 
     @Test
     fun `test serialization deserialization`() {
-        val gsonBuilder = GsonBuilder()
-        val gson = gsonBuilder.registerTypeAdapter(Long::class.java, sut).create()
-
+        val gson = Gson()
         val value = 12345L
         val json = gson.toJson(TestData(value))
         val deserialized = gson.fromJson(json, TestData::class.java)

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToLongSerializerDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToLongSerializerDeserializerTest.kt
@@ -1,0 +1,71 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonPrimitive
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class JsonElementToLongSerializerDeserializerTest {
+    private val sut = JsonElementToLongSerializerDeserializer()
+
+    @Test
+    fun `when value is true then null value is returned`() {
+        val jsonElement = JsonPrimitive(true)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is a valid string number then the value is returned`() {
+        val value = 12345L
+        val valueString = value.toString()
+        val jsonElement = JsonPrimitive(valueString)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isEqualTo(value)
+    }
+
+    @Test
+    fun `when value is an invalid string number then the value is returned`() {
+        val jsonElement = JsonPrimitive("12345_test")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is different number format then the value is parsed to long and returned`() {
+        val value = 12345L
+        val valueInt = value.toDouble()
+        val jsonElement = JsonPrimitive(valueInt)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isEqualTo(value)
+    }
+
+    @Test
+    fun `test serialization deserialization`() {
+        val gsonBuilder = GsonBuilder()
+        val gson = gsonBuilder.registerTypeAdapter(Long::class.java, sut).create()
+
+        val value = 12345L
+        val json = gson.toJson(TestData(value))
+        val deserialized = gson.fromJson(json, TestData::class.java)
+        assertThat(deserialized.value).isEqualTo(value)
+    }
+
+    data class TestData(val value: Long)
+}


### PR DESCRIPTION
Close https://github.com/woocommerce/woocommerce-android/issues/9159

### Description
This PR adds the new `JsonElementToLongSerializerDeserializer` to use on expected Long fields that could be modified by some extension returning a different type or an invalid value.

### Testing
Unit tests should cover all scenarios