### PR TITLE
Include bundle rules

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
@@ -11,6 +11,6 @@ class WCBundledProduct(
     @SerializedName("stock_status") val stockStatus: String,
     @SerializedName("quantity_min") val quantityMin: Long,
     @SerializedName("quantity_max") val quantityMax: Long,
-    @SerializedName("quantity_default") val quantityDefault: Long = 0,
-    @SerializedName("optional") val isOptional: Boolean = false,
+    @SerializedName("quantity_default") val quantityDefault: Long,
+    @SerializedName("optional") val isOptional: Boolean
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
@@ -2,10 +2,15 @@ package org.wordpress.android.fluxc.model
 
 import com.google.gson.annotations.SerializedName
 
+@Suppress("LongParameterList")
 class WCBundledProduct(
     @SerializedName("bundled_item_id") val id: Long,
     @SerializedName("product_id") val bundledProductId: Long,
     @SerializedName("menu_order") val menuOrder: Int,
     @SerializedName("title") val title: String,
-    @SerializedName("stock_status") val stockStatus: String
+    @SerializedName("stock_status") val stockStatus: String,
+    @SerializedName("quantity_min") val quantityMin: Long,
+    @SerializedName("quantity_max") val quantityMax: Long,
+    @SerializedName("quantity_default") val quantityDefault: Long = 0,
+    @SerializedName("optional") val isOptional: Boolean = false,
 )


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-android/issues/9541
### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow.

### Description
This small PR includes the bundle fields needed for configuring a bundle product.

### Testing
It is better to test this PR alongside the Woo PR