### PR TITLE
Adds fetch all-domains api call

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/DomainsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/DomainsFragment.kt
@@ -67,5 +67,24 @@ class DomainsFragment : StoreSelectingFragment() {
                 }
             }
         }
+
+        fetch_all_domains.setOnClickListener {
+            lifecycleScope.launch {
+                val result = store.fetchAllDomains(noWpCom = false) // fetching wpcom too for debugging purposes
+                when {
+                    result.isError -> {
+                        prependToLog("Error fetching all domains: ${result.error.message}")
+                    }
+                    else -> {
+                        prependToLog("All domains count: ${result.domains?.size}")
+                        val domains = result.domains
+                            ?.joinToString(separator = "\n") {
+                                "${it.domain} (type: ${it.type}), expiry: ${it.expiry}"
+                            }
+                        prependToLog("Domains:\n$domains")
+                    }
+                }
+            }
+        }
     }
 }

--- a/example/src/main/res/layout/fragment_domains.xml
+++ b/example/src/main/res/layout/fragment_domains.xml
@@ -24,5 +24,11 @@
             android:layout_height="wrap_content"
             android:text="Fetch domain price" />
 
+        <Button
+            android:id="@+id/fetch_all_domains"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Fetch all domain" />
+
     </LinearLayout>
 </ScrollView>

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -549,6 +549,46 @@ class SiteRestClientTest {
         }
     }
 
