### PR TITLE
[Nullability Annotations to Java Classes] Replace `org.jetbrains` with `androidx` annotations

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.rest;
 
+import androidx.annotation.Nullable;
+
 import com.android.volley.AuthFailureError;
 import com.android.volley.NetworkResponse;
 import com.android.volley.ParseError;
@@ -10,7 +12,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 
-import org.jetbrains.annotations.Nullable;
 import org.wordpress.android.fluxc.logging.FluxCCrashLogger;
 import org.wordpress.android.fluxc.logging.FluxCCrashLoggerProvider;
 import org.wordpress.android.fluxc.network.BaseRequest;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -2,12 +2,12 @@ package org.wordpress.android.fluxc.network.rest.wpcom;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.network.AcceptHeaderStrategy;
@@ -151,11 +151,11 @@ public abstract class BaseWPComRestClient {
     }
 
 
-    private @NotNull String getLocaleParamName(@NotNull String url) {
+    private @NonNull String getLocaleParamName(@NonNull String url) {
         return url.contains(WPCOM_V2_PREFIX) ? LOCALE_PARAM_NAME_FOR_V2 : LOCALE_PARAM_NAME_FOR_V1;
     }
 
-    protected @Nullable HttpUrl getHttpUrlWithLocale(@NotNull String url) {
+    protected @Nullable HttpUrl getHttpUrlWithLocale(@NonNull String url) {
         HttpUrl httpUrl = HttpUrl.parse(url);
 
         if (null != httpUrl) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -2,11 +2,12 @@ package org.wordpress.android.fluxc.network.rest.wpcom;
 
 import android.content.Context;
 
+import androidx.annotation.Nullable;
+
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.network.AcceptHeaderStrategy;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -8,7 +8,6 @@ import androidx.annotation.Nullable;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
 
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -320,7 +319,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    private @NotNull List<PostListItem> postListItemsFromPostsResponse(@Nullable Object[] response) {
+    private @NonNull List<PostListItem> postListItemsFromPostsResponse(@Nullable Object[] response) {
         if (response == null) {
             return Collections.emptyList();
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -11,7 +11,6 @@ import com.yarolegovich.wellsql.WellSql;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.fluxc.BuildConfig;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
@@ -104,8 +103,8 @@ public class PostStore extends Store {
 
     @SuppressWarnings("WeakerAccess")
     public static class FetchPostListResponsePayload extends Payload<PostError> {
-        @NotNull public PostListDescriptor listDescriptor;
-        @NotNull public List<PostListItem> postListItems;
+        @NonNull public PostListDescriptor listDescriptor;
+        @NonNull public List<PostListItem> postListItems;
         public boolean loadedMore;
         public boolean canLoadMore;
 


### PR DESCRIPTION
Parent #2795
Closes #2803

This PR replaces:
- All occurrences of `org.jetbrains.annotations.Nullable` with the `androidx.annotation.Nullable` annotation, and
- All occurrences of `org.jetbrains.annotations.NotNull` with the `androidx.annotation.NonNull` annotation.

-----

## To test:

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you really want to be thorough, quickly smoke test the example app and see if it is working as expected.