### PR TITLE
Parsing error fetching orders

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ListAction.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.annotations.ActionEnum
 import org.wordpress.android.fluxc.annotations.action.IAction
 import org.wordpress.android.fluxc.model.list.ListDescriptorTypeIdentifier
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
+import org.wordpress.android.fluxc.store.ListStore.OnListDataFailure
 import org.wordpress.android.fluxc.store.ListStore.ListItemsRemovedPayload
 import org.wordpress.android.fluxc.store.ListStore.RemoveExpiredListsPayload
 
@@ -20,6 +21,8 @@ enum class ListAction : IAction {
     LIST_DATA_INVALIDATED,
     @Action(payloadType = RemoveExpiredListsPayload::class)
     REMOVE_EXPIRED_LISTS,
+    @Action(payloadType = OnListDataFailure::class)
+    LIST_DATA_FAILURE,
     @Action
     REMOVE_ALL_LISTS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/PagedListWrapper.kt
@@ -15,6 +15,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.store.ListStore.ListError
 import org.wordpress.android.fluxc.store.ListStore.OnListChanged
+import org.wordpress.android.fluxc.store.ListStore.OnListDataFailure
 import org.wordpress.android.fluxc.store.ListStore.OnListDataInvalidated
 import org.wordpress.android.fluxc.store.ListStore.OnListRequiresRefresh
 import org.wordpress.android.fluxc.store.ListStore.OnListStateChanged
@@ -151,5 +152,11 @@ class PagedListWrapper<T>(
         if (listDescriptor.typeIdentifier == event.type) {
             invalidateData()
         }
+    }
+
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    @Suppress("unused")
+    fun onListDataFailure(event: OnListDataFailure) {
+        _listError.postValue(event.error)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -68,6 +68,7 @@ class ListStore @Inject constructor(
             LIST_DATA_INVALIDATED -> handleListDataInvalidated(action.payload as ListDescriptorTypeIdentifier)
             REMOVE_EXPIRED_LISTS -> handleRemoveExpiredLists(action.payload as RemoveExpiredListsPayload)
             REMOVE_ALL_LISTS -> handleRemoveAllLists()
+            ListAction.LIST_DATA_FAILURE -> handleDataFailure(action.payload as OnListDataFailure)
         }
     }
 
@@ -310,6 +311,10 @@ class ListStore @Inject constructor(
         listSqlUtils.deleteAllLists()
     }
 
+    private fun handleDataFailure(event : OnListDataFailure){
+        emitChange(event)
+    }
+
     /**
      * Deletes all the items for the given [ListDescriptor].
      */
@@ -397,6 +402,8 @@ class ListStore @Inject constructor(
      * @property remoteItemIds Remote item ids to be removed from the lists matching the [ListDescriptorTypeIdentifier].
      */
     class ListItemsRemovedPayload(val type: ListDescriptorTypeIdentifier, val remoteItemIds: List<Long>)
+
+    class OnListDataFailure(val type: ListDescriptorTypeIdentifier) : Store.OnChanged<ListError>()
 
     /**
      * This is the payload for [ListAction.FETCHED_LIST_ITEMS].

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -441,6 +441,7 @@ class ListStore @Inject constructor(
 
     enum class ListErrorType {
         GENERIC_ERROR,
-        PERMISSION_ERROR
+        PERMISSION_ERROR,
+        PARSE_ERROR
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -30,7 +30,9 @@ import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 import org.wordpress.android.fluxc.store.ListStore.ListError
 import org.wordpress.android.fluxc.store.ListStore.ListErrorType
+import org.wordpress.android.fluxc.store.ListStore.OnListDataFailure
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.PARSE_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -832,20 +834,37 @@ class WCOrderStore @Inject constructor(
                     payload.fetchedOrders.map { it.first }.map { it.orderId })
             }
 
+            // Notify listeners that the list of orders has changed (only call this if there is no error)
+            val listTypeIdentifier = WCOrderListDescriptor.calculateTypeIdentifier(localSiteId = payload.site.id)
+
             if (!payload.isError) {
                 // Save the list of orders to the database
 
                 insertOrder(*payload.fetchedOrders.toTypedArray())
 
-                // Notify listeners that the list of orders has changed (only call this if there is no error)
-                val listTypeIdentifier = WCOrderListDescriptor.calculateTypeIdentifier(localSiteId = payload.site.id)
                 mDispatcher.dispatch(
                     ListActionBuilder.newListDataInvalidatedAction(
                         listTypeIdentifier
                     )
                 )
-            }
+            } else {
+                val errorType = if(payload.error.type == PARSE_ERROR){
+                    ListErrorType.PARSE_ERROR
+                } else {
+                    ListErrorType.GENERIC_ERROR
+                }
 
+                mDispatcher.dispatch(
+                    ListActionBuilder.newListDataFailureAction(
+                            OnListDataFailure(listTypeIdentifier).apply {
+                                error = ListError(
+                                    errorType,
+                                    payload.error.message
+                                )
+                            }
+                    )
+                )
+            }
             emitChange(onOrdersFetchedByIds)
         }
     }


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/9170

### Why
We are not handling order errors when fetching orders from the API. If the get-orders-summaries request succeeds, but the fetch-order fails, we display the order skeleton view indefinitely instead of showing an error. This gives merchants the sense that the app is slow and never loads when, in reality, there is something wrong with the data received.

### Description
This PR dispatches the new `OnListDataFailure`, so list consumers can handle errors while fetching the orders

### Testing 
Is better to test this PR along side the [Woo PR](https://github.com/woocommerce/woocommerce-android/pull/9301)