### PR TITLE
Change range id type

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -41,7 +41,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 195
+        return 196
     }
 
     override fun getDbName(): String {
@@ -1975,6 +1975,20 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 194 -> migrate(version) {
                     db.execSQL("DROP TABLE IF EXISTS DynamicCard")
+                }
+                195 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("DROP TABLE IF EXISTS WCRevenueStatsModel")
+                    db.execSQL(
+                        "CREATE TABLE WCRevenueStatsModel(" +
+                            "LOCAL_SITE_ID INTEGER," +
+                            "INTERVAL TEXT NOT NULL," +
+                            "START_DATE TEXT NOT NULL," +
+                            "END_DATE TEXT NOT NULL," +
+                            "DATA TEXT NOT NULL," +
+                            "TOTAL TEXT NOT NULL," +
+                            "RANGE_ID TEXT NOT NULL," +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT)"
+                    )
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -20,7 +20,7 @@ data class WCRevenueStatsModel(@PrimaryKey @Column private var id: Int = 0) : Id
     @Column var endDate = "" // The end date of the data
     @Column var data = "" // JSON - A list of lists; each nested list contains the data for a time period
     @Column var total = "" // JSON - A map of total stats for a given time period
-    @Column var rangeId = 0 // A ID for easily fetch the Revenue Stats for a given start and end date
+    @Column var rangeId = "" // A ID for easily fetch the Revenue Stats for a given start and end date
 
     companion object {
         private val gson by lazy { Gson() }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -172,7 +172,7 @@ class OrderStatsRestClient @Inject constructor(
         endDate: String,
         perPage: Int,
         forceRefresh: Boolean = false,
-        revenueRangeId: Int = 0
+        revenueRangeId: String = ""
     ): FetchRevenueStatsResponsePayload {
         val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
         val params = mapOf(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCStatsSqlUtils.kt
@@ -133,7 +133,7 @@ object WCStatsSqlUtils {
     }
 
     private fun searchMatchingRevenueStatsInDatabase(stats: WCRevenueStatsModel): List<WCRevenueStatsModel> {
-        return if (stats.rangeId != 0) {
+        return if (stats.rangeId.isNotEmpty()) {
             WellSql.select(WCRevenueStatsModel::class.java)
                 .where().beginGroup()
                 .equals(WCRevenueStatsModelTable.LOCAL_SITE_ID, stats.localSiteId)
@@ -171,7 +171,7 @@ object WCStatsSqlUtils {
 
     fun getRevenueStatsFromRangeId(
         site: SiteModel,
-        revenueRangeId: Int
+        revenueRangeId: String
     ) = WellSql.select(WCRevenueStatsModel::class.java)
         .where()
         .beginGroup()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -140,7 +140,7 @@ class WCStatsStore @Inject constructor(
         val startDate: String? = null,
         val endDate: String? = null,
         val forced: Boolean = false,
-        val revenueRangeId: Int = 0
+        val revenueRangeId: String = ""
     ) : Payload<BaseNetworkError>()
 
     class FetchRevenueStatsResponsePayload(
@@ -829,6 +829,6 @@ class WCStatsStore @Inject constructor(
 
     fun getRawRevenueStatsFromRangeId(
         site: SiteModel,
-        revenueRangeId: Int
+        revenueRangeId: String
     ) = WCStatsSqlUtils.getRevenueStatsFromRangeId(site, revenueRangeId)
 }


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/9916

### Why
As part of the Reliability project, we added the `RANGE_ID` field to retrieve the cached revenue stats from the DB quickly. Aiming to have a more readable and performant `ID` we decided to define this field as an Integer. To generate this field's value, we used the selected time period name, the period start date, and the period end date values. We joined all these values as a string key and used the `hashCode()` to generate the integer key. The idea was that the hashCode generated should be unique, but after a close look at the `hashCode()` function, we realized that collisions are more common than we thought.

[Here](https://play.kotlinlang.org/#eyJ2ZXJzaW9uIjoiMS42LjIxIiwicGxhdGZvcm0iOiJqYXZhIiwiYXJncyI6IiIsIm5vbmVNYXJrZXJzIjp0cnVlLCJ0aGVtZSI6ImlkZWEiLCJjb2RlIjoiLyoqXG4gKiBZb3UgY2FuIGVkaXQsIHJ1biwgYW5kIHNoYXJlIHRoaXMgY29kZS5cbiAqIHBsYXkua290bGlubGFuZy5vcmdcbiAqL1xuZnVuIG1haW4oKSB7XG4gICAgdmFsIGEgPSBcIkZCXCIuaGFzaENvZGUoKVxuICAgIHZhbCBiID0gXCJFYVwiLmhhc2hDb2RlKClcbiAgICBcbiAgICBwcmludGxuKCBcIiRhIHNob3VsZCBiZSBkaWZmZXJlbnQgdGhhbiAkYlwiKVxufSJ9), you can check two different strings with the same hashCode

### Description
This PR changes the `RANGE_ID` from Int -> String. Changing the RANGE_ID from Int to String should be enough to prevent the `RANGE_ID` collisions.

### Testing
It is better to test this change using the Woo PR https://github.com/woocommerce/woocommerce-android/pull/9917