+    @Test
+    fun `given a network error, when all domains are requested, then return api error`() = test {
+        val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NETWORK_ERROR))
+        initAllDomainsResponse(error = error)
+
+        val response = restClient.fetchAllDomains(noWpCom = true)
+        assert(response is Response.Error)
+        with((response as Response.Error).error) {
+            assertThat(type).isEqualTo(GenericErrorType.NETWORK_ERROR)
+            assertThat(message).isNull()
+        }
+    }
+
+    @Test
+    fun `given timeout, when all domains are requested, then return timeout error`() = test {
+        val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.TIMEOUT))
+        initAllDomainsResponse(error = error)
+
+        val response = restClient.fetchAllDomains(noWpCom = true)
+        assert(response is Response.Error)
+        with((response as Response.Error).error) {
+            assertThat(type).isEqualTo(GenericErrorType.TIMEOUT)
+            assertThat(message).isNull()
+        }
+    }
+
+    @Test
+    fun `given not authenticated, when all domains are requested, then retun auth required error`() = test {
+        val tokenErrorMessage = "An active access token must be used to query information about the current user."
+        val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NOT_AUTHENTICATED, tokenErrorMessage))
+        initAllDomainsResponse(error = error)
+
+        val response = restClient.fetchAllDomains(noWpCom = true)
+        assert(response is Response.Error)
+        with((response as Response.Error).error) {
+            assertThat(type).isEqualTo(GenericErrorType.NOT_AUTHENTICATED)
+            assertThat(message).isEqualTo(tokenErrorMessage)
+        }
+    }
+
     private suspend fun initSiteResponse(
         data: SiteWPComRestResponse? = null,
         error: WPComGsonNetworkError? = null

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -543,9 +543,9 @@ class SiteRestClientTest {
         with((responseModel as Success).data) {
             assertThat(domains).hasSize(2)
             assertThat(domains[0].domain).isEqualTo("some.test.domain")
-            assertThat(domains[0].wpcomDomain).isFalse()
+            assertThat(domains[0].wpcomDomain).isFalse
             assertThat(domains[1].domain).isEqualTo("some.test.domain 2")
-            assertThat(domains[1].wpcomDomain).isTrue()
+            assertThat(domains[1].wpcomDomain).isTrue
         }
     }
 

--- a/example/src/test/resources/wp/all-domains/all-domains.json
+++ b/example/src/test/resources/wp/all-domains/all-domains.json
@@ -1,0 +1,32 @@
+{
+  "domains": [
+    {
+      "domain": "some.test.domain",
+      "blog_id": 11111,
+      "blog_name": "some test blog",
+      "type": "mapping",
+      "is_domain_only_site": false,
+      "is_wpcom_staging_domain": false,
+      "has_registration": false,
+      "registration_date": "2009-03-26T21:20:53+00:00",
+      "expiry": "2024-03-24T00:00:00+00:00",
+      "wpcom_domain": false,
+      "current_user_is_owner": true,
+      "site_slug": "test slug"
+    },
+    {
+      "domain": "some.test.domain 2",
+      "blog_id": 22222,
+      "blog_name": "some test blog 2",
+      "type": "mapping",
+      "is_domain_only_site": false,
+      "is_wpcom_staging_domain": false,
+      "has_registration": false,
+      "registration_date": "2009-03-26T21:20:53+00:00",
+      "expiry": "2024-03-24T00:00:00+00:00",
+      "wpcom_domain": true,
+      "current_user_is_owner": false,
+      "site_slug": "test slug 2"
+    }
+  ]
+}

--- a/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -43,6 +43,8 @@
 /read/site/$site#String/post_email_subscriptions/$action#String
 /read/site/$site#String/post_email_subscriptions/update
 
+/all-domains
+
 /domains/suggestions
 /domains/supported-countries/
 /domains/supported-states/$countryCode#String

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AllDomainsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AllDomainsResponse.kt
@@ -1,0 +1,38 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site
+
+import com.google.gson.annotations.JsonAdapter
+import com.google.gson.annotations.SerializedName
+
+data class AllDomainsResponse(val domains: List<AllDomainsDomain>)
+
+data class AllDomainsDomain(
+    @SerializedName("domain")
+    val domain: String? = null,
+    @SerializedName("blog_id")
+    val blogId: Long = 0,
+    @SerializedName("blog_name")
+    val blogName: String? = null,
+    @SerializedName("type")
+    val type: String? = null,
+    @SerializedName("is_domain_only_site")
+    @JsonAdapter(BooleanTypeAdapter::class)
+    val isDomainOnlySite: Boolean = false,
+    @SerializedName("is_wpcom_staging_domain")
+    @JsonAdapter(BooleanTypeAdapter::class)
+    val isWpcomStagingDomain: Boolean = false,
+    @SerializedName("has_registration")
+    @JsonAdapter(BooleanTypeAdapter::class)
+    val hasRegistration: Boolean = false,
+    @SerializedName("registration_date")
+    val registrationDate: String? = null,
+    @SerializedName("expiry")
+    val expiry: String? = null,
+    @SerializedName("wpcom_domain")
+    @JsonAdapter(BooleanTypeAdapter::class)
+    val wpcomDomain: Boolean = false,
+    @SerializedName("current_user_is_owner")
+    @JsonAdapter(BooleanTypeAdapter::class)
+    val currentUserIsOwner: Boolean = false,
+    @SerializedName("site_slug")
+    val siteSlug: String? = null,
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/BooleanTypeAdapter.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/BooleanTypeAdapter.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.site
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import java.lang.reflect.Type
+import java.util.Locale
+
+internal class BooleanTypeAdapter : JsonDeserializer<Boolean?> {
+    @Suppress("VariableNaming") private val TRUE_STRINGS: Set<String> = HashSet(listOf("true", "1", "yes"))
+
+    @Throws(JsonParseException::class)
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Boolean {
+        val jsonPrimitive = json.asJsonPrimitive
+        return when {
+            jsonPrimitive.isBoolean -> jsonPrimitive.asBoolean
+            jsonPrimitive.isNumber -> jsonPrimitive.asNumber.toInt() == 1
+            jsonPrimitive.isString -> TRUE_STRINGS.contains(jsonPrimitive.asString.toLowerCase(
+                Locale.getDefault()
+            ))
+            else -> false
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/DomainsResponse.kt
@@ -1,13 +1,8 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site
 
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
-import com.google.gson.JsonParseException
 import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
-import java.lang.reflect.Type
-import java.util.Locale
 
 data class DomainsResponse(val domains: List<Domain>)
 
@@ -155,17 +150,3 @@ data class TitanMailSubscription(
     val status: String? = null
 )
 
-internal class BooleanTypeAdapter : JsonDeserializer<Boolean?> {
-    @Suppress("VariableNaming") private val TRUE_STRINGS: Set<String> = HashSet(listOf("true", "1", "yes"))
-
-    @Throws(JsonParseException::class)
-    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Boolean {
-        val jsonPrimitive = json.asJsonPrimitive
-        return when {
-            jsonPrimitive.isBoolean -> jsonPrimitive.asBoolean
-            jsonPrimitive.isNumber -> jsonPrimitive.asNumber.toInt() == 1
-            jsonPrimitive.isString -> TRUE_STRINGS.contains(jsonPrimitive.asString.toLowerCase(Locale.getDefault()))
-            else -> false
-        }
-    }
-}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -837,6 +837,11 @@ class SiteRestClient @Inject constructor(
         add(request)
     }
 
+    suspend fun fetchAllDomains(noWpCom: Boolean = true): Response<AllDomainsResponse> {
+        val url = WPCOMREST.all_domains.urlV1_1
+        val params = mapOf("no_wpcom" to noWpCom.toString())
+        return wpComGsonRequestBuilder.syncGetRequest(this, url, params, AllDomainsResponse::class.java)
+    }
     suspend fun fetchSiteDomains(site: SiteModel): Response<DomainsResponse> {
         val url = WPCOMREST.sites.site(site.siteId).domains.urlV1_1
         return wpComGsonRequestBuilder.syncGetRequest(this, url, mapOf(), DomainsResponse::class.java)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -87,6 +87,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.site.SiteWPAPIRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
 import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainPriceResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
@@ -490,6 +491,11 @@ open class SiteStore @Inject constructor(
         }
     }
 
+    data class AllDomainsError @JvmOverloads constructor(
+        @JvmField val type: AllDomainsErrorType,
+        @JvmField val message: String? = null,
+    ) : OnChangedError
+
     data class SiteError @JvmOverloads constructor(
         @JvmField val type: SiteErrorType,
         @JvmField val message: String? = null,
@@ -757,6 +763,14 @@ open class SiteStore @Inject constructor(
         }
     }
 
+    data class FetchedAllDomainsPayload(
+        @JvmField val domains: List<AllDomainsDomain>? = null
+    ) : Payload<AllDomainsError>() {
+        constructor(error: AllDomainsError) : this() {
+            this.error = error
+        }
+    }
+
     data class FetchedDomainsPayload(
         @JvmField val site: SiteModel,
         @JvmField val domains: List<Domain>? = null
@@ -884,6 +898,10 @@ open class SiteStore @Inject constructor(
 
     enum class SiteErrorType {
         INVALID_SITE, UNKNOWN_SITE, DUPLICATE_SITE, INVALID_RESPONSE, UNAUTHORIZED, NOT_AUTHENTICATED, GENERIC_ERROR
+    }
+
+    enum class AllDomainsErrorType {
+        UNAUTHORIZED, GENERIC_ERROR
     }
 
     enum class SuggestDomainErrorType {
@@ -2080,6 +2098,24 @@ open class SiteStore @Inject constructor(
         emitChange(event)
     }
 
+    suspend fun fetchAllDomains(noWpCom: Boolean = true): FetchedAllDomainsPayload =
+        coroutineEngine.withDefaultContext(T.API, this, "Fetch all domains") {
+            return@withDefaultContext when (val response =
+                siteRestClient.fetchAllDomains(noWpCom)) {
+                is Success -> {
+                    val domains = response.data.domains
+                    FetchedAllDomainsPayload(domains)
+                }
+                is Error -> {
+                    val errorType = when (response.error.apiError) {
+                        "authorization_required" -> AllDomainsErrorType.UNAUTHORIZED
+                        else -> AllDomainsErrorType.GENERIC_ERROR
+                    }
+                    val domainsError = AllDomainsError(errorType, response.error.message)
+                    FetchedAllDomainsPayload(domainsError)
+                }
+            }
+        }
     suspend fun fetchSiteDomains(siteModel: SiteModel): FetchedDomainsPayload =
             coroutineEngine.withDefaultContext(T.API, this, "Fetch site domains") {
                 return@withDefaultContext when (val response =


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-Android/issues/19165

This PR adds the ability to fetch all domains for the logged in user.

Note: For simplicity and given that the domains management feature will use [the existing fetchSiteDomains call](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ba92dd07fbcc2987c91a8d8a37fd5952881d3286/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt#L840) I decided to add the new call in the `SiteStore` though it is not directly related to the current site.

**To test:**

1. Start the example app and sign in (note: [setup oauth first](https://github.com/wordpress-mobile/WordPress-FluxC-Android#oauth2-authentication))
2. Tap on the DOMAINS button
3. Tap on the FETCH ALL DOMAINS button
4. Verify that your domains are listed
5. Verify that the domains count is correct