### PR TITLE
Enables fetching product reviews by specific list of review ids

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -505,7 +505,6 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
         assertEquals(25, payload.reviews.size)
         assertNull(payload.filterProductIds)
         assertNull(payload.filterByStatus)
-        assertFalse(payload.loadedMore)
         assertTrue(payload.canLoadMore)
 
         // Save product reviews to the database

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -81,7 +81,9 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
     }
 
     @Inject internal lateinit var productStore: WCProductStore
-    @Inject internal lateinit var mediaStore: MediaStore // must be injected for onMediaListFetched()
+
+    @Inject
+    internal lateinit var mediaStore: MediaStore // must be injected for onMediaListFetched()
 
     private var nextEvent: TestEvent = TestEvent.NONE
     private val productModel = WCProductModel(8).apply {
@@ -131,7 +133,12 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         ProductSqlUtils.deleteProductsForSite(sSite)
         assertEquals(ProductSqlUtils.getProductCountForSite(sSite), 0)
 
-        productStore.fetchSingleProduct(FetchSingleProductPayload(sSite, productModel.remoteProductId))
+        productStore.fetchSingleProduct(
+            FetchSingleProductPayload(
+                sSite,
+                productModel.remoteProductId
+            )
+        )
 
         // Verify results
         val fetchedProduct = productStore.getProductByRemoteId(sSite, productModel.remoteProductId)
@@ -147,10 +154,16 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
     @Test
     fun testFetchSingleVariation() = runBlocking {
         // remove all variation for this site and verify there are none
-        ProductSqlUtils.deleteVariationsForProduct(sSite, productModelWithVariations.remoteProductId)
+        ProductSqlUtils.deleteVariationsForProduct(
+            sSite,
+            productModelWithVariations.remoteProductId
+        )
         assertEquals(
-                ProductSqlUtils.getVariationsForProduct(sSite, productModelWithVariations.remoteProductId).size,
-                0
+            ProductSqlUtils.getVariationsForProduct(
+                sSite,
+                productModelWithVariations.remoteProductId
+            ).size,
+            0
         )
 
         val result = productStore.fetchSingleVariation(
@@ -164,16 +177,19 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
         // Verify results
         val fetchedVariation = productStore.getVariationByRemoteId(
-                sSite,
-                variationModel.remoteProductId,
-                variationModel.remoteVariationId
+            sSite,
+            variationModel.remoteProductId,
+            variationModel.remoteVariationId
         )
         assertNotNull(fetchedVariation)
         assertEquals(fetchedVariation!!.remoteProductId, variationModel.remoteProductId)
         assertEquals(fetchedVariation.remoteVariationId, variationModel.remoteVariationId)
 
         // Verify there's only one variation for this site
-        assertEquals(1, ProductSqlUtils.getVariationsForProduct(sSite, variationModel.remoteProductId).size)
+        assertEquals(
+            1,
+            ProductSqlUtils.getVariationsForProduct(sSite, variationModel.remoteProductId).size
+        )
     }
 
     @Throws(InterruptedException::class)
@@ -186,8 +202,8 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.FETCHED_PRODUCTS
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
-                WCProductActionBuilder
-                        .newFetchProductsAction(FetchProductsPayload(sSite))
+            WCProductActionBuilder
+                .newFetchProductsAction(FetchProductsPayload(sSite))
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -200,8 +216,16 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
     @Test
     fun testFetchProductVariations() = runBlocking {
         // remove all variations for this product and verify there are none
-        ProductSqlUtils.deleteVariationsForProduct(sSite, productModelWithVariations.remoteProductId)
-        assertEquals(ProductSqlUtils.getVariationsForProduct(sSite, productModelWithVariations.remoteProductId).size, 0)
+        ProductSqlUtils.deleteVariationsForProduct(
+            sSite,
+            productModelWithVariations.remoteProductId
+        )
+        assertEquals(
+            ProductSqlUtils.getVariationsForProduct(
+                sSite,
+                productModelWithVariations.remoteProductId
+            ).size, 0
+        )
 
         productStore.fetchProductVariations(
             FetchProductVariationsPayload(
@@ -211,7 +235,10 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         )
 
         // Verify results
-        val fetchedVariations = productStore.getVariationsForProduct(sSite, productModelWithVariations.remoteProductId)
+        val fetchedVariations = productStore.getVariationsForProduct(
+            sSite,
+            productModelWithVariations.remoteProductId
+        )
         assertNotEquals(fetchedVariations.size, 0)
     }
 
@@ -228,9 +255,9 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.FETCHED_PRODUCT_SHIPPING_CLASS_LIST
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
-                WCProductActionBuilder.newFetchProductShippingClassListAction(
-                        FetchProductShippingClassListPayload(sSite)
-                )
+            WCProductActionBuilder.newFetchProductShippingClassListAction(
+                FetchProductShippingClassListPayload(sSite)
+            )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -253,15 +280,15 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
-                WCProductActionBuilder.newFetchSingleProductShippingClassAction(
-                        FetchSingleProductShippingClassPayload(sSite, remoteShippingClassId)
-                )
+            WCProductActionBuilder.newFetchSingleProductShippingClassAction(
+                FetchSingleProductShippingClassPayload(sSite, remoteShippingClassId)
+            )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         // Verify results
         val fetchedShippingClasses = productStore.getShippingClassByRemoteId(
-                sSite, remoteShippingClassId
+            sSite, remoteShippingClassId
         )
         assertNotNull(fetchedShippingClasses)
     }
@@ -276,7 +303,11 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.FETCH_PRODUCT_CATEGORIES
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
-                WCProductActionBuilder.newFetchProductCategoriesAction(FetchProductCategoriesPayload(sSite))
+            WCProductActionBuilder.newFetchProductCategoriesAction(
+                FetchProductCategoriesPayload(
+                    sSite
+                )
+            )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -300,9 +331,9 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
             name = "Test" + Random.nextInt(0, 10000)
         }
         mDispatcher.dispatch(
-                WCProductActionBuilder.newAddProductCategoryAction(
-                        AddProductCategoryPayload(sSite, productCategoryModel)
-                )
+            WCProductActionBuilder.newAddProductCategoryAction(
+                AddProductCategoryPayload(sSite, productCategoryModel)
+            )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -322,7 +353,10 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         productStore.deleteAllProductReviews()
         assertEquals(0, ProductSqlUtils.getProductReviewsForSite(sSite).size)
 
-        productStore.fetchProductReviews(FetchProductReviewsPayload(sSite, offset = 0))
+        productStore.fetchProductReviews(
+            FetchProductReviewsPayload(sSite, offset = 0),
+            deletePreviouslyCachedReviews = false
+        )
 
         // Verify results
         val fetchedReviewsAll = productStore.getProductReviewsForSite(sSite)
@@ -338,7 +372,10 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         productStore.deleteAllProductReviews()
         assertEquals(0, ProductSqlUtils.getProductReviewsForSite(sSite).size)
 
-        productStore.fetchProductReviews(FetchProductReviewsPayload(sSite, reviewIds = idsToFetch, offset = 0))
+        productStore.fetchProductReviews(
+            FetchProductReviewsPayload(sSite, reviewIds = idsToFetch, offset = 0),
+            deletePreviouslyCachedReviews = false
+        )
 
         // Verify results
         val fetchReviewsId = productStore.getProductReviewsForSite(sSite)
@@ -352,13 +389,25 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
         // Check to see how many reviews currently exist for these product IDs before deleting
         // from the database
-        val reviewsByProduct = productIdsToFetch.map { productStore.getProductReviewsForProductAndSiteId(sSite.id, it) }
+        val reviewsByProduct = productIdsToFetch.map {
+            productStore.getProductReviewsForProductAndSiteId(
+                sSite.id,
+                it
+            )
+        }
 
         // Remove all product reviews from the database
         productStore.deleteAllProductReviews()
         assertEquals(0, ProductSqlUtils.getProductReviewsForSite(sSite).size)
 
-        productStore.fetchProductReviews(FetchProductReviewsPayload(sSite, productIds = productIdsToFetch, offset = 0))
+        productStore.fetchProductReviews(
+            FetchProductReviewsPayload(
+                sSite,
+                productIds = productIdsToFetch,
+                offset = 0
+            ),
+            deletePreviouslyCachedReviews = false
+        )
 
         // Verify results
         val fetchedReviewsForProduct = productStore.getProductReviewsForSite(sSite)
@@ -372,14 +421,14 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.UPDATED_PRODUCT_PASSWORD
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
-                WCProductActionBuilder
-                        .newUpdateProductPasswordAction(
-                                UpdateProductPasswordPayload(
-                                        sSite,
-                                        productModel.remoteProductId,
-                                        updatedPassword
-                                )
-                        )
+            WCProductActionBuilder
+                .newUpdateProductPasswordAction(
+                    UpdateProductPasswordPayload(
+                        sSite,
+                        productModel.remoteProductId,
+                        updatedPassword
+                    )
+                )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -387,8 +436,13 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.FETCHED_PRODUCT_PASSWORD
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
-                WCProductActionBuilder
-                        .newFetchProductPasswordAction(FetchProductPasswordPayload(sSite, productModel.remoteProductId))
+            WCProductActionBuilder
+                .newFetchProductPasswordAction(
+                    FetchProductPasswordPayload(
+                        sSite,
+                        productModel.remoteProductId
+                    )
+                )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
     }
@@ -400,7 +454,12 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         productStore.deleteAllProductReviews()
         assertEquals(0, ProductSqlUtils.getProductReviewsForSite(sSite).size)
 
-        productStore.fetchSingleProductReview(FetchSingleProductReviewPayload(sSite, remoteProductReviewId))
+        productStore.fetchSingleProductReview(
+            FetchSingleProductReviewPayload(
+                sSite,
+                remoteProductReviewId
+            )
+        )
 
         // Verify results
         val review = productStore.getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
@@ -413,7 +472,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
             // Verify results - review should be deleted from db
             val savedReview = productStore
-                    .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
+                .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
             assertNull(savedReview)
         }
 
