### PR TITLE
Add: "_fields" parameter for text completion API call.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
@@ -26,6 +26,10 @@ class JetpackAIRestClient @Inject constructor(
     accessToken: AccessToken,
     userAgent: UserAgent
 ) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    companion object {
+        private const val FIELDS_TO_REQUEST = "completion"
+    }
+
     suspend fun fetchJetpackAIJWTToken(
         site: SiteModel
     ) : JetpackAIJWTTokenResponse {
@@ -58,6 +62,7 @@ class JetpackAIRestClient @Inject constructor(
             put("token", token)
             put("prompt", prompt)
             put("feature", feature)
+            put("_fields", FIELDS_TO_REQUEST)
         }
 
         val response = wpComGsonRequestBuilder.syncPostRequest(


### PR DESCRIPTION
The `text-completion` API call returns a bit more data than needed. With this change, we request only to get the "completion" field, to reduce the amount of data being transferred.

### To test:
1. Start example app, login to a WPCom account with a WPCom Woo site.
2. Go to Jetpack AI -> Select a site -> tap "Generate Haiku". Ensure that it still works and return value properly.