### PR TITLE
Woo: ability to bulk add categories

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductCategoriesFragment.kt
@@ -6,37 +6,52 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_woo_product_categories.*
+import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.example.R.layout
+import org.wordpress.android.fluxc.example.prependToLog
 import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesAdapter.OnProductCategoryClickListener
 import org.wordpress.android.fluxc.example.ui.products.WooProductCategoriesAdapter.ProductCategoryViewHolderModel
 import org.wordpress.android.fluxc.example.ui.products.WooUpdateProductFragment.ProductCategory
+import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
+import org.wordpress.android.fluxc.model.WCProductCategoryModel
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
 
 class WooProductCategoriesFragment : Fragment(), OnProductCategoryClickListener {
     private var resultCode: Int = -1
     private var productCategories: List<ProductCategory>? = null
     private var selectedProductCategories: MutableList<ProductCategory>? = null
+    private var selectedSitePosition: Int = 0
 
     private lateinit var productCategoriesAdapter: WooProductCategoriesAdapter
+
+    @Inject lateinit var woocommerceStore: WooCommerceStore
+    @Inject lateinit var wcProductStore: WCProductStore
 
     companion object {
         const val PRODUCT_CATEGORIES_REQUEST_CODE = 2000
         const val ARG_RESULT_CODE = "ARG_RESULT_CODE"
         const val ARG_PRODUCT_CATEGORIES = "ARG_PRODUCT_CATEGORIES"
         const val ARG_SELECTED_PRODUCT_CATEGORIES = "ARG_SELECTED_PRODUCT_CATEGORIES"
+        const val ARG_SELECTED_SITE_POSITION = "ARG_SELECTED_SITE_POSITION"
 
         fun newInstance(
             fragment: Fragment,
             resultCode: Int,
             productCategories: List<ProductCategory>,
-            selectedProductCategories: MutableList<ProductCategory>?
+            selectedProductCategories: MutableList<ProductCategory>?,
+            selectedSitePosition: Int
         ) = WooProductCategoriesFragment().apply {
             this.setTargetFragment(fragment, PRODUCT_CATEGORIES_REQUEST_CODE)
             this.resultCode = resultCode
             this.productCategories = productCategories
             this.selectedProductCategories = selectedProductCategories
+            this.selectedSitePosition = selectedSitePosition
         }
     }
 
@@ -55,6 +70,7 @@ class WooProductCategoriesFragment : Fragment(), OnProductCategoryClickListener 
             resultCode = it.getInt(ARG_RESULT_CODE)
             productCategories = it.getParcelableArrayList(ARG_PRODUCT_CATEGORIES)
             selectedProductCategories = it.getParcelableArrayList(ARG_SELECTED_PRODUCT_CATEGORIES)
+            selectedSitePosition = it.getInt(ARG_SELECTED_SITE_POSITION)
         }
 
         productCategoriesAdapter = WooProductCategoriesAdapter(requireContext(), this)
@@ -63,14 +79,13 @@ class WooProductCategoriesFragment : Fragment(), OnProductCategoryClickListener 
             adapter = productCategoriesAdapter
         }
 
-        val allCategories = productCategories?.map { productCategory ->
-            ProductCategoryViewHolderModel(
-                    category = productCategory,
-                    isSelected = selectedProductCategories?.any { it.name == productCategory.name } ?: false
-            )
-        } ?: emptyList()
+        val allCategories = productCategories?.toViewHolders() ?: emptyList()
 
         productCategoriesAdapter.setProductCategories(allCategories.toList())
+
+        btn_add.setOnClickListener {
+            handleCreatingProductCategories()
+        }
 
         btn_done.setOnClickListener {
             val intent = activity?.intent
@@ -91,6 +106,7 @@ class WooProductCategoriesFragment : Fragment(), OnProductCategoryClickListener 
         selectedProductCategories?.let {
             outState.putParcelableArrayList(ARG_SELECTED_PRODUCT_CATEGORIES, it as? ArrayList)
         }
+        outState.putInt(ARG_SELECTED_SITE_POSITION, selectedSitePosition)
     }
 
     override fun onProductCategoryClick(productCategoryViewHolderModel: ProductCategoryViewHolderModel) {
@@ -102,5 +118,43 @@ class WooProductCategoriesFragment : Fragment(), OnProductCategoryClickListener 
         } else if (productCategoryViewHolderModel.isSelected && found == null) {
             selectedProductCategories?.add(productCategoryViewHolderModel.category)
         }
