### PR TITLE
Make file field from MediaDetails nullable to avoid crashes

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaWPRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaWPRestResponse.kt
@@ -37,7 +37,7 @@ data class MediaWPRESTResponse(
     data class MediaDetails(
         val width: Int,
         val height: Int,
-        val file: String,
+        val file: String?,
         val sizes: Sizes?
     )
 
@@ -70,7 +70,7 @@ fun MediaWPRESTResponse.toMediaModel(localSiteId: Int): MediaModel {
     mediaModel.url = sourceURL
     mediaModel.guid = guid.rendered
     mediaModel.fileName = mediaDetails.file
-    mediaModel.fileExtension = mediaDetails.file.substringAfterLast('.', "")
+    mediaModel.fileExtension = mediaDetails.file?.substringAfterLast('.', "")
     mediaModel.mimeType = mimeType
     mediaModel.title = StringEscapeUtils.unescapeHtml4(title.rendered)
     mediaModel.caption = StringEscapeUtils.unescapeHtml4(caption.rendered)


### PR DESCRIPTION
[Fixes crash](https://github.com/woocommerce/woocommerce-android/issues/8748) when `file` field is null. 

### Fixes Crash 
Happening in WooCommerce app when trying to add images to products from the WP media library:

```
NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter <this>
    at kotlin.text.StringsKt__StringsKt.substringAfterLast
    at kotlin.text.StringsKt.substringAfterLast
    at org.wordpress.android.fluxc.network.rest.wpapi.media.MediaWPRestResponseKt.toMediaModel(MediaWPRestResponse.kt:73)
    at org.wordpress.android.fluxc.network.rest.wpapi.media.BaseWPV2MediaRestClient.syncFetchMediaList(BaseWPV2MediaRestClient.kt:209)
    at org.wordpress.android.fluxc.network.rest.wpapi.media.BaseWPV2MediaRestClient.access$parseUploadError(BaseWPV2MediaRestClient.kt:47)
...
(8 additional frame(s) were not displayed)
```

### Context
Copying and pasting [all the context](https://github.com/woocommerce/woocommerce-android/issues/8748#issuecomment-1623728702) from my investigation on this issue:

- The issue happens when users try to add a product image using WordPress media library and there's a file in the media library that is lacking the `MediaDetails.file` string field. The `file` field from the API response is null:
```kotlin
    data class MediaDetails(
        val width: Int,
        val height: Int,
        val file: String,
        val sizes: Sizes?
    )
```
- The `file` field inside `MediaDetails` is non-nullable field, but since we are using Gson to serialize the json into this model it looks like [Gson doesn't care whether](https://stackoverflow.com/a/52837775/2979970) the field is nullable or not, so it will set `null` value into Kotlin non-nullable fields. 
- But looking at the stack trace and decompiling the `substringAfterLast` ext function to Java is clear that the receiver parameter `this`  (which is `file` value) is null: 
```java
   @NotNull
   public static final String substringAfterLast(@NotNull String $this$substringAfterLast, char delimiter, @NotNull String missingDelimiterValue) {
      Intrinsics.checkNotNullParameter($this$substringAfterLast, "<this>");
      Intrinsics.checkNotNullParameter(missingDelimiterValue, "missingDelimiterValue");
...
```
- The crash only happens on self-hosted sites. I can see in the user's logs the `blog_id` for any tracked event is 0. This only happens for users that have logged in with application passwords and thus are self-hosted sites without Jetpack. 
- The request leading to the crash is: `radical-scallop.jurassic.ninja/wp-json/wp/v2/media/` 
- I've tried all sorts of ways to upload a file to WP media library that resulted in a file without a name but this simply not possible to do. I tested this on Jurassic ninja self-hosted sites. I suspect users might be using a buggy plugin for managing media that can result is files empty names?


### Solution
A possible solution to this crash is making the `val file: String,` from `MediaDetails` nullable and that would resolve the crash by calling `mediaDetails.file?.substringAfterLast('.', "")` in a nullable safe way. This of course could simply hide the crash and move it elsewhere, or maybe not: I've tested directly replacing: 
```kotlin
    mediaModel.fileName = mediaDetails.file
    mediaModel.fileExtension = mediaDetails.file.substringAfterLast('.', "")
```
with 
```kotlin
    mediaModel.fileName = null
    mediaModel.fileExtension = null
```

and checked how the app would behave for the cases where `file` is null in the API response. I was expecting it would crash or fail when using the media library to add products, but turns out everything worked as expected. 

Since the problem seems to be in the media library API response we can add this fix which is a non-breaking change and see if the issue is resolved. 


### Test

Since the crash in the Woo app is not reproducible there's not much to test. This is a non breaking change so it should be safe anyway



