### PR TITLE
Feature/jetpack ai update endpoint

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/JetpackAIFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/JetpackAIFragment.kt
@@ -10,7 +10,8 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_jetpackai.*
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsResponse.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsResponse.Success
 import org.wordpress.android.fluxc.store.jetpackai.JetpackAIStore
 import javax.inject.Inject
 
@@ -31,17 +32,17 @@ class JetpackAIFragment : StoreSelectingFragment() {
         generate_haiku.setOnClickListener {
             selectedSite?.let {
                 lifecycleScope.launch {
-                    val result = store.fetchJetpackAICompletionsForSite(
+                    val result = store.fetchJetpackAICompletions(
                         site = it,
                         prompt = "Please make me a haiku",
-                        skipCache = true
+                        feature = "fluxc-example"
                     )
 
                     when (result) {
-                        is JetpackAIRestClient.JetpackAICompletionsResponse.Success -> {
+                        is Success -> {
                             prependToLog("Haiku:\n${result.completion}")
                         }
-                        is JetpackAIRestClient.JetpackAICompletionsResponse.Error -> {
+                        is Error -> {
                             prependToLog("Error fetching haiku: ${result.message}")
                         }
                     }

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -40,6 +40,9 @@
 
 /sites/$site/jetpack-ai/completions
 
+/sites/$site/jetpack-openai-query/jwt
+/text-completion
+
 /sites/$site/jetpack-social
 
 /users/username/suggestions/

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
@@ -48,15 +48,15 @@ class JetpackAIRestClient @Inject constructor(
     }
 
     suspend fun fetchJetpackAITextCompletion(
-        prompt: String,
         token: String,
+        prompt: String,
         feature: String
     ): JetpackAICompletionsResponse {
         val url = WPCOMV2.text_completion.url
         val body = mutableMapOf<String, Any>()
         body.apply {
-            put("prompt", prompt)
             put("token", token)
+            put("prompt", prompt)
             put("feature", feature)
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
@@ -53,7 +53,7 @@ class JetpackAIRestClient @Inject constructor(
         feature: String
     ): JetpackAICompletionsResponse {
         val url = WPCOMV2.text_completion.url
-        val body = mutableMapOf<String, Any>()
+        val body = mutableMapOf<String, String>()
         body.apply {
             put("token", token)
             put("prompt", prompt)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.jetpackai
 
 import android.content.Context
 import com.android.volley.RequestQueue
+import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
 import org.wordpress.android.fluxc.model.SiteModel
@@ -25,6 +26,27 @@ class JetpackAIRestClient @Inject constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchJetpackAIJWTToken(
+        siteId: Long
+    ) : JetpackAIJWTTokenResponse {
+        val url = WPCOMV2.sites.site(siteId).jetpack_openai_query.jwt.url
+        val response = wpComGsonRequestBuilder.syncPostRequest(
+            restClient = this,
+            url = url,
+            params = null,
+            body = null,
+            clazz = JetpackAIJWTTokenDto::class.java,
+        )
+
+        return when (response) {
+            is Response.Success -> JetpackAIJWTTokenResponse.Success(response.data.token)
+            is Response.Error -> JetpackAIJWTTokenResponse.Error(
+                response.error.toJetpackAICompletionsError(),
+                response.error.message
+            )
+        }
+    }
+
     /**
      * Fetches Jetpack AI completions for a given prompt.
      *
@@ -67,6 +89,19 @@ class JetpackAIRestClient @Inject constructor(
                 response.error.message
             )
         }
+    }
+
+    internal class data class JetpackAIJWTTokenDto(
+        @SerializedName ("success") val success: Boolean,
+        @SerializedName("token") val token: String
+    )
+
+    sealed class JetpackAIJWTTokenResponse {
+        data class Success(val token: String) : JetpackAIJWTTokenResponse()
+        data class Error(
+            val type: JetpackAICompletionsErrorType,
+            val message: String? = null
+        ) : JetpackAIJWTTokenResponse()
     }
 
     sealed class JetpackAICompletionsResponse {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/jetpackai/JetpackAIStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/jetpackai/JetpackAIStore.kt
@@ -2,8 +2,13 @@ package org.wordpress.android.fluxc.store.jetpackai
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsErrorType.AUTH_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAIJWTTokenResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAIJWTTokenResponse.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAIJWTTokenResponse.Success
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.PreferenceUtils.PreferenceUtilsWrapper
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -11,8 +16,12 @@ import javax.inject.Singleton
 @Singleton
 class JetpackAIStore @Inject constructor(
     private val jetpackAIRestClient: JetpackAIRestClient,
-    private val coroutineEngine: CoroutineEngine
+    private val coroutineEngine: CoroutineEngine,
+    private val preferenceUtils: PreferenceUtilsWrapper
 ) {
+    companion object {
+        const val JETPACK_AI_JWT_TOKEN_KEY = "JETPACK_AI_JWT_TOKEN_KEY"
+    }
     /**
      * Fetches Jetpack AI completions for a given prompt to be used on a particular post.
      *
@@ -60,12 +69,65 @@ class JetpackAIStore @Inject constructor(
         jetpackAIRestClient.fetchJetpackAICompletions(site, prompt, feature, skipCache, postId)
     }
 
-     private suspend fun fetchJetpackAIJWTToken(siteId: Long)
+    suspend fun fetchJetpackAICompletions(
+        site: SiteModel,
+        prompt: String,
+        feature: String
+    ): JetpackAICompletionsResponse = coroutineEngine.withDefaultContext(
+        tag = AppLog.T.API,
+        caller = this,
+        loggedMessage = "fetch Jetpack AI completions"
+    ) {
+        val token = preferenceUtils.getFluxCPreferences().getString(JETPACK_AI_JWT_TOKEN_KEY, null)
+
+        val result = if (token != null) {
+            jetpackAIRestClient.fetchJetpackAITextCompletion(token, prompt, feature)
+        } else {
+            handleJetpackAIJWTTokenResponse(fetchJetpackAIJWTToken(site), prompt, feature)
+        }
+
+        return@withDefaultContext when {
+            // Fetch token anew if using existing token returns AUTH_ERROR
+            result is JetpackAICompletionsResponse.Error && result.type == AUTH_ERROR ->
+                handleJetpackAIJWTTokenResponse(fetchJetpackAIJWTToken(site), prompt, feature)
+
+            else -> result
+        }
+    }
+
+    private suspend fun handleJetpackAIJWTTokenResponse(
+        jwtTokenResponse: JetpackAIJWTTokenResponse,
+        prompt: String,
+        feature: String
+    ): JetpackAICompletionsResponse {
+        return when (jwtTokenResponse) {
+            is Error -> {
+                JetpackAICompletionsResponse.Error(
+                    type = AUTH_ERROR,
+                    message = jwtTokenResponse.message,
+                )
+            }
+
+            is Success -> {
+                preferenceUtils.getFluxCPreferences().edit().putString(
+                    JETPACK_AI_JWT_TOKEN_KEY, jwtTokenResponse.token
+                ).apply()
+
+                jetpackAIRestClient.fetchJetpackAITextCompletion(
+                    jwtTokenResponse.token,
+                    prompt,
+                    feature
+                )
+            }
+        }
+    }
+
+     private suspend fun fetchJetpackAIJWTToken(site: SiteModel)
      : JetpackAIJWTTokenResponse = coroutineEngine.withDefaultContext(
         tag = AppLog.T.API,
         caller = this,
         loggedMessage = "fetch Jetpack AI JWT token"
     ) {
-        jetpackAIRestClient.fetchJetpackAIJWTToken(siteId)
+        jetpackAIRestClient.fetchJetpackAIJWTToken(site)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/jetpackai/JetpackAIStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/jetpackai/JetpackAIStore.kt
@@ -83,19 +83,22 @@ class JetpackAIStore @Inject constructor(
         val result = if (token != null) {
             jetpackAIRestClient.fetchJetpackAITextCompletion(token, prompt, feature)
         } else {
-            handleJetpackAIJWTTokenResponse(fetchJetpackAIJWTToken(site), prompt, feature)
+            val jwtTokenResponse = fetchJetpackAIJWTToken(site)
+            fetchCompletionsWithToken(jwtTokenResponse, prompt, feature)
         }
 
         return@withDefaultContext when {
             // Fetch token anew if using existing token returns AUTH_ERROR
-            result is JetpackAICompletionsResponse.Error && result.type == AUTH_ERROR ->
-                handleJetpackAIJWTTokenResponse(fetchJetpackAIJWTToken(site), prompt, feature)
+            result is JetpackAICompletionsResponse.Error && result.type == AUTH_ERROR -> {
+                val jwtTokenResponse = fetchJetpackAIJWTToken(site)
+                fetchCompletionsWithToken(jwtTokenResponse, prompt, feature)
+            }
 
             else -> result
         }
     }
 
-    private suspend fun handleJetpackAIJWTTokenResponse(
+    private suspend fun fetchCompletionsWithToken(
         jwtTokenResponse: JetpackAIJWTTokenResponse,
         prompt: String,
         feature: String

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/jetpackai/JetpackAIStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/jetpackai/JetpackAIStore.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.store.jetpackai
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAIJWTTokenResponse
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
@@ -57,5 +58,14 @@ class JetpackAIStore @Inject constructor(
         loggedMessage = "fetch Jetpack AI completions"
     ) {
         jetpackAIRestClient.fetchJetpackAICompletions(site, prompt, feature, skipCache, postId)
+    }
+
+     private suspend fun fetchJetpackAIJWTToken(siteId: Long)
+     : JetpackAIJWTTokenResponse = coroutineEngine.withDefaultContext(
+        tag = AppLog.T.API,
+        caller = this,
+        loggedMessage = "fetch Jetpack AI JWT token"
+    ) {
+        jetpackAIRestClient.fetchJetpackAIJWTToken(siteId)
     }
 }


### PR DESCRIPTION
This implements new endpoint as outlined in pe5sF9-1Il-p2

Part of: https://github.com/woocommerce/woocommerce-android/issues/9425

### Description
This PR updates the text completion to use the WPCom `text-completion` endpoint. As part of this, some changes are added (the endpoint now requires `feature` value, and no longer require site ID). The new endpoint also does not have the `skipCache` parameter, but it seems like it always fetches fresh and so should not be a problem.

The use of this endpoint requires a valid JWT token, which has to be fetched first. The token is valid for a few minutes, so it's saved in FluxC's shared preferences to be re-used. If during re-use it doesn't work, then FluxC will attempt to fetch once and use the fresh token.


### Design decisions
1. FluxC will handle the token fetching, persisting, and checking.
2. FluxC will only attempt to fetch token once, or pass error. This applies both for the case whether a token already exists or not.
3. FluxC does not format the resulting completion from the endpoint. Sometimes the resulting string can have elements like the `\n` endline character. The client is responsible for handling these if needed.
4. This PR does not delete functions related to the previously used endpoints. This is in case the store functions are also used in JP/WP apps. Some research will need to be done if they're actually used, and if not, they can be deleted safely in a separate PR.

### Testing
1. Run Example app, login to a WordPress.com account, then go to "Jetpack AI".
2. Select a WordPress.com site, then click "Generate Haiku". Make sure it works and returns value as shown in the console area.
3. Try again quickly and make sure it generates something different (to show that it's not cached).