@@ -425,7 +484,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
             // Verify results
             val savedReview = productStore
-                    .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
+                .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
             assertNotNull(savedReview)
             assertEquals(newStatus, savedReview!!.status)
         }
@@ -437,7 +496,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
             // Verify results - review should be deleted from db
             val savedReview = productStore
-                    .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
+                .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
             assertNull(savedReview)
         }
 
@@ -448,7 +507,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
             // Verify results
             val savedReview = productStore
-                    .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
+                .getProductReviewByRemoteId(sSite.id, remoteProductReviewId)
             assertNotNull(savedReview)
             assertEquals(newStatus, savedReview!!.status)
         }
@@ -474,9 +533,9 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
             it.add(WCProductImageModel.fromMediaModel(mediaModelForProduct))
         }
         mDispatcher.dispatch(
-                WCProductActionBuilder.newUpdateProductImagesAction(
-                        UpdateProductImagesPayload(sSite, productModel.remoteProductId, imageList)
-                )
+            WCProductActionBuilder.newUpdateProductImagesAction(
+                UpdateProductImagesPayload(sSite, productModel.remoteProductId, imageList)
+            )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -539,7 +598,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.UPDATED_PRODUCT
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
-                WCProductActionBuilder.newUpdateProductAction(UpdateProductPayload(sSite, productModel))
+            WCProductActionBuilder.newUpdateProductAction(UpdateProductPayload(sSite, productModel))
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -591,7 +650,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         nextEvent = TestEvent.UPDATED_PRODUCT
         mCountDownLatch = CountDownLatch(1)
         mDispatcher.dispatch(
-                WCProductActionBuilder.newUpdateProductAction(UpdateProductPayload(sSite, productModel))
+            WCProductActionBuilder.newUpdateProductAction(UpdateProductPayload(sSite, productModel))
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -626,9 +685,9 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         }
 
         val updatedVariation = productStore.getVariationByRemoteId(
-                sSite,
-                variationModel.remoteProductId,
-                variationModel.remoteVariationId
+            sSite,
+            variationModel.remoteProductId,
+            variationModel.remoteVariationId
         )
         assertNotNull(updatedVariation)
         assertEquals(variationModel.remoteProductId, updatedVariation?.remoteProductId)
@@ -647,7 +706,11 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
         nextEvent = TestEvent.FETCHED_PRODUCT_TAGS
         mCountDownLatch = CountDownLatch(1)
-        mDispatcher.dispatch(WCProductActionBuilder.newFetchProductTagsAction(FetchProductTagsPayload(sSite)))
+        mDispatcher.dispatch(
+            WCProductActionBuilder.newFetchProductTagsAction(
+                FetchProductTagsPayload(sSite)
+            )
+        )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
         // Verify results
@@ -667,9 +730,9 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
         val productTags = listOf("Test" + Date().time, "Test1" + Date().time)
         mDispatcher.dispatch(
-                WCProductActionBuilder.newAddProductTagsAction(
-                        AddProductTagsPayload(sSite, productTags)
-                )
+            WCProductActionBuilder.newAddProductTagsAction(
+                AddProductTagsPayload(sSite, productTags)
+            )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
 
@@ -707,7 +770,12 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
         mCountDownLatch = CountDownLatch(1)
 
         mDispatcher.dispatch(
-                WCProductActionBuilder.newAddedProductAction(RemoteAddProductPayload(sSite, productModel))
+            WCProductActionBuilder.newAddedProductAction(
+                RemoteAddProductPayload(
+                    sSite,
+                    productModel
+                )
+            )
         )
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
     }
@@ -745,6 +813,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
                 assertEquals(TestEvent.FETCHED_PRODUCTS, nextEvent)
                 mCountDownLatch.countDown()
             }
