### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to `TaxonomyRestClient` (`safe`)

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import androidx.annotation.NonNull;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Test;
 import org.wordpress.android.fluxc.TestUtils;
@@ -27,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     @Inject TaxonomyStore mTaxonomyStore;
@@ -327,37 +330,52 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mCountDownLatch.countDown();
     }
 
-    private void setupTermAttributes(TermModel term) {
+    private void setupTermAttributes(@NonNull TermModel term) {
         term.setName(TERM_DEFAULT_NAME + "-" + RandomStringUtils.randomAlphanumeric(4));
         term.setDescription(TERM_DEFAULT_DESCRIPTION);
     }
 
+    @NonNull
     private TermModel createNewCategory() {
         TermModel term = mTaxonomyStore.instantiateCategory(sSite);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        if (term != null) {
+            assertEquals(0, term.getRemoteTermId());
+            assertNotSame(0, term.getId());
+            assertNotSame(0, term.getLocalSiteId());
+        } else {
+            fail("Failed to instantiate new category!");
+        }
 
         return term;
     }
 
+    @NonNull
     private TermModel createNewTag() {
         TermModel term = mTaxonomyStore.instantiateTag(sSite);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        if (term != null) {
+            assertEquals(0, term.getRemoteTermId());
+            assertNotSame(0, term.getId());
+            assertNotSame(0, term.getLocalSiteId());
+        } else {
+            fail("Failed to instantiate new tag!");
+        }
 
         return term;
     }
 
-    private TermModel createNewTerm(TaxonomyModel taxonomy) {
+    @NonNull
+    private TermModel createNewTerm(@NonNull TaxonomyModel taxonomy) {
         TermModel term = mTaxonomyStore.instantiateTerm(sSite, taxonomy);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        if (term != null) {
+            assertEquals(0, term.getRemoteTermId());
+            assertNotSame(0, term.getId());
+            assertNotSame(0, term.getLocalSiteId());
+        } else {
+            fail("Failed to instantiate new term!");
+        }
 
         return term;
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -93,11 +93,15 @@ public class TaxonomiesFragment extends Fragment {
 
     private void createCategory() {
         TermModel newCategory = mTaxonomyStore.instantiateCategory(getFirstSite());
-        newCategory.setName("FluxC-category-" + new Random().nextLong());
-        newCategory.setDescription("From FluxC example app");
+        if (newCategory != null) {
+            newCategory.setName("FluxC-category-" + new Random().nextLong());
+            newCategory.setDescription("From FluxC example app");
 
-        RemoteTermPayload payload = new RemoteTermPayload(newCategory, getFirstSite());
-        mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload));
+            RemoteTermPayload payload = new RemoteTermPayload(newCategory, getFirstSite());
+            mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload));
+        } else {
+            prependToLog("Error: no category found!");
+        }
     }
 
     @SuppressWarnings("unused")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -136,7 +136,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void deleteTerm(final TermModel term, final SiteModel site) {
+    public void deleteTerm(@NonNull final TermModel term, @NonNull final SiteModel site) {
         final String taxonomy = term.getTaxonomy();
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms
                 .slug(term.getSlug()).delete.getUrlV1_1();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -53,7 +53,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         final String slug = term.getSlug();
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms.slug(slug).getUrlV1_1();
 
-        final WPComGsonRequest request = WPComGsonRequest.buildGetRequest(url, null,
+        final WPComGsonRequest<TermWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, null,
                 TermWPComRestResponse.class,
                 new Listener<TermWPComRestResponse>() {
                     @Override
@@ -86,7 +86,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         Map<String, String> params = new HashMap<>();
         params.put("number", "1000");
 
-        final WPComGsonRequest request = WPComGsonRequest.buildGetRequest(url, params,
+        final WPComGsonRequest<TermsResponse> request = WPComGsonRequest.buildGetRequest(url, params,
                 TermsResponse.class,
                 new Listener<TermsResponse>() {
                     @Override
@@ -126,7 +126,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
 
         Map<String, Object> body = termModelToParams(term);
 
-        final WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, body,
+        final WPComGsonRequest<TermWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 TermWPComRestResponse.class,
                 new Listener<TermWPComRestResponse>() {
                     @Override
@@ -162,7 +162,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms
                 .slug(term.getSlug()).delete.getUrlV1_1();
 
-        final WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, null,
+        final WPComGsonRequest<TermWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
                 TermWPComRestResponse.class,
                 new Listener<TermWPComRestResponse>() {
                     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -158,7 +158,8 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    private TermModel termResponseToTermModel(TermWPComRestResponse from) {
+    @NonNull
+    private TermModel termResponseToTermModel(@NonNull TermWPComRestResponse from) {
         TermModel term = new TermModel();
         term.setRemoteTermId(from.ID);
         term.setName(StringEscapeUtils.unescapeHtml4(from.name));
@@ -166,7 +167,6 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         term.setDescription(StringEscapeUtils.unescapeHtml4(from.description));
         term.setParentRemoteId(from.parent);
         term.setPostCount(from.post_count);
-
         return term;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -2,10 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.taxonomy;
 
 import android.content.Context;
 
-import androidx.annotation.NonNull;
-
 import com.android.volley.RequestQueue;
-import com.android.volley.Response.Listener;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -18,8 +15,6 @@ import org.wordpress.android.fluxc.model.TermsModel;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
-import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.taxonomy.TermWPComRestResponse.TermsResponse;
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermResponsePayload;
@@ -55,27 +50,21 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
 
         final WPComGsonRequest<TermWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, null,
                 TermWPComRestResponse.class,
-                new Listener<TermWPComRestResponse>() {
-                    @Override
-                    public void onResponse(TermWPComRestResponse response) {
-                        TermModel fetchedTerm = termResponseToTermModel(response);
-                        fetchedTerm.setId(term.getId());
-                        fetchedTerm.setTaxonomy(taxonomy);
-                        fetchedTerm.setLocalSiteId(site.getId());
+                response -> {
+                    TermModel fetchedTerm = termResponseToTermModel(response);
+                    fetchedTerm.setId(term.getId());
+                    fetchedTerm.setTaxonomy(taxonomy);
+                    fetchedTerm.setLocalSiteId(site.getId());
 
-                        FetchTermResponsePayload payload = new FetchTermResponsePayload(fetchedTerm, site);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
-                    }
+                    FetchTermResponsePayload payload = new FetchTermResponsePayload(fetchedTerm, site);
+                    mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
                 },
-                new WPComErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
-                        // Possible non-generic errors: 400 invalid_taxonomy
-                        TaxonomyError taxonomyError = new TaxonomyError(error.apiError, error.message);
-                        FetchTermResponsePayload payload = new FetchTermResponsePayload(term, site);
-                        payload.error = taxonomyError;
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
-                    }
+                error -> {
+                    // Possible non-generic errors: 400 invalid_taxonomy
+                    TaxonomyError taxonomyError = new TaxonomyError(error.apiError, error.message);
+                    FetchTermResponsePayload payload = new FetchTermResponsePayload(term, site);
+                    payload.error = taxonomyError;
+                    mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
                 });
         add(request);
     }
@@ -88,31 +77,25 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
 
         final WPComGsonRequest<TermsResponse> request = WPComGsonRequest.buildGetRequest(url, params,
                 TermsResponse.class,
-                new Listener<TermsResponse>() {
-                    @Override
-                    public void onResponse(TermsResponse response) {
-                        List<TermModel> termArray = new ArrayList<>();
-                        TermModel term;
-                        for (TermWPComRestResponse termResponse : response.terms) {
-                            term = termResponseToTermModel(termResponse);
-                            term.setTaxonomy(taxonomyName);
-                            term.setLocalSiteId(site.getId());
-                            termArray.add(term);
-                        }
+                response -> {
+                    List<TermModel> termArray = new ArrayList<>();
+                    TermModel term;
+                    for (TermWPComRestResponse termResponse : response.terms) {
+                        term = termResponseToTermModel(termResponse);
+                        term.setTaxonomy(taxonomyName);
+                        term.setLocalSiteId(site.getId());
+                        termArray.add(term);
+                    }
 
-                        FetchTermsResponsePayload payload = new FetchTermsResponsePayload(new TermsModel(termArray),
-                                site, taxonomyName);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
-                    }
+                    FetchTermsResponsePayload payload = new FetchTermsResponsePayload(new TermsModel(termArray),
+                            site, taxonomyName);
+                    mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
                 },
-                new WPComErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
-                        // Possible non-generic errors: 400 invalid_taxonomy
-                        TaxonomyError taxonomyError = new TaxonomyError(error.apiError, error.message);
-                        FetchTermsResponsePayload payload = new FetchTermsResponsePayload(taxonomyError, taxonomyName);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
-                    }
+                error -> {
+                    // Possible non-generic errors: 400 invalid_taxonomy
+                    TaxonomyError taxonomyError = new TaxonomyError(error.apiError, error.message);
+                    FetchTermsResponsePayload payload = new FetchTermsResponsePayload(taxonomyError, taxonomyName);
+                    mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
                 });
         add(request);
     }
@@ -128,27 +111,21 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
 
         final WPComGsonRequest<TermWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 TermWPComRestResponse.class,
-                new Listener<TermWPComRestResponse>() {
-                    @Override
-                    public void onResponse(TermWPComRestResponse response) {
-                        TermModel uploadedTerm = termResponseToTermModel(response);
+                response -> {
+                    TermModel uploadedTerm = termResponseToTermModel(response);
 
-                        uploadedTerm.setId(term.getId());
-                        uploadedTerm.setLocalSiteId(site.getId());
-                        uploadedTerm.setTaxonomy(taxonomy);
+                    uploadedTerm.setId(term.getId());
+                    uploadedTerm.setLocalSiteId(site.getId());
+                    uploadedTerm.setTaxonomy(taxonomy);
 
-                        RemoteTermPayload payload = new RemoteTermPayload(uploadedTerm, site);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
-                    }
+                    RemoteTermPayload payload = new RemoteTermPayload(uploadedTerm, site);
+                    mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                 },
-                new WPComErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
-                        // Possible non-generic errors: 400 invalid_taxonomy, 409 duplicate
-                        RemoteTermPayload payload = new RemoteTermPayload(term, site);
-                        payload.error = new TaxonomyError(error.apiError, error.message);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
-                    }
+                error -> {
+                    // Possible non-generic errors: 400 invalid_taxonomy, 409 duplicate
+                    RemoteTermPayload payload = new RemoteTermPayload(term, site);
+                    payload.error = new TaxonomyError(error.apiError, error.message);
+                    mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                 });
 
         request.addQueryParameter("context", "edit");
@@ -164,21 +141,15 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
 
         final WPComGsonRequest<TermWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, null,
                 TermWPComRestResponse.class,
-                new Listener<TermWPComRestResponse>() {
-                    @Override
-                    public void onResponse(TermWPComRestResponse response) {
-                        RemoteTermPayload payload = new RemoteTermPayload(term, site);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
-                    }
+                response -> {
+                    RemoteTermPayload payload = new RemoteTermPayload(term, site);
+                    mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
                 },
-                new WPComErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull WPComGsonNetworkError error) {
-                        // Possible non-generic errors: 400 invalid_taxonomy, 409 duplicate
-                        RemoteTermPayload payload = new RemoteTermPayload(term, site);
-                        payload.error = new TaxonomyError(error.apiError, error.message);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
-                    }
+                error -> {
+                    // Possible non-generic errors: 400 invalid_taxonomy, 409 duplicate
+                    RemoteTermPayload payload = new RemoteTermPayload(term, site);
+                    payload.error = new TaxonomyError(error.apiError, error.message);
+                    mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
                 });
 
         request.disableRetries();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -170,7 +170,8 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         return term;
     }
 
-    private Map<String, Object> termModelToParams(TermModel term) {
+    @NonNull
+    private Map<String, Object> termModelToParams(@NonNull TermModel term) {
         Map<String, Object> body = new HashMap<>();
 
         body.put("name", StringUtils.notNullStr(term.getName()));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -39,11 +39,12 @@ import javax.inject.Singleton;
 
 @Singleton
 public class TaxonomyRestClient extends BaseWPComRestClient {
-    @Inject public TaxonomyRestClient(Context appContext,
-                              Dispatcher dispatcher,
-                              @Named("regular") RequestQueue requestQueue,
-                              AccessToken accessToken,
-                              UserAgent userAgent) {
+    @Inject public TaxonomyRestClient(
+            Context appContext,
+            Dispatcher dispatcher,
+            @Named("regular") RequestQueue requestQueue,
+            AccessToken accessToken,
+            UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
     }
 
@@ -75,8 +76,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         payload.error = taxonomyError;
                         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -113,8 +113,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         FetchTermsResponsePayload payload = new FetchTermsResponsePayload(taxonomyError, taxonomyName);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -150,8 +149,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         payload.error = new TaxonomyError(error.apiError, error.message);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                     }
-                }
-        );
+                });
 
         request.addQueryParameter("context", "edit");
 
@@ -181,8 +179,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                         payload.error = new TaxonomyError(error.apiError, error.message);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
                     }
-                }
-        );
+                });
 
         request.disableRetries();
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.network.rest.wpcom.taxonomy;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import com.android.volley.RequestQueue;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -43,7 +45,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
     }
 
