### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to `TaxonomyXMLRPCClient` (`safe`)

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -94,7 +94,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void fetchTerms(final SiteModel site, final String taxonomyName) {
+    public void fetchTerms(@NonNull final SiteModel site, @NonNull final String taxonomyName) {
         List<Object> params = new ArrayList<>(4);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -60,7 +60,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_TERM, params,
                 (Listener<Object>) response -> {
-                    if (response != null && response instanceof Map) {
+                    if (response instanceof Map) {
                         TermModel termModel = termResponseObjectToTermModel(response, site);
                         FetchTermResponsePayload payload;
                         if (termModel != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -242,7 +242,8 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         );
     }
 
-    private static Map<String, Object> termModelToContentStruct(TermModel term) {
+    @NonNull
+    private static Map<String, Object> termModelToContentStruct(@NonNull TermModel term) {
         Map<String, Object> contentStruct = new HashMap<>();
 
         contentStruct.put("name", term.getName());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -143,7 +143,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                 (Listener<Object>) response -> {
                     // `term_id` is only returned for XMLRPC.NEW_TERM
                     if (!updatingExistingTerm) {
-                        term.setRemoteTermId(Long.valueOf((String) response));
+                        term.setRemoteTermId(Long.parseLong((String) response));
                     }
 
                     RemoteTermPayload payload = new RemoteTermPayload(term, site);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -39,10 +39,11 @@ import javax.inject.Singleton;
 
 @Singleton
 public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
-    @Inject public TaxonomyXMLRPCClient(Dispatcher dispatcher,
-                                @Named("custom-ssl") RequestQueue requestQueue,
-                                UserAgent userAgent,
-                                HTTPAuthManager httpAuthManager) {
+    @Inject public TaxonomyXMLRPCClient(
+            Dispatcher dispatcher,
+            @Named("custom-ssl") RequestQueue requestQueue,
+            UserAgent userAgent,
+            HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);
     }
 
@@ -62,22 +63,22 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                 new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
-                    if (response != null && response instanceof Map) {
-                        TermModel termModel = termResponseObjectToTermModel(response, site);
-                        FetchTermResponsePayload payload;
-                        if (termModel != null) {
-                            if (origin == TaxonomyAction.PUSH_TERM) {
-                                termModel.setId(term.getId());
+                        if (response != null && response instanceof Map) {
+                            TermModel termModel = termResponseObjectToTermModel(response, site);
+                            FetchTermResponsePayload payload;
+                            if (termModel != null) {
+                                if (origin == TaxonomyAction.PUSH_TERM) {
+                                    termModel.setId(term.getId());
+                                }
+                                payload = new FetchTermResponsePayload(termModel, site);
+                            } else {
+                                payload = new FetchTermResponsePayload(term, site);
+                                payload.error = new TaxonomyError(TaxonomyErrorType.INVALID_RESPONSE);
                             }
-                            payload = new FetchTermResponsePayload(termModel, site);
-                        } else {
-                            payload = new FetchTermResponsePayload(term, site);
-                            payload.error = new TaxonomyError(TaxonomyErrorType.INVALID_RESPONSE);
-                        }
-                        payload.origin = origin;
+                            payload.origin = origin;
 
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
-                    }
+                            mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
+                        }
                     }
                 },
                 new BaseErrorListener() {
@@ -101,8 +102,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                         payload.origin = origin;
                         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermAction(payload));
                     }
-                }
-        );
+                });
 
         add(request);
     }
@@ -148,8 +148,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                         FetchTermsResponsePayload payload = new FetchTermsResponsePayload(taxonomyError, taxonomyName);
                         mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
                     }
-                }
-        );
+                });
 
         add(request);
     }
@@ -203,8 +202,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                         payload.error = taxonomyError;
                         mDispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload));
                     }
-                }
-        );
+                });
 
         request.disableRetries();
         add(request);
@@ -241,8 +239,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
                         payload.error = taxonomyError;
                         mDispatcher.dispatch(TaxonomyActionBuilder.newDeletedTermAction(payload));
                     }
