### PR TITLE
Remove unused method from SiteModel

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1085,10 +1085,6 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         return !isJetpackInstalled();
     }
 
-    public List<String> getPlanActiveFeaturesList() {
-        return Arrays.asList(mPlanActiveFeatures.split(","));
-    }
-
     public String getPlanActiveFeatures() {
         return mPlanActiveFeatures;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Retention;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.List;
 
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 


### PR DESCRIPTION
Removes unused method from `SiteModel` added in the context of JP Social feature.