### PR TITLE
Send new app installation date to WcTracker

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerRestClient.kt
@@ -4,23 +4,28 @@ import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 internal class TrackerRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
-    suspend fun sendTelemetry(appVersion: String, site: SiteModel): WooPayload<Unit> {
+    suspend fun sendTelemetry(
+        appVersion: String,
+        site: SiteModel,
+        installationDate: String?
+    ): WooPayload<Unit> {
         val url = WOOCOMMERCE.tracker.pathWcTelemetry
 
         val response = wooNetwork.executePostGsonRequest(
             site = site,
             path = url,
             clazz = Unit::class.java,
-            body = mapOf(
+            body = mutableMapOf(
                 "platform" to "android",
-                "version" to appVersion
-            )
+                "version" to appVersion,
+            ).putIfNotEmpty("installation_date" to installationDate)
         )
 
         return response.toWooPayload()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
@@ -31,7 +31,7 @@ class TrackerStore @Inject internal constructor(
         val formattedInstallationDate = installationDate?.let { ISO8601_FORMAT.format(it) }
         appLogWrapper.d(
             STATS,
-            "Sending Telemetry. Values: appVersion=$appVersion, site=${site.id}, " +
+            "Sending Telemetry. Values: appVersion=$appVersion, site=${site.siteId}, " +
                     "installationDate=$formattedInstallationDate"
         )
         return restClient.sendTelemetry(appVersion, site, formattedInstallationDate)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.util.AppLog.T.STATS
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -17,6 +18,9 @@ class TrackerStore @Inject internal constructor(
 ) {
     private companion object {
         val ISO8601_FORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT)
+            .apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
     }
 
     suspend fun sendTelemetry(
@@ -27,7 +31,7 @@ class TrackerStore @Inject internal constructor(
         val formattedInstallationDate = installationDate?.let { ISO8601_FORMAT.format(it) }
         appLogWrapper.d(
             STATS,
-            "Sending Telemetry. Values: appVersion=$appVersion, siteId=${site.id}, " +
+            "Sending Telemetry. Values: appVersion=$appVersion, site=${site.id}, " +
                     "installationDate=$formattedInstallationDate"
         )
         return restClient.sendTelemetry(appVersion, site, formattedInstallationDate)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
@@ -10,7 +10,7 @@ class TrackerStore @Inject internal constructor(private val restClient: TrackerR
     suspend fun sendTelemetry(
         appVersion: String,
         site: SiteModel,
-        installationDateIso8601: String? = null
+        installationDateIso8601: String?
     ): WooPayload<Unit> {
         return restClient.sendTelemetry(appVersion, site, installationDateIso8601)
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
@@ -2,38 +2,16 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.tracker
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.utils.AppLogWrapper
-import org.wordpress.android.util.AppLog.T.STATS
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class TrackerStore @Inject internal constructor(
-    private val restClient: TrackerRestClient,
-    private val appLogWrapper: AppLogWrapper
-) {
-    private companion object {
-        val ISO8601_FORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT)
-            .apply {
-                timeZone = TimeZone.getTimeZone("UTC")
-            }
-    }
-
+class TrackerStore @Inject internal constructor(private val restClient: TrackerRestClient) {
     suspend fun sendTelemetry(
         appVersion: String,
         site: SiteModel,
-        installationDate: Date? = null
+        installationDateIso8601: String? = null
     ): WooPayload<Unit> {
-        val formattedInstallationDate = installationDate?.let { ISO8601_FORMAT.format(it) }
-        appLogWrapper.d(
-            STATS,
-            "Sending Telemetry. Values: appVersion=$appVersion, site=${site.siteId}, " +
-                    "installationDate=$formattedInstallationDate"
-        )
-        return restClient.sendTelemetry(appVersion, site, formattedInstallationDate)
+        return restClient.sendTelemetry(appVersion, site, installationDateIso8601)
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/tracker/TrackerStore.kt
@@ -2,12 +2,34 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.tracker
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.util.AppLog.T.STATS
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class TrackerStore @Inject internal constructor(private val restClient: TrackerRestClient) {
-    suspend fun sendTelemetry(appVersion: String, site: SiteModel): WooPayload<Unit> {
-        return restClient.sendTelemetry(appVersion, site)
+class TrackerStore @Inject internal constructor(
+    private val restClient: TrackerRestClient,
+    private val appLogWrapper: AppLogWrapper
+) {
+    private companion object {
+        val ISO8601_FORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT)
+    }
+
+    suspend fun sendTelemetry(
+        appVersion: String,
+        site: SiteModel,
+        installationDate: Date? = null
+    ): WooPayload<Unit> {
+        val formattedInstallationDate = installationDate?.let { ISO8601_FORMAT.format(it) }
+        appLogWrapper.d(
+            STATS,
+            "Sending Telemetry. Values: appVersion=$appVersion, siteId=${site.id}, " +
+                    "installationDate=$formattedInstallationDate"
+        )
+        return restClient.sendTelemetry(appVersion, site, formattedInstallationDate)
     }
 }


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-android/issues/9584

Adds required FluxC changes to send the app installation date in ISO 8601 `yyyy-MM-dd'T'HH:mm:ss'Z'`

The new parameter is optional so the API changes are non-breaking. To test the changes, follow instructions from this PR: https://github.com/woocommerce/woocommerce-android/pull/9594