+
             else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)
         }
     }
@@ -809,7 +878,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
     fun onProductShippingClassesChanged(event: OnProductShippingClassesChanged) {
         event.error?.let {
             throw AssertionError(
-                    "OnProductShippingClassesChanged has unexpected error: ${it.type}, ${it.message}"
+                "OnProductShippingClassesChanged has unexpected error: ${it.type}, ${it.message}"
             )
         }
 
@@ -820,10 +889,12 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
                 assertEquals(TestEvent.FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS, nextEvent)
                 mCountDownLatch.countDown()
             }
+
             WCProductAction.FETCH_PRODUCT_SHIPPING_CLASS_LIST -> {
                 assertEquals(TestEvent.FETCHED_PRODUCT_SHIPPING_CLASS_LIST, nextEvent)
                 mCountDownLatch.countDown()
             }
+
             else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)
         }
     }
@@ -842,10 +913,12 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
                 assertEquals(TestEvent.FETCH_PRODUCT_CATEGORIES, nextEvent)
                 mCountDownLatch.countDown()
             }
+
             WCProductAction.ADDED_PRODUCT_CATEGORY -> {
                 assertEquals(TestEvent.ADDED_PRODUCT_CATEGORY, nextEvent)
                 mCountDownLatch.countDown()
             }
