### PR TITLE
Woo: Rest client and store functionalities for saving site title.

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -16,6 +16,7 @@ class WooSystemRestClient @Inject constructor(private val wooNetwork: WooNetwork
     companion object {
         private const val NOT_FOUND = 404
         private const val FORBIDDEN = 403
+        private const val SAVE_SITE_TITLE_RESPONSE_FIELD = "title"
     }
 
     suspend fun fetchInstalledPlugins(site: SiteModel): WooPayload<WCSystemPluginResponse> {
@@ -87,6 +88,26 @@ class WooSystemRestClient @Inject constructor(private val wooNetwork: WooNetwork
 
         return response.toWooPayload()
     }
+
+    suspend fun saveSiteTitle(site: SiteModel, siteTitle: String): WooPayload<SaveSiteTitleResponse> {
+        val url = WPAPI.settings.urlV2
+
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = SaveSiteTitleResponse::class.java,
+            body = mapOf(
+                "title" to siteTitle,
+                "_fields" to SAVE_SITE_TITLE_RESPONSE_FIELD
+            )
+        )
+
+        return response.toWooPayload()
+    }
+
+    data class SaveSiteTitleResponse(
+        @SerializedName("title") val title: String? = null
+    )
 
     data class SSRResponse(
         val environment: JsonElement? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
@@ -35,6 +35,7 @@ class OnboardingStore @Inject constructor(
                         .firstOrNull { it.id == ONBOARDING_TASKS_KEY }
                         ?.tasks ?: emptyList()
                 )
+
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }
@@ -48,12 +49,17 @@ class OnboardingStore @Inject constructor(
                 response.result?.title != null -> {
                     val fetchResult = wooCommerceStore.fetchWooCommerceSite(site)
                     if (fetchResult.isError) {
-                        AppLog.e(API, "Error fetching WooCommerce site: ${fetchResult.error.message}")
-                        WooResult(response.error)
+                        AppLog.e(
+                            API,
+                            "Error fetching WooCommerce site after saving title: " +
+                                "${fetchResult.error.message}"
+                        )
+                        WooResult(WooError(fetchResult.error.type, fetchResult.error.original))
                     } else {
                         WooResult(response.result.title)
                     }
                 }
+
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding.OnboardingRe
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding.TaskDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.API
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -18,6 +19,7 @@ class OnboardingStore @Inject constructor(
     private val restClient: OnboardingRestClient,
     private val systemRestClient: WooSystemRestClient,
     private val coroutineEngine: CoroutineEngine,
+    private val wooCommerceStore: WooCommerceStore
 ) {
     private companion object {
         const val ONBOARDING_TASKS_KEY = "setup"
@@ -43,7 +45,15 @@ class OnboardingStore @Inject constructor(
 
             when {
                 response.isError -> WooResult(response.error)
-                response.result?.title != null -> WooResult(response.result.title)
+                response.result?.title != null -> {
+                    val fetchResult = wooCommerceStore.fetchWooCommerceSite(site)
+                    if (fetchResult.isError) {
+                        AppLog.e(API, "Error fetching WooCommerce site: ${fetchResult.error.message}")
+                        WooResult(response.error)
+                    } else {
+                        WooResult(response.result.title)
+                    }
+                }
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OnboardingStore.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ER
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding.OnboardingRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.onboarding.TaskDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog.T.API
 import javax.inject.Inject
@@ -15,6 +16,7 @@ import javax.inject.Singleton
 @Singleton
 class OnboardingStore @Inject constructor(
     private val restClient: OnboardingRestClient,
+    private val systemRestClient: WooSystemRestClient,
     private val coroutineEngine: CoroutineEngine,
 ) {
     private companion object {
@@ -31,6 +33,17 @@ class OnboardingStore @Inject constructor(
                         .firstOrNull { it.id == ONBOARDING_TASKS_KEY }
                         ?.tasks ?: emptyList()
                 )
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+
+    suspend fun saveSiteTitle(site: SiteModel, siteTitle: String): WooResult<String> =
+        coroutineEngine.withDefaultContext(API, this, "saveSiteTitleOnboarding") {
+            val response = systemRestClient.saveSiteTitle(site, siteTitle)
+
+            when {
+                response.isError -> WooResult(response.error)
+                response.result?.title != null -> WooResult(response.result.title)
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }


### PR DESCRIPTION
This adds API call to save site title, as well as onboarding store functionality to do the same.

Some points:

1. the API call is put in `WooSystemRestClient` to follow an existing function that also hits the same endpoint, `fetchSiteSettings()`
2. The store function is in `OnboardingStore` because currently saving site is used in the context of site onboarding.

There is nothing to test here but instead it should be tested with the accompanying WooCommerce android PR (coming soon)