### PR TITLE
[WOOCOMMERCE]`wc-analytics/customers` add filter_empty support

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCCustomerTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCCustomerTest.kt
@@ -85,4 +85,32 @@ class ReleaseStack_WCCustomerTest : ReleaseStack_WCBase() {
             assertThat(result.model?.get(0)?.id).isEqualTo(1)
         }
     }
+
+    @Test
+    fun testFetchOrdersFilterEmptyAndSearchByWithResults() {
+        runBlocking {
+            val result = wcCustomerStore.fetchCustomersFromAnalytics(
+                sSite,
+                page = 1,
+                searchQuery = "John",
+                searchBy = "name",
+                filterEmpty = listOf("email", "city", "state", "country")
+            )
+            assertThat(result.model?.size).isEqualTo(1)
+            assertThat(result.model?.get(0)?.id).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun testFetchOrdersFilterEmptyWithResults() {
+        runBlocking {
+            val result = wcCustomerStore.fetchCustomersFromAnalytics(
+                sSite,
+                page = 1,
+                filterEmpty = listOf("email")
+            )
+            assertThat(result.model?.size).isEqualTo(1)
+            assertThat(result.model?.get(0)?.id).isEqualTo(1)
+        }
+    }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCCustomerTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCCustomerTest.kt
@@ -19,7 +19,7 @@ class ReleaseStack_WCCustomerTest : ReleaseStack_WCBase() {
     }
 
     @Test
-    fun testFetchOrdersFirstPage() {
+    fun testFetchCustomersFromAnalyticsFirstPage() {
         runBlocking {
             val result = wcCustomerStore.fetchCustomersFromAnalytics(sSite, page = 1)
             assertThat(result.model?.size).isEqualTo(1)
@@ -38,7 +38,7 @@ class ReleaseStack_WCCustomerTest : ReleaseStack_WCBase() {
     }
 
     @Test
-    fun testFetchOrdersSecondPage() {
+    fun testFetchCustomersFromAnalyticsSecondPage() {
         runBlocking {
             val result = wcCustomerStore.fetchCustomersFromAnalytics(sSite, page = 2)
             assertThat(result.model?.size).isEqualTo(0)
@@ -46,7 +46,7 @@ class ReleaseStack_WCCustomerTest : ReleaseStack_WCBase() {
     }
 
     @Test
-    fun testFetchOrdersSearchWithResults() {
+    fun testFetchCustomersFromAnalyticsSearchWithResults() {
         runBlocking {
             val result = wcCustomerStore.fetchCustomersFromAnalytics(
                 sSite,
@@ -60,7 +60,7 @@ class ReleaseStack_WCCustomerTest : ReleaseStack_WCBase() {
     }
 
     @Test
-    fun testFetchOrdersSearchByEmailWithoutResults() {
+    fun testFetchCustomersFromAnalyticsSearchByEmailWithoutResults() {
         runBlocking {
             val result = wcCustomerStore.fetchCustomersFromAnalytics(
                 sSite,
@@ -73,7 +73,21 @@ class ReleaseStack_WCCustomerTest : ReleaseStack_WCBase() {
     }
 
     @Test
-    fun testFetchOrdersSearchByWithResults() {
+    fun testFetchCustomersFromAnalyticsSearchByAllWithResults() {
+        runBlocking {
+            val result = wcCustomerStore.fetchCustomersFromAnalytics(
+                sSite,
+                page = 1,
+                searchQuery = "admin",
+                searchBy = "all",
+            )
+            assertThat(result.model?.size).isEqualTo(1)
+            assertThat(result.model?.get(0)?.id).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun testFetchCustomersFromAnalyticsSearchByWithResults() {
         runBlocking {
             val result = wcCustomerStore.fetchCustomersFromAnalytics(
                 sSite,
@@ -87,7 +101,7 @@ class ReleaseStack_WCCustomerTest : ReleaseStack_WCBase() {
     }
 
     @Test
-    fun testFetchOrdersFilterEmptyAndSearchByWithResults() {
+    fun testFetchCustomersFromAnalyticsFilterEmptyAndSearchByWithResults() {
         runBlocking {
             val result = wcCustomerStore.fetchCustomersFromAnalytics(
                 sSite,
@@ -102,7 +116,7 @@ class ReleaseStack_WCCustomerTest : ReleaseStack_WCBase() {
     }
 
     @Test
-    fun testFetchOrdersFilterEmptyWithResults() {
+    fun testFetchCustomersFromAnalyticsFilterEmptyWithResults() {
         runBlocking {
             val result = wcCustomerStore.fetchCustomersFromAnalytics(
                 sSite,

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCCustomerTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCCustomerTest.kt
@@ -73,20 +73,6 @@ class ReleaseStack_WCCustomerTest : ReleaseStack_WCBase() {
     }
 
     @Test
-    fun testFetchCustomersFromAnalyticsSearchByAllWithResults() {
-        runBlocking {
-            val result = wcCustomerStore.fetchCustomersFromAnalytics(
-                sSite,
-                page = 1,
-                searchQuery = "admin",
-                searchBy = "all",
-            )
-            assertThat(result.model?.size).isEqualTo(1)
-            assertThat(result.model?.get(0)?.id).isEqualTo(1)
-        }
-    }
-
-    @Test
     fun testFetchCustomersFromAnalyticsSearchByWithResults() {
         runBlocking {
             val result = wcCustomerStore.fetchCustomersFromAnalytics(

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -219,7 +219,7 @@ class WCCustomerMapperTest {
         assertThat(result.lastName).isEqualTo("lastname")
         assertThat(result.email).isEqualTo("email")
         assertThat(result.isPayingCustomer).isEqualTo(true)
-        assertThat(result.remoteCustomerId).isEqualTo(1L)
+        assertThat(result.remoteCustomerId).isEqualTo(13L)
         assertThat(result.dateCreated).isEqualTo("dateRegistered")
         assertThat(result.dateModified).isEqualTo("dateLastActive")
 

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClientTest.kt
@@ -16,7 +16,7 @@ class CustomerRestClientTest {
     private val client = CustomerRestClient(wooNetwork)
 
     @Test
-    fun `given searchQuery and searchBy, when fetchCustomersFromAnalytics, then that passed to API`() {
+    fun `given searchQuery searchBy filter empty, when fetchCustomersFromAnalytics, then that passed to API`() {
         test {
             // GIVEN
             val searchQuery = "searchQuery"
@@ -36,7 +36,8 @@ class CustomerRestClientTest {
                         "order" to "asc",
                         "orderby" to "name",
                         "search" to searchQuery,
-                        "searchby" to searchBy
+                        "searchby" to searchBy,
+                        "filter_empty" to "email,city,state,country"
                     ),
                     clazz = Array<CustomerFromAnalyticsDTO>::class.java
                 )
@@ -53,7 +54,8 @@ class CustomerRestClientTest {
                 page = page,
                 sortType = sortType,
                 searchQuery = searchQuery,
-                searchBy = searchBy
+                searchBy = searchBy,
+                filterEmpty = listOf("email", "city", "state", "country")
             )
 
             // THEN
@@ -66,7 +68,8 @@ class CustomerRestClientTest {
                     "order" to "asc",
                     "orderby" to "name",
                     "search" to searchQuery,
-                    "searchby" to searchBy
+                    "searchby" to searchBy,
+                    "filter_empty" to "email,city,state,country"
                 ),
                 clazz = Array<CustomerFromAnalyticsDTO>::class.java
             )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
@@ -88,7 +88,7 @@ class WCCustomerMapper @Inject constructor() {
     fun mapToModel(site: SiteModel, dto: CustomerFromAnalyticsDTO): WCCustomerModel {
         return WCCustomerModel().apply {
             localSiteId = site.id
-            remoteCustomerId = dto.userId ?: 0
+            remoteCustomerId = dto.id ?: 0
             email = dto.email ?: ""
             firstName = dto.name.firstNameFromName()
             lastName = dto.name.lastNameFromName()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/customer/CustomerRestClient.kt
@@ -126,6 +126,7 @@ class CustomerRestClient @Inject constructor(private val wooNetwork: WooNetwork)
         sortType: CustomerSorting = NAME_ASC,
         searchQuery: String? = null,
         searchBy: String? = null,
+        filterEmpty: List<String>? = null,
     ): WooPayload<Array<CustomerFromAnalyticsDTO>> {
         val url = WOOCOMMERCE.reports.customers.pathV4Analytics
 
@@ -148,6 +149,10 @@ class CustomerRestClient @Inject constructor(private val wooNetwork: WooNetwork)
         ).run {
             putIfNotEmpty("search" to searchQuery)
             putIfNotEmpty("searchby" to searchBy)
+        }
+
+        if (!filterEmpty.isNullOrEmpty()) {
+            params["filter_empty"] = filterEmpty.joinToString(",")
         }
 
         val response = wooNetwork.executeGetGsonRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCCustomerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCCustomerStore.kt
@@ -183,6 +183,7 @@ class WCCustomerStore @Inject constructor(
         sortType: CustomerSorting = DEFAULT_CUSTOMER_SORTING,
         searchQuery: String? = null,
         searchBy: String? = null,
+        filterEmpty: List<String>? = null,
     ): WooResult<List<WCCustomerModel>> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchCustomersFromAnalytics") {
             val response = restClient.fetchCustomersFromAnalytics(
@@ -192,6 +193,7 @@ class WCCustomerStore @Inject constructor(
                 sortType = sortType,
                 searchQuery = searchQuery,
                 searchBy = searchBy,
+                filterEmpty = filterEmpty,
             )
             when {
                 response.isError -> {


### PR DESCRIPTION
The PR adds support for  `filter_empty` parameters. The backend that supports this param still not merged