### PR TITLE
Expose document mime types to client apps

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt
@@ -204,6 +204,9 @@ class MimeTypes {
     fun getAudioTypesOnly(plan: Plan = NO_PLAN_SPECIFIED) =
             (getAudioMimeTypesOnly(plan).toStrings()).toSet().toTypedArray()
 
+    fun getDocumentTypesOnly(plan: Plan = NO_PLAN_SPECIFIED) =
+        (getDocumentMimeTypesOnly(plan).toStrings()).toSet().toTypedArray()
+
     private fun getAudioMimeTypesOnly(plan: Plan = NO_PLAN_SPECIFIED): List<MimeType> {
         return when (plan) {
             WP_COM_PAID, SELF_HOSTED, NO_PLAN_SPECIFIED -> audioTypes


### PR DESCRIPTION
⚠️ Please don't merge, I'll handle merging myself to synchronize between the different PRs.

This PR simply adds a function to the `MimeTypes` object to expose the document types to client apps, same as what we do with other file formats.

There is nothing to test, just a code review.