### PR TITLE
[JP Social/New Post] Add the for=mobile query param on post creation

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -348,6 +348,7 @@ public class PostRestClient extends BaseWPComRestClient {
         );
 
         request.addQueryParameter("context", "edit");
+        if (post.isLocalDraft()) request.addQueryParameter("for", "mobile");
 
         request.disableRetries();
         add(request);


### PR DESCRIPTION
This new param identifies that the post is being created from the mobile apps in order to make sure it properly updates the metadata for JP social sharing and only shares the post to social networks selected by the user (sent as metadata in the post creation request).

Testing can be done using the version from PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18920

Ref: p1691410760076329/1691399612.659809-slack-C05362VSXFU