+    }
+
+    private fun handleCreatingProductCategories() {
+        lifecycleScope.launch {
+            val input = showSingleLineDialog(
+                activity = requireActivity(),
+                message = "Enter categories separated by a comma",
+                isNumeric = false
+            )?.takeIf { it.isNotEmpty() } ?: return@launch
+
+            val categories = input.split(",").map {
+                WCProductCategoryModel().apply {
+                    name = it
+                }
+            }
+            val site = woocommerceStore.getWooCommerceSites()[selectedSitePosition]
+
+            val result = wcProductStore.addProductCategories(site, categories)
+
+            if (result.isError) {
+                prependToLog("Error adding product categories: ${result.error?.message}")
+                return@launch
+            }
+
+            prependToLog("Product categories created successfully: ${result.model?.map { it.name }}")
+
+            productCategories = wcProductStore.getProductCategoriesForSite(site).map {
+                ProductCategory(it.remoteCategoryId, it.name, it.slug)
+            }
+            productCategoriesAdapter.setProductCategories(productCategories!!.toViewHolders())
+        }
+    }
+
+    private fun List<ProductCategory>.toViewHolders() = map { productCategory ->
+        ProductCategoryViewHolderModel(
+            category = productCategory,
+            isSelected = selectedProductCategories?.any { it.name == productCategory.name } ?: false
+        )
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooUpdateProductFragment.kt
@@ -370,7 +370,8 @@ class WooUpdateProductFragment : Fragment() {
                                 fragment = this,
                                 productCategories = categories,
                                 resultCode = LIST_RESULT_CODE_CATEGORIES,
-                                selectedProductCategories = selectedProductCategories?.toMutableList()
+                                selectedProductCategories = selectedProductCategories?.toMutableList(),
+                                selectedSitePosition = selectedSitePosition
                         )
                 )
             }

--- a/example/src/main/res/layout/fragment_woo_product_categories.xml
+++ b/example/src/main/res/layout/fragment_woo_product_categories.xml
@@ -1,30 +1,32 @@
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:layout_margin="@dimen/activity_start_end_margin"
-    tools:ignore="HardcodedText"
-    android:layout_height="match_parent">
+    android:orientation="vertical"
+    tools:ignore="HardcodedText">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/category_list"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         tools:itemCount="10"
-        tools:listitem="@layout/product_category_list_item"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/btn_done"/>
+        tools:listitem="@layout/product_category_list_item" />
+
+    <Button
+        android:id="@+id/btn_add"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="Add Categories" />
 
     <Button
         android:id="@+id/btn_done"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
-        android:text="Done"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        android:text="Done" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -23,6 +23,7 @@
 
 /products/categories/
 /products/categories/<id>/
+/products/categories/batch/
 
 /products/tags/
 /products/tags/<id>/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductCategoryApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductCategoryApiResponse.kt
@@ -1,15 +1,16 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
+import com.google.gson.JsonObject
+import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.network.Response
 
-@Suppress("PropertyName")
 class ProductCategoryApiResponse : Response {
     val id: Long = 0L
-    var localSiteId = 0
     var name: String? = null
     var slug: String? = null
     var parent: Long? = null
+    val error: JsonObject? = null
 
     fun asProductCategoryModel(): WCProductCategoryModel {
         val response = this
@@ -21,3 +22,8 @@ class ProductCategoryApiResponse : Response {
         }
     }
 }
+
+data class ProductCategoryBatchApiResponse(
+    @SerializedName("create")
+    val createdCategories: List<ProductCategoryApiResponse> = emptyList()
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductShippingClassModel
 import org.wordpress.android.fluxc.model.WCProductTagModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.PARSE_ERROR
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
@@ -26,9 +27,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGson
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.post.PostWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductVariationMapper.variantModelToProductJsonBody
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_CATEGORY_SORTING
 import org.wordpress.android.fluxc.store.WCProductStore.Companion.DEFAULT_PRODUCT_CATEGORY_PAGE_SIZE
@@ -1431,6 +1435,55 @@ class ProductRestClient @Inject constructor(
                     dispatcher.dispatch(WCProductActionBuilder.newAddedProductCategoryAction(payload))
                 }
             }
