### PR TITLE
feat: export application password

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -22,7 +22,7 @@ class ApplicationPasswordsStore @Inject constructor(
     }
 
     fun getApplicationPasswordAuthOption(site: SiteModel): String? = encryptedPreferences.getString(
-        site.passwordPrefKey,
+        site.usernamePrefKey,
         null
     ) + ":" + encryptedPreferences.getString(site.passwordPrefKey, null)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -22,6 +22,10 @@ class ApplicationPasswordsStore @Inject constructor(
         private const val UUID_PREFERENCE_KEY_PREFIX = "app_password_uuid_"
     }
 
+    /*
+    Exposed only to pass to React Native instance so we can authenticate via application password
+    there. Do not use directly in WCAndroid app.
+     */
     fun getApplicationPasswordAuthHeader(site: SiteModel): String =
         Credentials.basic(
             username = encryptedPreferences.getString(site.usernamePrefKey, null).orEmpty(),

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import okhttp3.Credentials
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
@@ -21,10 +22,11 @@ class ApplicationPasswordsStore @Inject constructor(
         private const val UUID_PREFERENCE_KEY_PREFIX = "app_password_uuid_"
     }
 
-    fun getApplicationPasswordAuthOption(site: SiteModel): String? = encryptedPreferences.getString(
-        site.usernamePrefKey,
-        null
-    ) + ":" + encryptedPreferences.getString(site.passwordPrefKey, null)
+    fun getApplicationPasswordAuthHeader(site: SiteModel): String =
+        Credentials.basic(
+            username = encryptedPreferences.getString(site.usernamePrefKey, null).orEmpty(),
+            password = encryptedPreferences.getString(site.passwordPrefKey, null).orEmpty()
+        )
 
     @Inject internal lateinit var configuration: ApplicationPasswordsConfiguration
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -21,6 +21,9 @@ class ApplicationPasswordsStore @Inject constructor(
         private const val UUID_PREFERENCE_KEY_PREFIX = "app_password_uuid_"
     }
 
+    fun getApplicationPassword(site: SiteModel): String? =
+        encryptedPreferences.getString(site.passwordPrefKey, null)
+
     @Inject internal lateinit var configuration: ApplicationPasswordsConfiguration
 
     private val applicationName: String

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -21,8 +21,10 @@ class ApplicationPasswordsStore @Inject constructor(
         private const val UUID_PREFERENCE_KEY_PREFIX = "app_password_uuid_"
     }
 
-    fun getApplicationPassword(site: SiteModel): String? =
-        encryptedPreferences.getString(site.passwordPrefKey, null)
+    fun getApplicationPasswordAuthOption(site: SiteModel): String? = encryptedPreferences.getString(
+        site.passwordPrefKey,
+        null
+    ) + ":" + encryptedPreferences.getString(site.passwordPrefKey, null)
 
     @Inject internal lateinit var configuration: ApplicationPasswordsConfiguration
 


### PR DESCRIPTION
We need to export application password header so we can pass it to React Native instance to enable application password authentication there.