### PR TITLE
HACK Week: Increase max attribute terms parameter

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -42,9 +42,13 @@ class ProductAttributeRestClient @Inject constructor(private val wooNetwork: Woo
 
     suspend fun fetchAllAttributeTerms(
         site: SiteModel,
-        attributeID: Long
+        attributeID: Long,
+        pageSize: Int = 100
     ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.pathV3
-            .request<Array<AttributeTermApiResponse>>(site)
+            .request<Array<AttributeTermApiResponse>>(
+                site = site,
+                params = mapOf("per_page" to pageSize.toString())
+            )
 
     suspend fun postNewTerm(
         site: SiteModel,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -43,7 +43,7 @@ class ProductAttributeRestClient @Inject constructor(private val wooNetwork: Woo
     suspend fun fetchAllAttributeTerms(
         site: SiteModel,
         attributeID: Long,
-        pageSize: Int = 100
+        pageSize: Int
     ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.pathV3
             .request<Array<AttributeTermApiResponse>>(
                 site = site,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -69,11 +69,13 @@ class ProductAttributeRestClient @Inject constructor(private val wooNetwork: Woo
             .delete<AttributeTermApiResponse>(site)
 
     private suspend inline fun <reified T : Any> String.request(
-        site: SiteModel
+        site: SiteModel,
+        params: Map<String, String> = emptyMap()
     ) = wooNetwork.executeGetGsonRequest(
         site = site,
         path = this,
-        clazz = T::class.java
+        clazz = T::class.java,
+        params = params
     ).toWooPayload()
 
     private suspend inline fun <reified T : Any> String.post(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
@@ -54,8 +54,9 @@ class WCGlobalAttributeStore @Inject constructor(
 
     suspend fun fetchAttributeTerms(
         site: SiteModel,
-        attributeID: Long
-    ) = restClient.fetchAllAttributeTerms(site, attributeID)
+        attributeID: Long,
+        pageSize: Int = 100
+    ) = restClient.fetchAllAttributeTerms(site, attributeID, pageSize)
             .result?.map { mapper.responseToAttributeTermModel(it, attributeID.toInt(), site) }
             ?.apply {
                 insertAttributeTermsFromScratch(attributeID.toInt(), site.id, this)


### PR DESCRIPTION
Why
==========
This is a temporary fix for issue https://github.com/woocommerce/woocommerce-android/issues/9583. 

The current attributes term fetching doesn't use any pagination strategy and the `per_page` default value is 10. Because of this limitation, some users are reporting problems to see all terms of an attribute. 

How
==========
This PR solves this problem with brute force by making the `per_page` maxed to 100, but this won't be the final solution.

In the upcoming PRs under work right now, a proper pagination system is being introduced to make the attributes term loading more intelligent and capable of loading any amount of terms.

How to Test
==========
1. Make sure unit tests and CI are green.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
