### PR TITLE
[Woo] Add a store to allow interaction with WC Admin Options API

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/FragmentsModule.kt
@@ -51,6 +51,7 @@ import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.storecreation.WooStoreCreationFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
+import org.wordpress.android.fluxc.example.ui.wooadmin.WooAdminFragment
 
 @Module
 internal interface FragmentsModule {
@@ -200,4 +201,7 @@ internal interface FragmentsModule {
 
     @ContributesAndroidInjector
     fun provideJetpackAIFragment(): JetpackAIFragment
+
+    @ContributesAndroidInjector
+    fun provideWooAdminFragment(): WooAdminFragment
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.fluxc.example.ui.stats.WooRevenueStatsFragment
 import org.wordpress.android.fluxc.example.ui.stats.WooStatsFragment
 import org.wordpress.android.fluxc.example.ui.storecreation.WooStoreCreationFragment
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
+import org.wordpress.android.fluxc.example.ui.wooadmin.WooAdminFragment
 import org.wordpress.android.fluxc.store.WCDataStore
 import org.wordpress.android.fluxc.store.WCUserStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -232,6 +233,10 @@ class WooCommerceFragment : StoreSelectingFragment() {
 
         store_onboarding.setOnClickListener {
             replaceFragment(WooOnboardingFragment())
+        }
+
+        woo_admin.setOnClickListener {
+            replaceFragment(WooAdminFragment())
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/wooadmin/WooAdminFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/wooadmin/WooAdminFragment.kt
@@ -1,0 +1,78 @@
+package org.wordpress.android.fluxc.example.ui.wooadmin
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
+import com.google.gson.Gson
+import kotlinx.android.synthetic.main.fragment_woo_admin.*
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.example.R
+import org.wordpress.android.fluxc.example.prependToLog
+import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
+import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.admin.WooAdminStore
+import javax.inject.Inject
+
+class WooAdminFragment : StoreSelectingFragment() {
+    @Inject internal lateinit var wooAdminStore: WooAdminStore
+    private val gson = Gson()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.fragment_woo_admin, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        fetch_options.setOnClickListener {
+            lifecycleScope.launch {
+                selectedSite?.let { site ->
+                    val keys = showSingleLineDialog(
+                        activity = requireActivity(),
+                        message = "Please enter the keys to fetch separated by a comma",
+                        isNumeric = false
+                    )?.split(",")?.map { it.trim() } ?: return@launch
+                    wooAdminStore.getOptions(site, keys).let { result ->
+                        when {
+                            result.isError -> prependToLog("Fetching Admin Options failed, " +
+                                "${result.error.type}: ${result.error.message}")
+                            else -> prependToLog(
+                                "Admin Options: ${
+                                    result.model!!.entries.joinToString { entry ->
+                                        "${entry.key}:${entry.value}"
+                                    }
+                                }"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        update_options.setOnClickListener {
+            lifecycleScope.launch {
+                selectedSite?.let { site ->
+                    val keyValues = showSingleLineDialog(
+                        activity = requireActivity(),
+                        message = "Please enter the options to update in the format key:value separated by a comma",
+                        isNumeric = false
+                    )?.split(",")?.map { keyValue ->
+                        keyValue.trim().split(":").let { Pair(it[0], it[1]) }
+                    } ?: return@launch
+
+                    wooAdminStore.updateOptions(site, keyValues.toMap()).let { result ->
+                        when {
+                            result.isError -> prependToLog("Updating Admin Options failed, " +
+                                "${result.error.type}: ${result.error.message}")
+                            else -> prependToLog("Admin options updated successfully")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/example/src/main/res/layout/fragment_woo_admin.xml
+++ b/example/src/main/res/layout/fragment_woo_admin.xml
@@ -1,0 +1,31 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/activity_start_end_margin"
+    tools:ignore="HardcodedText">
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp">
+
+        <Button
+            android:id="@+id/fetch_options"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Fetch Options" />
+
+        <Button
+            android:id="@+id/update_options"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Update Options" />
+    </LinearLayout>
+</ScrollView>

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -147,5 +147,11 @@
             android:layout_height="wrap_content"
             android:text="Store onboarding" />
 
+        <Button
+            android:id="@+id/woo_admin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="WooCommerce Admin" />
+
     </LinearLayout>
 </ScrollView>

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -106,3 +106,5 @@
 /subscriptions/<id>/
 
 /reports/products
+
+/options

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/admin/WooAdminRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/admin/WooAdminRestClient.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.admin
+
+import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.utils.toMap
+import org.wordpress.android.fluxc.utils.toWooPayload
+import javax.inject.Inject
+
+class WooAdminRestClient @Inject constructor(
+    private val wooNetwork: WooNetwork
+) {
+    suspend fun getOptions(
+        site: SiteModel,
+        keys: List<String>
+    ): WooPayload<Map<String, Any>> {
+        val params = mapOf("options" to keys.joinToString(","))
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = WOOCOMMERCE.options.pathWcAdmin,
+            params = params,
+            clazz = JsonElement::class.java
+        ).toWooPayload { jsonElement -> jsonElement.toMap() }
+    }
+
+    suspend fun updateOptions(
+        site: SiteModel,
+        options: Map<String, Any>
+    ): WooPayload<Unit> {
+        return wooNetwork.executePostGsonRequest(
+            site = site,
+            path = WOOCOMMERCE.options.pathWcAdmin,
+            body = options,
+            clazz = Unit::class.java
+        ).toWooPayload()
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/admin/WooAdminStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/admin/WooAdminStore.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.admin
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooAdminStore @Inject constructor(
+    private val restClient: WooAdminRestClient
+) {
+    suspend fun getOptions(
+        site: SiteModel,
+        keys: List<String>
+    ): WooResult<Map<String, Any>> =
+        restClient.getOptions(site, keys).asWooResult()
+
+    suspend fun updateOptions(
+        site: SiteModel,
+        options: Map<String, Any>
+    ): WooResult<Unit> = restClient.updateOptions(site, options).asWooResult()
+}


### PR DESCRIPTION
This PR adds a Store to allow interacting with the Woo endpoint `wc-admin/options`, this is needed for the task https://github.com/woocommerce/woocommerce-android/pull/9629.

### Testing instructions
1. Open the example app.
2. Make sure you are signed in.
3. Click on Woo, then "WooCommerce Admin"
4. Select a site.
5. Click on Update options.
6. Enter some sample data, for example: `test1:1,test2:2`
7. Confirm the call succeeds
8. Click on Fetch options
9. Enter some keys, for example: `test1,test2` (to match what we updated in 6).
10. Confirm the correct values are fetched (the output should be `Admin Options: test1:1, test2:2`