+
             else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)
         }
     }
@@ -855,7 +928,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
     fun onProductTagChanged(event: OnProductTagChanged) {
         event.error?.let {
             throw AssertionError(
-                    "OnProductTagChanged has unexpected error: ${it.type}, ${it.message}"
+                "OnProductTagChanged has unexpected error: ${it.type}, ${it.message}"
             )
         }
 
@@ -866,10 +939,12 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
                 assertEquals(TestEvent.FETCHED_PRODUCT_TAGS, nextEvent)
                 mCountDownLatch.countDown()
             }
+
             WCProductAction.ADDED_PRODUCT_TAGS -> {
                 assertEquals(TestEvent.ADDED_PRODUCT_TAGS, nextEvent)
                 mCountDownLatch.countDown()
             }
+
             else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)
         }
     }
@@ -889,6 +964,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
                 assertEquals(event.remoteProductId, productModel.remoteProductId)
                 mCountDownLatch.countDown()
             }
+
             else -> throw AssertionError("Unexpected cause of change: " + event.causeOfChange)
         }
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -82,8 +82,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
     @Inject internal lateinit var productStore: WCProductStore
 
-    @Inject
-    internal lateinit var mediaStore: MediaStore // must be injected for onMediaListFetched()
+    @Inject internal lateinit var mediaStore: MediaStore // must be injected for onMediaListFetched()
 
     private var nextEvent: TestEvent = TestEvent.NONE
     private val productModel = WCProductModel(8).apply {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -307,7 +307,8 @@ class WooProductsFragment : StoreSelectingFragment() {
                                     FetchProductReviewsPayload(
                                             site,
                                             productIds = listOf(remoteProductId)
-                                    )
+                                    ),
+                                    deletePreviouslyCachedReviews = false
                             )
                             prependToLog("Fetched ${result.rowsAffected} product reviews")
                         }