-                }
-        );
+                });
 
         request.disableRetries();
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -47,11 +47,14 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);
     }
 
-    public void fetchTerm(final TermModel term, final SiteModel site) {
+    public void fetchTerm(@NonNull final TermModel term, @NonNull final SiteModel site) {
         fetchTerm(term, site, TaxonomyAction.FETCH_TERM);
     }
 
-    public void fetchTerm(final TermModel term, final SiteModel site, final TaxonomyAction origin) {
+    public void fetchTerm(
+            @NonNull final TermModel term,
+            @NonNull final SiteModel site,
+            @NonNull final TaxonomyAction origin) {
         List<Object> params = new ArrayList<>(5);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.xmlrpc.taxonomy;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
@@ -99,16 +100,17 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
 
         final XMLRPCRequest request = new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_TERMS, params,
                 response -> {
+                    FetchTermsResponsePayload payload;
                     TermsModel terms = termsResponseToTermsModel(response, site);
-
-                    FetchTermsResponsePayload payload = new FetchTermsResponsePayload(terms, site, taxonomyName);
-
                     if (terms != null) {
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
+                        payload = new FetchTermsResponsePayload(terms, site, taxonomyName);
                     } else {
-                        payload.error = new TaxonomyError(TaxonomyErrorType.INVALID_RESPONSE);
-                        mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
+                        payload = new FetchTermsResponsePayload(
+                                new TaxonomyError(TaxonomyErrorType.INVALID_RESPONSE),
+                                taxonomyName
+                        );
                     }
+                    mDispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload));
                 },
                 error -> {
                     // Possible non-generic errors:
@@ -185,6 +187,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
+    @Nullable
     private TermsModel termsResponseToTermsModel(Object[] response, SiteModel site) {
         List<Map<?, ?>> termsList = new ArrayList<>();
         for (Object responseObject : response) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -215,7 +215,8 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         return new TermsModel(termArray);
     }
 
-    private TermModel termResponseObjectToTermModel(Object termObject, SiteModel site) {
+    @Nullable
+    private TermModel termResponseObjectToTermModel(@NonNull Object termObject, @NonNull SiteModel site) {
         // Sanity checks
         if (!(termObject instanceof Map)) {
             return null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -128,7 +128,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void pushTerm(final TermModel term, final SiteModel site) {
+    public void pushTerm(@NonNull final TermModel term, @NonNull final SiteModel site) {
         Map<String, Object> contentStruct = termModelToContentStruct(term);
         final boolean updatingExistingTerm = term.getRemoteTermId() > 0;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -191,7 +191,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
     }
 
     @Nullable
-    private TermsModel termsResponseToTermsModel(Object[] response, SiteModel site) {
+    private TermsModel termsResponseToTermsModel(@NonNull Object[] response, @NonNull SiteModel site) {
         List<Map<?, ?>> termsList = new ArrayList<>();
         for (Object responseObject : response) {
             Map<?, ?> termMap = (Map<?, ?>) responseObject;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java
@@ -167,7 +167,7 @@ public class TaxonomyXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void deleteTerm(final TermModel term, final SiteModel site) {
+    public void deleteTerm(@NonNull final TermModel term, @NonNull final SiteModel site) {
         List<Object> params = new ArrayList<>(4);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());


### PR DESCRIPTION
Parent #2798

This PR adds any missing nullability annotation to [TaxonomyXMLRPCClient.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/56bfb5d2e34172909794502e2460fbce4c80b23d/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/taxonomy/TaxonomyXMLRPCClient.java#L4).

FYI.1: This change is `safe`, meaning that there shouldn't be any (major) compile-time changes associated with this change. Having said that, testing is highly recommended since the changes in this PR can affect one or more clients (ie. [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), [WCAndroid](https://github.com/woocommerce/woocommerce-android), etc)

FYI.2: An analysis on `TaxonomyStore` and its usages with our main clients suggests that this store is only being utilizing [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android). AFAIA [WCAndroid](https://github.com/woocommerce/woocommerce-android) is not using that store and as such can be safely ignored from testing.

-----

PS: @irfano I added you as the main reviewer, not so randomly, due to the fact that you've also reviewed #2826, and I wanted you from the Jetpack/WordPress mobile team again to be aware of and sign-off on that change for JP/WPAndroid. Feel free to merge this PR directly yourself if you deem so.

-----

Nullability Annotation List:

1. [Add missing n-a to fetch term on taxonomy xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/57d01082bfa5a69edf9e46c7f4dce7f09568144f)
2. [Add missing n-a to fetch terms on taxonomy xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/1a74d6eea45254d9d6e2b4941b4c8d469ca011f4)
3. [Add missing n-a to push term on taxonomy xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/b71a97538d6c74a5a98839e5e2521f10cfb1b99c)
4. [Add missing n-a to delete term on taxonomy xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/59d6eab3e99ba9e7b2c0e717516091cbf07ebe47)
5. [Add missing n-a to terms response to terms model method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/19a3870b02d412d068547d41015cbc1fa211a426)
6. [Add missing n-a to term response object to term model method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/c5fc4ff17fa9d69cc1686d3c8e2a1429f333f3e2)
7. [Add missing n-a to term model to content struct method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/e17f6557457b1dd3ebb2007d9a8b3977dc4b3308)

Nullability Checks List:

1. [Remove unnecessary is response null check](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/411634ac9c7768befff9ab3599020cf40d11964a)
8. [Guard usages of terms response to terms model method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/efd5eaa9b94505becce0cfb9dcb06e0cce19ca2e)

Warnings Resolutions List:

1. [Create missing switch cases for taxonomy xmlrpc client errors](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/345c8a824cada60ee8c3df6966c1a7f49f39393a)
2. [Replace value of with long parse long for string reponse](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/173df0e181684b9138e135564b799d2343d7b235)

Refactor List:

1. [Reformat taxonomy xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/ccbed76a35138e2d11c6593ba9dba6950a436dac)
9. [Replace anonymous classes with lambda](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2866/commits/fc6f0d6ad6b19bd17e7516ac4e5697ed021232cd)

-----

## Associated Clients

It is highly recommending that this change is being tested on the below associated clients:

- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android)

-----

## To Test:

- Create a new self-hosted WordPress site for XMLRPC testing purposes ([jurassic.ninja](https://jurassic.ninja/)).
- Smoke test the `FluxC Example` app via the `TAXONOMIES` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any `TaxonomyStore` related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

<details>
    <summary>1. Categories Settings Screen [CategoriesListFragment.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.
⚠️ It seems that this setting is not available for self-hosted WordPress sites.

- Go to `Menu` sub-tab on the initial `My Site` screen and click on `Site Settings` under the
`Manage` section.
- Find the `Categories` under the `Writing` section and click on it.
- Verify that the `Categories` screen is displayed and that everything works as expected.

</details>

<details>
    <summary>2. Tags Settings Screen [SiteSettingsTagListActivity.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.
⚠️ It seems that this setting is not available for self-hosted WordPress sites.

- Go to `Menu` sub-tab on the initial `My Site` screen and click on `Site Settings` under the
`Manage` section.
- Find the `Tags` under the `Writing` section and click on it.
- Verify that the `Tags` screen is displayed and that everything works as expected.

</details>


<details>
    <summary>3. Prepublishing Screens [PrepublishingTagsFragment.kt + PrepublishingCategoriesFragment.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Posts` screen and edit any post.
- Click on the `UPDATE` button to have the bottom sheet appear (`top-right`).
- Click on the `Tags` row and add, remove or edit any tag for this post. Click back.
- Click on the `Categories` row and add, remove or create a new category for this post. Click back.
- Click on the `UPDATE NOW` button to update this post (`bottom`).
- Verify that this post's `Tags`/`Categories` are updated and that everything works as expected.

</details>