### PR TITLE
Add new field can_blaze to site model

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1,13 +1,9 @@
 package org.wordpress.android.fluxc.model;
 
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
-
-import com.yarolegovich.wellsql.core.Identifiable;
-import com.yarolegovich.wellsql.core.annotation.Column;
-import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
-import com.yarolegovich.wellsql.core.annotation.RawConstraints;
-import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
@@ -22,7 +18,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.RawConstraints;
+import com.yarolegovich.wellsql.core.annotation.Table;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})
@@ -249,6 +249,8 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     private int mBloggingReminderMinute;
     @Column
     private String mApplicationPasswordsAuthorizeUrl;
+    @Column
+    private Boolean mCanBlaze;
 
     @Override
     public int getId() {
@@ -1065,5 +1067,13 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setPublishedStatus(int publishedStatus) {
         this.mPublishedStatus = publishedStatus;
+    }
+
+    public Boolean getCanBlaze() {
+        return mCanBlaze;
+    }
+
+    public void setCanBlaze(Boolean mCanBlaze) {
+        this.mCanBlaze = mCanBlaze;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1,9 +1,13 @@
 package org.wordpress.android.fluxc.model;
 
-import static java.lang.annotation.RetentionPolicy.SOURCE;
-
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
+
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.RawConstraints;
+import com.yarolegovich.wellsql.core.annotation.Table;
 
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
@@ -18,11 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 
-import com.yarolegovich.wellsql.core.Identifiable;
-import com.yarolegovich.wellsql.core.annotation.Column;
-import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
-import com.yarolegovich.wellsql.core.annotation.RawConstraints;
-import com.yarolegovich.wellsql.core.annotation.Table;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @Table
 @RawConstraints({"UNIQUE (SITE_ID, URL)"})

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1035,6 +1035,7 @@ class SiteRestClient @Inject constructor(
             site.showOnFront = from.options.show_on_front
             site.pageOnFront = from.options.page_on_front
             site.pageForPosts = from.options.page_for_posts
+            site.canBlaze = from.options.can_blaze
             site.setIsPublicizePermanentlyDisabled(from.options.publicize_permanently_disabled)
             if (from.options.active_modules != null) {
                 site.activeModules = from.options.active_modules.joinToString(",")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -36,6 +36,7 @@ public class SiteWPComRestResponse implements Response {
         public List<String> jetpack_connection_active_plugins;
         public BloggingPromptsSettings blogging_prompts_settings;
         public int blog_public;
+        public boolean can_blaze;
     }
 
     public static class Plan {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 188
+        return 189
     }
 
     override fun getDbName(): String {
@@ -1947,6 +1947,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 187 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD PUBLISHED_STATUS INTEGER")
+                }
+                188 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD CAN_BLAZE BOOLEAN")
                 }
             }
         }


### PR DESCRIPTION
Part of this [task](https://github.com/woocommerce/woocommerce-android/issues/9209). 

Adds a new available API field to site model: `can_blaze`. The field is nested inside the site's data options when fetching sites, for example from `me/sites` endpoint. 

There's nothing to test on this PR. Changes can be tested in [this PR](https://github.com/woocommerce/woocommerce-android/pull/9228) where the new field is used. 