### PR TITLE
Add subscription metadata to supported keys

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.model
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.fluxc.model.WCProductModel.AddOnsMetadataKeys
 import org.wordpress.android.fluxc.model.WCProductModel.QuantityRulesMetadataKeys
 import org.wordpress.android.fluxc.utils.EMPTY_JSON_ARRAY
@@ -28,6 +29,7 @@ class StripProductMetaData @Inject internal constructor(private val gson: Gson) 
         val SUPPORTED_KEYS: Set<String> = buildSet {
             add(AddOnsMetadataKeys.ADDONS_METADATA_KEY)
             addAll(QuantityRulesMetadataKeys.ALL_KEYS)
+            addAll(SubscriptionMetadataKeys.ALL_KEYS)
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -559,6 +559,27 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         return storedFiles == updatedFiles
     }
 
+    object SubscriptionMetadataKeys {
+        const val SUBSCRIPTION_PRICE = "_subscription_price"
+        const val SUBSCRIPTION_PERIOD = "_subscription_period"
+        const val SUBSCRIPTION_PERIOD_INTERVAL = "_subscription_period_interval"
+        const val SUBSCRIPTION_LENGTH = "_subscription_length"
+        const val SUBSCRIPTION_SIGN_UP_FEE = "_subscription_sign_up_fee"
+        const val SUBSCRIPTION_TRIAL_PERIOD = "_subscription_trial_period"
+        const val SUBSCRIPTION_TRIAL_LENGTH = "_subscription_trial_length"
+        const val SUBSCRIPTION_ONE_TIME_SHIPPING = "_subscription_one_time_shipping"
+        val ALL_KEYS = setOf(
+            SUBSCRIPTION_PRICE,
+            SUBSCRIPTION_TRIAL_LENGTH,
+            SUBSCRIPTION_SIGN_UP_FEE,
+            SUBSCRIPTION_PERIOD,
+            SUBSCRIPTION_PERIOD_INTERVAL,
+            SUBSCRIPTION_LENGTH,
+            SUBSCRIPTION_TRIAL_PERIOD,
+            SUBSCRIPTION_ONE_TIME_SHIPPING
+        )
+    }
+
     object AddOnsMetadataKeys {
         const val ADDONS_METADATA_KEY = "_product_addons"
     }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/StripProductMetaDataTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/StripProductMetaDataTest.kt
@@ -7,6 +7,9 @@ import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.wordpress.android.fluxc.model.StripProductMetaData
 import org.wordpress.android.fluxc.model.WCMetaData
+import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
+import org.wordpress.android.fluxc.model.WCProductModel.AddOnsMetadataKeys
+import org.wordpress.android.fluxc.model.WCProductModel.QuantityRulesMetadataKeys
 import org.wordpress.android.fluxc.utils.EMPTY_JSON_ARRAY
 
 class StripProductMetaDataTest {
@@ -67,6 +70,24 @@ class StripProductMetaDataTest {
     fun `when metadata is null, then empty array is return`() {
         val result = sut.invoke(null)
         Assertions.assertThat(result).isEqualTo(EMPTY_JSON_ARRAY)
+    }
+
+    @Test
+    fun `assert no regression in subscription metadata`() {
+        Assertions.assertThat(StripProductMetaData.SUPPORTED_KEYS)
+            .containsAll(SubscriptionMetadataKeys.ALL_KEYS)
+    }
+
+    @Test
+    fun `assert no regression in quantity rules metadata`() {
+        Assertions.assertThat(StripProductMetaData.SUPPORTED_KEYS)
+            .containsAll(QuantityRulesMetadataKeys.ALL_KEYS)
+    }
+
+    @Test
+    fun `assert no regression in add-ons metadata`() {
+        Assertions.assertThat(StripProductMetaData.SUPPORTED_KEYS)
+            .contains(AddOnsMetadataKeys.ADDONS_METADATA_KEY)
     }
 
     private fun getOneItemMetadata(itemKey: String, itemValue: String?): String {


### PR DESCRIPTION
### Why
As part of the Reliability project, we introduced a new metadata strip function to save only the allowed product's metadata keys in the database and optimize the app's memory usage. Unfortunately, this optimization broke the simple subscription read-only functionality by not saving the subscription metadata needed to display the subscription information.

### Description
This PR adds the subscription metadata keys to the list of the supported private keys. This change prevents the strip function from removing the subscription metadata keys and restores the subscription's read-only functionality.

### Testing
It is better to test this change with the Woo PR  https://github.com/woocommerce/woocommerce-android/pull/9600