### PR TITLE
Disable connected tests

### DIFF
--- a/.buildkite/connected-tests.sh
+++ b/.buildkite/connected-tests.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Connected tests are disabled because of how unreliable they have been in Firebase.
+# We are looking into possibilities to run these tests on a separate machine, but it'll
+# be a while until that happens. We are also hoping to improve general flakiness of the
+# tests which also will take time.
+#
+# Instead of completely disabling this job, we'll only assemble the tests so that
+# we at least keep that module up to date.
+
 set -euo pipefail
 
 echo "--- :closed_lock_with_key: Installing Secrets"
@@ -9,33 +17,33 @@ cp gradle.properties-example gradle.properties
 echo -e "\n--- :open_file_folder: Merge Properties Files"
 ./gradlew :example:combineTestsPropertiesWithExtraTestsProperties
 
-echo -e "\n--- :gcloud: Logging into Google Cloud"
-gcloud auth activate-service-account --key-file .configure-files/firebase.secrets.json
+# echo -e "\n--- :gcloud: Logging into Google Cloud"
+# gcloud auth activate-service-account --key-file .configure-files/firebase.secrets.json
 
 echo -e "\n--- :hammer_and_wrench: Building Tests"
 ./gradlew example:assembleDebug example:assembleDebugAndroidTest
 
-echo -e "\n--- :firebase: Run Tests"
-mkdir -p build/test-results
-gcloud firebase test android run \
-	--type "instrumentation" \
-	--app "example/build/outputs/apk/debug/example-debug.apk" \
-	--test "example/build/outputs/apk/androidTest/debug/example-debug-androidTest.apk" \
-	--timeout "60m" \
-	--device "model=Pixel3,version=30,locale=en,orientation=portrait" \
-	--project "api-project-108380595987" \
-	--verbosity info \
-	--no-record-video \
-	--results-history-name "fluxc-connected-tests" \
-	--test-targets "package org.wordpress.android.fluxc" \
-	|& tee build/test-results/firebase-test-log.txt || EXIT_CODE=$?
-
-echo -e "--- :gcloud: Download Test Results"
-TEST_BUCKET=$(cat build/test-results/firebase-test-log.txt | grep -o "gs://test\-lab\-.*/" | head -1)
-gsutil cp "$TEST_BUCKET**/test_result*.xml" build/test-results/connected-tests.xml
-
-echo -e "--- :buildkite: Upload Test Results to Test Analytics"
-upload_buildkite_test_analytics_junit build/test-results/connected-tests.xml $BUILDKITE_ANALYTICS_TOKEN_CONNECTED_TESTS
-
-echo -e "\n--- Emitting original exit code"
-exit ${EXIT_CODE:-0}
+# echo -e "\n--- :firebase: Run Tests"
+# mkdir -p build/test-results
+# gcloud firebase test android run \
+# 	--type "instrumentation" \
+# 	--app "example/build/outputs/apk/debug/example-debug.apk" \
+# 	--test "example/build/outputs/apk/androidTest/debug/example-debug-androidTest.apk" \
+# 	--timeout "60m" \
+# 	--device "model=Pixel3,version=30,locale=en,orientation=portrait" \
+# 	--project "api-project-108380595987" \
+# 	--verbosity info \
+# 	--no-record-video \
+# 	--results-history-name "fluxc-connected-tests" \
+# 	--test-targets "package org.wordpress.android.fluxc" \
+# 	|& tee build/test-results/firebase-test-log.txt || EXIT_CODE=$?
+#
+# echo -e "--- :gcloud: Download Test Results"
+# TEST_BUCKET=$(cat build/test-results/firebase-test-log.txt | grep -o "gs://test\-lab\-.*/" | head -1)
+# gsutil cp "$TEST_BUCKET**/test_result*.xml" build/test-results/connected-tests.xml
+#
+# echo -e "--- :buildkite: Upload Test Results to Test Analytics"
+# upload_buildkite_test_analytics_junit build/test-results/connected-tests.xml $BUILDKITE_ANALYTICS_TOKEN_CONNECTED_TESTS
+#
+# echo -e "\n--- Emitting original exit code"
+# exit ${EXIT_CODE:-0}

--- a/.buildkite/connected-tests.sh
+++ b/.buildkite/connected-tests.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-# Connected tests are disabled because of how unreliable they have been in Firebase.
-# We are looking into possibilities to run these tests on a separate machine, but it'll
-# be a while until that happens. We are also hoping to improve general flakiness of the
-# tests which also will take time.
-#
-# Instead of completely disabling this job, we'll only assemble the tests so that
-# we at least keep that module up to date.
-
 set -euo pipefail
 
 echo "--- :closed_lock_with_key: Installing Secrets"
@@ -22,6 +14,18 @@ echo -e "\n--- :open_file_folder: Merge Properties Files"
 
 echo -e "\n--- :hammer_and_wrench: Building Tests"
 ./gradlew example:assembleDebug example:assembleDebugAndroidTest
