### PR TITLE
Fix too many sql variables crash in deleteItemsFromLists()

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
@@ -5,6 +5,7 @@ import com.wellsql.generated.ListModelTable
 import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.list.ListItemModel
+import org.wordpress.android.fluxc.persistence.WellSqlConfig.Companion.SQLITE_MAX_VARIABLE_NUMBER
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -73,11 +74,14 @@ class ListItemSqlUtils @Inject constructor() {
             return
         }
 
-        WellSql.delete(ListItemModel::class.java)
+        val batches = listIds.chunked(SQLITE_MAX_VARIABLE_NUMBER - remoteItemIds.count())
+        batches.forEach {
+            WellSql.delete(ListItemModel::class.java)
                 .where()
-                .isIn(ListItemModelTable.LIST_ID, listIds)
+                .isIn(ListItemModelTable.LIST_ID, it)
                 .isIn(ListItemModelTable.REMOTE_ITEM_ID, remoteItemIds)
                 .endWhere()
                 .execute()
+        }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/UploadSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/UploadSqlUtils.java
@@ -24,6 +24,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.wordpress.android.fluxc.persistence.WellSqlConfig.SQLITE_MAX_VARIABLE_NUMBER;
+
 public class UploadSqlUtils {
     public static int insertOrUpdateMedia(MediaUploadModel media) {
         if (media == null) return 0;
@@ -169,11 +171,8 @@ public class UploadSqlUtils {
     }
 
     public static @NonNull List<PostModel> getPostModelsForPostUploadModels(List<PostUploadModel> postUploadModels) {
-        // The maximum value of a host parameter number is SQLITE_MAX_VARIABLE_NUMBER, which defaults to 999 for
-        // SQLite versions prior to 3.32.0 (2020-05-22) or 32766 for SQLite versions after 3.32.0.
-        // @see https://www.sqlite.org/limits.html
         if (postUploadModels.size() > 0) {
-            List<List<PostUploadModel>> batches = getBatches(postUploadModels, 999);
+            List<List<PostUploadModel>> batches = getBatches(postUploadModels, SQLITE_MAX_VARIABLE_NUMBER);
             List<PostModel> postModelList = new ArrayList<>();
 
             for (List<PostUploadModel> batch : batches) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -23,6 +23,11 @@ import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
 open class WellSqlConfig : DefaultWellConfig {
     companion object {
         const val ADDON_WOOCOMMERCE = "WC"
+
+        // The maximum value of a host parameter number is SQLITE_MAX_VARIABLE_NUMBER, which defaults to 999 for
+        // SQLite versions prior to 3.32.0 (2020-05-22) or 32766 for SQLite versions after 3.32.0.
+        // @see https://www.sqlite.org/limits.html
+        const val SQLITE_MAX_VARIABLE_NUMBER = 999
     }
 
     constructor(context: Context) : super(context)


### PR DESCRIPTION
Fixes #2781 
The maximum parameter limit is 999 in SQLite statements. `deleteItemsFromLists()` was crashing when it runs with parameters more than 999.
As a solution for the crash, I divided a single SQLite statement with too many lists into multiple statements. 
We could apply this solution to all SQLite statements, but it's not worth the effort. This is a rare case, and the problem will be resolved when we migrate to Room from WellSql.

**To test:**
 > **Note**
 > I added 2 reviewers, but 1 review is enough.
- A new test case, `testDeleteItemFromTooManyLists()` should be enough to verify this PR.
- To test on WPAndroid, use this PR for the FluxC version on WPAndroid and delete a post from "TRASHED" tab. That will call `deleteItemsFromLists()`.
<img src="https://github.com/wordpress-mobile/WordPress-FluxC-Android/assets/2471769/c0d8716d-1b50-47da-95f9-556aead3d7c9" width=320>