@@ -321,7 +322,10 @@ class WooProductsFragment : StoreSelectingFragment() {
                 coroutineScope.launch {
                     prependToLog("Submitting request to fetch product reviews for site ${site.id}")
                     val payload = FetchProductReviewsPayload(site)
-                    val result = wcProductStore.fetchProductReviews(payload)
+                    val result = wcProductStore.fetchProductReviews(
+                        payload,
+                        deletePreviouslyCachedReviews = false
+                    )
                     prependToLog("Fetched ${result.rowsAffected} product reviews")
                 }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1488,8 +1488,7 @@ class ProductRestClient @Inject constructor(
                         reviews,
                         productIds,
                         filterByStatus,
-                        offset > 0,
-                        reviews.size == WCProductStore.NUM_REVIEWS_PER_FETCH
+                        canLoadMore = reviews.size == WCProductStore.NUM_REVIEWS_PER_FETCH
                     )
                 } else {
                     FetchProductReviewsResponsePayload(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -491,6 +491,15 @@ object ProductSqlUtils {
                 .asModel
     }
 
+    fun getProductReviewsByReviewIds(reviewIds: List<Long>): List<WCProductReviewModel> {
+        return WellSql.select(WCProductReviewModel::class.java)
+                .where()
+                .isIn(WCProductReviewModelTable.REMOTE_PRODUCT_REVIEW_ID, reviewIds)
+                .endWhere()
+                .orderBy(WCProductReviewModelTable.DATE_CREATED, SelectQuery.ORDER_DESCENDING)
+                .asModel
+    }
+
     fun getProductReviewsForProductAndSiteId(
         localSiteId: Int,
         remoteProductId: Long

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -84,6 +84,7 @@ class WCProductStore @Inject constructor(
 
         override fun toString() = name.toLowerCase(Locale.US)
     }
+
     enum class SkuSearchOptions {
         Disabled, ExactSearch, PartialMatch
     }
@@ -825,6 +826,9 @@ class WCProductStore @Inject constructor(
     fun getProductReviewsForSite(site: SiteModel): List<WCProductReviewModel> =
         ProductSqlUtils.getProductReviewsForSite(site)
 
+    fun getProductReviewsByReviewId(reviewIds: List<Long>): List<WCProductReviewModel> =
+        ProductSqlUtils.getProductReviewsByReviewIds(reviewIds)
+
     fun getProductReviewsForProductAndSiteId(localSiteId: Int, remoteProductId: Long): List<WCProductReviewModel> =
         ProductSqlUtils.getProductReviewsForProductAndSiteId(localSiteId, remoteProductId)
 
@@ -887,64 +891,92 @@ class WCProductStore @Inject constructor(
             // remote actions
             WCProductAction.FETCH_PRODUCT_SKU_AVAILABILITY ->
                 fetchProductSkuAvailability(action.payload as FetchProductSkuAvailabilityPayload)
+
             WCProductAction.FETCH_PRODUCTS ->
                 fetchProducts(action.payload as FetchProductsPayload)
+
             WCProductAction.SEARCH_PRODUCTS ->
                 searchProducts(action.payload as SearchProductsPayload)
+
             WCProductAction.UPDATE_PRODUCT_IMAGES ->
                 updateProductImages(action.payload as UpdateProductImagesPayload)
+
             WCProductAction.UPDATE_PRODUCT ->
                 updateProduct(action.payload as UpdateProductPayload)
+
             WCProductAction.FETCH_SINGLE_PRODUCT_SHIPPING_CLASS ->
                 fetchProductShippingClass(action.payload as FetchSingleProductShippingClassPayload)
+
             WCProductAction.FETCH_PRODUCT_SHIPPING_CLASS_LIST ->
                 fetchProductShippingClasses(action.payload as FetchProductShippingClassListPayload)
+
             WCProductAction.FETCH_PRODUCT_PASSWORD ->
                 fetchProductPassword(action.payload as FetchProductPasswordPayload)
+
             WCProductAction.UPDATE_PRODUCT_PASSWORD ->
                 updateProductPassword(action.payload as UpdateProductPasswordPayload)
+
             WCProductAction.FETCH_PRODUCT_CATEGORIES ->
                 fetchProductCategories(action.payload as FetchProductCategoriesPayload)
+
             WCProductAction.ADD_PRODUCT_CATEGORY ->
                 addProductCategory(action.payload as AddProductCategoryPayload)
+
             WCProductAction.FETCH_PRODUCT_TAGS ->
                 fetchProductTags(action.payload as FetchProductTagsPayload)
+
             WCProductAction.ADD_PRODUCT_TAGS ->
                 addProductTags(action.payload as AddProductTagsPayload)
+
             WCProductAction.ADD_PRODUCT ->
                 addProduct(action.payload as AddProductPayload)
+
             WCProductAction.DELETE_PRODUCT ->
                 deleteProduct(action.payload as DeleteProductPayload)
 
             // remote responses
             WCProductAction.FETCHED_PRODUCT_SKU_AVAILABILITY ->
                 handleFetchProductSkuAvailabilityCompleted(action.payload as RemoteProductSkuAvailabilityPayload)
+
             WCProductAction.FETCHED_PRODUCTS ->
                 handleFetchProductsCompleted(action.payload as RemoteProductListPayload)
+
             WCProductAction.SEARCHED_PRODUCTS ->
                 handleSearchProductsCompleted(action.payload as RemoteSearchProductsPayload)
+
             WCProductAction.UPDATED_PRODUCT_IMAGES ->
                 handleUpdateProductImages(action.payload as RemoteUpdateProductImagesPayload)
+
             WCProductAction.UPDATED_PRODUCT ->
                 handleUpdateProduct(action.payload as RemoteUpdateProductPayload)
+
             WCProductAction.FETCHED_PRODUCT_SHIPPING_CLASS_LIST ->
                 handleFetchProductShippingClassesCompleted(action.payload as RemoteProductShippingClassListPayload)
+
             WCProductAction.FETCHED_SINGLE_PRODUCT_SHIPPING_CLASS ->
                 handleFetchProductShippingClassCompleted(action.payload as RemoteProductShippingClassPayload)
+
             WCProductAction.FETCHED_PRODUCT_PASSWORD ->
                 handleFetchProductPasswordCompleted(action.payload as RemoteProductPasswordPayload)
+
             WCProductAction.UPDATED_PRODUCT_PASSWORD ->
                 handleUpdatedProductPasswordCompleted(action.payload as RemoteUpdatedProductPasswordPayload)
+
             WCProductAction.FETCHED_PRODUCT_CATEGORIES ->
                 handleFetchProductCategories(action.payload as RemoteProductCategoriesPayload)
+
             WCProductAction.ADDED_PRODUCT_CATEGORY ->
                 handleAddProductCategory(action.payload as RemoteAddProductCategoryResponsePayload)
+
             WCProductAction.FETCHED_PRODUCT_TAGS ->
                 handleFetchProductTagsCompleted(action.payload as RemoteProductTagsPayload)
+
             WCProductAction.ADDED_PRODUCT_TAGS ->
                 handleAddProductTags(action.payload as RemoteAddProductTagsResponsePayload)
+
             WCProductAction.ADDED_PRODUCT ->
                 handleAddNewProduct(action.payload as RemoteAddProductPayload)
+
             WCProductAction.DELETED_PRODUCT ->
                 handleDeleteProduct(action.payload as RemoteDeleteProductPayload)
         }
@@ -1447,6 +1479,7 @@ class WCProductStore @Inject constructor(
                     val canLoadMore = response.result.size == pageSize
                     WooResult(canLoadMore)
                 }
+
                 else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
             }
         }
@@ -1492,6 +1525,7 @@ class WCProductStore @Inject constructor(
                     val canLoadMore = response.result.size == pageSize
                     WooResult(canLoadMore)
                 }
+
                 else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
             }
         }
