### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to All `Taxonomy` & `Term` SqlUtils & Model Classes (`breaking`)

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -113,8 +113,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.TERM_UPDATED;
         mCountDownLatch = new CountDownLatch(1);
 
-        TermModel term = new TermModel();
-        term.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
+        TermModel term = new TermModel(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
         term.setSlug("uncategorized");
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermAction(new RemoteTermPayload(term, sSite)));
 
@@ -434,9 +433,8 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     @Nullable
     private TermModel instantiateTermModel(@NonNull SiteModel site, @NonNull String taxonomyName) {
-        TermModel newTerm = new TermModel();
+        TermModel newTerm = new TermModel(taxonomyName);
         newTerm.setLocalSiteId(site.getId());
-        newTerm.setTaxonomy(taxonomyName);
 
         // Insert the term into the db, updating the object to include the local ID
         TermModel insertedTerm = insertTermForResult(newTerm);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -247,7 +247,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onTaxonomyChanged(OnTaxonomyChanged event) {
+    public void onTaxonomyChanged(@NonNull OnTaxonomyChanged event) {
         AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
         if (event.isError()) {
             AppLog.i(T.API, "OnTaxonomyChanged has error: " + event.error.type + " - " + event.error.message);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
     @Inject TaxonomyStore mTaxonomyStore;
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -100,8 +100,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         mNextEvent = TestEvents.ERROR_INVALID_TAXONOMY;
         mCountDownLatch = new CountDownLatch(1);
 
-        TaxonomyModel taxonomyModel = new TaxonomyModel();
-        taxonomyModel.setName("roads");
+        TaxonomyModel taxonomyModel = new TaxonomyModel("roads");
 
         FetchTermsPayload payload = new FetchTermsPayload(sSite, taxonomyModel);
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermsAction(payload));
@@ -189,8 +188,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     @Test
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
-        TaxonomyModel taxonomyModel = new TaxonomyModel();
-        taxonomyModel.setName(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
+        TaxonomyModel taxonomyModel = new TaxonomyModel(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
 
         // Instantiate new term
         TermModel term = createNewTerm(taxonomyModel);
@@ -209,8 +207,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     @Test
     public void testUploadTermForInvalidTaxonomy() throws InterruptedException {
-        TaxonomyModel taxonomyModel = new TaxonomyModel();
-        taxonomyModel.setName("roads");
+        TaxonomyModel taxonomyModel = new TaxonomyModel("roads");
 
         // Instantiate new term
         TermModel term = createNewTerm(taxonomyModel);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -421,7 +421,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
 
         String newDescription = "newDescription";
-        assertFalse(newDescription.equals(uploadedTerm.getDescription()));
+        assertNotEquals(newDescription, uploadedTerm.getDescription());
         uploadedTerm.setDescription(newDescription);
 
         uploadTerm(uploadedTerm);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -281,7 +281,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
                 break;
             case FETCH_TERMS:
                 if (mNextEvent.equals(TestEvents.TERMS_FETCHED)) {
-                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " " + event.taxonomyName + " terms");
+                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " terms");
                     mCountDownLatch.countDown();
                 }
                 break;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -296,6 +296,15 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
                     mCountDownLatch.countDown();
                 }
                 break;
+            case FETCH_TERM:
+            case PUSH_TERM:
+            case DELETE_TERM:
+            case FETCHED_TERMS:
+            case FETCHED_TERM:
+            case PUSHED_TERM:
+            case DELETED_TERM:
+            case REMOVE_ALL_TERMS:
+                break;
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestWPCom.java
@@ -301,7 +301,7 @@ public class ReleaseStack_TaxonomyTestWPCom extends ReleaseStack_WPComBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onTermUploaded(OnTermUploaded event) {
+    public void onTermUploaded(@NonNull OnTermUploaded event) {
         AppLog.i(T.API, "Received OnTermUploaded");
         if (event.isError()) {
             AppLog.i(T.API, "OnTermUploaded has error: " + event.error.type + " - " + event.error.message);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.release;
 
+import androidx.annotation.NonNull;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -318,7 +320,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onTermUploaded(OnTermUploaded event) {
+    public void onTermUploaded(@NonNull OnTermUploaded event) {
         AppLog.i(T.API, "Received OnTermUploaded");
         if (event.isError()) {
             AppLog.i(T.API, "OnTermUploaded has error: " + event.error.type + " - " + event.error.message);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
@@ -368,9 +369,13 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private TermModel createNewCategory() {
         TermModel term = mTaxonomyStore.instantiateCategory(sSite);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        if (term != null) {
+            assertEquals(0, term.getRemoteTermId());
+            assertNotSame(0, term.getId());
+            assertNotSame(0, term.getLocalSiteId());
+        } else {
+            fail("Failed to instantiate new category!");
+        }
 
         return term;
     }
@@ -378,9 +383,13 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private TermModel createNewTag() {
         TermModel term = mTaxonomyStore.instantiateTag(sSite);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        if (term != null) {
+            assertEquals(0, term.getRemoteTermId());
+            assertNotSame(0, term.getId());
+            assertNotSame(0, term.getLocalSiteId());
+        } else {
+            fail("Failed to instantiate new tag!");
+        }
 
         return term;
     }
@@ -388,9 +397,13 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     private TermModel createNewTerm(TaxonomyModel taxonomy) {
         TermModel term = mTaxonomyStore.instantiateTerm(sSite, taxonomy);
 
-        assertEquals(0, term.getRemoteTermId());
-        assertNotSame(0, term.getId());
-        assertNotSame(0, term.getLocalSiteId());
+        if (term != null) {
+            assertEquals(0, term.getRemoteTermId());
+            assertNotSame(0, term.getId());
+            assertNotSame(0, term.getLocalSiteId());
+        } else {
+            fail("Failed to instantiate new term!");
+        }
 
         return term;
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -365,7 +365,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         term.setDescription(TERM_DEFAULT_DESCRIPTION);
     }
 
-    private TermModel createNewCategory() throws InterruptedException {
+    private TermModel createNewCategory() {
         TermModel term = mTaxonomyStore.instantiateCategory(sSite);
 
         assertEquals(0, term.getRemoteTermId());
@@ -375,7 +375,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         return term;
     }
 
-    private TermModel createNewTag() throws InterruptedException {
+    private TermModel createNewTag() {
         TermModel term = mTaxonomyStore.instantiateTag(sSite);
 
         assertEquals(0, term.getRemoteTermId());
@@ -385,7 +385,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         return term;
     }
 
-    private TermModel createNewTerm(TaxonomyModel taxonomy) throws InterruptedException {
+    private TermModel createNewTerm(TaxonomyModel taxonomy) {
         TermModel term = mTaxonomyStore.instantiateTerm(sSite, taxonomy);
 
         assertEquals(0, term.getRemoteTermId());

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -265,7 +265,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onTaxonomyChanged(OnTaxonomyChanged event) {
+    public void onTaxonomyChanged(@NonNull OnTaxonomyChanged event) {
         AppLog.i(T.API, "Received OnTaxonomyChanged, causeOfChange: " + event.causeOfChange);
         if (event.isError()) {
             AppLog.i(T.API, "OnTaxonomyChanged has error: " + event.error.type + " - " + event.error.message);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -124,8 +124,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mNextEvent = TestEvents.TERM_UPDATED;
         mCountDownLatch = new CountDownLatch(1);
 
-        TermModel term = new TermModel();
-        term.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
+        TermModel term = new TermModel(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
         term.setSlug("uncategorized");
         term.setRemoteTermId(1);
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermAction(new RemoteTermPayload(term, sSite)));
@@ -452,9 +451,8 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     @Nullable
     private TermModel instantiateTermModel(@NonNull SiteModel site, @NonNull String taxonomyName) {
-        TermModel newTerm = new TermModel();
+        TermModel newTerm = new TermModel(taxonomyName);
         newTerm.setLocalSiteId(site.getId());
-        newTerm.setTaxonomy(taxonomyName);
 
         // Insert the term into the db, updating the object to include the local ID
         TermModel insertedTerm = insertTermForResult(newTerm);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -300,7 +300,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
                 break;
             case FETCH_TERMS:
                 if (mNextEvent.equals(TestEvents.TERMS_FETCHED)) {
-                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " " + event.taxonomyName + " terms");
+                    AppLog.i(T.API, "Fetched " + event.rowsAffected + " terms");
                     mCountDownLatch.countDown();
                 }
                 break;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -107,8 +107,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mNextEvent = TestEvents.ERROR_GENERIC;
         mCountDownLatch = new CountDownLatch(1);
 
-        TaxonomyModel taxonomyModel = new TaxonomyModel();
-        taxonomyModel.setName("roads");
+        TaxonomyModel taxonomyModel = new TaxonomyModel("roads");
 
         FetchTermsPayload payload = new FetchTermsPayload(sSite, taxonomyModel);
         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchTermsAction(payload));
@@ -188,8 +187,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     @Test
     public void testUploadNewCategoryAsTerm() throws InterruptedException {
-        TaxonomyModel taxonomyModel = new TaxonomyModel();
-        taxonomyModel.setName(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
+        TaxonomyModel taxonomyModel = new TaxonomyModel(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
 
         // Instantiate new term
         TermModel termModel = createNewTerm(taxonomyModel);
@@ -208,8 +206,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     @Test
     public void testUploadTermForInvalidTaxonomy() throws InterruptedException {
-        TaxonomyModel taxonomyModel = new TaxonomyModel();
-        taxonomyModel.setName("roads");
+        TaxonomyModel taxonomyModel = new TaxonomyModel("roads");
 
         // Instantiate new term
         TermModel term = createNewTerm(taxonomyModel);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -315,6 +315,15 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
                     mCountDownLatch.countDown();
                 }
                 break;
+            case FETCH_TERM:
+            case PUSH_TERM:
+            case DELETE_TERM:
+            case FETCHED_TERMS:
+            case FETCHED_TERM:
+            case PUSHED_TERM:
+            case DELETED_TERM:
+            case REMOVE_ALL_TERMS:
+                break;
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
@@ -416,7 +416,7 @@ public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertNotSame(0, uploadedTerm.getRemoteTermId());
 
         String newDescription = "newDescription";
-        assertFalse(newDescription.equals(uploadedTerm.getDescription()));
+        assertNotEquals(newDescription, uploadedTerm.getDescription());
         uploadedTerm.setDescription(newDescription);
 
         uploadTerm(uploadedTerm);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_TaxonomyTestXMLRPC.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_TaxonomyTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @Inject TaxonomyStore mTaxonomyStore;
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -107,7 +107,7 @@ public class TaxonomiesFragment extends Fragment {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onTaxonomyChanged(OnTaxonomyChanged event) {
+    public void onTaxonomyChanged(@NonNull OnTaxonomyChanged event) {
         AppLog.i(T.API, "OnTaxonomyChanged: rowsAffected=" + event.rowsAffected);
         if (event.isError()) {
             String error = "Error: " + event.error.type + " - " + event.error.message;

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -122,7 +123,7 @@ public class TaxonomiesFragment extends Fragment {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onTermUploaded(OnTermUploaded event) {
+    public void onTermUploaded(@NonNull OnTermUploaded event) {
         prependToLog("Term uploaded! Remote category id: " + event.term.getRemoteTermId());
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.TaxonomyAction;
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TermModel;
@@ -114,9 +115,18 @@ public class TaxonomiesFragment extends Fragment {
             prependToLog(error);
             AppLog.i(T.TESTS, error);
         } else {
-            List<TermModel> terms = mTaxonomyStore.getTermsForSite(getFirstSite(), event.taxonomyName);
-            for (TermModel term : terms) {
-                prependToLog(event.taxonomyName + " " + term.getRemoteTermId() + ": " + term.getName());
+            if (event.causeOfChange == TaxonomyAction.FETCH_CATEGORIES) {
+                List<TermModel> terms = mTaxonomyStore.getCategoriesForSite(getFirstSite());
+                for (TermModel term : terms) {
+                    prependToLog("category" + " " + term.getRemoteTermId() + ": " + term.getName());
+                }
+            } else if (event.causeOfChange == TaxonomyAction.FETCH_TAGS) {
+                List<TermModel> terms = mTaxonomyStore.getTagsForSite(getFirstSite());
+                for (TermModel term : terms) {
+                    prependToLog("tag" + " " + term.getRemoteTermId() + ": " + term.getName());
+                }
+            } else {
+                prependToLog(event.causeOfChange + " " + event.rowsAffected);
             }
         }
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -94,11 +94,11 @@ public class TaxonomiesFragment extends Fragment {
     }
 
     private void createCategory() {
-        TermModel newCategory = new TermModel();
-        newCategory.setLocalSiteId(getFirstSite().getId());
-        newCategory.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
-        newCategory.setName("FluxC-category-" + new Random().nextLong());
-        newCategory.setDescription("From FluxC example app");
+        TermModel newCategory = new TermModel(
+                TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+                "FluxC-Category-" + new Random().nextLong(),
+                0
+        );
         RemoteTermPayload payload = new RemoteTermPayload(newCategory, getFirstSite());
         mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload));
     }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/TaxonomiesFragment.java
@@ -94,16 +94,13 @@ public class TaxonomiesFragment extends Fragment {
     }
 
     private void createCategory() {
-        TermModel newCategory = mTaxonomyStore.instantiateCategory(getFirstSite());
-        if (newCategory != null) {
-            newCategory.setName("FluxC-category-" + new Random().nextLong());
-            newCategory.setDescription("From FluxC example app");
-
-            RemoteTermPayload payload = new RemoteTermPayload(newCategory, getFirstSite());
-            mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload));
-        } else {
-            prependToLog("Error: no category found!");
-        }
+        TermModel newCategory = new TermModel();
+        newCategory.setLocalSiteId(getFirstSite().getId());
+        newCategory.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
+        newCategory.setName("FluxC-category-" + new Random().nextLong());
+        newCategory.setDescription("From FluxC example app");
+        RemoteTermPayload payload = new RemoteTermPayload(newCategory, getFirstSite());
+        mDispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload));
     }
 
     @SuppressWarnings("unused")

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -46,8 +46,7 @@ public class TaxonomyStoreUnitTest {
 
     @Test
     public void testSimpleInsertionAndRetrieval() {
-        TermModel termModel = new TermModel();
-        termModel.setRemoteTermId(42);
+        TermModel termModel = new TermModel(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
         TaxonomySqlUtils.insertOrUpdateTerm(termModel);
 
         assertEquals(1, TaxonomyTestUtils.getTermsCount());

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -37,7 +37,7 @@ public class TaxonomyStoreUnitTest {
 
     @Before
     public void setUp() {
-        Context appContext = RuntimeEnvironment.application.getApplicationContext();
+        Context appContext = RuntimeEnvironment.getApplication().getApplicationContext();
 
         WellSqlConfig config = new SingleStoreWellSqlConfigForTests(appContext, TermModel.class);
         WellSql.init(config);

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -45,13 +45,6 @@ public class TaxonomyStoreUnitTest {
     }
 
     @Test
-    public void testInsertNullTerm() {
-        assertEquals(0, TaxonomySqlUtils.insertOrUpdateTerm(null));
-
-        assertEquals(0, TaxonomyTestUtils.getTermsCount());
-    }
-
-    @Test
     public void testSimpleInsertionAndRetrieval() {
         TermModel termModel = new TermModel();
         termModel.setRemoteTermId(42);

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -29,8 +29,11 @@ import static org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_T
 
 @RunWith(RobolectricTestRunner.class)
 public class TaxonomyStoreUnitTest {
-    private TaxonomyStore mTaxonomyStore = new TaxonomyStore(new Dispatcher(), Mockito.mock(TaxonomyRestClient.class),
-            Mockito.mock(TaxonomyXMLRPCClient.class));
+    private final TaxonomyStore mTaxonomyStore = new TaxonomyStore(
+            new Dispatcher(),
+            Mockito.mock(TaxonomyRestClient.class),
+            Mockito.mock(TaxonomyXMLRPCClient.class)
+    );
 
     @Before
     public void setUp() {

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyStoreUnitTest.java
@@ -178,7 +178,8 @@ public class TaxonomyStoreUnitTest {
         assertEquals(4, TaxonomyTestUtils.getTermsCount());
         assertEquals(2, mTaxonomyStore.getCategoriesForSite(site).size());
 
-        TaxonomySqlUtils.clearTaxonomyForSite(site, DEFAULT_TAXONOMY_CATEGORY);
+        int deletedTermModels = TaxonomySqlUtils.clearTaxonomyForSite(site, DEFAULT_TAXONOMY_CATEGORY);
+        assertEquals(2, deletedTermModels);
 
         assertEquals(0, mTaxonomyStore.getCategoriesForSite(site).size());
         assertEquals(2, TaxonomyTestUtils.getTermsCount());

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TaxonomyTestUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.taxonomy;
 
+import androidx.annotation.NonNull;
+
 import com.yarolegovich.wellsql.WellSql;
 
 import org.wordpress.android.fluxc.model.TermModel;
@@ -8,34 +10,37 @@ import org.wordpress.android.fluxc.store.TaxonomyStore;
 import java.util.List;
 
 class TaxonomyTestUtils {
-    private static TermModel generateSampleTerm() {
-        TermModel example = new TermModel();
-        example.setLocalSiteId(6);
-        example.setRemoteTermId(5);
-        example.setSlug("travel");
-        example.setName("Travel");
-        example.setDescription("Post about travelling");
-        return example;
+    @NonNull
+    private static TermModel generateSampleTerm(@NonNull String taxonomy) {
+        return new TermModel(
+                0,
+                6,
+                5,
+                taxonomy,
+                "Travel",
+                "travel",
+                "Post about travelling",
+                0,
+                0
+        );
     }
 
+    @NonNull
     public static TermModel generateSampleCategory() {
-        TermModel exampleCategory = generateSampleTerm();
-        exampleCategory.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
-        return exampleCategory;
+        return generateSampleTerm(TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY);
     }
 
+    @NonNull
     public static TermModel generateSampleTag() {
-        TermModel exampleTag = generateSampleTerm();
-        exampleTag.setTaxonomy(TaxonomyStore.DEFAULT_TAXONOMY_TAG);
-        return exampleTag;
+        return generateSampleTerm(TaxonomyStore.DEFAULT_TAXONOMY_TAG);
     }
 
+    @NonNull
     public static TermModel generateSampleAuthor() {
-        TermModel exampleAuthor = generateSampleTerm();
-        exampleAuthor.setTaxonomy("author");
-        return exampleAuthor;
+        return generateSampleTerm("author");
     }
 
+    @NonNull
     static List<TermModel> getTerms() {
         return WellSql.select(TermModel.class).getAsModel();
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TermModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/taxonomy/TermModelTest.java
@@ -9,12 +9,12 @@ import static org.junit.Assert.assertTrue;
 public class TermModelTest {
     @Test
     public void testEquals() {
-        TermModel testCategory = TaxonomyTestUtils.generateSampleCategory();
+        TermModel testCategory1 = TaxonomyTestUtils.generateSampleCategory();
         TermModel testCategory2 = TaxonomyTestUtils.generateSampleCategory();
 
-        testCategory2.setRemoteTermId(testCategory.getRemoteTermId() + 1);
-        assertFalse(testCategory.equals(testCategory2));
-        testCategory2.setRemoteTermId(testCategory.getRemoteTermId());
-        assertTrue(testCategory.equals(testCategory2));
+        testCategory2.setRemoteTermId(testCategory1.getRemoteTermId() + 1);
+        assertFalse(testCategory1.equals(testCategory2));
+        testCategory2.setRemoteTermId(testCategory1.getRemoteTermId());
+        assertTrue(testCategory1.equals(testCategory2));
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
@@ -90,6 +90,7 @@ public class TaxonomyModel extends Payload<BaseNetworkError> implements Identifi
     }
 
     @Override
+    @SuppressWarnings("ConditionCoveredByFurtherCondition")
     public boolean equals(@Nullable Object other) {
         if (this == other) return true;
         if (other == null || !(other instanceof TaxonomyModel)) return false;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
@@ -15,7 +15,6 @@ import org.wordpress.android.util.StringUtils;
 import java.io.Serializable;
 
 @Table
-@SuppressWarnings("NotNullFieldNotInitialized")
 public class TaxonomyModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     private static final long serialVersionUID = 8855881690971305398L;
 
@@ -27,6 +26,48 @@ public class TaxonomyModel extends Payload<BaseNetworkError> implements Identifi
     @Nullable @Column private String mDescription;
     @Column private boolean mIsHierarchical;
     @Column private boolean mIsPublic;
+
+    @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    public TaxonomyModel() {
+        this.mId = 0;
+        this.mLocalSiteId = 0;
+        this.mName = "";
+        this.mLabel = null;
+        this.mDescription = null;
+        this.mIsHierarchical = false;
+        this.mIsPublic = false;
+    }
+
+    /**
+     * Use when adding a new taxonomy.
+     */
+    public TaxonomyModel(@NonNull String name) {
+        this.mId = 0;
+        this.mLocalSiteId = 0;
+        this.mName = name;
+        this.mLabel = null;
+        this.mDescription = null;
+        this.mIsHierarchical = false;
+        this.mIsPublic = false;
+    }
+
+    public TaxonomyModel(
+            int id,
+            int localSiteId,
+            @NonNull String name,
+            @Nullable String label,
+            @Nullable String description,
+            boolean isHierarchical,
+            boolean isPublic) {
+        this.mId = id;
+        this.mLocalSiteId = localSiteId;
+        this.mName = name;
+        this.mLabel = label;
+        this.mDescription = description;
+        this.mIsHierarchical = isHierarchical;
+        this.mIsPublic = isPublic;
+    }
 
     @Override
     public int getId() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.model;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
@@ -12,15 +15,16 @@ import org.wordpress.android.util.StringUtils;
 import java.io.Serializable;
 
 @Table
+@SuppressWarnings("NotNullFieldNotInitialized")
 public class TaxonomyModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     private static final long serialVersionUID = 8855881690971305398L;
 
     @PrimaryKey
     @Column private int mId;
     @Column private int mLocalSiteId;
-    @Column private String mName;
-    @Column private String mLabel;
-    @Column private String mDescription;
+    @NonNull @Column private String mName;
+    @Nullable @Column private String mLabel;
+    @Nullable @Column private String mDescription;
     @Column private boolean mIsHierarchical;
     @Column private boolean mIsPublic;
 
@@ -42,27 +46,30 @@ public class TaxonomyModel extends Payload<BaseNetworkError> implements Identifi
         mLocalSiteId = localSiteId;
     }
 
+    @NonNull
     public String getName() {
         return mName;
     }
 
-    public void setName(String name) {
+    public void setName(@NonNull String name) {
         mName = name;
     }
 
+    @Nullable
     public String getLabel() {
         return mLabel;
     }
 
-    public void setLabel(String label) {
+    public void setLabel(@Nullable String label) {
         mLabel = label;
     }
 
+    @Nullable
     public String getDescription() {
         return mDescription;
     }
 
-    public void setDescription(String description) {
+    public void setDescription(@Nullable String description) {
         mDescription = description;
     }
 
@@ -83,7 +90,7 @@ public class TaxonomyModel extends Payload<BaseNetworkError> implements Identifi
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (this == other) return true;
         if (other == null || !(other instanceof TaxonomyModel)) return false;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
@@ -15,7 +15,6 @@ import org.wordpress.android.util.StringUtils;
 import java.io.Serializable;
 
 @Table
-@SuppressWarnings("NotNullFieldNotInitialized")
 public class TermModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     private static final long serialVersionUID = -1484257248446576276L;
 
@@ -29,6 +28,75 @@ public class TermModel extends Payload<BaseNetworkError> implements Identifiable
     @Nullable @Column private String mDescription;
     @Column private long mParentRemoteId;
     @Column private int mPostCount;
+
+    @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    public TermModel() {
+        this.mId = 0;
+        this.mLocalSiteId = 0;
+        this.mRemoteTermId = 0;
+        this.mTaxonomy = "";
+        this.mName = "";
+        this.mSlug = null;
+        this.mDescription = null;
+        this.mParentRemoteId = 0;
+        this.mPostCount = 0;
+    }
+
+    /**
+     * Use when starting with an empty term.
+     */
+    public TermModel(@NonNull String taxonomy) {
+        this.mId = 0;
+        this.mLocalSiteId = 0;
+        this.mRemoteTermId = 0;
+        this.mTaxonomy = taxonomy;
+        this.mName = "";
+        this.mSlug = null;
+        this.mDescription = null;
+        this.mParentRemoteId = 0;
+        this.mPostCount = 0;
+    }
+
+    /**
+     * Use when adding a new term.
+     */
+    public TermModel(
+            @NonNull String taxonomy,
+            @NonNull String name,
+            long parentRemoteId
+    ) {
+        this.mId = 0;
+        this.mLocalSiteId = 0;
+        this.mRemoteTermId = 0;
+        this.mTaxonomy = taxonomy;
+        this.mName = name;
+        this.mSlug = null;
+        this.mDescription = null;
+        this.mParentRemoteId = parentRemoteId;
+        this.mPostCount = 0;
+    }
+
+    public TermModel(
+            int id,
+            int localSiteId,
+            long remoteTermId,
+            @NonNull String taxonomy,
+            @NonNull String name,
+            @Nullable String slug,
+            @Nullable String description,
+            long parentRemoteId,
+            int postCount) {
+        this.mId = id;
+        this.mLocalSiteId = localSiteId;
+        this.mRemoteTermId = remoteTermId;
+        this.mTaxonomy = taxonomy;
+        this.mName = name;
+        this.mSlug = slug;
+        this.mDescription = description;
+        this.mParentRemoteId = parentRemoteId;
+        this.mPostCount = postCount;
+    }
 
     @Override
     public int getId() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
@@ -109,6 +109,7 @@ public class TermModel extends Payload<BaseNetworkError> implements Identifiable
     }
 
     @Override
+    @SuppressWarnings("ConditionCoveredByFurtherCondition")
     public boolean equals(@Nullable Object other) {
         if (this == other) return true;
         if (other == null || !(other instanceof TermModel)) return false;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.model;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
@@ -12,6 +15,7 @@ import org.wordpress.android.util.StringUtils;
 import java.io.Serializable;
 
 @Table
+@SuppressWarnings("NotNullFieldNotInitialized")
 public class TermModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     private static final long serialVersionUID = -1484257248446576276L;
 
@@ -19,10 +23,10 @@ public class TermModel extends Payload<BaseNetworkError> implements Identifiable
     @Column private int mId;
     @Column private int mLocalSiteId;
     @Column private long mRemoteTermId;
-    @Column private String mTaxonomy;
-    @Column private String mName;
-    @Column private String mSlug;
-    @Column private String mDescription;
+    @NonNull @Column private String mTaxonomy;
+    @NonNull @Column private String mName;
+    @Nullable @Column private String mSlug;
+    @Nullable @Column private String mDescription;
     @Column private long mParentRemoteId;
     @Column private int mPostCount;
 
@@ -52,35 +56,39 @@ public class TermModel extends Payload<BaseNetworkError> implements Identifiable
         mRemoteTermId = remoteTermId;
     }
 
+    @NonNull
     public String getTaxonomy() {
         return mTaxonomy;
     }
 
-    public void setTaxonomy(String taxonomy) {
+    public void setTaxonomy(@NonNull String taxonomy) {
         mTaxonomy = taxonomy;
     }
 
+    @NonNull
     public String getName() {
         return mName;
     }
 
-    public void setName(String name) {
+    public void setName(@NonNull String name) {
         mName = name;
     }
 
+    @Nullable
     public String getSlug() {
         return mSlug;
     }
 
-    public void setSlug(String slug) {
+    public void setSlug(@Nullable String slug) {
         mSlug = slug;
     }
 
+    @Nullable
     public String getDescription() {
         return mDescription;
     }
 
-    public void setDescription(String description) {
+    public void setDescription(@Nullable String description) {
         mDescription = description;
     }
 
@@ -101,7 +109,7 @@ public class TermModel extends Payload<BaseNetworkError> implements Identifiable
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (this == other) return true;
         if (other == null || !(other instanceof TermModel)) return false;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermsModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermsModel.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TermsModel extends Payload<BaseNetworkError> {
-    private List<TermModel> mTerms;
+    @NonNull private List<TermModel> mTerms;
 
     public TermsModel() {
         mTerms = new ArrayList<>();
@@ -19,11 +19,12 @@ public class TermsModel extends Payload<BaseNetworkError> {
         mTerms = terms;
     }
 
+    @NonNull
     public List<TermModel> getTerms() {
         return mTerms;
     }
 
-    public void setTerms(List<TermModel> terms) {
+    public void setTerms(@NonNull List<TermModel> terms) {
         this.mTerms = terms;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -53,11 +53,11 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         final WPComGsonRequest<TermWPComRestResponse> request = WPComGsonRequest.buildGetRequest(url, null,
                 TermWPComRestResponse.class,
                 response -> {
-                    TermModel fetchedTerm = termResponseToTermModel(response);
-                    fetchedTerm.setId(term.getId());
-                    fetchedTerm.setTaxonomy(taxonomy);
-                    fetchedTerm.setLocalSiteId(site.getId());
-
+                    TermModel fetchedTerm = termResponseToTermModel(
+                            term.getId(),
+                            site.getId(),
+                            taxonomy,
+                            response);
                     FetchTermResponsePayload payload = new FetchTermResponsePayload(fetchedTerm, site);
                     mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
                 },
@@ -83,9 +83,11 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
                     List<TermModel> termArray = new ArrayList<>();
                     TermModel term;
                     for (TermWPComRestResponse termResponse : response.terms) {
-                        term = termResponseToTermModel(termResponse);
-                        term.setTaxonomy(taxonomyName);
-                        term.setLocalSiteId(site.getId());
+                        term = termResponseToTermModel(
+                                0,
+                                site.getId(),
+                                taxonomyName,
+                                termResponse);
                         termArray.add(term);
                     }
 
@@ -114,12 +116,11 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
         final WPComGsonRequest<TermWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 TermWPComRestResponse.class,
                 response -> {
-                    TermModel uploadedTerm = termResponseToTermModel(response);
-
-                    uploadedTerm.setId(term.getId());
-                    uploadedTerm.setLocalSiteId(site.getId());
-                    uploadedTerm.setTaxonomy(taxonomy);
-
+                    TermModel uploadedTerm = termResponseToTermModel(
+                            term.getId(),
+                            site.getId(),
+                            taxonomy,
+                            response);
                     RemoteTermPayload payload = new RemoteTermPayload(uploadedTerm, site);
                     mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                 },
@@ -159,15 +160,22 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
     }
 
     @NonNull
-    private TermModel termResponseToTermModel(@NonNull TermWPComRestResponse from) {
-        TermModel term = new TermModel();
-        term.setRemoteTermId(from.ID);
-        term.setName(StringEscapeUtils.unescapeHtml4(from.name));
-        term.setSlug(from.slug);
-        term.setDescription(StringEscapeUtils.unescapeHtml4(from.description));
-        term.setParentRemoteId(from.parent);
-        term.setPostCount(from.post_count);
-        return term;
+    private TermModel termResponseToTermModel(
+            int termId,
+            int siteId,
+            @NonNull String taxonomy,
+            @NonNull TermWPComRestResponse from) {
+        return new TermModel(
+                termId,
+                siteId,
+                from.ID,
+                taxonomy,
+                StringEscapeUtils.unescapeHtml4(from.name),
+                from.slug,
+                StringEscapeUtils.unescapeHtml4(from.description),
+                from.parent,
+                from.post_count
+        );
     }
 
     @NonNull

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java
@@ -174,7 +174,7 @@ public class TaxonomyRestClient extends BaseWPComRestClient {
     private Map<String, Object> termModelToParams(@NonNull TermModel term) {
         Map<String, Object> body = new HashMap<>();
 
-        body.put("name", StringUtils.notNullStr(term.getName()));
+        body.put("name", term.getName());
         body.put("description", StringUtils.notNullStr(term.getDescription()));
         body.put("parent", String.valueOf(term.getParentRemoteId()));
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -279,24 +279,23 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         }
 
         Map<?, ?> termMap = (Map<?, ?>) termObject;
-        TermModel term = new TermModel();
-
         String termId = MapUtils.getMapStr(termMap, "term_id");
         if (TextUtils.isEmpty(termId)) {
             // If we don't have a term ID, move on
             return null;
         }
 
-        term.setLocalSiteId(site.getId());
-        term.setRemoteTermId(Integer.valueOf(termId));
-        term.setSlug(MapUtils.getMapStr(termMap, "slug"));
-        term.setName(StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(termMap, "name")));
-        term.setDescription(StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(termMap, "description")));
-        term.setParentRemoteId(MapUtils.getMapLong(termMap, "parent"));
-        term.setTaxonomy(MapUtils.getMapStr(termMap, "taxonomy"));
-        term.setPostCount(MapUtils.getMapInt(termMap, "count", 0));
-
-        return term;
+        return new TermModel(
+                0,
+                site.getId(),
+                Long.parseLong(termId),
+                MapUtils.getMapStr(termMap, "taxonomy"),
+                StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(termMap, "name")),
+                MapUtils.getMapStr(termMap, "slug"),
+                StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(termMap, "description")),
+                MapUtils.getMapLong(termMap, "parent"),
+                MapUtils.getMapInt(termMap, "count", 0)
+        );
     }
 
     private static Map<String, Object> termModelToContentStruct(TermModel term) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -58,11 +58,11 @@ public class TaxonomySqlUtils {
                 .getAsModel();
     }
 
-    public static TermModel getTermByRemoteId(SiteModel site, long remoteTermId, String taxonomyName) {
-        if (site == null || taxonomyName == null) {
-            return null;
-        }
-
+    @Nullable
+    public static TermModel getTermByRemoteId(
+            @NonNull SiteModel site,
+            long remoteTermId,
+            @NonNull String taxonomyName) {
         List<TermModel> termResult = WellSql.select(TermModel.class)
                 .where().beginGroup()
                 .equals(TermModelTable.LOCAL_SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -45,11 +45,10 @@ public class TaxonomySqlUtils {
         return term;
     }
 
-    public static List<TermModel> getTermsForSite(SiteModel site, String taxonomyName) {
-        if (site == null || taxonomyName == null) {
-            return Collections.emptyList();
-        }
-
+    @NonNull
+    public static List<TermModel> getTermsForSite(
+            @NonNull SiteModel site,
+            @NonNull String taxonomyName) {
         return WellSql.select(TermModel.class)
                 .where().beginGroup()
                 .equals(TermModelTable.LOCAL_SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -36,12 +36,6 @@ public class TaxonomySqlUtils {
     }
 
     @NonNull
-    public static TermModel insertTermForResult(@NonNull TermModel term) {
-        WellSql.insert(term).asSingleTransaction(true).execute();
-        return term;
-    }
-
-    @NonNull
     public static List<TermModel> getTermsForSite(
             @NonNull SiteModel site,
             @NonNull String taxonomyName) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -95,9 +95,12 @@ public class TaxonomySqlUtils {
         return null;
     }
 
-    public static List<TermModel> getTermsFromRemoteIdList(List<Long> remoteTermIds, SiteModel site,
-                                                           String taxonomyName) {
-        if (taxonomyName == null || remoteTermIds == null || remoteTermIds.isEmpty()) {
+    @NonNull
+    public static List<TermModel> getTermsFromRemoteIdList(
+            @NonNull List<Long> remoteTermIds,
+            @NonNull SiteModel site,
+            @NonNull String taxonomyName) {
+        if (remoteTermIds.isEmpty()) {
             return Collections.emptyList();
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.persistence;
 
+import androidx.annotation.NonNull;
+
 import com.wellsql.generated.TermModelTable;
 import com.yarolegovich.wellsql.WellSql;
 
@@ -108,9 +110,12 @@ public class TaxonomySqlUtils {
                 .getAsModel();
     }
 
-    public static List<TermModel> getTermsFromRemoteNameList(List<String> remoteTermNames, SiteModel site,
-                                                             String taxonomyName) {
-        if (taxonomyName == null || remoteTermNames == null || remoteTermNames.isEmpty()) {
+    @NonNull
+    public static List<TermModel> getTermsFromRemoteNameList(
+            @NonNull List<String> remoteTermNames,
+            @NonNull SiteModel site,
+            @NonNull String taxonomyName) {
+        if (remoteTermNames.isEmpty()) {
             return Collections.emptyList();
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.persistence;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.wellsql.generated.TermModelTable;
 import com.yarolegovich.wellsql.WellSql;
@@ -76,11 +77,11 @@ public class TaxonomySqlUtils {
         return null;
     }
 
-    public static TermModel getTermByName(SiteModel site, String termName, String taxonomyName) {
-        if (site == null || taxonomyName == null) {
-            return null;
-        }
-
+    @Nullable
+    public static TermModel getTermByName(
+            @NonNull SiteModel site,
+            @NonNull String termName,
+            @NonNull String taxonomyName) {
         List<TermModel> termResult = WellSql.select(TermModel.class)
                 .where().beginGroup()
                 .equals(TermModelTable.LOCAL_SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -127,11 +127,9 @@ public class TaxonomySqlUtils {
                 .getAsModel();
     }
 
-    public static int clearTaxonomyForSite(SiteModel site, String taxonomyName) {
-        if (site == null || taxonomyName == null) {
-            return 0;
-        }
-
+    public static int clearTaxonomyForSite(
+            @NonNull SiteModel site,
+            @NonNull String taxonomyName) {
         return WellSql.delete(TermModel.class)
                 .where().beginGroup()
                 .equals(TermModelTable.LOCAL_SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -39,9 +39,9 @@ public class TaxonomySqlUtils {
         }
     }
 
-    public static TermModel insertTermForResult(TermModel term) {
+    @NonNull
+    public static TermModel insertTermForResult(@NonNull TermModel term) {
         WellSql.insert(term).asSingleTransaction(true).execute();
-
         return term;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -13,11 +13,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class TaxonomySqlUtils {
-    public static int insertOrUpdateTerm(TermModel term) {
-        if (term == null) {
-            return 0;
-        }
-
+    public static int insertOrUpdateTerm(@NonNull TermModel term) {
         List<TermModel> termResult = WellSql.select(TermModel.class)
                 .where().beginGroup()
                 .equals(TermModelTable.ID, term.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/TaxonomySqlUtils.java
@@ -144,11 +144,7 @@ public class TaxonomySqlUtils {
                 .execute();
     }
 
-    public static int removeTerm(TermModel term) {
-        if (term == null) {
-            return 0;
-        }
-
+    public static int removeTerm(@NonNull TermModel term) {
         return WellSql.delete(TermModel.class)
                 .where().beginGroup()
                 .equals(TermModelTable.TAXONOMY, term.getTaxonomy())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -259,7 +259,8 @@ public class TaxonomyStore extends Store {
     /**
      * Returns all the tags for the given post as a {@link TermModel} list.
      */
-    public List<TermModel> getTagsForPost(PostImmutableModel post, SiteModel site) {
+    @NonNull
+    public List<TermModel> getTagsForPost(@NonNull PostImmutableModel post, @NonNull SiteModel site) {
         return TaxonomySqlUtils.getTermsFromRemoteNameList(post.getTagNameList(), site, DEFAULT_TAXONOMY_TAG);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -252,7 +252,8 @@ public class TaxonomyStore extends Store {
     /**
      * Returns all the categories for the given post as a {@link TermModel} list.
      */
-    public List<TermModel> getCategoriesForPost(PostImmutableModel post, SiteModel site) {
+    @NonNull
+    public List<TermModel> getCategoriesForPost(@NonNull PostImmutableModel post, @NonNull SiteModel site) {
         return TaxonomySqlUtils.getTermsFromRemoteIdList(post.getCategoryIdList(), site, DEFAULT_TAXONOMY_CATEGORY);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -95,9 +95,9 @@ public class TaxonomyStore extends Store {
     }
 
     public static class OnTermUploaded extends OnChanged<TaxonomyError> {
-        public TermModel term;
+        @NonNull public TermModel term;
 
-        public OnTermUploaded(TermModel term) {
+        public OnTermUploaded(@NonNull TermModel term) {
             this.term = term;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -81,22 +81,10 @@ public class TaxonomyStore extends Store {
     // OnChanged events
     public static class OnTaxonomyChanged extends OnChanged<TaxonomyError> {
         public int rowsAffected;
-        @Nullable public String taxonomyName;
         @NonNull public TaxonomyAction causeOfChange;
-
-        public OnTaxonomyChanged(
-                int rowsAffected,
-                @NonNull String taxonomyName,
-                @NonNull TaxonomyAction causeOfChange
-        ) {
-            this.rowsAffected = rowsAffected;
-            this.taxonomyName = taxonomyName;
-            this.causeOfChange = causeOfChange;
-        }
 
         public OnTaxonomyChanged(int rowsAffected, @NonNull String taxonomyName) {
             this.rowsAffected = rowsAffected;
-            this.taxonomyName = taxonomyName;
             this.causeOfChange = taxonomyActionFromName(taxonomyName);
         }
 
@@ -420,7 +408,6 @@ public class TaxonomyStore extends Store {
         if (payload.isError()) {
             OnTaxonomyChanged event = new OnTaxonomyChanged(
                     0,
-                    payload.term.getTaxonomy(),
                     TaxonomyAction.UPDATE_TERM
             );
             event.error = payload.error;
@@ -434,7 +421,6 @@ public class TaxonomyStore extends Store {
         if (payload.isError()) {
             OnTaxonomyChanged event = new OnTaxonomyChanged(
                     0,
-                    payload.term.getTaxonomy(),
                     TaxonomyAction.DELETE_TERM
             );
             event.error = payload.error;
@@ -486,7 +472,6 @@ public class TaxonomyStore extends Store {
 
         OnTaxonomyChanged onTaxonomyChanged = new OnTaxonomyChanged(
                 rowsAffected,
-                term.getTaxonomy(),
                 TaxonomyAction.UPDATE_TERM
         );
         emitChange(onTaxonomyChanged);
@@ -497,7 +482,6 @@ public class TaxonomyStore extends Store {
 
         OnTaxonomyChanged onTaxonomyChanged = new OnTaxonomyChanged(
                 rowsAffected,
-                term.getTaxonomy(),
                 TaxonomyAction.REMOVE_TERM
         );
         emitChange(onTaxonomyChanged);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -414,7 +414,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void handleDeleteTermCompleted(RemoteTermPayload payload) {
+    private void handleDeleteTermCompleted(@NonNull RemoteTermPayload payload) {
         if (payload.isError()) {
             OnTaxonomyChanged event = new OnTaxonomyChanged(0, payload.term.getTaxonomy());
             event.error = payload.error;
@@ -425,7 +425,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void handlePushTermCompleted(RemoteTermPayload payload) {
+    private void handlePushTermCompleted(@NonNull RemoteTermPayload payload) {
         if (payload.isError()) {
             OnTermUploaded onTermUploaded = new OnTermUploaded(payload.term);
             onTermUploaded.error = payload.error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -41,18 +41,19 @@ public class TaxonomyStore extends Store {
         }
     }
 
+    @SuppressWarnings("NotNullFieldNotInitialized")
     public static class FetchTermsResponsePayload extends Payload<TaxonomyError> {
-        public TermsModel terms;
-        public SiteModel site;
-        public String taxonomy;
+        @NonNull public TermsModel terms;
+        @NonNull public SiteModel site;
+        @NonNull public String taxonomy; // This field is also included in error payload.
 
-        public FetchTermsResponsePayload(TermsModel terms, SiteModel site, String taxonomy) {
+        public FetchTermsResponsePayload(@NonNull TermsModel terms, @NonNull SiteModel site, @NonNull String taxonomy) {
             this.terms = terms;
             this.site = site;
             this.taxonomy = taxonomy;
         }
 
-        public FetchTermsResponsePayload(TaxonomyError error, String taxonomy) {
+        public FetchTermsResponsePayload(@NonNull TaxonomyError error, @NonNull String taxonomy) {
             this.error = error;
             this.taxonomy = taxonomy;
         }
@@ -330,7 +331,7 @@ public class TaxonomyStore extends Store {
         fetchTerms(payload.site, payload.taxonomy.getName());
     }
 
-    private void handleFetchTermsCompleted(FetchTermsResponsePayload payload) {
+    private void handleFetchTermsCompleted(@NonNull FetchTermsResponsePayload payload) {
         OnTaxonomyChanged onTaxonomyChanged;
 
         if (payload.isError()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -115,10 +115,10 @@ public class TaxonomyStore extends Store {
     }
 
     public static class TaxonomyError implements OnChangedError {
-        public TaxonomyErrorType type;
-        public String message;
+        @NonNull public TaxonomyErrorType type;
+        @NonNull public String message;
 
-        public TaxonomyError(TaxonomyErrorType type, @NonNull String message) {
+        public TaxonomyError(@NonNull TaxonomyErrorType type, @NonNull String message) {
             this.type = type;
             this.message = message;
         }
@@ -128,7 +128,7 @@ public class TaxonomyStore extends Store {
             this.message = message;
         }
 
-        public TaxonomyError(TaxonomyErrorType type) {
+        public TaxonomyError(@NonNull TaxonomyErrorType type) {
             this(type, "");
         }
     }
@@ -140,12 +140,11 @@ public class TaxonomyStore extends Store {
         INVALID_RESPONSE,
         GENERIC_ERROR;
 
-        public static TaxonomyErrorType fromString(String string) {
-            if (string != null) {
-                for (TaxonomyErrorType v : TaxonomyErrorType.values()) {
-                    if (string.equalsIgnoreCase(v.name())) {
-                        return v;
-                    }
+        @NonNull
+        public static TaxonomyErrorType fromString(@NonNull String string) {
+            for (TaxonomyErrorType v : TaxonomyErrorType.values()) {
+                if (string.equalsIgnoreCase(v.name())) {
+                    return v;
                 }
             }
             return GENERIC_ERROR;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -177,13 +177,13 @@ public class TaxonomyStore extends Store {
         newTerm.setTaxonomy(taxonomyName);
 
         // Insert the term into the db, updating the object to include the local ID
-        newTerm = TaxonomySqlUtils.insertTermForResult(newTerm);
+        TermModel insertedTerm = TaxonomySqlUtils.insertTermForResult(newTerm);
 
         // id is set to -1 if insertion fails
-        if (newTerm.getId() == -1) {
+        if (insertedTerm.getId() == -1) {
             return null;
         }
-        return newTerm;
+        return insertedTerm;
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -392,7 +392,7 @@ public class TaxonomyStore extends Store {
         emitChange(onTaxonomyChanged);
     }
 
-    private void handleFetchSingleTermCompleted(FetchTermResponsePayload payload) {
+    private void handleFetchSingleTermCompleted(@NonNull FetchTermResponsePayload payload) {
         if (payload.origin == TaxonomyAction.PUSH_TERM) {
             OnTermUploaded onTermUploaded = new OnTermUploaded(payload.term);
             if (payload.isError()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -190,6 +190,7 @@ public class TaxonomyStore extends Store {
      * Returns all categories for the given site as a {@link TermModel} list.
      */
     @NonNull
+    @SuppressWarnings("unused")
     public List<TermModel> getCategoriesForSite(@NonNull SiteModel site) {
         return TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_CATEGORY);
     }
@@ -198,6 +199,7 @@ public class TaxonomyStore extends Store {
      * Returns all tags for the given site as a {@link TermModel} list.
      */
     @NonNull
+    @SuppressWarnings("unused")
     public List<TermModel> getTagsForSite(@NonNull SiteModel site) {
         return TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_TAG);
     }
@@ -206,6 +208,7 @@ public class TaxonomyStore extends Store {
      * Returns all the terms of a taxonomy for the given site as a {@link TermModel} list.
      */
     @NonNull
+    @SuppressWarnings("unused")
     public List<TermModel> getTermsForSite(@NonNull SiteModel site, @NonNull String taxonomyName) {
         return TaxonomySqlUtils.getTermsForSite(site, taxonomyName);
     }
@@ -214,6 +217,7 @@ public class TaxonomyStore extends Store {
      * Returns a category as a {@link TermModel} given its remote id.
      */
     @Nullable
+    @SuppressWarnings("unused")
     public TermModel getCategoryByRemoteId(@NonNull SiteModel site, long remoteId) {
         return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, DEFAULT_TAXONOMY_CATEGORY);
     }
@@ -222,6 +226,7 @@ public class TaxonomyStore extends Store {
      * Returns a tag as a {@link TermModel} given its remote id.
      */
     @Nullable
+    @SuppressWarnings("unused")
     public TermModel getTagByRemoteId(@NonNull SiteModel site, long remoteId) {
         return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, DEFAULT_TAXONOMY_TAG);
     }
@@ -230,6 +235,7 @@ public class TaxonomyStore extends Store {
      * Returns a term as a {@link TermModel} given its remote id.
      */
     @Nullable
+    @SuppressWarnings("unused")
     public TermModel getTermByRemoteId(@NonNull SiteModel site, long remoteId, @NonNull String taxonomyName) {
         return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, taxonomyName);
     }
@@ -238,6 +244,7 @@ public class TaxonomyStore extends Store {
      * Returns a category as a {@link TermModel} given its name.
      */
     @Nullable
+    @SuppressWarnings("unused")
     public TermModel getCategoryByName(@NonNull SiteModel site, @NonNull String categoryName) {
         return TaxonomySqlUtils.getTermByName(site, categoryName, DEFAULT_TAXONOMY_CATEGORY);
     }
@@ -246,6 +253,7 @@ public class TaxonomyStore extends Store {
      * Returns a tag as a {@link TermModel} given its name.
      */
     @Nullable
+    @SuppressWarnings("unused")
     public TermModel getTagByName(@NonNull SiteModel site, @NonNull String tagName) {
         return TaxonomySqlUtils.getTermByName(site, tagName, DEFAULT_TAXONOMY_TAG);
     }
@@ -254,6 +262,7 @@ public class TaxonomyStore extends Store {
      * Returns a term as a {@link TermModel} given its name.
      */
     @Nullable
+    @SuppressWarnings("unused")
     public TermModel getTermByName(@NonNull SiteModel site, @NonNull String termName, @NonNull String taxonomyName) {
         return TaxonomySqlUtils.getTermByName(site, termName, taxonomyName);
     }
@@ -262,6 +271,7 @@ public class TaxonomyStore extends Store {
      * Returns all the categories for the given post as a {@link TermModel} list.
      */
     @NonNull
+    @SuppressWarnings("unused")
     public List<TermModel> getCategoriesForPost(@NonNull PostImmutableModel post, @NonNull SiteModel site) {
         return TaxonomySqlUtils.getTermsFromRemoteIdList(post.getCategoryIdList(), site, DEFAULT_TAXONOMY_CATEGORY);
     }
@@ -270,6 +280,7 @@ public class TaxonomyStore extends Store {
      * Returns all the tags for the given post as a {@link TermModel} list.
      */
     @NonNull
+    @SuppressWarnings("unused")
     public List<TermModel> getTagsForPost(@NonNull PostImmutableModel post, @NonNull SiteModel site) {
         return TaxonomySqlUtils.getTermsFromRemoteNameList(post.getTagNameList(), site, DEFAULT_TAXONOMY_TAG);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -285,8 +285,9 @@ public class TaxonomyStore extends Store {
         return TaxonomySqlUtils.getTermsFromRemoteNameList(post.getTagNameList(), site, DEFAULT_TAXONOMY_TAG);
     }
 
-    @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    @SuppressWarnings("rawtypes")
     public void onAction(Action action) {
         IAction actionType = action.getType();
         if (!(actionType instanceof TaxonomyAction)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -210,21 +210,24 @@ public class TaxonomyStore extends Store {
     /**
      * Returns a category as a {@link TermModel} given its remote id.
      */
-    public TermModel getCategoryByRemoteId(SiteModel site, long remoteId) {
+    @Nullable
+    public TermModel getCategoryByRemoteId(@NonNull SiteModel site, long remoteId) {
         return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, DEFAULT_TAXONOMY_CATEGORY);
     }
 
     /**
      * Returns a tag as a {@link TermModel} given its remote id.
      */
-    public TermModel getTagByRemoteId(SiteModel site, long remoteId) {
+    @Nullable
+    public TermModel getTagByRemoteId(@NonNull SiteModel site, long remoteId) {
         return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, DEFAULT_TAXONOMY_TAG);
     }
 
     /**
      * Returns a term as a {@link TermModel} given its remote id.
      */
-    public TermModel getTermByRemoteId(SiteModel site, long remoteId, String taxonomyName) {
+    @Nullable
+    public TermModel getTermByRemoteId(@NonNull SiteModel site, long remoteId, @NonNull String taxonomyName) {
         return TaxonomySqlUtils.getTermByRemoteId(site, remoteId, taxonomyName);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -166,37 +166,6 @@ public class TaxonomyStore extends Store {
         AppLog.d(AppLog.T.API, "TaxonomyStore onRegister");
     }
 
-    @Nullable
-    public TermModel instantiateCategory(@NonNull SiteModel site) {
-        return instantiateTermModel(site, DEFAULT_TAXONOMY_CATEGORY);
-    }
-
-    @Nullable
-    public TermModel instantiateTag(@NonNull SiteModel site) {
-        return instantiateTermModel(site, DEFAULT_TAXONOMY_TAG);
-    }
-
-    @Nullable
-    public TermModel instantiateTerm(@NonNull SiteModel site, @NonNull TaxonomyModel taxonomy) {
-        return instantiateTermModel(site, taxonomy.getName());
-    }
-
-    @Nullable
-    private TermModel instantiateTermModel(@NonNull SiteModel site, @NonNull String taxonomyName) {
-        TermModel newTerm = new TermModel();
-        newTerm.setLocalSiteId(site.getId());
-        newTerm.setTaxonomy(taxonomyName);
-
-        // Insert the term into the db, updating the object to include the local ID
-        TermModel insertedTerm = TaxonomySqlUtils.insertTermForResult(newTerm);
-
-        // id is set to -1 if insertion fails
-        if (insertedTerm.getId() == -1) {
-            return null;
-        }
-        return insertedTerm;
-    }
-
     /**
      * Returns all categories for the given site as a {@link TermModel} list.
      */

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -32,10 +32,10 @@ public class TaxonomyStore extends Store {
     public static final String DEFAULT_TAXONOMY_TAG = "post_tag";
 
     public static class FetchTermsPayload extends Payload<BaseNetworkError> {
-        public SiteModel site;
-        public TaxonomyModel taxonomy;
+        @NonNull public SiteModel site;
+        @NonNull public TaxonomyModel taxonomy;
 
-        public FetchTermsPayload(SiteModel site, TaxonomyModel taxonomy) {
+        public FetchTermsPayload(@NonNull SiteModel site, @NonNull TaxonomyModel taxonomy) {
             this.site = site;
             this.taxonomy = taxonomy;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -436,7 +436,7 @@ public class TaxonomyStore extends Store {
         }
     }
 
-    private void updateTerm(TermModel term) {
+    private void updateTerm(@NonNull TermModel term) {
         int rowsAffected = TaxonomySqlUtils.insertOrUpdateTerm(term);
 
         OnTaxonomyChanged onTaxonomyChanged = new OnTaxonomyChanged(rowsAffected, term.getTaxonomy());
@@ -444,7 +444,7 @@ public class TaxonomyStore extends Store {
         emitChange(onTaxonomyChanged);
     }
 
-    private void removeTerm(TermModel term) {
+    private void removeTerm(@NonNull TermModel term) {
         int rowsAffected = TaxonomySqlUtils.removeTerm(term);
 
         OnTaxonomyChanged onTaxonomyChanged = new OnTaxonomyChanged(rowsAffected, term.getTaxonomy());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -316,6 +316,9 @@ public class TaxonomyStore extends Store {
             case REMOVE_ALL_TERMS:
                 removeAllTerms();
                 break;
+            case UPDATE_TERM:
+            case REMOVE_TERM:
+                break;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -189,21 +189,24 @@ public class TaxonomyStore extends Store {
     /**
      * Returns all categories for the given site as a {@link TermModel} list.
      */
-    public List<TermModel> getCategoriesForSite(SiteModel site) {
+    @NonNull
+    public List<TermModel> getCategoriesForSite(@NonNull SiteModel site) {
         return TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_CATEGORY);
     }
 
     /**
      * Returns all tags for the given site as a {@link TermModel} list.
      */
-    public List<TermModel> getTagsForSite(SiteModel site) {
+    @NonNull
+    public List<TermModel> getTagsForSite(@NonNull SiteModel site) {
         return TaxonomySqlUtils.getTermsForSite(site, DEFAULT_TAXONOMY_TAG);
     }
 
     /**
      * Returns all the terms of a taxonomy for the given site as a {@link TermModel} list.
      */
-    public List<TermModel> getTermsForSite(SiteModel site, String taxonomyName) {
+    @NonNull
+    public List<TermModel> getTermsForSite(@NonNull SiteModel site, @NonNull String taxonomyName) {
         return TaxonomySqlUtils.getTermsForSite(site, taxonomyName);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -231,21 +231,24 @@ public class TaxonomyStore extends Store {
     /**
      * Returns a category as a {@link TermModel} given its name.
      */
-    public TermModel getCategoryByName(SiteModel site, String categoryName) {
+    @Nullable
+    public TermModel getCategoryByName(@NonNull SiteModel site, @NonNull String categoryName) {
         return TaxonomySqlUtils.getTermByName(site, categoryName, DEFAULT_TAXONOMY_CATEGORY);
     }
 
     /**
      * Returns a tag as a {@link TermModel} given its name.
      */
-    public TermModel getTagByName(SiteModel site, String tagName) {
+    @Nullable
+    public TermModel getTagByName(@NonNull SiteModel site, @NonNull String tagName) {
         return TaxonomySqlUtils.getTermByName(site, tagName, DEFAULT_TAXONOMY_TAG);
     }
 
     /**
      * Returns a term as a {@link TermModel} given its name.
      */
-    public TermModel getTermByName(SiteModel site, String termName, String taxonomyName) {
+    @Nullable
+    public TermModel getTermByName(@NonNull SiteModel site, @NonNull String termName, @NonNull String taxonomyName) {
         return TaxonomySqlUtils.getTermByName(site, termName, taxonomyName);
     }
 


### PR DESCRIPTION
Parent #2799
Closes #2839

This PR adds any missing nullability annotation to all `Taxonomy` & `Term` related sql-util & model classes.

FYI: This change is `breaking`, meaning that any client that depended on the `Taxonomy` & `Term` models should update to the new APIs (`non-default constructors`) as the existing API (`default constructor`) are now deprecated. As such, this change is inherently `risky`, meaning that there are compile-time changes associated with this change and thus needs testing to verify correctness, both on the library's and client's side.

PS: Any other changes on any other class are just some propagating missing nullability annotation changes, which stem from the main set of classes being updated, this PR's focus, plus, some other extra minor analysis, refactor and test related changes.

-----

~~@mkevins~~ @AjeshRPai let me know how I did on this PR, that is, in terms of adding non-default constructors to all the `@Table` related model, [TaxonomyModel.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/838d24279068169e761c5e356fd72392a4296198/fluxc/src/main/java/org/wordpress/android/fluxc/model/TaxonomyModel.java#L4) (actually unused) and [TermModel.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/838d24279068169e761c5e356fd72392a4296198/fluxc/src/main/java/org/wordpress/android/fluxc/model/TermModel.java#L4) (our main focus), in order to utilize the nullability annotations added on their fields and thus make them null proof. If you also feel that this is a good way to proceed with such PRs, I'll then use this pattern across the board and follow a similar approach on every such PR.

FYI: To understand why I proceeded with the non-default constructors, take a look at this [WCTopPerformerProductModel.kt](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7a56411d95316e8c26015b31c5dd97c33a110f90/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/leaderboards/WCTopPerformerProductModel.kt#L4) `@Table` related Kotlin data class. You will see that this pattern is actually already used to make it possible to use Kotlin with such models. This gave me a bit more confidence in term of proceeding with this change. Also, by applying this change now, will enable such Java models to be easily converted to Kotlin models in the future.

-----

Nullability Annotations List (`Model`):

1. [Add missing n-a to taxonomy model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/288221081fb95cba116e454c8a5e90451ef6395e)
2. [Add missing n-a to term model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/b34ed2fdfc2b055c5ba22edc53e8b529e3510714)
3. [Add missing n-a to terms model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/f902b5e121a493a53b3912e6335f80f598edbbf7)
4. [Add default and non-default constructors for taxonomy model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/fdbcdc03b43b978fc1afc96058a9e77f69b2b6be) (`breaking`)
5. [Add default and non-default constructors for term model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/11b5817417dbd37791e5dab07716e1f4485bf65f) (`breaking`)

Nullability Annotations List (`SqlUtils`):

1. [Add missing n-a to remove term sql utils methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/7d823c93b689c0e54467310c6cbf4ffa7e92d4fd)
2. [Add missing n-a to insert term for result sql utils methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/74fe47a0df3914aefb31dacd0c1169c854e0b5a0)
3. [Add missing n-a to insert or update term sql utils methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/42dba85ed39567b0aab9ff6c2747790b4c2ec784)
4. [Add missing n-a to clear taxonomy for site sql utils methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/8ff128ca2657b131890335e3206d845985ca3784)

Nullability Annotations List (`Store`):

1. [Add missing n-a to fetch terms payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/458ef95b557a4aa3123cb70c821c04e333db614d)
2. [Add missing n-a to fetch terms response payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/4deacc9fba36cd9d62be0a10baab396d5673be24)
3. [Add missing n-a to on term uploaded store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/f37428ad03a6428e2ba9f1f98fafa9158feb69c2)
4. [Add missing n-a to on term update/remove term store methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/0b49e4c9dce10ad6d26089ab22548e229d6e0c8d)
5. [Add missing n-a to on get tags for post store method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/41c56a553239d0d88da58611f0699b7cfcd1f4c2)
6. [Add missing n-a to on get categories for post store method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/a8d1f27b1aa04eed94502a9e970414deed6b9a18)
7. [Add missing n-a to on get term by name store methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/8d75e7becd6d606716c85b78c2e81f85a5df6bad)
8. [Add missing n-a to on get term by remote id store methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/a075f398b15b11939c41cb7cbb24b3affb3d1c86)
9. [Add missing n-a to on get terms for site store methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/05a852f9ac341c40905ed51fe28a4c8b64ee8429)
10. [Add missing n-a to handle fetch single term completed method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/2fd3d9d23513bc490c9a465a91a6956b1b8ffc35)
11. [Add missing n-a to handle delete/push term completed methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/0849403403b7fa8376fd7fb3c02e7b4edf570b80)
12. [Add missing n-a to on taxonomy changed](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/42e8bec03b695e24a7760f7f69f13860c8f2a90c)
13. [Add missing n-a to taxonomy error](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/52cf542e688eb6fbd7e9a172048578f466afc748)

Warnings Resolution List:

1. [Create missing switch cases for store actions](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/9547923fbbd841eb9c692e48ecc75628c3f17197)
2. [Use inserted term on instantiate term model store method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/4db457aeb9703f4c30413024b471c5002dee105d)

Warnings Suppression List:

1. [Suppress condition covered by further condition warning](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/a51d38b7f562e153e1f0059cdf32e32603fe8ea4)
2. [Suppress unused warnings on get related store methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/30e6133df2df1d5884400a1866700164f17e6469)
3. [Suppress raw types warnings for store action method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/ab818371f9c21b12d0a31d413cbf1bc14699906a)
4. [Suppress condition covered by further condition warning](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/2f9ad78264d3a5d5a76c5925550fb735f54dc2a5)

Refactor List:

1. [Remove unnecessary taxonomy name field from taxonomy changed](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/7b53e452883d4617b7cf784b13eaf78d1878b2fa)
2. [Remove test only taxonomy store methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/0d408d3b5efef22e38315505c4d1288dcc5c5dc3)

Test List:

1. [Add missing final keyword on taxonomy store unit test fields](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/7de74703d8af3929eb262c142604aecbcae36acf)
2. [Resolve robolectric related application deprecation warning](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/c66f686f9eb2ab33057b6c38cbbf3b9c7a27337b)
3. [Create missing switch branches for on taxonomy changed](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/25118ec7d1489fe088a6e05fc0c4ead02b97ba41)
4. [Suppress new class naming convention for connected test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/21e64249dde26846d54ea10e9631ed6fddf25c34)
5. [Simplify assertion for check update existing term](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/646d2c64869f3dc147116e0a9cdfe05d71d3a659)
6. [Assert for deleted term models on taxonomy store test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/1d5b073f60a6ec54d885eb3337590da42a9db51e)
7. [Remove unnecessary interrupted exception from private test methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/860235652787723bfaa603261d806ff3ee19065c)
8. [Guard usages of instantiate term model methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851/commits/30f1880a7b026bafeb9eefc44b6a5ef246f08a4b)

-----

## Associated Clients

It is highly recommending that this change is being tested alongside the below associated clients and their accompanying PRs:

- [JP/WPAndroid#19158](https://github.com/wordpress-mobile/WordPress-Android/pull/19158)

-----

## To test:

- Smoke test the `FluxC Example` app via the `TAXONOMIES` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any `TaxonomyStore` related functionality and `TermModel` related instantialization on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

<details>
    <summary>1. Categories Settings Screen [CategoriesListFragment.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Menu` sub-tab on the initial `My Site` screen and click on `Site Settings` under the
`Manage` section.
- Find the `Categories` under the `Writing` section and click on it.
- Verify that the `Categories` screen is displayed and that everything works as expected.

</details>

<details>
    <summary>2. Tags Settings Screen [SiteSettingsTagListActivity.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Menu` sub-tab on the initial `My Site` screen and click on `Site Settings` under the
`Manage` section.
- Find the `Tags` under the `Writing` section and click on it.
- Verify that the `Tags` screen is displayed and that everything works as expected.

</details>

<details>
    <summary>3. Prepublishing Screens [PrepublishingTagsFragment.kt + PrepublishingCategoriesFragment.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Posts` screen and edit any post.
- Click on the `UPDATE` button to have the bottom sheet appear (`top-right`).
- Click on the `Tags` row and add, remove or edit any tag for this post. Click back.
- Click on the `Categories` row and add, remove or create a new category for this post. Click back.
- Click on the `UPDATE NOW` button to update this post (`bottom`).
- Verify that this post's `Tags`/`Categories` are updated and that everything works as expected.

</details>

-----

## Merge instructions:

1. [x] Wait for the accompanying [JP/WPAndroid#19158](https://github.com/wordpress-mobile/WordPress-Android/pull/19158) to be reviewed and approved.
2. [x] Remove the `[PR] Not Ready for Merge` label.
3. [x] Merge this PR.
4. [x] Follow-up with the merge instructions on the accompanying [JP/WPAndroid#19158](https://github.com/wordpress-mobile/WordPress-Android/pull/19158) client PR.