### PR TITLE
Only wait to publish artifacts for tags and on trunk branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,16 +97,14 @@ steps:
       - github_commit_status:
           context: "Publish :fluxc-build-connected-tests"
 
+  - wait: ~
+    if: build.branch == "trunk" || build.tag != null
+
   ############################
   # Publish artefacts to S3
   ############################
   - group: 🚀 Publish to S3
     key: publish-to-s3
-    depends_on:
-      - all-linters
-      - all-unit-tests
-      # Note: Dependency on `connected-tests` is disabled for now until they are more stable to not become a blocker
-      # - connected-tests
     steps:
       - label: "🚀 Publish :fluxc-annotations"
         key: "publish-fluxc-annotations"


### PR DESCRIPTION
The full suite of Buildkite jobs in this repository have been taking upwards of 30 minutes. In my opinion, this is way too long for a library. This PR is part of changes that I am working to improve these times.

**With the following proposed changes, the build for this PR took a total of `17m 16s` as opposed to the previous PR that was merged that took `32m 42s`.**

---

The publish step had been depending on lint & unit test tasks. Although these are useful checks when we are publishing a proper release, they are not really necessary during a PR process. So, this PR proposes using [`wait` step](https://buildkite.com/docs/pipelines/wait-step) instead of `depends_on`, so that we can add a filter to it. This makes it so that publishing steps start as soon as possible for PRs.

Since we have a GitHub branch protection that requires the lint & unit tests tasks to be successful, this should have no adverse effect.

**To Test**

Here is a screenshot from this PR's build which shows that the publish job started as soon as possible. Once we merge the PR, I'll also verify that the `wait` step works as expected. So, no testing is necessary.

<img width="1573" alt="Screenshot 2023-08-14 at 5 21 55 PM" src="https://github.com/wordpress-mobile/WordPress-FluxC-Android/assets/662023/ff3845e8-227a-44e8-a357-cd9eafae9828">
