### PR TITLE
Resilient strip product variation

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
@@ -3,18 +3,19 @@ package org.wordpress.android.fluxc.model
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import org.wordpress.android.fluxc.utils.isElementNullOrEmpty
 import javax.inject.Inject
 
 class StripProductVariationMetaData @Inject internal constructor(private val gson: Gson) {
     operator fun invoke(metadata: String?): String? {
-        if (metadata == null) return null
+        if (metadata.isNullOrEmpty()) return null
 
         return gson.fromJson(metadata, JsonArray::class.java)
             .mapNotNull { it as? JsonObject }
             .asSequence()
             .filter { jsonObject ->
-                jsonObject[WCMetaData.KEY]?.asString.orEmpty() in SUPPORTED_KEYS &&
-                    jsonObject[WCMetaData.VALUE]?.asString.orEmpty().isNotBlank()
+                val isNullOrEmpty = jsonObject[WCMetaData.VALUE].isElementNullOrEmpty()
+                jsonObject[WCMetaData.KEY]?.asString.orEmpty() in SUPPORTED_KEYS && isNullOrEmpty.not()
             }.toList()
             .takeIf { it.isNotEmpty() }
             ?.let { gson.toJson(it) }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/StripProductVariationMetaDataTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/StripProductVariationMetaDataTest.kt
@@ -61,6 +61,41 @@ class StripProductVariationMetaDataTest {
         assertThat(resultItem[WCMetaData.VALUE].asString).isEqualTo(value)
     }
 
+    @Test
+    fun `when metadata is null, then null is return`() {
+        val result = sut.invoke(null)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when metadata is empty, then null is return`() {
+        val result = sut.invoke("")
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when metadata contains a supported key with an ARRAY value, then value is kept`() {
+        val supportedKey = StripProductVariationMetaData.SUPPORTED_KEYS.first()
+        val value = JsonArray().apply {
+            add("Value 1")
+            add("Value 2")
+        }
+        val item = JsonObject().apply {
+            addProperty(WCMetaData.KEY, supportedKey)
+            add(WCMetaData.VALUE, value)
+        }
+        val jsonArray = JsonArray().apply { add(item) }
+        val metadata = gson.toJson(jsonArray)
+
+        val result = sut.invoke(metadata)
+
+        val jsonResult = gson.fromJson(result, JsonArray::class.java)
+        val resultItem = jsonResult[0] as JsonObject
+        assertThat(result).isNotNull
+        assertThat(resultItem[WCMetaData.KEY].asString).isEqualTo(supportedKey)
+        assertThat(resultItem[WCMetaData.VALUE].asJsonArray).isEqualTo(value)
+    }
+
     private fun getOneItemMetadata(itemKey: String, itemValue: String?): String {
         val item = JsonObject().apply {
             addProperty(WCMetaData.KEY, itemKey)


### PR DESCRIPTION
### Description 
This PR prevents the StripProductVariationMetaData from crashing when it receives unexpected data. 
The line `gson.fromJson(metadata, JsonArray::class.java)` will crash when the metadata value is empty `""`
Calling ` jsonObject[WCMetaData.VALUE]?.asString` will crash when the jsonObject value is an array with more than one element

### Testing instructions

1. Apply the patch and check that unit tests fail.
2. Revert the changes, run unit tests again, and check that everything pass.

<details>
  <summary>Patch with the old version</summary>

```
Index: plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt	(revision fdec197d8f5ffe04d2141f32071a4d0e6045a754)
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt	(date 1687280251643)
@@ -3,19 +3,18 @@
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import org.wordpress.android.fluxc.utils.isElementNullOrEmpty
 import javax.inject.Inject
 
 class StripProductVariationMetaData @Inject internal constructor(private val gson: Gson) {
     operator fun invoke(metadata: String?): String? {
-        if (metadata.isNullOrEmpty()) return null
+        if (metadata == null) return null
 
         return gson.fromJson(metadata, JsonArray::class.java)
             .mapNotNull { it as? JsonObject }
             .asSequence()
             .filter { jsonObject ->
-                val isNullOrEmpty = jsonObject[WCMetaData.VALUE].isElementNullOrEmpty()
-                jsonObject[WCMetaData.KEY]?.asString.orEmpty() in SUPPORTED_KEYS && isNullOrEmpty.not()
+                jsonObject[WCMetaData.KEY]?.asString.orEmpty() in SUPPORTED_KEYS &&
+                    jsonObject[WCMetaData.VALUE]?.asString.orEmpty().isNotBlank()
             }.toList()
             .takeIf { it.isNotEmpty() }
             ?.let { gson.toJson(it) }

```

</details>