### PR TITLE
Parse `woocommerce_rest_invalid_coupon` error code

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -33,7 +33,8 @@ enum class WooErrorType {
     AUTHORIZATION_REQUIRED,
     INVALID_PARAM,
     PLUGIN_NOT_ACTIVE,
-    EMPTY_RESPONSE
+    EMPTY_RESPONSE,
+    INVALID_COUPON
 }
 
 fun WPComGsonNetworkError.toWooError(): WooError {
@@ -79,6 +80,7 @@ fun WPAPINetworkError.toWooError(): WooError {
             when (errorCode) {
                 "rest_invalid_param" -> WooErrorType.INVALID_PARAM
                 "rest_no_route" -> WooErrorType.PLUGIN_NOT_ACTIVE
+                "woocommerce_rest_invalid_coupon" -> WooErrorType.INVALID_COUPON
                 else -> WooErrorType.GENERIC_ERROR
             }
         }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/WPAPIResponseExtTests.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/WPAPIResponseExtTests.kt
@@ -54,4 +54,18 @@ class WPAPIResponseExtTests {
         assertThat(result.error.original).isEqualTo(error.toWooError().original)
         assertThat(result.error.message).isEqualTo(error.toWooError().message)
     }
+
+    @Test
+    fun `given invalid coupon error, when converting, then map the error type`() {
+        val error = WPAPINetworkError(
+            BaseNetworkError(BaseRequest.GenericErrorType.UNKNOWN),
+            "woocommerce_rest_invalid_coupon"
+        )
+        val response = WPAPIResponse.Error<String>(error)
+
+        val result = response.toWooPayload { it.hashCode() }
+
+        assertThat(result.isError).isTrue
+        assertThat(result.error.type).isEqualTo(WooErrorType.INVALID_COUPON)
+    }
 }


### PR DESCRIPTION
Added parsing of `UNKNOWN` network error with code with error code `woocommerce_rest_invalid_coupon`.

Required for: https://github.com/woocommerce/woocommerce-android/pull/9263