### PR TITLE
Handle nulls as empty string

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.model
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.utils.JsonElementToLongSerializerDeserializer
 
 @Suppress("LongParameterList")
 class WCBundledProduct(
@@ -9,8 +11,11 @@ class WCBundledProduct(
     @SerializedName("menu_order") val menuOrder: Int,
     @SerializedName("title") val title: String,
     @SerializedName("stock_status") val stockStatus: String,
-    @SerializedName("quantity_min") val quantityMin: Long,
-    @SerializedName("quantity_max") val quantityMax: Long,
-    @SerializedName("quantity_default") val quantityDefault: Long,
+    @JsonAdapter(JsonElementToLongSerializerDeserializer::class)
+    @SerializedName("quantity_min") val quantityMin: Long?,
+    @JsonAdapter(JsonElementToLongSerializerDeserializer::class)
+    @SerializedName("quantity_max") val quantityMax: Long?,
+    @JsonAdapter(JsonElementToLongSerializerDeserializer::class)
+    @SerializedName("quantity_default") val quantityDefault: Long?,
     @SerializedName("optional") val isOptional: Boolean
 )


### PR DESCRIPTION
### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow.

### Description
The values of `quantity_min`, `quantity_max`, and `quantity_default` can be `null`. When these values are `null` the API will return the empty string `""` crashing the app when trying to parse a Long value from the empty string. This PR fix that by using JsonElementToLongSerializerDeserializer that will convert the empty string or any not valid value to null.

### Testing
Test with the Woo PR https://github.com/woocommerce/woocommerce-android/pull/9646