+        }
+    }
+
+    suspend fun addProductCategories(
+        site: SiteModel,
+        categories: List<WCProductCategoryModel>
+    ): WooPayload<List<WCProductCategoryModel>> {
+        val path = WOOCOMMERCE.products.categories.batch.pathV3
+
+        val body = mutableMapOf(
+            "create" to categories.map { category ->
+                mapOf(
+                    "name" to category.name,
+                    "parent" to category.parent.toString()
+                )
+            }
+        )
+
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = path,
+            body = body,
+            clazz = ProductCategoryBatchApiResponse::class.java
+        )
+
+        return when {
+            response is WPAPIResponse.Success && response.data == null -> WooPayload(
+                WooError(
+                    type = WooErrorType.EMPTY_RESPONSE,
+                    original = GenericErrorType.UNKNOWN,
+                    message = "Success response with empty data"
+                )
+            )
+
+            response is WPAPIResponse.Success -> {
+                WooPayload(
+                    response.data!!.createdCategories
+                        .filter { it.error == null }
+                        .map {
+                            it.asProductCategoryModel().apply {
+                                localSiteId = site.id
+                            }
+                        }
+                )
+            }
+
+            else -> return WooPayload(
+                error = (response as WPAPIResponse.Error).error.toWooError()
+            )
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1404,7 +1404,7 @@ class ProductRestClient @Inject constructor(
 
             val body = mutableMapOf(
                 "name" to category.name,
-                "parent" to category.parent.toString()
+                "parent" to category.parent
             )
 
             val response = wooNetwork.executePostGsonRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1305,6 +1305,24 @@ class WCProductStore @Inject constructor(
         with(payload) { wcProductRestClient.addProductCategory(site, category) }
     }
 
+    suspend fun addProductCategories(
+        site: SiteModel,
+        categories: List<WCProductCategoryModel>
+    ): WooResult<List<WCProductCategoryModel>> = coroutineEngine.withDefaultContext(API, this, "addProductCategories") {
+        val result = wcProductRestClient.addProductCategories(
+            site = site,
+            categories = categories
+        )
+
+        if (!result.isError) {
+            result.result?.forEach { category ->
+                ProductSqlUtils.insertOrUpdateProductCategory(category)
+            }
+        }
+
+        return@withDefaultContext result.asWooResult()
+    }
+
     private fun fetchProductTags(payload: FetchProductTagsPayload) {
         with(payload) { wcProductRestClient.fetchProductTags(site, pageSize, offset, searchQuery) }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1315,7 +1315,15 @@ class WCProductStore @Inject constructor(
         )
 
         if (!result.isError) {
-            result.result?.forEach { category ->
+            val addedCategories = result.result!!
+            if (addedCategories.size < categories.size) {
+                AppLog.w(
+                    API,
+                    "addProductCategories: not all categories were added. " +
+                        "Expected: ${categories.size}, added: ${addedCategories.size}")
+            }
+
+            addedCategories.forEach { category ->
                 ProductSqlUtils.insertOrUpdateProductCategory(category)
             }
         }


### PR DESCRIPTION
Needed for https://github.com/woocommerce/woocommerce-android/issues/9878

This PR adds support for bulk creating categories, using the `/batch` endpoint from the Woo API.
As agreed, there is no advanced handling for individual errors, and the consumers are expected to fetch updated resources before sending a request to create new ones.
I still added a statement to log a warning if some categories couldn't be created.

#### Testing
1. Open the example app and sign in.
2. Click on Woo, then pick a site.
3. Click on Products then pick a site (We need to fix this 😅)
4. Click on Update product.
5. Enter a product id.
6. Click on Select Categories.
7. Click on Add categories.
8. Enter some names separated by comma.
9. Confirm the creation succeeds, and the categories are shown in the list.