### PR TITLE
HACK Week: Add pagination support to attribute list fetching

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/attributes/ProductAttributeRestClient.kt
@@ -43,11 +43,15 @@ class ProductAttributeRestClient @Inject constructor(private val wooNetwork: Woo
     suspend fun fetchAllAttributeTerms(
         site: SiteModel,
         attributeID: Long,
+        page: Int,
         pageSize: Int
     ) = WOOCOMMERCE.products.attributes.attribute(attributeID).terms.pathV3
             .request<Array<AttributeTermApiResponse>>(
                 site = site,
-                params = mapOf("per_page" to pageSize.toString())
+                params = mapOf(
+                    "page" to page.toString(),
+                    "per_page" to pageSize.toString()
+                )
             )
 
     suspend fun postNewTerm(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
@@ -55,7 +55,7 @@ class WCGlobalAttributeStore @Inject constructor(
     suspend fun fetchAttributeTerms(
         site: SiteModel,
         attributeID: Long,
-        page: Int,
+        page: Int = 1,
         pageSize: Int = 100
     ) = restClient.fetchAllAttributeTerms(site, attributeID, page, pageSize)
             .result?.map { mapper.responseToAttributeTermModel(it, attributeID.toInt(), site) }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
@@ -55,8 +55,9 @@ class WCGlobalAttributeStore @Inject constructor(
     suspend fun fetchAttributeTerms(
         site: SiteModel,
         attributeID: Long,
+        page: Int,
         pageSize: Int = 100
-    ) = restClient.fetchAllAttributeTerms(site, attributeID, pageSize)
+    ) = restClient.fetchAllAttributeTerms(site, attributeID, page, pageSize)
             .result?.map { mapper.responseToAttributeTermModel(it, attributeID.toInt(), site) }
             ?.apply {
                 insertAttributeTermsFromScratch(attributeID.toInt(), site.id, this)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGlobalAttributeStore.kt
@@ -55,8 +55,8 @@ class WCGlobalAttributeStore @Inject constructor(
     suspend fun fetchAttributeTerms(
         site: SiteModel,
         attributeID: Long,
-        page: Int = 1,
-        pageSize: Int = 100
+        page: Int = DEFAULT_PAGE_INDEX,
+        pageSize: Int = DEFAULT_PAGE_SIZE
     ) = restClient.fetchAllAttributeTerms(site, attributeID, page, pageSize)
             .result?.map { mapper.responseToAttributeTermModel(it, attributeID.toInt(), site) }
             ?.apply {
@@ -193,5 +193,10 @@ class WCGlobalAttributeStore @Inject constructor(
         fetchAttribute(site, attributeID)
                 .model
                 ?.let { updateSingleAttributeTermsMapping(attributeID.toInt(), termsId, site.id) }
+    }
+
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 100
+        const val DEFAULT_PAGE_INDEX = 1
     }
 }


### PR DESCRIPTION
⚠️ Do not merge before https://github.com/woocommerce/woocommerce-android/pull/9748

Why
==========
Part of the actual fix for issue https://github.com/woocommerce/woocommerce-android/issues/9583. 

The current attributes term fetching doesn't use any pagination strategy and the `per_page` default value is 10. Because of this limitation, some users are reporting problems seeing all terms of an attribute. 

How
==========
This PR solves this problem by allowing pagination for the Global attributes fetching.

The main part of this work is done through https://github.com/woocommerce/woocommerce-android/pull/9748. I recommend testing the changes introduced in this PR from there.

How to Test
==========
1. Make sure unit tests and CI are green.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
