### PR TITLE
Check for orders enhancement

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -542,6 +542,17 @@ class WCOrderStore @Inject constructor(
         with(payload) { wcOrderRestClient.fetchOrderCount(site, statusFilter) }
     }
 
+    suspend fun hasOrders(site: SiteModel): HasOrdersResult {
+        return coroutineEngine.withDefaultContext(T.API, this, "checkIfHasOrders") {
+            val ordersCount = ordersDao.getOrderCountForSite(site.localId())
+            return@withDefaultContext if (ordersCount > 0) {
+                HasOrdersResult.Success(true)
+            } else {
+                fetchHasOrders(site, null)
+            }
+        }
+    }
+
     suspend fun fetchHasOrders(site: SiteModel, status: String?): HasOrdersResult {
         return coroutineEngine.withDefaultContext(T.API, this, "fetchHasOrders") {
             val result = wcOrderRestClient.fetchHasOrders(site, status)


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/9462

### Why
As part of the Reliability project, we are reducing the number of requests we make to the API.

### Description
This PR adds the new `hasOrders` function to the orders store. This new function first checks the existence of orders on the local database before sending the request to the API. If there is at least one order in the local database, we can assume that the store has orders, and we don't need to request this data from the API.

### Testing
It is better to test this PR using the [Woo PR](https://github.com/woocommerce/woocommerce-android/pull/9464)