### PR TITLE
Fix NPE NonceRestClient crash

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
@@ -67,7 +67,7 @@ class NonceRestClientTest {
 
         val actual = subject.requestNonce(site)
 
-        TestCase.assertEquals(Nonce.Available(expectedNonce, site.username), actual)
+        TestCase.assertEquals(Nonce.Available(expectedNonce, site.username!!), actual)
     }
 
     @Test
@@ -152,7 +152,7 @@ class NonceRestClientTest {
         givenLoginResponse(WPAPIResponse.Error(baseNetworkError))
 
         val actual = subject.requestNonce(site)
-        TestCase.assertEquals(Nonce.Unknown(site.username), actual)
+        TestCase.assertEquals(Nonce.Unknown(site.username!!), actual)
     }
 
     @Test
@@ -212,7 +212,7 @@ class NonceRestClientTest {
 
     private suspend fun givenLoginResponse(response: WPAPIResponse<String>) {
         val body = mapOf(
-            "log" to site.username,
+            "log" to site.username!!,
             "pwd" to site.password,
             "redirect_to" to nonceRequestUrl
         )

--- a/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/ReactNativeStoreWPAPITest.kt
@@ -89,7 +89,7 @@ class ReactNativeStoreWPAPITest {
                 .thenReturn(restUrl)
 
         // retrieves nonce
-        val nonce = Available("a_nonce", site.username)
+        val nonce = Available("a_nonce", site.username!!)
         whenever(nonceRestClient.requestNonce(site))
                 .thenReturn(nonce)
 
@@ -121,7 +121,7 @@ class ReactNativeStoreWPAPITest {
             .thenReturn(restUrl)
 
         // retrieves nonce
-        val nonce = Available("a_nonce", site.username)
+        val nonce = Available("a_nonce", site.username!!)
         whenever(nonceRestClient.requestNonce(site))
             .thenReturn(nonce)
 
@@ -296,7 +296,7 @@ class ReactNativeStoreWPAPITest {
     fun `refreshed nonce leads to unauthorized error, so returns error`() = test {
         // nonce never requested, so retrieves nonce
         initStore(null)
-        val nonce = Available("a_nonce", site.username)
+        val nonce = Available("a_nonce", site.username!!)
         whenever(nonceRestClient.getNonce(site))
                 .thenReturn(nonce)
 
@@ -316,7 +316,7 @@ class ReactNativeStoreWPAPITest {
 
     @Test
     fun `reusing saved nonce leads to unauthorized error, updates nonce but nonce is same, so returns error`() = test {
-        val savedNonce = Available("saved_nonce", site.username)
+        val savedNonce = Available("saved_nonce", site.username!!)
         initStore(savedNonce)
 
         // initial fetch uses saved nonce and fails with unauthorized
@@ -339,7 +339,7 @@ class ReactNativeStoreWPAPITest {
 
     @Test
     fun `reusing saved nonce leads to unauthorized error, successfully updates nonce, so tries call again`() = test {
-        val savedNonce = Available("saved_nonce", site.username)
+        val savedNonce = Available("saved_nonce", site.username!!)
         initStore(savedNonce)
 
         // initial fetch uses saved nonce and fails with unauthorized
@@ -349,7 +349,7 @@ class ReactNativeStoreWPAPITest {
                 .thenReturn(initialResponseWithUnauthorizedError)
 
         // fetches new nonce successfully
-        val updatedNonce = Available("updated_nonce", site.username)
+        val updatedNonce = Available("updated_nonce", site.username!!)
         whenever(nonceRestClient.requestNonce(site))
                 .thenReturn(updatedNonce)
 
@@ -370,7 +370,7 @@ class ReactNativeStoreWPAPITest {
 
     @Test
     fun `reusing saved nonce leads to unauthorized error, fails to update nonce, so returns original error`() = test {
-        val savedNonce = Available("saved_nonce", site.username)
+        val savedNonce = Available("saved_nonce", site.username!!)
         initStore(savedNonce)
 
         // initial fetch uses saved nonce and fails with unauthorized
@@ -396,7 +396,7 @@ class ReactNativeStoreWPAPITest {
         // previous nonce faield, and was "recent"
         val fourMinuteOldFailedNonceRequest = FailedRequest(
             currentTime - 4 * 60 * 1000,
-            site.username,
+            site.username!!,
             Nonce.CookieNonceErrorType.GENERIC_ERROR
         )
         initStore(fourMinuteOldFailedNonceRequest)
@@ -418,13 +418,13 @@ class ReactNativeStoreWPAPITest {
         // previous nonce request failed, but was not "recent"
         val sixMinuteOldUnavailableNonce = FailedRequest(
             currentTime - 6 * 60 * 1000,
-            site.username,
+            site.username!!,
             Nonce.CookieNonceErrorType.GENERIC_ERROR
         )
         initStore(sixMinuteOldUnavailableNonce)
 
         // refreshes nonce because latest attempt to refresh nonce was not recent
-        val nonce = Available("a_nonce", site.username)
+        val nonce = Available("a_nonce", site.username!!)
         whenever(nonceRestClient.requestNonce(site))
                 .thenReturn(nonce)
 
@@ -444,10 +444,10 @@ class ReactNativeStoreWPAPITest {
     @Test
     fun `nonce unknown, so requests nonce`() = test {
         // previous nonce request unknown
-        initStore(Unknown(site.username))
+        initStore(Unknown(site.username!!))
 
         // refreshes nonce because latest attempt to refresh nonce was not recent
-        val nonce = Available("a_nonce", site.username)
+        val nonce = Available("a_nonce", site.username!!)
         whenever(nonceRestClient.requestNonce(site))
                 .thenReturn(nonce)
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.model;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
@@ -96,7 +97,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     // The siteId for self hosted sites. Jetpack sites will also have a mSiteId, which is their id on wpcom
     @Column
     private long mSelfHostedSiteId;
-    @Column
+    @Nullable @Column
     private String mUsername;
     @Column
     private String mPassword;
@@ -334,11 +335,11 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mIsWPCom = wpCom;
     }
 
-    public String getUsername() {
+    @Nullable public String getUsername() {
         return mUsername;
     }
 
-    public void setUsername(String username) {
+    public void setUsername(@Nullable String username) {
         mUsername = username;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -36,8 +36,8 @@ class NonceRestClient @Inject constructor(
      *  [rest-nonce endpoint](https://developer.wordpress.org/reference/functions/wp_ajax_rest_nonce/)
      *  that became available in WordPress 5.3.
      */
-    suspend fun requestNonce(site: SiteModel): Nonce {
-        return requestNonce(site.url, site.username, site.password)
+    suspend fun requestNonce(site: SiteModel) = site.username?.let { username ->
+        requestNonce(site.url, username, site.password)
     }
 
     /**


### PR DESCRIPTION
This fixes a NullPointerException because the `username` field is nullable in the model table for `SiteModel`, and it is accessed as a platform type from Kotlin code. The fix uses the `@Nullable` annotation, and follows up by making the dependent `Nonce` return type optional.

Note: other fields in this (as well as other) models are also left unannotated, even when they are nullable. These are not addressed here to limit the scope of this fix to this single crash (which is currently our [most impactful NPE](https://github.com/wordpress-mobile/WordPress-Android/issues/18623)).