+
+INFO_MESSAGE=$(cat <<-END
+Connected tests are disabled because of how unreliable they have been in Firebase.
+We are looking into possibilities to run these tests on a separate machine, but it'll
+be a while until that happens. We are also hoping to improve general flakiness of the
+tests which also will take time.
+
+Instead of completely disabling connected tests, we'll only assemble the module so that
+we can at least keep it up to date.
+END
+)
+buildkite-agent annotate "$INFO_MESSAGE" --style "info" --context "ctx-info"
 
 # echo -e "\n--- :firebase: Run Tests"
 # mkdir -p build/test-results

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -88,15 +88,14 @@ steps:
   ############################
   # Connected Tests
   ############################
-  - label: "🔬 Connected Tests"
+  - label: "🔬 Build Connected Tests"
     key: connected-tests
     command: .buildkite/connected-tests.sh
     artifact_paths: *artifact_paths
     plugins: *common_plugins
-    # The connected tests are currently failing. We want to keep running these tests to collect
-    # data about the failures. However, we don't want to publish the GitHub status to avoid confusion.
-    # That's why we don't have a `notify` block for this step.
-    # See: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2515
+    notify:
+      - github_commit_status:
+          context: "Publish :fluxc-build-connected-tests"
 
   ############################
   # Publish artefacts to S3

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPApiPluginTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WPApiPluginTest.kt
@@ -99,7 +99,7 @@ class ReleaseStack_WPApiPluginTest : ReleaseStack_Base() {
     ): SitePluginModel {
         pluginCoroutineStore.syncConfigureSitePlugin(site, plugin.name, plugin.slug, true)
 
-        val activatedPlugin = PluginSqlUtils.getSitePluginBySlug(site, plugin.slug)
+        val activatedPlugin = requireNotNull(PluginSqlUtils.getSitePluginBySlug(site, plugin.slug))
 
         assertTrue(activatedPlugin.isActive)
         return activatedPlugin
@@ -111,7 +111,7 @@ class ReleaseStack_WPApiPluginTest : ReleaseStack_Base() {
     ): SitePluginModel {
         pluginCoroutineStore.syncConfigureSitePlugin(site, plugin.name, plugin.slug, false)
 
-        val deactivatedPlugin = PluginSqlUtils.getSitePluginBySlug(site, plugin.slug)
+        val deactivatedPlugin = requireNotNull(PluginSqlUtils.getSitePluginBySlug(site, plugin.slug))
 
         assertFalse(deactivatedPlugin.isActive)
         return deactivatedPlugin
@@ -120,11 +120,11 @@ class ReleaseStack_WPApiPluginTest : ReleaseStack_Base() {
     private suspend fun installPlugin(
         site: SiteModel
     ): SitePluginModel {
-        val result = pluginCoroutineStore.syncInstallSitePlugin(site, pluginSlug)
+        val result = requireNotNull(pluginCoroutineStore.syncInstallSitePlugin(site, pluginSlug))
 
         assertFalse(result.isError)
 
-        val installedPlugin = PluginSqlUtils.getSitePluginBySlug(site, pluginSlug)
+        val installedPlugin = requireNotNull(PluginSqlUtils.getSitePluginBySlug(site, pluginSlug))
 
         assertNotNull(installedPlugin)
         assertTrue(installedPlugin.isActive)


### PR DESCRIPTION
Connected tests for this project have been been flaky for a very long time. Our previous attempts at solving this showed that this is _mostly_ related to Firebase and not the tests themselves - although their setup is not great either. In order to avoid blocking developers, in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2515 we disabled notifying GitHub when these tests failed.

Since then, the tests have been consistently failing, but we are not able to concretely use that data in any way at the moment. Furthermore, it turns out the build itself has started to fail recently and we didn't even realize it. The situation with these tests is a discussion that frequently comes up, and we have some ideas as to how we might get them working again - possibly using our own infrastructure instead of Firebase, however we are some time away from anything concrete.

I think it's time to completely disable these tests. This PR fully disables the Firebase integration, but still keeps a task to assemble the tests, so we can keep them up to date. This should require minimal maintenance and will be useful when we can tackle the infrastructure change. This CI job is notified in GitHub and I intend to make it a required check for PRs, since there shouldn't be anything flaky about them.

Normally, I am in favor of removing any code that's not in use instead of commenting it out. However, in this case, I wanted for us to have an easy way to refer to the previous setup without digging through the git history.

I also fixed the build failure in edc75281bbeaf323ad13cf08c82a999315bb776c and added a Buildkite annotation to all builds in b425a1bd16f7552a48cebebe0b7c581a29c3fcf9, so developers are aware of the latest situation. I don't love the wording of the message, so if you have any suggestions to improve it, I'd appreciate it!

P.S: I checked in with @jkmassel and he is onboard with disabling these tests.