-    public void fetchTerm(final TermModel term, final SiteModel site) {
+    public void fetchTerm(@NonNull final TermModel term, @NonNull final SiteModel site) {
         final String taxonomy = term.getTaxonomy();
         final String slug = term.getSlug();
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomy).terms.slug(slug).getUrlV1_1();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -71,7 +71,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void fetchTerms(final SiteModel site, final String taxonomyName) {
+    public void fetchTerms(@NonNull final SiteModel site, @NonNull final String taxonomyName) {
         String url = WPCOMREST.sites.site(site.getSiteId()).taxonomies.taxonomy(taxonomyName).terms.getUrlV1_1();
 
         Map<String, String> params = new HashMap<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -102,7 +102,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void pushTerm(final TermModel term, final SiteModel site) {
+    public void pushTerm(@NonNull final TermModel term, @NonNull final SiteModel site) {
         final String taxonomy = term.getTaxonomy();
         TaxonomiesEndpoint endpoint = WPCOMREST.sites.site(site.getSiteId()).taxonomies;
         String url = term.getRemoteTermId() > 0

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
@@ -1,18 +1,21 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.taxonomy;
 
+import androidx.annotation.NonNull;
+
 import org.wordpress.android.fluxc.network.Response;
 
 import java.util.List;
 
+@SuppressWarnings("NotNullFieldNotInitialized")
 public class TermWPComRestResponse implements Response {
     public static class TermsResponse {
-        public List<TermWPComRestResponse> terms;
+        @NonNull public List<TermWPComRestResponse> terms;
     }
 
     public long ID;
-    public String name;
-    public String slug;
-    public String description;
+    @NonNull public String name;
+    @NonNull public String slug;
+    @NonNull public String description;
     public int post_count;
     public long parent;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.network.Response;
 import java.util.List;
 
 public class TermWPComRestResponse implements Response {
-    public class TermsResponse {
+    public static class TermsResponse {
         public List<TermWPComRestResponse> terms;
     }
 
@@ -17,10 +17,10 @@ public class TermWPComRestResponse implements Response {
     public long parent;
     public Meta meta;
 
-    public class Meta {
+    public static class Meta {
         public Links links;
 
-        public class Links {
+        public static class Links {
             public String self;
             public String help;
             public String site;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java
@@ -15,15 +15,4 @@ public class TermWPComRestResponse implements Response {
     public String description;
     public int post_count;
     public long parent;
-    public Meta meta;
-
-    public static class Meta {
-        public Links links;
-
-        public static class Links {
-            public String self;
-            public String help;
-            public String site;
-        }
-    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -316,7 +316,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void fetchTerms(SiteModel site, String taxonomyName) {
+    private void fetchTerms(@NonNull SiteModel site, @NonNull String taxonomyName) {
         // TODO: Support large number of terms (currently pulling 100 from REST, and ? from XML-RPC) - pagination?
         if (site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.fetchTerms(site, taxonomyName);
@@ -326,7 +326,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void fetchTerms(FetchTermsPayload payload) {
+    private void fetchTerms(@NonNull FetchTermsPayload payload) {
         fetchTerms(payload.site, payload.taxonomy.getName());
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -427,7 +427,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void deleteTerm(RemoteTermPayload payload) {
+    private void deleteTerm(@NonNull RemoteTermPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.deleteTerm(payload.term, payload.site);
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -307,7 +307,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void fetchTerm(RemoteTermPayload payload) {
+    private void fetchTerm(@NonNull RemoteTermPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.fetchTerm(payload.term, payload.site);
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -59,19 +59,20 @@ public class TaxonomyStore extends Store {
     }
 
     public static class RemoteTermPayload extends Payload<TaxonomyError> {
-        public TermModel term;
-        public SiteModel site;
+        @NonNull public TermModel term;
+        @NonNull public SiteModel site;
 
-        public RemoteTermPayload(TermModel term, SiteModel site) {
+        public RemoteTermPayload(@NonNull TermModel term, @NonNull SiteModel site) {
             this.term = term;
             this.site = site;
         }
     }
 
     public static class FetchTermResponsePayload extends RemoteTermPayload {
-        public TaxonomyAction origin = TaxonomyAction.FETCH_TERM; // Used to track fetching newly uploaded XML-RPC terms
+        // Used to track fetching newly uploaded XML-RPC terms
+        @NonNull public TaxonomyAction origin = TaxonomyAction.FETCH_TERM;
 
-        public FetchTermResponsePayload(TermModel term, SiteModel site) {
+        public FetchTermResponsePayload(@NonNull TermModel term, @NonNull SiteModel site) {
             super(term, site);
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.store;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -152,19 +153,23 @@ public class TaxonomyStore extends Store {
         AppLog.d(AppLog.T.API, "TaxonomyStore onRegister");
     }
 
-    public TermModel instantiateCategory(SiteModel site) {
+    @Nullable
+    public TermModel instantiateCategory(@NonNull SiteModel site) {
         return instantiateTermModel(site, DEFAULT_TAXONOMY_CATEGORY);
     }
 
-    public TermModel instantiateTag(SiteModel site) {
+    @Nullable
+    public TermModel instantiateTag(@NonNull SiteModel site) {
         return instantiateTermModel(site, DEFAULT_TAXONOMY_TAG);
     }
 
-    public TermModel instantiateTerm(SiteModel site, TaxonomyModel taxonomy) {
+    @Nullable
+    public TermModel instantiateTerm(@NonNull SiteModel site, @NonNull TaxonomyModel taxonomy) {
         return instantiateTermModel(site, taxonomy.getName());
     }
 
-    private TermModel instantiateTermModel(SiteModel site, String taxonomyName) {
+    @Nullable
+    private TermModel instantiateTermModel(@NonNull SiteModel site, @NonNull String taxonomyName) {
         TermModel newTerm = new TermModel();
         newTerm.setLocalSiteId(site.getId());
         newTerm.setTaxonomy(taxonomyName);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -418,7 +418,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void pushTerm(RemoteTermPayload payload) {
+    private void pushTerm(@NonNull RemoteTermPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.pushTerm(payload.term, payload.site);
         } else {


### PR DESCRIPTION
Parent #2798

This PR adds any missing nullability annotation to [TaxonomyRestClient.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/56bfb5d2e34172909794502e2460fbce4c80b23d/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java#L4), all its related response classes and anything in between (ie. `TaxonomyStore`). See response classes below:
- [TermWPComRestResponse.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/838d24279068169e761c5e356fd72392a4296198/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TermWPComRestResponse.java#L4)

FYI.1: This change is `safe`, meaning that there shouldn't be any (major) compile-time changes associated with this change. Having said that, testing is highly recommended since the changes in this PR can affect one or more clients (ie. [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), [WCAndroid](https://github.com/woocommerce/woocommerce-android), etc)

FYI.2: An analysis on `TaxonomyStore` and its usages with our main clients suggests that this store is only being utilizing [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android). AFAIA [WCAndroid](https://github.com/woocommerce/woocommerce-android) is not using that store and as such can be safely ignored from testing.

-----

PS: @irfano I added you as the main reviewer, randomly so, since I just wanted someone from the Jetpack/WordPress mobile team to be aware of and sign-off on that change for JP/WPAndroid. Feel free to merge this PR directly yourself if you deem so.

-----

Nullability Annotation List:

1. [Add missing n-a to instantiate term model methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/eeba6c47841c0f35b86d275b94974b6ee80be598)
2. [Add missing n-a to remote term payload and children](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/72d8d8e4f2ce6f3c9918db260bf797d1f74012cb)
3. [Add missing n-a to fetch term on taxonomy rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/3bfb807b03940b672e141188f7763f2503aa055a)
4. [Add missing n-a to fetch terms on taxonomy rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/7670c29205858563a8ad92e7c70c99c63eaffc66)
5. [Add missing n-a to push term on taxonomy rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/c638c0b06e1fe777e1391c7caad94c5736934206)
6. [Add missing n-a to delete term on taxonomy rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/6bfe66c8890e1260abf1704e187964deae99236e)
7. [Add missing n-a to term response to term model method on trc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/f8d6e05e637f23e80a3b1a248c18dfd90444cd91)
8. [Add missing n-a to term model to params method on trc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/4204aa22bfcb664ff94f7bd38184bea3fbe744f9)
9. [Add missing n-a to term wp com rest response fields](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/038569f5653afd2e95328cceb33668d311ccc4a0)

Nullability Checks List:

1. [Guard usages of instantiate term model methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/fdc7276621ad0b5047a174936df1eed151d357ff) 

Warnings Resolutions List:

1. [Change type of request to include the missing generic type](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/6c0139751d6edc5252104889f23e7e961b84ae92)
2. [Make inner classes static on term wp com rest response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/c5a51fd4ab2cba581759501e8b0c518f0534785d)

Refactor List:

1. [Reformat taxonomy rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/ed339886bf7a1cc25b0c5d1531805ed4f8ef0106)
2. [Replace anonymous classes with lambda](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/704eb6a2dba616030e090ccf473534ed374269bf)
3. [Remove unused meta field from term wp com rest response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/02a1967f28ce793dbdf3571c4131f74e886265e2)

-----

## Associated Clients

It is highly recommending that this change is being tested on the below associated clients:

- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android)

-----

## To Test:

- Smoke test the `FluxC Example` app via the `TAXONOMIES` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any `TaxonomyStore` related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

<details>
    <summary>1. Categories Settings Screen [CategoriesListFragment.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Menu` sub-tab on the initial `My Site` screen and click on `Site Settings` under the
`Manage` section.
- Find the `Categories` under the `Writing` section and click on it.
- Verify that the `Categories` screen is displayed and that everything works as expected.

</details>

<details>
    <summary>2. Tags Settings Screen [SiteSettingsTagListActivity.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Menu` sub-tab on the initial `My Site` screen and click on `Site Settings` under the
`Manage` section.
- Find the `Tags` under the `Writing` section and click on it.
- Verify that the `Tags` screen is displayed and that everything works as expected.

</details>