### PR TITLE
Customer list cache usage changes

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/WCCustomerStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/WCCustomerStoreTest.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RE
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.CustomerRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.dto.CustomerDTO
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.customer.dto.CustomerFromAnalyticsDTO
 import org.wordpress.android.fluxc.persistence.CustomerSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.test
@@ -394,95 +393,6 @@ class WCCustomerStoreTest {
         assertFalse(result.isError)
         assertEquals(customerModel, result.model)
     }
-
-    @Test
-    fun `given page 1, when fetchCustomersFromAnalytics, then result deleted and stored`() =
-        test {
-            // given
-            val siteModelId = 1
-            val siteModel = SiteModel().apply { id = siteModelId }
-            val customerOne: CustomerFromAnalyticsDTO = mock()
-            val customerTwo: CustomerFromAnalyticsDTO = mock()
-            val response = arrayOf(customerOne, customerTwo)
-            whenever(
-                restClient.fetchCustomersFromAnalytics(
-                    siteModel,
-                    page = 1,
-                    pageSize = 25
-                )
-            ).thenReturn(WooPayload(response))
-            val modelOne = WCCustomerModel().apply {
-                remoteCustomerId = 1L
-                localSiteId = siteModelId
-            }
-            val modelTwo = WCCustomerModel().apply {
-                remoteCustomerId = 2L
-                localSiteId = siteModelId
-            }
-            whenever(mapper.mapToModel(siteModel, customerOne)).thenReturn(modelOne)
-            whenever(mapper.mapToModel(siteModel, customerTwo)).thenReturn(modelTwo)
-
-            // when
-            val result = store.fetchCustomersFromAnalytics(siteModel, 1)
-
-            // then
-            assertThat(result.isError).isFalse
-            assertThat(result.model).isEqualTo(listOf(modelOne, modelTwo))
-            assertThat(CustomerSqlUtils.getCustomersForSite(siteModel)).isEqualTo(
-                listOf(modelOne, modelTwo)
-            )
-        }
-
-    @Test
-    fun `given page 1 then page 2, when fetchCustomersFromAnalytics, then both result stored`() =
-        test {
-            // given
-            val siteModelId = 1
-            val siteModel = SiteModel().apply { id = siteModelId }
-            val customerOne: CustomerFromAnalyticsDTO = mock()
-            val customerTwo: CustomerFromAnalyticsDTO = mock()
-            val response = arrayOf(customerOne, customerTwo)
-            whenever(
-                restClient.fetchCustomersFromAnalytics(
-                    siteModel,
-                    page = 1,
-                    pageSize = 25
-                )
-            ).thenReturn(WooPayload(response))
-            whenever(
-                restClient.fetchCustomersFromAnalytics(
-                    siteModel,
-                    page = 2,
-                    pageSize = 25
-                )
-            ).thenReturn(WooPayload(response))
-            val modelOne = WCCustomerModel().apply {
-                remoteCustomerId = 1L
-                localSiteId = siteModelId
-            }
-            val modelTwo = WCCustomerModel().apply {
-                remoteCustomerId = 2L
-                localSiteId = siteModelId
-            }
-            whenever(mapper.mapToModel(siteModel, customerOne)).thenReturn(modelOne)
-            whenever(mapper.mapToModel(siteModel, customerTwo)).thenReturn(modelTwo)
-
-            // when
-            val result = store.fetchCustomersFromAnalytics(siteModel, 1)
-            val result2 = store.fetchCustomersFromAnalytics(siteModel, 2)
-
-            // then
-            assertThat(result.isError).isFalse
-            assertThat(result.model).isEqualTo(listOf(modelOne, modelTwo))
-            assertThat(CustomerSqlUtils.getCustomersForSite(siteModel)).isEqualTo(
-                listOf(modelOne, modelTwo)
-            )
-            assertThat(result2.isError).isFalse
-            assertThat(result2.model).isEqualTo(listOf(modelOne, modelTwo))
-            assertThat(CustomerSqlUtils.getCustomersForSite(siteModel)).isEqualTo(
-                listOf(modelOne, modelTwo)
-            )
-        }
 
     @Test
     fun `given error, when fetchCustomersFromAnalytics, then nothing is stored and error`() =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/CustomerSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/CustomerSqlUtils.kt
@@ -65,7 +65,13 @@ object CustomerSqlUtils {
     }
 
     fun insertOrUpdateCustomers(customers: List<WCCustomerModel>): Int {
-        return customers.sumBy { insertOrUpdateCustomer(it) }
+        return customers.sumOf { insertOrUpdateCustomer(it) }
+    }
+
+    fun insertCustomers(customers: List<WCCustomerModel>) {
+        customers.forEach {
+            WellSql.insert(it).asSingleTransaction(true).execute()
+        }
     }
     // endregion
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCCustomerStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCCustomerStore.kt
@@ -42,6 +42,14 @@ class WCCustomerStore @Inject constructor(
     fun getCustomerByRemoteIds(site: SiteModel, remoteCustomerId: List<Long>) =
         CustomerSqlUtils.getCustomerByRemoteIds(site, remoteCustomerId)
 
+    fun saveCustomers(customers: List<WCCustomerModel>) {
+        CustomerSqlUtils.insertCustomers(customers)
+    }
+
+    fun deleteCustomersForSite(site: SiteModel) {
+        CustomerSqlUtils.deleteCustomersForSite(site)
+    }
+
     /**
      * returns a customer with provided remote id
      */
@@ -201,11 +209,7 @@ class WCCustomerStore @Inject constructor(
                     WooResult(response.error)
                 }
                 response.result != null -> {
-                    val customers = response.result.map { mapper.mapToModel(site, it) }
-                    if (page == 1) CustomerSqlUtils.deleteCustomersForSite(site)
-                    CustomerSqlUtils.insertOrUpdateCustomers(customers)
-
-                    WooResult(customers)
+                    WooResult(response.result.map { mapper.mapToModel(site, it) })
                 }
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }


### PR DESCRIPTION
The PR adds `insertCustomers` method along with exposing `saveCustomers` and `deleteCustomersForSite` methods from the `WCCustomerStore`

Can be tested with https://github.com/woocommerce/woocommerce-android/pull/9835