### PR TITLE
Add functionality to add a plan to the cart

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsFixtures.kt
@@ -18,6 +18,16 @@ val CREATE_SHOPPING_CART_RESPONSE = CreateShoppingCartResponse(
         )
 )
 
+val CREATE_SHOPPING_CART_WITH_PLAN_RESPONSE = CreateShoppingCartResponse(
+    76,
+    22.toString(),
+    listOf(
+        Product(76, "superraredomainname156726.blog", Extra(true)),
+        Product(1009, "Plan", Extra(true)),
+        Product(1001, "other product", Extra(true))
+    )
+)
+
 val DOMAIN_CONTACT_INFORMATION = DomainContactModel(
         "Wapu",
         "Wordpress",

--- a/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
@@ -58,13 +58,13 @@ class TransactionsStoreTest {
     }
 
     @Test
-    fun createShoppingCart() = test {
+    fun createShoppingCartWithDomain() = test {
         whenever(
                 transactionsRestClient.createShoppingCart(
                         siteModel,
                         TEST_DOMAIN_PRODUCT_ID,
                         TEST_DOMAIN_NAME,
-                        isPrivacyProtectionEnabled = true,
+                        isDomainPrivacyProtectionEnabled = true,
                         isTemporary = true
                 )
         ).thenReturn(

--- a/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/TransactionsStoreTest.kt
@@ -13,10 +13,12 @@ import org.wordpress.android.fluxc.action.TransactionAction
 import org.wordpress.android.fluxc.generated.TransactionActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.CREATE_SHOPPING_CART_RESPONSE
+import org.wordpress.android.fluxc.network.rest.wpcom.transactions.CREATE_SHOPPING_CART_WITH_PLAN_RESPONSE
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.DOMAIN_CONTACT_INFORMATION
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.SUPPORTED_COUNTRIES_MODEL
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient
 import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartPayload
+import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartWithDomainAndPlanPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.CreatedShoppingCartPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.FetchedSupportedCountriesPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartPayload
@@ -34,6 +36,7 @@ class TransactionsStoreTest {
     companion object {
         private const val TEST_DOMAIN_NAME = "superraredomainname156726.blog"
         private const val TEST_DOMAIN_PRODUCT_ID = 76
+        private const val TEST_PLAN_PRODUCT_ID = 1009
     }
 
     @Before
@@ -93,6 +96,50 @@ class TransactionsStoreTest {
         )
 
         val expectedEvent = TransactionsStore.OnShoppingCartCreated(CREATE_SHOPPING_CART_RESPONSE)
+        verify(dispatcher).emitChange(eq(expectedEvent))
+    }
+
+    @Test
+    fun createShoppingCartWithDomainAndPlan() = test {
+        whenever(
+            transactionsRestClient.createShoppingCart(
+                siteModel,
+                TEST_DOMAIN_PRODUCT_ID,
+                TEST_DOMAIN_NAME,
+                isDomainPrivacyProtectionEnabled = true,
+                isTemporary = true,
+                planProductId = TEST_PLAN_PRODUCT_ID
+            )
+        ).thenReturn(
+            CreatedShoppingCartPayload(
+                CREATE_SHOPPING_CART_WITH_PLAN_RESPONSE
+            )
+        )
+
+        val payload = CreateShoppingCartWithDomainAndPlanPayload(
+            site = siteModel,
+            domainProductId = TEST_DOMAIN_PRODUCT_ID,
+            domainName = TEST_DOMAIN_NAME,
+            isDomainPrivacyEnabled = true,
+            planProductId = TEST_PLAN_PRODUCT_ID,
+            isTemporary = true
+        )
+
+        val action = TransactionActionBuilder.newCreateShoppingCartWithDomainAndPlanAction(payload)
+        transactionsStore.onAction(action)
+
+        verify(transactionsRestClient).createShoppingCart(
+            site = payload.site,
+            domainProductId = payload.domainProductId,
+            domainName = payload.domainName,
+            isDomainPrivacyProtectionEnabled = payload.isDomainPrivacyEnabled,
+            isTemporary = payload.isTemporary,
+            planProductId = payload.planProductId
+        )
+
+        val expectedEvent = TransactionsStore.OnShoppingCartCreated(
+            CREATE_SHOPPING_CART_WITH_PLAN_RESPONSE
+        )
         verify(dispatcher).emitChange(eq(expectedEvent))
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/TransactionAction.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/TransactionAction.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.annotations.Action
 import org.wordpress.android.fluxc.annotations.ActionEnum
 import org.wordpress.android.fluxc.annotations.action.IAction
 import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartPayload
+import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartWithDomainAndPlanPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.RedeemShoppingCartPayload
 
 @ActionEnum
@@ -12,6 +13,8 @@ enum class TransactionAction : IAction {
     FETCH_SUPPORTED_COUNTRIES,
     @Action(payloadType = CreateShoppingCartPayload::class)
     CREATE_SHOPPING_CART,
+    @Action(payloadType = CreateShoppingCartWithDomainAndPlanPayload::class)
+    CREATE_SHOPPING_CART_WITH_DOMAIN_AND_PLAN,
     @Action(payloadType = RedeemShoppingCartPayload::class)
     REDEEM_CART_WITH_CREDITS
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
@@ -56,22 +56,30 @@ class TransactionsRestClient @Inject constructor(
 
     suspend fun createShoppingCart(
         site: SiteModel,
-        productId: Int,
+        domainProductId: Int,
         domainName: String,
-        isPrivacyProtectionEnabled: Boolean,
-        isTemporary: Boolean
+        isDomainPrivacyProtectionEnabled: Boolean,
+        isTemporary: Boolean,
+        planProductId: Int? = null
     ): CreatedShoppingCartPayload {
         val url = WPCOMREST.me.shopping_cart.site(site.siteId).urlV1_1
 
         val domainProduct = mapOf(
-                "product_id" to productId,
+                "product_id" to domainProductId,
                 "meta" to domainName,
-                "extra" to PrivacyExtra(isPrivacyProtectionEnabled)
+                "extra" to PrivacyExtra(isDomainPrivacyProtectionEnabled)
         )
+
+        var products = arrayOf(domainProduct)
+
+        planProductId?.let {
+            val planProduct = mapOf("product_id" to it)
+            products += planProduct
+        }
 
         val body = mapOf(
                 "temporary" to isTemporary,
-                "products" to arrayOf(domainProduct)
+                "products" to products
         )
 
         return when (val response = wpComGsonRequestBuilder.syncPostRequest(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
@@ -130,11 +130,32 @@ class TransactionsStore @Inject constructor(
 
     // Payloads
 
+    // Shopping cart with only domain
+    @Deprecated("Use CreateShoppingCartWithDomainAndPlanPayload with null 'planProductId' instead")
     class CreateShoppingCartPayload(
         val site: SiteModel,
         val productId: Int,
         val domainName: String,
         val isPrivacyEnabled: Boolean,
+        val isTemporary: Boolean = true
+    ) : Payload<BaseRequest.BaseNetworkError>() {
+        fun toCreateShoppingCartWithDomainAndPlanPayload() =
+                CreateShoppingCartWithDomainAndPlanPayload(
+                        site = site,
+                        domainProductId = productId,
+                        domainName = domainName,
+                        isDomainPrivacyEnabled = isPrivacyEnabled,
+                        planProductId = null,
+                        isTemporary = isTemporary
+                ).apply { error = this@CreateShoppingCartPayload.error }
+    }
+
+    class CreateShoppingCartWithDomainAndPlanPayload(
+        val site: SiteModel,
+        val domainProductId: Int,
+        val domainName: String,
+        val isDomainPrivacyEnabled: Boolean,
+        val planProductId: Int? = null,
         val isTemporary: Boolean = true
     ) : Payload<BaseRequest.BaseNetworkError>()
 


### PR DESCRIPTION
This adds functionality to add plans to the shopping cart.

Previously, `TransactionAction.CREATE_SHOPPING_CART` would allow only adding a domain to the cart. This PR adds `TransactionAction.CREATE_SHOPPING_CART_WITH_DOMAIN_AND_PLAN` that takes a domain and a plan.

If we pass null `planProductId` to the `TransactionAction.CREATE_SHOPPING_CART_WITH_DOMAIN_AND_PLAN`, that will be equal to `TransactionAction.CREATE_SHOPPING_CART`. I haven't removed `TransactionAction.CREATE_SHOPPING_CART` because it's also used in [WooCommerce](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/FreeDomainRegistrationViewModel.kt#L131).

The change can be tested in https://github.com/wordpress-mobile/WordPress-Android/pull/19303 