@@ -1525,6 +1559,7 @@ class WCProductStore @Inject constructor(
                     val canLoadMore = response.result.size == pageSize
                     WooResult(ProductSearchResult(products, canLoadMore))
                 }
+
                 else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
             }
         }
@@ -1560,6 +1595,7 @@ class WCProductStore @Inject constructor(
                     val canLoadMore = response.result.size == pageSize
                     WooResult(ProductCategorySearchResult(categories, canLoadMore))
                 }
+
                 else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
             }
         }
@@ -1599,6 +1635,7 @@ class WCProductStore @Inject constructor(
                     val canLoadMore = response.result.size == pageSize
                     WooResult(canLoadMore)
                 }
+
                 else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
             }
         }
@@ -1649,6 +1686,7 @@ class WCProductStore @Inject constructor(
                 response.result != null -> {
                     WooResult(response.result.sumOf { it.total })
                 }
+
                 else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1222,7 +1222,7 @@ class WCProductStore @Inject constructor(
 
     suspend fun fetchProductReviews(
         payload: FetchProductReviewsPayload,
-        deletePreviouslyCachedReviews: Boolean = true
+        deletePreviouslyCachedReviews: Boolean
     ): OnProductReviewChanged {
         return coroutineEngine.withDefaultContext(API, this, "fetchProductReviews") {
             val response = with(payload) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1233,7 +1233,7 @@ class WCProductStore @Inject constructor(
                 // Clear existing product reviews if this is a fresh fetch (loadMore = false).
                 // This is the simplest way to keep our local reviews in sync with remote reviews
                 // in case of deletions.
-                if (!response.loadedMore) {
+                if (!response.loadedMore && payload.reviewIds == null) {
                     ProductSqlUtils.deleteAllProductReviewsForSite(response.site)
                 }
                 val rowsAffected = ProductSqlUtils.insertOrUpdateProductReviews(response.reviews)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -568,7 +568,6 @@ class WCProductStore @Inject constructor(
         val reviews: List<WCProductReviewModel> = emptyList(),
         val filterProductIds: List<Long>? = null,
         val filterByStatus: List<String>? = null,
-        val loadedMore: Boolean = false,
         val canLoadMore: Boolean = false
     ) : Payload<ProductError>() {
         constructor(error: ProductError, site: SiteModel) : this(site) {


### PR DESCRIPTION
Enables retrieving product reviews from database by product review id. Additionally it adds a small refactor to make behavior more explicit about clearing the product reviews database after fetching reviews from the API. 

Nothin to test in this PR. The new function will be tested in real scenario in this PR: https://github.com/woocommerce/woocommerce-android/pull/9753