### PR TITLE
REST API: Fix login issue when the site uses a custom WP url

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -72,7 +72,7 @@ class SiteWPAPIRestClient @Inject constructor(
                     }
 
                     wpApiRestUrl = discoveredWpApiUrl
-                    this.url = response?.url ?: cleanedUrl.replaceBefore("://", urlScheme)
+                    this.url = cleanedUrl.replaceBefore("://", urlScheme)
                     this.username = payload.username
                     this.password = payload.password
                 }


### PR DESCRIPTION
This PR updates the logic used when persisting the fetched site for REST API login, now we will use the site address as was entered by the user, instead of using the one from the `/wp-json` endpoint, and the cause is that the one returned from the API can be changed by the user, and when this happens, we won't be able to match the site address using the URL that we were given.

Check https://github.com/woocommerce/woocommerce-android/pull/9846 for test instructions.