### PR TITLE
Preparations for Jetpack AI assistant eligibility checks

### DIFF
--- a/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -19,6 +19,7 @@
 /me/domain-contact-information/
 /me/settings/
 /me/sites/
+/me/sites/features
 /me/send-verification-email/
 /me/social-login/connect/
 /me/username/

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SitesFeaturesRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SitesFeaturesRestResponse.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site
+
+data class SitesFeaturesRestResponse(
+    val features: Map<Long, SiteFeatures>
+)
+
+data class SiteFeatures(
+    val active: List<String>
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
@@ -3,9 +3,10 @@ package org.wordpress.android.fluxc.model
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.fluxc.model.WCProductModel.AddOnsMetadataKeys
+import org.wordpress.android.fluxc.model.WCProductModel.OtherKeys
 import org.wordpress.android.fluxc.model.WCProductModel.QuantityRulesMetadataKeys
+import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.fluxc.utils.EMPTY_JSON_ARRAY
 import org.wordpress.android.fluxc.utils.isElementNullOrEmpty
 import javax.inject.Inject
@@ -30,6 +31,7 @@ class StripProductMetaData @Inject internal constructor(private val gson: Gson) 
             add(AddOnsMetadataKeys.ADDONS_METADATA_KEY)
             addAll(QuantityRulesMetadataKeys.ALL_KEYS)
             addAll(SubscriptionMetadataKeys.ALL_KEYS)
+            add(OtherKeys.HEAD_START_POST)
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -119,6 +119,11 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             ?.find { it.key == ADDONS_METADATA_KEY }
             ?.addons
 
+    val isSampleProduct: Boolean
+        get() = Gson().fromJson(metadata, Array<WCMetaData>::class.java)
+            ?.any { it.key == OtherKeys.HEAD_START_POST && it.value == "_hs_extra" }
+            ?: false
+
     @Suppress("SwallowedException", "TooGenericExceptionCaught") private val WCMetaData.addons
         get() =
             try {
@@ -595,5 +600,9 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             GROUP_OF_QUANTITY,
             ALLOW_COMBINATION
         )
+    }
+
+    object OtherKeys {
+        const val HEAD_START_POST = "_headstart_post"
     }
 }


### PR DESCRIPTION
This PR contains two changes to make it possible for checking the site's eligibility for AI assistant usage:

##### Make sure the site's plan features are fetched correctly 5f96f8f

In the PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1936, the URL used for fetching user's sites changed from `/v1.1/me/sites` to `/v1.2/me/sites`, but this had an impact that wasn't noticed: the response of the v1.2 doesn't include the plan's features list.

This PR attempts to fix this by following this logic:
1. If `fetchSites` includes any filtering, it will make two requests: `/v1.2/me/sites` and `/v1.1/me/sites/features`, then combine their responses.
2. If `fetchSites` was called without filters, it will simply call `/v1.1/me/sites`

The above will make sure we always include the plan's features, while optimizing the time of the request when we don't need any filtering.

##### Allow checking if a product is a sample product generated by WooExpress bb10a96
This is a simple change that makes sure the metadata for sample products is saved and exposed to client apps following the logic pecCkj-Zo-p2#comment-506

---
Testing will be done in the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/9798