### PR TITLE
Analytics Performance: Add access to revenue stats from range ID queries

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -1249,7 +1249,7 @@ class WCStatsStoreTest {
     @Test
     fun testFetchCurrentDayRevenueStatsDate() = runBlocking {
         val plus12SiteDate = SiteModel().apply { timezone = "12" }.let {
-            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
@@ -1260,7 +1260,7 @@ class WCStatsStoreTest {
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
             verify(mockOrderStatsRestClient).fetchRevenueStats(any(), any(),
-                    dateArgument.capture(), any(), any(), any())
+                    dateArgument.capture(), any(), any(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate
@@ -1269,7 +1269,7 @@ class WCStatsStoreTest {
         reset(mockOrderStatsRestClient)
 
         val minus12SiteDate = SiteModel().apply { timezone = "-12" }.let {
-            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
@@ -1280,7 +1280,7 @@ class WCStatsStoreTest {
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
             verify(mockOrderStatsRestClient).fetchRevenueStats(any(), any(), dateArgument.capture(), any(),
-                    any(), any())
+                    any(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate
@@ -1296,7 +1296,7 @@ class WCStatsStoreTest {
     @Test
     fun testFetchCurrentDayRevenueStatsDateSpecificEndDate() = runBlocking {
         val plus12SiteDate = SiteModel().apply { timezone = "12" }.let {
-            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val endDate = DateUtils.formatDate("yyyy-MM-dd", Date())
@@ -1309,7 +1309,7 @@ class WCStatsStoreTest {
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
             verify(mockOrderStatsRestClient).fetchRevenueStats(any(), any(),
-                    dateArgument.capture(), any(), any(), any())
+                    dateArgument.capture(), any(), any(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate
@@ -1318,7 +1318,7 @@ class WCStatsStoreTest {
         reset(mockOrderStatsRestClient)
 
         val minus12SiteDate = SiteModel().apply { timezone = "-12" }.let {
-            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any())
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
@@ -1329,7 +1329,7 @@ class WCStatsStoreTest {
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
             verify(mockOrderStatsRestClient).fetchRevenueStats(any(), any(), dateArgument.capture(), any(),
-                    any(), any())
+                    any(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate
@@ -1349,7 +1349,7 @@ class WCStatsStoreTest {
         val currentDayStatsModel = WCStatsTestUtils.generateSampleRevenueStatsModel()
         val site = SiteModel().apply { id = currentDayStatsModel.localSiteId }
         val currentDayGranularity = StatsGranularity.valueOf(currentDayStatsModel.interval.toUpperCase())
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(
                         FetchRevenueStatsResponsePayload(
                                 site,
@@ -1388,7 +1388,7 @@ class WCStatsStoreTest {
         val currentWeekPayload = FetchRevenueStatsResponsePayload(
                 site, curretnWeekGranularity, currentWeekStatsModel
         )
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(currentWeekPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(
@@ -1421,7 +1421,7 @@ class WCStatsStoreTest {
         val currentMonthPayload = FetchRevenueStatsResponsePayload(
                 site, currentMonthGranularity, currentMonthStatsModel
         )
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(currentMonthPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(
@@ -1454,7 +1454,7 @@ class WCStatsStoreTest {
         val allSiteCurrentDayPayload = FetchRevenueStatsResponsePayload(
                 site, allSiteCurrentDayGranularity, altSiteOrderStatsModel
         )
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(allSiteCurrentDayPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(
@@ -1484,7 +1484,7 @@ class WCStatsStoreTest {
         val nonExistentPayload = FetchRevenueStatsResponsePayload(
                 nonExistentSite, nonExistentSiteGranularity, altSiteOrderStatsModel
         )
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(nonExistentPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(
@@ -1509,7 +1509,7 @@ class WCStatsStoreTest {
         assertTrue(nonExistentOrderStats.isEmpty())
 
         // missing data
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(nonExistentPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -41,7 +41,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 190
+        return 191
     }
 
     override fun getDbName(): String {
@@ -1958,6 +1958,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 189 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD PLAN_ACTIVE_FEATURES TEXT")
+                }
+                190 -> migrate(version) {
+                    db.execSQL("ALTER TABLE WCRevenueStatsModel ADD RANGE_ID INTEGER")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1963,7 +1963,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE PostModel ADD AUTO_SHARE_MESSAGE TEXT")
                     db.execSQL("ALTER TABLE PostModel ADD AUTO_SHARE_ID INTEGER")
                 }
-                191 -> migrate(version) {
+                191 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCRevenueStatsModel ADD RANGE_ID INTEGER")
                 }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -20,6 +20,7 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
     @Column var endDate = "" // The end date of the data
     @Column var data = "" // JSON - A list of lists; each nested list contains the data for a time period
     @Column var total = "" // JSON - A map of total stats for a given time period
+    @Column var rangeId = 0 // A ID for easily fetch the Revenue Stats for a given start and end date
 
     companion object {
         private val gson by lazy { Gson() }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -172,7 +172,7 @@ class OrderStatsRestClient @Inject constructor(
         endDate: String,
         perPage: Int,
         forceRefresh: Boolean = false,
-        customRevenueId: Int = 0
+        revenueRangeId: Int = 0
     ): FetchRevenueStatsResponsePayload {
         val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
         val params = mapOf(
@@ -196,7 +196,7 @@ class OrderStatsRestClient @Inject constructor(
         return when (response) {
             is WPAPIResponse.Success -> {
                 response.data?.let {
-                        val model = WCRevenueStatsModel(id = customRevenueId).apply {
+                        val model = WCRevenueStatsModel(id = revenueRangeId).apply {
                             this.localSiteId = site.id
                             this.interval = granularity.toString()
                             this.data = it.intervals.toString()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -171,7 +171,8 @@ class OrderStatsRestClient @Inject constructor(
         startDate: String,
         endDate: String,
         perPage: Int,
-        forceRefresh: Boolean = false
+        forceRefresh: Boolean = false,
+        customRevenueId: Int = 0
     ): FetchRevenueStatsResponsePayload {
         val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
         val params = mapOf(
@@ -195,7 +196,7 @@ class OrderStatsRestClient @Inject constructor(
         return when (response) {
             is WPAPIResponse.Success -> {
                 response.data?.let {
-                        val model = WCRevenueStatsModel().apply {
+                        val model = WCRevenueStatsModel(id = customRevenueId).apply {
                             this.localSiteId = site.id
                             this.interval = granularity.toString()
                             this.data = it.intervals.toString()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -196,13 +196,14 @@ class OrderStatsRestClient @Inject constructor(
         return when (response) {
             is WPAPIResponse.Success -> {
                 response.data?.let {
-                        val model = WCRevenueStatsModel(id = revenueRangeId).apply {
+                        val model = WCRevenueStatsModel().apply {
                             this.localSiteId = site.id
                             this.interval = granularity.toString()
                             this.data = it.intervals.toString()
                             this.total = it.totals.toString()
                             this.startDate = startDate
                             this.endDate = endDate
+                            this.rangeId = revenueRangeId
                         }
 
                     FetchRevenueStatsResponsePayload(site, granularity, model)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
@@ -156,14 +156,14 @@ object WCStatsSqlUtils {
                 .asModel.firstOrNull()
     }
 
-    fun getRevenueStatsForId(
+    fun getRevenueStatsFromRangeId(
         site: SiteModel,
         revenueRangeId: Int
     ) = WellSql.select(WCRevenueStatsModel::class.java)
         .where()
         .beginGroup()
         .equals(WCRevenueStatsModelTable.LOCAL_SITE_ID, site.id)
-        .equals(WCRevenueStatsModelTable.ID, revenueRangeId)
+        .equals(WCRevenueStatsModelTable.RANGE_ID, revenueRangeId)
         .endGroup().endWhere()
         .asModel.firstOrNull()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
@@ -155,4 +155,15 @@ object WCStatsSqlUtils {
                 .endGroup().endWhere()
                 .asModel.firstOrNull()
     }
+
+    fun getRevenueStatsForId(
+        site: SiteModel,
+        revenueRangeId: Int
+    ) = WellSql.select(WCRevenueStatsModel::class.java)
+        .where()
+        .beginGroup()
+        .equals(WCRevenueStatsModelTable.LOCAL_SITE_ID, site.id)
+        .equals(WCRevenueStatsModelTable.ID, revenueRangeId)
+        .endGroup().endWhere()
+        .asModel.firstOrNull()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
@@ -118,14 +118,7 @@ object WCStatsSqlUtils {
      * Methods to support the new v4 revenue stats api
      */
     fun insertOrUpdateRevenueStats(stats: WCRevenueStatsModel): Int {
-        val statsResult = WellSql.select(WCRevenueStatsModel::class.java)
-                .where().beginGroup()
-                .equals(WCRevenueStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
-                .equals(WCRevenueStatsModelTable.INTERVAL, stats.interval)
-                .equals(WCRevenueStatsModelTable.START_DATE, stats.startDate)
-                .equals(WCRevenueStatsModelTable.END_DATE, stats.endDate)
-                .endGroup().endWhere()
-                .asModel
+        val statsResult = searchMatchingRevenueStatsInDatabase(stats)
 
         return if (statsResult.isEmpty()) {
             // insert
@@ -136,6 +129,26 @@ object WCStatsSqlUtils {
             val oldId = statsResult[0].id
             WellSql.update(WCRevenueStatsModel::class.java).whereId(oldId)
                     .put(stats, UpdateAllExceptId(WCRevenueStatsModel::class.java)).execute()
+        }
+    }
+
+    private fun searchMatchingRevenueStatsInDatabase(stats: WCRevenueStatsModel): List<WCRevenueStatsModel> {
+        return if (stats.rangeId != 0) {
+            WellSql.select(WCRevenueStatsModel::class.java)
+                .where().beginGroup()
+                .equals(WCRevenueStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
+                .equals(WCRevenueStatsModelTable.RANGE_ID, stats.rangeId)
+                .endGroup().endWhere()
+                .asModel
+        } else {
+            WellSql.select(WCRevenueStatsModel::class.java)
+                .where().beginGroup()
+                .equals(WCRevenueStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
+                .equals(WCRevenueStatsModelTable.INTERVAL, stats.interval)
+                .equals(WCRevenueStatsModelTable.START_DATE, stats.startDate)
+                .equals(WCRevenueStatsModelTable.END_DATE, stats.endDate)
+                .endGroup().endWhere()
+                .asModel
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -827,8 +827,8 @@ class WCStatsStore @Inject constructor(
                 site, granularity, startDate, endDate)
     }
 
-    fun getRawRevenueStatsFromId(
+    fun getRawRevenueStatsFromRangeId(
         site: SiteModel,
         revenueRangeId: Int
-    ) = WCStatsSqlUtils.getRevenueStatsForId(site, revenueRangeId)
+    ) = WCStatsSqlUtils.getRevenueStatsFromRangeId(site, revenueRangeId)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -826,4 +826,9 @@ class WCStatsStore @Inject constructor(
         return WCStatsSqlUtils.getRevenueStatsForSiteIntervalAndDate(
                 site, granularity, startDate, endDate)
     }
+
+    fun getRawRevenueStatsFromId(
+        site: SiteModel,
+        revenueRangeId: Int
+    ) = WCStatsSqlUtils.getRevenueStatsForId(site, revenueRangeId)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -688,7 +688,8 @@ class WCStatsStore @Inject constructor(
                 startDate = startDate,
                 endDate = endDate,
                 perPage = getPerPageQuantityForRevenueStatsGranularity(payload.granularity),
-                forceRefresh = payload.forced
+                forceRefresh = payload.forced,
+                revenueRangeId = payload.revenueRangeId
             )
 
             with(result) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -139,7 +139,8 @@ class WCStatsStore @Inject constructor(
         val granularity: StatsGranularity,
         val startDate: String? = null,
         val endDate: String? = null,
-        val forced: Boolean = false
+        val forced: Boolean = false,
+        val revenueRangeId: Int = 0
     ) : Payload<BaseNetworkError>()
 
     class FetchRevenueStatsResponsePayload(


### PR DESCRIPTION
⚠️ This PR has breaking changes that are connected with https://github.com/woocommerce/woocommerce-android/pull/9453, do not merge it until everything is approved.

Summary
==========
Introduces an external way to define a Revenue Stats range through an ID, making sure that we can insert/update/select any Revenue stats data through a range ID when available.

How to Test
==========
1. I recommend testing the changes introduced here through https://github.com/woocommerce/woocommerce-android/pull/9453. Just make sure all unit tests are OK.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.