### PR TITLE
Persist `was_ecommerce_trial` and `product_slug` for WPCom API endpoints `sites/<site_id>` and `/me/sites/`

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -87,7 +87,7 @@ class SiteRestClientTest {
                 mapOf(
                         "fields" to "ID,URL,name,description,jetpack,jetpack_connection," +
                                 "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
-                                "organization_id"
+                                "organization_id,was_ecommerce_trial"
                 )
         )
     }
@@ -136,7 +136,7 @@ class SiteRestClientTest {
                         "filters" to "wpcom",
                         "fields" to "ID,URL,name,description,jetpack,jetpack_connection," +
                                 "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
-                                "organization_id"
+                                "organization_id,was_ecommerce_trial"
                 )
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -254,6 +254,8 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     // Comma-separated list of active features in the site's plan
     @Column
     private String mPlanActiveFeatures;
+    @Column
+    private Boolean mWasEcommerceTrial;
 
     @Override
     public int getId() {
@@ -1078,6 +1080,14 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setCanBlaze(Boolean mCanBlaze) {
         this.mCanBlaze = mCanBlaze;
+    }
+
+    public Boolean getWasEcommerceTrial() {
+        return mWasEcommerceTrial;
+    }
+
+    public void setWasEcommerceTrial(Boolean wasEcommerceTrial) {
+        this.mWasEcommerceTrial = wasEcommerceTrial;
     }
 
     public boolean isHostedAtWPCom() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -151,6 +151,8 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column
     private String mPlanShortName;
     @Column
+    private String mPlanProductSlug;
+    @Column
     private String mIconUrl;
     @Column
     private boolean mHasFreePlan;
@@ -646,6 +648,14 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setPlanShortName(String planShortName) {
         mPlanShortName = planShortName;
+    }
+
+    public String getPlanProductSlug() {
+        return mPlanProductSlug;
+    }
+
+    public void setPlanProductSlug(String planProductSlug) {
+        mPlanProductSlug = planProductSlug;
     }
 
     public long getPlanId() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1097,7 +1097,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     }
 
     public void setWasEcommerceTrial(Boolean wasEcommerceTrial) {
-        this.mWasEcommerceTrial = wasEcommerceTrial;
+        mWasEcommerceTrial = wasEcommerceTrial;
     }
 
     public boolean isHostedAtWPCom() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1150,6 +1150,7 @@ class SiteRestClient @Inject constructor(
         }
         site.origin = SiteModel.ORIGIN_WPCOM_REST
         site.planActiveFeatures = (from.plan?.features?.active?.joinToString(",")).orEmpty()
+        site.wasEcommerceTrial = from.was_ecommerce_trial
         return site
     }
 
@@ -1211,7 +1212,8 @@ class SiteRestClient @Inject constructor(
     companion object {
         private const val NEW_SITE_TIMEOUT_MS = 90000
         private const val SITE_FIELDS = "ID,URL,name,description,jetpack,jetpack_connection,visible,is_private," +
-                "options,plan,capabilities,quota,icon,meta,zendesk_site_meta,organization_id"
+                "options,plan,capabilities,quota,icon,meta,zendesk_site_meta,organization_id," +
+                "was_ecommerce_trial"
         private const val FIELDS = "fields"
         private const val FILTERS = "filters"
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1103,6 +1103,7 @@ class SiteRestClient @Inject constructor(
                 }
             }
             site.planShortName = from.plan.product_name_short
+            site.planProductSlug = from.plan.product_slug
             site.hasFreePlan = from.plan.is_free
         }
         if (from.capabilities != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -44,6 +44,7 @@ public class SiteWPComRestResponse implements Response {
     public static class Plan {
         public String product_id;
         public String product_name_short;
+        public String product_slug;
         public boolean is_free;
         @Nullable public Features features;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -123,4 +123,5 @@ public class SiteWPComRestResponse implements Response {
     public Meta meta;
     public Quota quota;
     public ZendeskSiteMeta zendesk_site_meta;
+    public boolean was_ecommerce_trial;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -41,7 +41,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 192
+        return 193
     }
 
     override fun getDbName(): String {
@@ -1965,6 +1965,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 191 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCRevenueStatsModel ADD RANGE_ID INTEGER")
+                }
+                192 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD WAS_ECOMMERCE_TRIAL BOOLEAN")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1968,6 +1968,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 192 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD WAS_ECOMMERCE_TRIAL BOOLEAN")
+                    db.execSQL("ALTER TABLE SiteModel ADD PLAN_PRODUCT_SLUG TEXT")
                 }
             }
         }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-android/issues/9513

The purpose for this PR is to also persist `was_ecommerce_trial` and `product_slug` values in the SiteModel db table. These values are returned by API calls to WPCom's `sites/<site_id>` and `/me/sites/`. 

These will be used for analytics tracking for the WooCommerce app.

For testing, this will be ideally tested with the accompanying WooCommerce Android PR (coming soon).

For now, it's also possible to test by:
1. Start Example app,
2. "Sign in & Fetch Sites" to a WPCom account and make sure it doesn't crash.
3. Go to "Sites" > "Fetch All Sites" and make sure it doesn't crash.
4. In Android Studio, check "App Inspection" panel > "Database Inspector". Select "SiteModel" table and make sure it contains both "PLAN_PRODUCT_SLUG" and "WAS_ECOMMERCE_TRIAL" fields.