### PR TITLE
Parse auto-share message and ID in PostModel metadata

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostImmutableModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostImmutableModel.kt
@@ -48,6 +48,8 @@ interface PostImmutableModel {
     val hasCapabilityEditPost: Boolean
     val hasCapabilityDeletePost: Boolean
     val dateLocallyChanged: String
+    val autoShareMessage: String
+    val autoShareId: Long
 
     fun hasFeaturedImage(): Boolean
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -541,11 +541,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     @Override
     @NonNull
     public String getAutoShareMessage() {
-        if (mAutoShareMessage == null) {
-            return "";
-        } else {
-            return mAutoShareMessage;
-        }
+        return StringUtils.notNullStr(mAutoShareMessage);
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -98,6 +98,10 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
 
     @Column private int mAnsweredPromptId;
 
+    // Auto-share message
+    @Column private String mAutoShareMessage;
+    @Column private long mAutoShareId;
+
     public PostModel() {}
 
     @Override
@@ -528,6 +532,22 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
 
     public void setAnsweredPromptId(int answeredPromptId) {
         mAnsweredPromptId = answeredPromptId;
+    }
+
+    public void setAutoShareMessage(String autoShareMessage) {
+        mAutoShareMessage = autoShareMessage;
+    }
+
+    public String getAutoShareMessage() {
+        return mAutoShareMessage;
+    }
+
+    public long getAutoShareId() {
+        return mAutoShareId;
+    }
+
+    public void setAutoShareId(long autoShareId) {
+        mAutoShareId = autoShareId;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -538,10 +538,17 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         mAutoShareMessage = autoShareMessage;
     }
 
+    @Override
+    @NonNull
     public String getAutoShareMessage() {
-        return mAutoShareMessage;
+        if (mAutoShareMessage == null) {
+            return "";
+        } else {
+            return mAutoShareMessage;
+        }
     }
 
+    @Override
     public long getAutoShareId() {
         return mAutoShareId;
     }
@@ -587,7 +594,9 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
                 && StringUtils.equals(getAuthorDisplayName(), otherPost.getAuthorDisplayName())
                 && StringUtils.equals(getDateLocallyChanged(), otherPost.getDateLocallyChanged())
                 && StringUtils.equals(getAutoSaveModified(), otherPost.getAutoSaveModified())
-                && StringUtils.equals(getAutoSavePreviewUrl(), otherPost.getAutoSavePreviewUrl());
+                && StringUtils.equals(getAutoSavePreviewUrl(), otherPost.getAutoSavePreviewUrl())
+                && StringUtils.equals(getAutoShareMessage(), otherPost.getAutoShareMessage())
+                && getAutoShareId() == otherPost.getAutoShareId();
     }
 
     /**
@@ -630,6 +639,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         result = 31 * result + (mIsPage ? 1 : 0);
         result = 31 * result + (int) (mParentId ^ (mParentId >>> 32));
         result = 31 * result + (mParentTitle != null ? mParentTitle.hashCode() : 0);
+        result = 31 * result + (mAutoShareMessage != null ? mAutoShareMessage.hashCode() : 0);
         return result;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -542,6 +542,17 @@ public class PostRestClient extends BaseWPComRestClient {
                             post.setAnsweredPromptId(Integer.parseInt(metaDataValue.toString()));
                         }
                     }
+
+                    if (key.equals("_wpas_mess")) {
+                        final Object metaDataValue = metaData.getValue();
+                        if (metaDataValue instanceof String) {
+                            post.setAutoShareMessage(metaDataValue.toString());
+                        }
+                        final long metaDataId = metaData.getId();
+                        if (metaDataId > 0) {
+                            post.setAutoShareId(metaDataId);
+                        }
+                    }
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -702,7 +702,7 @@ public class PostRestClient extends BaseWPComRestClient {
             Map<String, Object> autoShareMessageParams = new HashMap<>();
             autoShareMessageParams.put("key", "_wpas_mess");
             autoShareMessageParams.put("value", post.getAutoShareMessage());
-            if (post.getAutoShareId() >= 0) {
+            if (post.getAutoShareId() > 0) {
                 autoShareMessageParams.put("id", post.getAutoShareId());
             }
             metadata.add(autoShareMessageParams);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -698,6 +698,16 @@ public class PostRestClient extends BaseWPComRestClient {
             }
         }
 
+        if (post.getAutoShareMessage().length() > 0) {
+            Map<String, Object> autoShareMessageParams = new HashMap<>();
+            autoShareMessageParams.put("key", "_wpas_mess");
+            autoShareMessageParams.put("value", post.getAutoShareMessage());
+            if (post.getAutoShareId() >= 0) {
+                autoShareMessageParams.put("id", post.getAutoShareId());
+            }
+            metadata.add(autoShareMessageParams);
+        }
+
         if (!metadata.isEmpty()) {
             params.put("metadata", metadata);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -36,7 +36,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 190
+        return 191
     }
 
     override fun getDbName(): String {
@@ -1953,6 +1953,10 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 189 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD PLAN_ACTIVE_FEATURES TEXT")
+                }
+                190 -> migrate(version) {
+                    db.execSQL("ALTER TABLE PostModel ADD AUTO_SHARE_MESSAGE TEXT")
+                    db.execSQL("ALTER TABLE PostModel ADD AUTO_SHARE_ID INTEGER")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -2128,13 +2128,6 @@ open class SiteStore @Inject constructor(
             }
         }
 
-    suspend fun getJetpackSocial(siteLocalId: Int): JetpackSocial {
-        val entity = jetpackSocialDao.getJetpackSocial(siteLocalId)
-        return jetpackSocialMapper.mapDomain(entity)
-    }
-
-
-
     suspend fun deleteApplicationPassword(site: SiteModel): OnApplicationPasswordDeleted =
         coroutineEngine.withDefaultContext(T.API, this, "Delete Application Password") {
             when (val result = applicationPasswordsManagerProvider.get().deleteApplicationCredentials(site)) {


### PR DESCRIPTION
Parses auto-share message and ID in `PostModel` metadata.

WordPress-Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18790