### PR TITLE
[Jetpack Social] Parse features in SiteModel plan object

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -252,6 +252,9 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column
     private Boolean mCanBlaze;
 
+    // Jetpack Social
+    @Column private boolean mHasSocialShares1000Active;
+
     @Override
     public int getId() {
         return mId;
@@ -1075,5 +1078,17 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setCanBlaze(Boolean mCanBlaze) {
         this.mCanBlaze = mCanBlaze;
+    }
+
+    public boolean isHostedAtWPCom() {
+        return !isJetpackInstalled();
+    }
+
+    public boolean getHasSocialShares1000Active() {
+        return mHasSocialShares1000Active;
+    }
+
+    public void setHasSocialShares1000Active(final boolean socialShares1000Active) {
+        mHasSocialShares1000Active = socialShares1000Active;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -254,7 +254,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     private Boolean mCanBlaze;
     // Comma-separated list of active features in the site's plan
     @Column
-    private String mActiveFeatures;
+    private String mPlanActiveFeatures;
 
     @Override
     public int getId() {
@@ -1085,15 +1085,15 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         return !isJetpackInstalled();
     }
 
-    public List<String> getActiveFeaturesList() {
-        return Arrays.asList(mActiveFeatures.split(","));
+    public List<String> getPlanActiveFeaturesList() {
+        return Arrays.asList(mPlanActiveFeatures.split(","));
     }
 
-    public String getActiveFeatures() {
-        return mActiveFeatures;
+    public String getPlanActiveFeatures() {
+        return mPlanActiveFeatures;
     }
 
-    public void setActiveFeatures(final String activeFeatures) {
-        this.mActiveFeatures = activeFeatures;
+    public void setPlanActiveFeatures(final String planActiveFeatures) {
+        this.mPlanActiveFeatures = planActiveFeatures;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Retention;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.List;
 
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
@@ -251,9 +252,9 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     private String mApplicationPasswordsAuthorizeUrl;
     @Column
     private Boolean mCanBlaze;
-
-    // Jetpack Social
-    @Column private boolean mHasSocialShares1000Active;
+    // Comma-separated list of active features in the site's plan
+    @Column
+    private String mActiveFeatures;
 
     @Override
     public int getId() {
@@ -1084,11 +1085,15 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         return !isJetpackInstalled();
     }
 
-    public boolean getHasSocialShares1000Active() {
-        return mHasSocialShares1000Active;
+    public List<String> getActiveFeaturesList() {
+        return Arrays.asList(mActiveFeatures.split(","));
     }
 
-    public void setHasSocialShares1000Active(final boolean socialShares1000Active) {
-        mHasSocialShares1000Active = socialShares1000Active;
+    public String getActiveFeatures() {
+        return mActiveFeatures;
+    }
+
+    public void setActiveFeatures(final String activeFeatures) {
+        this.mActiveFeatures = activeFeatures;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1139,7 +1139,7 @@ class SiteRestClient @Inject constructor(
             site.setIsWPCom(true)
         }
         site.origin = SiteModel.ORIGIN_WPCOM_REST
-        site.activeFeatures = (from.plan?.features?.active?.joinToString(",")).orEmpty()
+        site.planActiveFeatures = (from.plan?.features?.active?.joinToString(",")).orEmpty()
         return site
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1139,6 +1139,8 @@ class SiteRestClient @Inject constructor(
             site.setIsWPCom(true)
         }
         site.origin = SiteModel.ORIGIN_WPCOM_REST
+        site.hasSocialShares1000Active =
+            from.plan?.features?.active?.find { it == "social-shares-1000" } != null
         return site
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1139,8 +1139,7 @@ class SiteRestClient @Inject constructor(
             site.setIsWPCom(true)
         }
         site.origin = SiteModel.ORIGIN_WPCOM_REST
-        site.hasSocialShares1000Active =
-            from.plan?.features?.active?.find { it == "social-shares-1000" } != null
+        site.activeFeatures = (from.plan?.features?.active?.joinToString(",")).orEmpty()
         return site
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site;
 
+import androidx.annotation.Nullable;
+
 import org.wordpress.android.fluxc.network.Response;
 
 import java.util.List;
@@ -43,6 +45,11 @@ public class SiteWPComRestResponse implements Response {
         public String product_id;
         public String product_name_short;
         public boolean is_free;
+        @Nullable public Features features;
+    }
+
+    public class Features {
+        @Nullable public List<String> active;
     }
 
     public static class Capabilities {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 189
+        return 190
     }
 
     override fun getDbName(): String {
@@ -1950,6 +1950,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 188 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD CAN_BLAZE BOOLEAN")
+                }
+                189 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD HAS_SOCIAL_SHARES1000ACTIVE BOOLEAN")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1952,7 +1952,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE SiteModel ADD CAN_BLAZE BOOLEAN")
                 }
                 189 -> migrate(version) {
-                    db.execSQL("ALTER TABLE SiteModel ADD ACTIVE_FEATURES TEXT")
+                    db.execSQL("ALTER TABLE SiteModel ADD PLAN_ACTIVE_FEATURES TEXT")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1952,7 +1952,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE SiteModel ADD CAN_BLAZE BOOLEAN")
                 }
                 189 -> migrate(version) {
-                    db.execSQL("ALTER TABLE SiteModel ADD HAS_SOCIAL_SHARES1000ACTIVE BOOLEAN")
+                    db.execSQL("ALTER TABLE SiteModel ADD ACTIVE_FEATURES TEXT")
                 }
             }
         }


### PR DESCRIPTION
Parent issue: https://github.com/wordpress-mobile/WordPress-Android/issues/18730
Parent PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18735

This PR parses the `features` object in `SiteModel` and adds `hasSocialShares1000Active` property so we can use it to determine if we should show the social sharing limit to a site.