### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to `Comment` Network Client Classes (`safe`)

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
     @Inject CommentStore mCommentStore;
     @Inject PostStore mPostStore;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -80,7 +80,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
 
     // Note: This test is not specific to WPCOM (local changes only)
     @Test
-    public void testInstantiateComment() throws InterruptedException {
+    public void testInstantiateComment() {
         // New Comment
         createNewComment();
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("NewClassNamingConvention")
@@ -251,7 +252,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
 
         // Make sure the comment was deleted (local test only, but should mean it was deleted correctly on the server)
         comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertEquals(comment, null);
+        assertNull(comment);
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -37,6 +37,7 @@ import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("NewClassNamingConvention")
@@ -281,7 +282,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Make sure the comment was deleted (local test only, but should mean it was deleted correctly on the server)
         comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
-        assertEquals(null, comment);
+        assertNull(comment);
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @Inject CommentStore mCommentStore;
     @Inject PostStore mPostStore;

--- a/example/src/test/java/org/wordpress/android/fluxc/comment/CommentSqlUtilsTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comment/CommentSqlUtilsTest.kt
@@ -31,7 +31,7 @@ class CommentSqlUtilsTest {
 
     @Before
     fun setUp() {
-        val appContext = RuntimeEnvironment.application.applicationContext
+        val appContext = RuntimeEnvironment.getApplication().applicationContext
         val config: WellSqlConfig = SingleStoreWellSqlConfigForTests(
                 appContext,
                 listOf(

--- a/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
@@ -24,6 +24,7 @@ import java.util.Random;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(RobolectricTestRunner.class)
 public class CommentStoreUnitTest {
@@ -50,7 +51,11 @@ public class CommentStoreUnitTest {
 
         // Get comment by site and remote id
         CommentModel queriedComment = CommentSqlUtils.getCommentBySiteAndRemoteId(siteModel, remoteCommentId);
-        assertEquals("Best ponies come from the future.", queriedComment.getContent());
+        if (queriedComment != null) {
+            assertEquals("Best ponies come from the future.", queriedComment.getContent());
+        } else {
+            fail("Failed to instantiate new comment model!");
+        }
     }
 
     @Test
@@ -62,15 +67,27 @@ public class CommentStoreUnitTest {
 
         // Get comment by site and remote id
         CommentModel queriedComment = CommentSqlUtils.getCommentBySiteAndRemoteId(siteModel, 10);
-        assertEquals("Pony #10", queriedComment.getContent());
+        if (queriedComment != null) {
+            assertEquals("Pony #10", queriedComment.getContent());
+        } else {
+            fail("Failed to instantiate new comment model!");
+        }
 
         // Get comment by site and remote id
         queriedComment = CommentSqlUtils.getCommentBySiteAndRemoteId(siteModel, 11);
-        assertEquals("Pony #11", queriedComment.getContent());
+        if (queriedComment != null) {
+            assertEquals("Pony #11", queriedComment.getContent());
+        } else {
+            fail("Failed to instantiate new comment model!");
+        }
 
         // Get comment by site and remote id
         queriedComment = CommentSqlUtils.getCommentBySiteAndRemoteId(siteModel, 12);
-        assertEquals("Pony #12", queriedComment.getContent());
+        if (queriedComment != null) {
+            assertEquals("Pony #12", queriedComment.getContent());
+        } else {
+            fail("Failed to instantiate new comment model!");
+        }
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
@@ -23,6 +23,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -92,7 +93,7 @@ public class CommentStoreUnitTest {
 
     @Test
     public void testFailToGetCommentBySiteAndRemoteId() {
-        assertEquals(null, CommentSqlUtils.getCommentBySiteAndRemoteId(new SiteModel(), 42));
+        assertNull(CommentSqlUtils.getCommentBySiteAndRemoteId(new SiteModel(), 42));
     }
 
 

--- a/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/comment/CommentStoreUnitTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 public class CommentStoreUnitTest {
     @Before
     public void setUp() {
-        Context appContext = RuntimeEnvironment.application.getApplicationContext();
+        Context appContext = RuntimeEnvironment.getApplication().getApplicationContext();
         WellSqlConfig config = new WellSqlConfig(appContext);
         WellSql.init(config);
         config.reset();

--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
@@ -45,6 +45,7 @@ class CommentsXMLRPCClientTest {
     private var countDownLatch: CountDownLatch? = null
 
     @Before
+    @Suppress("UNCHECKED_CAST")
     fun setUp() {
         dispatcher = Mockito.mock(Dispatcher::class.java)
         requestQueue = Mockito.mock(RequestQueue::class.java)

--- a/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/comments/CommentsXMLRPCClientTest.kt
@@ -358,7 +358,7 @@ class CommentsXMLRPCClientTest {
     }
 
     @Test
-    fun `createNewReply returns udpated reply`() = test {
+    fun `createNewReply returns updated reply`() = test {
         mockedResponse = """
             <?xml version="1.0" encoding="UTF-8"?>
             <methodResponse>
@@ -387,7 +387,7 @@ class CommentsXMLRPCClientTest {
     }
 
     @Test
-    fun `createNewComment returns udpated comment`() = test {
+    fun `createNewComment returns updated comment`() = test {
         mockedResponse = """
             <?xml version="1.0" encoding="UTF-8"?>
             <methodResponse>

--- a/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
@@ -43,7 +43,10 @@ class CommentsMapperTest {
 
     @Test
     fun `xmlrpc dto list is converted to entity list`() {
-        val commentList = getDefaultCommentList(false).map { it.copy(id = 0, authorProfileImageUrl = null) }
+        val commentList = getDefaultCommentList(false).map { it.copy(
+            id = 0,
+            authorProfileImageUrl = null
+        ) }
         val site = SiteModel().apply {
             id = commentList.first().localSiteId
             selfHostedSiteId = commentList.first().remoteSiteId
@@ -120,27 +123,27 @@ class CommentsMapperTest {
         val entity = this
         return CommentWPComRestResponse().apply {
             ID = entity.remoteCommentId
-            URL = entity.url
+            URL = entity.url ?: ""
             author = Author().apply {
                 ID = entity.authorId
-                URL = entity.authorUrl
-                avatar_URL = entity.authorProfileImageUrl
-                email = entity.authorEmail
-                name = entity.authorName
+                URL = entity.authorUrl ?: ""
+                avatar_URL = entity.authorProfileImageUrl ?: ""
+                email = entity.authorEmail ?: ""
+                name = entity.authorName ?: ""
             }
-            content = entity.content
-            date = entity.datePublished
+            content = entity.content ?: ""
+            date = entity.datePublished ?: ""
             i_like = entity.iLike
             parent = CommentParent().apply {
                 ID = entity.parentId
             }
             post = Post().apply {
                 type = "post"
-                title = entity.postTitle
+                title = entity.postTitle ?: ""
                 link = "https://public-api.wordpress.com/rest/v1.1/sites/185464053/posts/85"
                 ID = entity.remotePostId
             }
-            status = entity.status
+            status = entity.status ?: ""
         }
     }
 
@@ -188,22 +191,22 @@ class CommentsMapperTest {
 
     private fun getDefaultComment(allowNulls: Boolean): CommentEntity {
         return CommentEntity(
-                id = 0,
-                remoteCommentId = 10,
-                remotePostId = 100,
-                authorId = 44,
+                id = 0L,
+                remoteCommentId = 10L,
+                remotePostId = 100L,
+                authorId = 44L,
                 localSiteId = 10_000,
-                remoteSiteId = 100_000,
-                authorUrl = if (allowNulls) null else "https://test-debug-site.wordpress.com",
-                authorName = if (allowNulls) null else "authorname",
-                authorEmail = if (allowNulls) null else "email@wordpress.com",
-                authorProfileImageUrl = if (allowNulls) null else "https://gravatar.com/avatar/111222333",
-                postTitle = if (allowNulls) null else "again",
+                remoteSiteId = 100_000L,
+                authorUrl = if (allowNulls) "" else "https://test-debug-site.wordpress.com",
+                authorName = if (allowNulls) "" else "authorname",
+                authorEmail = if (allowNulls) "" else "email@wordpress.com",
+                authorProfileImageUrl = if (allowNulls) "" else "https://gravatar.com/avatar/111222333",
+                postTitle = if (allowNulls) "" else "again",
                 status = APPROVED.toString(),
-                datePublished = if (allowNulls) null else "2021-05-12T15:10:40+02:00",
+                datePublished = if (allowNulls) "" else "2021-05-12T15:10:40+02:00",
                 publishedTimestamp = 1_000_000,
-                content = if (allowNulls) null else "content example",
-                url = if (allowNulls) null else "https://test-debug-site.wordpress.com/2021/02/25/again/#comment-137",
+                content = if (allowNulls) "" else "content example",
+                url = if (allowNulls) "" else "https://test-debug-site.wordpress.com/2021/02/25/again/#comment-137",
                 hasParent = true,
                 parentId = 1_000L,
                 iLike = false
@@ -213,10 +216,10 @@ class CommentsMapperTest {
     private fun getDefaultCommentList(allowNulls: Boolean): CommentEntityList {
         val comment = getDefaultComment(allowNulls)
         return listOf(
-                comment.copy(id = 1, remoteCommentId = 10, datePublished = "2021-07-24T00:51:43+02:00"),
-                comment.copy(id = 2, remoteCommentId = 20, datePublished = "2021-07-24T00:51:43+02:00"),
-                comment.copy(id = 3, remoteCommentId = 30, datePublished = "2021-07-24T00:51:43+02:00"),
-                comment.copy(id = 4, remoteCommentId = 40, datePublished = "2021-07-24T00:51:43+02:00")
+                comment.copy(id = 1L, remoteCommentId = 10L, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id = 2L, remoteCommentId = 20L, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id = 3L, remoteCommentId = 30L, datePublished = "2021-07-24T00:51:43+02:00"),
+                comment.copy(id = 4L, remoteCommentId = 40L, datePublished = "2021-07-24T00:51:43+02:00")
         )
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
@@ -189,7 +189,7 @@ class CommentsMapperTest {
         )
     }
 
-    private fun getDefaultComment(allowNulls: Boolean): CommentEntity {
+    private fun getDefaultComment(withEmpty: Boolean): CommentEntity {
         return CommentEntity(
                 id = 0L,
                 remoteCommentId = 10L,
@@ -197,24 +197,25 @@ class CommentsMapperTest {
                 authorId = 44L,
                 localSiteId = 10_000,
                 remoteSiteId = 100_000L,
-                authorUrl = if (allowNulls) "" else "https://test-debug-site.wordpress.com",
-                authorName = if (allowNulls) "" else "authorname",
-                authorEmail = if (allowNulls) "" else "email@wordpress.com",
-                authorProfileImageUrl = if (allowNulls) "" else "https://gravatar.com/avatar/111222333",
-                postTitle = if (allowNulls) "" else "again",
+                authorUrl = if (withEmpty) "" else "https://test-debug-site.wordpress.com",
+                authorName = if (withEmpty) "" else "authorname",
+                authorEmail = if (withEmpty) "" else "email@wordpress.com",
+                authorProfileImageUrl = if (withEmpty) "" else "https://gravatar.com/avatar/111222333",
+                postTitle = if (withEmpty) "" else "again",
                 status = APPROVED.toString(),
-                datePublished = if (allowNulls) "" else "2021-05-12T15:10:40+02:00",
+                datePublished = if (withEmpty) "" else "2021-05-12T15:10:40+02:00",
                 publishedTimestamp = 1_000_000,
-                content = if (allowNulls) "" else "content example",
-                url = if (allowNulls) "" else "https://test-debug-site.wordpress.com/2021/02/25/again/#comment-137",
+                content = if (withEmpty) "" else "content example",
+                url = if (withEmpty) "" else "https://test-debug-site.wordpress.com/2021/02/25/again/#comment-137",
                 hasParent = true,
                 parentId = 1_000L,
                 iLike = false
         )
     }
 
-    private fun getDefaultCommentList(allowNulls: Boolean): CommentEntityList {
-        val comment = getDefaultComment(allowNulls)
+    @Suppress("SameParameterValue")
+    private fun getDefaultCommentList(withEmpty: Boolean): CommentEntityList {
+        val comment = getDefaultComment(withEmpty)
         return listOf(
                 comment.copy(id = 1L, remoteCommentId = 10L, datePublished = "2021-07-24T00:51:43+02:00"),
                 comment.copy(id = 2L, remoteCommentId = 20L, datePublished = "2021-07-24T00:51:43+02:00"),

--- a/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
@@ -11,6 +11,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.comments.CommentsMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentParent
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.Author
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.Post
 import org.wordpress.android.fluxc.persistence.comments.CommentEntityList
 import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
 import org.wordpress.android.fluxc.utils.DateTimeUtilsWrapper

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
@@ -77,12 +77,12 @@ class CommentsRestClientTest {
     fun `fetchCommentsPage returns fetched page`() = test {
         val response = getDefaultDto()
 
-        val commentsReponse = response.CommentsWPComRestResponse()
-        commentsReponse.comments = listOf(response, response, response)
+        val commentsResponse = response.CommentsWPComRestResponse()
+        commentsResponse.comments = listOf(response, response, response)
 
         whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(response.toEntity())
 
-        initFetchPageResponse(commentsReponse)
+        initFetchPageResponse(commentsResponse)
 
         val payload = restClient.fetchCommentsPage(
                 site = site,
@@ -94,7 +94,7 @@ class CommentsRestClientTest {
         assertThat(payload.isError).isFalse
 
         val comments = payload.response!!
-        assertThat(comments.size).isEqualTo(commentsReponse.comments.size)
+        assertThat(comments.size).isEqualTo(commentsResponse.comments.size)
         assertThat(urlCaptor.lastValue).isEqualTo(
                 "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/"
         )

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
@@ -30,7 +30,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentLikeWPComRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentParent
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.Author
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.CommentsWPComRestResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentWPComRestResponse.Post
 import org.wordpress.android.fluxc.network.rest.wpcom.comment.CommentsRestClient
 import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
 import org.wordpress.android.fluxc.store.CommentStore.CommentError
@@ -77,7 +79,7 @@ class CommentsRestClientTest {
     fun `fetchCommentsPage returns fetched page`() = test {
         val response = getDefaultDto()
 
-        val commentsResponse = response.CommentsWPComRestResponse()
+        val commentsResponse = CommentsWPComRestResponse()
         commentsResponse.comments = listOf(response, response, response)
 
         whenever(commentsMapper.commentDtoToEntity(response, site)).thenReturn(response.toEntity())

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
@@ -459,7 +459,6 @@ class CommentsRestClientTest {
         )
 
         assertThat(payload.isError).isFalse
-        val commentResponse = payload.response!!
         assertThat(urlCaptor.lastValue).isEqualTo(
                 "https://public-api.wordpress.com/rest/v1.1/sites/" +
                         "${site.siteId}/comments/${comment.remoteCommentId}/likes/new/"

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
@@ -96,7 +96,7 @@ class CommentsRestClientTest {
         assertThat(payload.isError).isFalse
 
         val comments = payload.response!!
-        assertThat(comments.size).isEqualTo(commentsResponse.comments.size)
+        assertThat(comments.size).isEqualTo(commentsResponse.comments?.size)
         assertThat(urlCaptor.lastValue).isEqualTo(
                 "https://public-api.wordpress.com/rest/v1.1/sites/${site.siteId}/comments/"
         )
@@ -600,10 +600,10 @@ class CommentsRestClientTest {
 
     private fun getDefaultDto(): CommentWPComRestResponse {
         return CommentWPComRestResponse().apply {
-            ID = 137
+            ID = 137L
             URL = "https://test-site.wordpress.com/2021/02/25/again/#comment-137"
             author = Author().apply {
-                ID = 0
+                ID = 0L
                 URL = "https://debugging-test.wordpress.com"
                 avatar_URL = "https://gravatar.com/avatar/avatarurl"
                 email = "email@mydomain.com"
@@ -612,9 +612,9 @@ class CommentsRestClientTest {
             content = "example content"
             date = "2021-05-12T15:10:40+02:00"
             i_like = true
-            parent = CommentParent().apply { ID = 41 }
+            parent = CommentParent().apply { ID = 41L }
             post = Post().apply {
-                ID = 85
+                ID = 85L
                 link = "https://public-api.wordpress.com/rest/v1.1/sites/11111111/posts/85"
                 title = "again"
                 type = "post"
@@ -627,31 +627,31 @@ class CommentsRestClientTest {
         return CommentLikeWPComRestResponse().apply {
             success = true
             i_like = iLike
-            like_count = 100
+            like_count = 100L
         }
     }
 
     private fun CommentWPComRestResponse.toEntity(): CommentEntity {
         val dto = this
         return CommentEntity(
-                id = 0,
+                id = 0L,
                 remoteCommentId = dto.ID,
-                remotePostId = dto.post.ID,
-                authorId = dto.author.ID,
+                remotePostId = dto.post?.ID ?: 0L,
+                authorId = dto.author?.ID ?: 0L,
                 localSiteId = 10,
-                remoteSiteId = 200,
-                authorUrl = dto.author.URL,
-                authorName = dto.author.name,
-                authorEmail = dto.author.email,
-                authorProfileImageUrl = dto.author.avatar_URL,
-                postTitle = dto.post.title,
+                remoteSiteId = 200L,
+                authorUrl = dto.author?.URL,
+                authorName = dto.author?.name,
+                authorEmail = dto.author?.email,
+                authorProfileImageUrl = dto.author?.avatar_URL,
+                postTitle = dto.post?.title,
                 status = dto.status,
                 datePublished = dto.date,
-                publishedTimestamp = 132456,
+                publishedTimestamp = 132456L,
                 content = dto.content,
                 url = dto.URL,
                 hasParent = dto.parent != null,
-                parentId = dto.parent.ID,
+                parentId = dto.parent?.ID ?: 0L,
                 iLike = dto.i_like
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentStatus.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentStatus.java
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.model;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import java.util.Locale;
 
 public enum CommentStatus {
@@ -22,7 +25,8 @@ public enum CommentStatus {
         return this.name().toLowerCase(Locale.US);
     }
 
-    public static CommentStatus fromString(String string) {
+    @NonNull
+    public static CommentStatus fromString(@Nullable String string) {
         if (string != null) {
             for (CommentStatus v : CommentStatus.values()) {
                 if (string.equalsIgnoreCase(v.name())) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
@@ -37,7 +37,7 @@ class CommentsMapper @Inject constructor(
                 }
             },
             authorProfileImageUrl = commentDto.author?.avatar_URL,
-            remotePostId = commentDto.post?.ID ?: 0,
+            remotePostId = commentDto.post?.ID ?: 0L,
             postTitle = StringEscapeUtils.unescapeHtml4(commentDto.post?.title),
             status = commentDto.status,
             datePublished = commentDto.date,
@@ -46,7 +46,7 @@ class CommentsMapper @Inject constructor(
             url = commentDto.URL,
             authorId = commentDto.author?.ID ?: 0L,
             hasParent = commentDto.parent != null,
-            parentId = commentDto.parent?.ID ?: 0,
+            parentId = commentDto.parent?.ID ?: 0L,
             iLike = commentDto.i_like
         )
     }
@@ -139,7 +139,7 @@ class CommentsMapper @Inject constructor(
                 content = XMLRPCUtils.safeGetMapValue(commentMap, "content", ""),
                 url = XMLRPCUtils.safeGetMapValue(commentMap, "link", ""),
                 hasParent = remoteParentCommentId > 0,
-                parentId = if (remoteParentCommentId > 0) remoteParentCommentId else 0,
+                parentId = if (remoteParentCommentId > 0) remoteParentCommentId else 0L,
                 iLike = false
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -168,12 +168,10 @@ public class CommentRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void deleteComment(final SiteModel site, long remoteCommentId, @Nullable final CommentModel comment) {
-        // Prioritize CommentModel over comment id.
-        if (comment != null) {
-            remoteCommentId = comment.getRemoteCommentId();
-        }
-
+    public void deleteComment(
+            @NonNull final SiteModel site,
+            long remoteCommentId,
+            @Nullable final CommentModel comment) {
         String url = WPCOMREST.sites.site(site.getSiteId()).comments.comment(remoteCommentId).delete.getUrlV1_1();
         final WPComGsonRequest<CommentWPComRestResponse> request = WPComGsonRequest.buildPostRequest(
                 url, null, CommentWPComRestResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -79,7 +79,9 @@ public class CommentRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void pushComment(final SiteModel site, @NonNull final CommentModel comment) {
+    public void pushComment(
+            @NonNull final SiteModel site,
+            @NonNull final CommentModel comment) {
         String url = WPCOMREST.sites.site(site.getSiteId()).comments.comment(comment.getRemoteCommentId()).getUrlV1_1();
         Map<String, Object> params = new HashMap<>();
         params.put("content", comment.getContent());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -190,7 +190,10 @@ public class CommentRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void createNewReply(final SiteModel site, final CommentModel comment, final CommentModel reply) {
+    public void createNewReply(
+            @NonNull final SiteModel site,
+            @NonNull final CommentModel comment,
+            @NonNull final CommentModel reply) {
         String url = WPCOMREST.sites.site(site.getSiteId()).comments.comment(comment.getRemoteCommentId())
                 .replies.new_.getUrlV1_1();
         Map<String, Object> params = new HashMap<>();
@@ -209,7 +212,10 @@ public class CommentRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void createNewComment(final SiteModel site, final PostModel post, final CommentModel comment) {
+    public void createNewComment(
+            @NonNull final SiteModel site,
+            @NonNull final PostModel post,
+            @NonNull final CommentModel comment) {
         String url = WPCOMREST.sites.site(site.getSiteId()).posts.post(post.getRemotePostId())
                 .replies.new_.getUrlV1_1();
         Map<String, Object> params = new HashMap<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -69,8 +69,9 @@ public class CommentRestClient extends BaseWPComRestClient {
                 url, params, CommentsWPComRestResponse.class,
                 response -> {
                     List<CommentModel> comments = commentsResponseToCommentList(response, site);
-                    FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(comments, site, number,
-                            offset, status);
+                    FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(
+                            comments, site, number, offset, status
+                    );
                     mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentsAction(payload));
                 },
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -296,6 +296,7 @@ public class CommentRestClient extends BaseWPComRestClient {
         comment.setPublishedTimestamp(DateTimeUtils.timestampFromIso8601(response.date));
 
         if (response.author != null) {
+            comment.setAuthorId(response.author.ID);
             comment.setAuthorUrl(response.author.URL);
             comment.setAuthorName(StringEscapeUtils.unescapeHtml4(response.author.name));
             if ("false".equals(response.author.email)) {
@@ -309,10 +310,6 @@ public class CommentRestClient extends BaseWPComRestClient {
         if (response.post != null) {
             comment.setRemotePostId(response.post.ID);
             comment.setPostTitle(StringEscapeUtils.unescapeHtml4(response.post.title));
-        }
-
-        if (response.author != null) {
-            comment.setAuthorId(response.author.ID);
         }
 
         if (response.parent != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -234,13 +234,11 @@ public class CommentRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void likeComment(final SiteModel site, long remoteCommentId, @Nullable final CommentModel comment,
-                            boolean like) {
-        // Prioritize CommentModel over comment id.
-        if (comment != null) {
-            remoteCommentId = comment.getRemoteCommentId();
-        }
-
+    public void likeComment(
+            @NonNull final SiteModel site,
+            long remoteCommentId,
+            @Nullable final CommentModel comment,
+            boolean like) {
         String url;
         if (like) {
             url = WPCOMREST.sites.site(site.getSiteId()).comments.comment(remoteCommentId).likes.new_.getUrlV1_1();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -54,7 +54,11 @@ public class CommentRestClient extends BaseWPComRestClient {
         mLikesUtilsProvider = likesUtilsProvider;
     }
 
-    public void fetchComments(final SiteModel site, final int number, final int offset, final CommentStatus status) {
+    public void fetchComments(
+            @NonNull final SiteModel site,
+            final int number,
+            final int offset,
+            @NonNull final CommentStatus status) {
         String url = WPCOMREST.sites.site(site.getSiteId()).comments.getUrlV1_1();
         Map<String, String> params = new HashMap<>();
         params.put("status", status.toString());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -52,8 +52,7 @@ public class CommentRestClient extends BaseWPComRestClient {
             @Named("regular") RequestQueue requestQueue,
             AccessToken accessToken,
             UserAgent userAgent,
-            LikesUtilsProvider likesUtilsProvider
-    ) {
+            LikesUtilsProvider likesUtilsProvider) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
         mLikesUtilsProvider = likesUtilsProvider;
     }
@@ -83,8 +82,7 @@ public class CommentRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentsAction(
                                 CommentErrorUtils.commentErrorToFetchCommentsPayload(error, site)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -112,8 +110,7 @@ public class CommentRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(CommentActionBuilder.newPushedCommentAction(
                                 CommentErrorUtils.commentErrorToPushCommentPayload(error, comment)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -141,8 +138,7 @@ public class CommentRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -150,8 +146,7 @@ public class CommentRestClient extends BaseWPComRestClient {
             final long siteId,
             final long commentId,
             final boolean requestNextPage,
-            final int pageLength
-    ) {
+            final int pageLength) {
         String url = WPCOMREST.sites.site(siteId).comments.comment(commentId).likes.getUrlV1_2();
 
         Map<String, String> params = new HashMap<>();
@@ -161,8 +156,7 @@ public class CommentRestClient extends BaseWPComRestClient {
             Map<String, String> pageOffsetParams = mLikesUtilsProvider.getPageOffsetParams(
                     LikeType.COMMENT_LIKE,
                     siteId,
-                    commentId
-            );
+                    commentId);
             if (pageOffsetParams != null) {
                 params.putAll(pageOffsetParams);
             }
@@ -177,8 +171,7 @@ public class CommentRestClient extends BaseWPComRestClient {
                                 response,
                                 siteId,
                                 commentId,
-                                LikeType.COMMENT_LIKE
-                        );
+                                LikeType.COMMENT_LIKE);
 
                         FetchedCommentLikesResponsePayload payload = new FetchedCommentLikesResponsePayload(
                                 likes,
@@ -200,12 +193,9 @@ public class CommentRestClient extends BaseWPComRestClient {
                                         siteId,
                                         commentId,
                                         requestNextPage,
-                                        true
-                                )
-                        ));
+                                        true)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -237,8 +227,7 @@ public class CommentRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(CommentActionBuilder.newDeletedCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -265,8 +254,7 @@ public class CommentRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(CommentActionBuilder.newCreatedNewCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, reply)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -293,8 +281,7 @@ public class CommentRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(CommentActionBuilder.newCreatedNewCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -332,8 +319,7 @@ public class CommentRestClient extends BaseWPComRestClient {
                         mDispatcher.dispatch(CommentActionBuilder.newLikedCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
-                }
-        );
+                });
         add(request);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -41,7 +41,7 @@ import javax.inject.Singleton;
 
 @Singleton
 public class CommentRestClient extends BaseWPComRestClient {
-    LikesUtilsProvider mLikesUtilsProvider;
+    @NonNull private final LikesUtilsProvider mLikesUtilsProvider;
 
     @Inject public CommentRestClient(
             Context appContext,
@@ -49,7 +49,7 @@ public class CommentRestClient extends BaseWPComRestClient {
             @Named("regular") RequestQueue requestQueue,
             AccessToken accessToken,
             UserAgent userAgent,
-            LikesUtilsProvider likesUtilsProvider) {
+            @NonNull LikesUtilsProvider likesUtilsProvider) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
         mLikesUtilsProvider = likesUtilsProvider;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -264,7 +264,10 @@ public class CommentRestClient extends BaseWPComRestClient {
 
     // Private methods
 
-    private List<CommentModel> commentsResponseToCommentList(CommentsWPComRestResponse response, SiteModel site) {
+    @NonNull
+    private List<CommentModel> commentsResponseToCommentList(
+            @NonNull CommentsWPComRestResponse response,
+            @NonNull SiteModel site) {
         List<CommentModel> comments = new ArrayList<>();
         if (response.comments != null) {
             for (CommentWPComRestResponse restComment : response.comments) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -278,7 +278,10 @@ public class CommentRestClient extends BaseWPComRestClient {
         return comments;
     }
 
-    private CommentModel commentResponseToComment(CommentWPComRestResponse response, SiteModel site) {
+    @NonNull
+    private CommentModel commentResponseToComment(
+            @NonNull CommentWPComRestResponse response,
+            @NonNull SiteModel site) {
         CommentModel comment = new CommentModel();
 
         comment.setRemoteCommentId(response.ID);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java
@@ -101,12 +101,10 @@ public class CommentRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void fetchComment(final SiteModel site, long remoteCommentId, @Nullable final CommentModel comment) {
-        // Prioritize CommentModel over comment id.
-        if (comment != null) {
-            remoteCommentId = comment.getRemoteCommentId();
-        }
-
+    public void fetchComment(
+            @NonNull final SiteModel site,
+            long remoteCommentId,
+            @Nullable final CommentModel comment) {
         String url = WPCOMREST.sites.site(site.getSiteId()).comments.comment(remoteCommentId).getUrlV1_1();
         final WPComGsonRequest<CommentWPComRestResponse> request = WPComGsonRequest.buildGetRequest(
                 url, null, CommentWPComRestResponse.class,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentWPComRestResponse.java
@@ -1,34 +1,38 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.comment;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import java.util.List;
 
+@SuppressWarnings("NotNullFieldNotInitialized")
 public class CommentWPComRestResponse {
     public static class CommentsWPComRestResponse {
-        public List<CommentWPComRestResponse> comments;
+        @Nullable public List<CommentWPComRestResponse> comments;
     }
 
     public static class Post {
         public long ID;
-        public String title;
-        public String type;
-        public String link;
+        @NonNull public String title;
+        @NonNull public String type;
+        @NonNull public String link;
     }
 
     public static class Author {
         public long ID;
-        public String email; // can be boolean "false" if not set
-        public String name;
-        public String URL;
-        public String avatar_URL;
+        @NonNull public String email; // can be boolean "false" if not set
+        @NonNull public String name;
+        @NonNull public String URL;
+        @NonNull public String avatar_URL;
     }
 
     public long ID;
-    public CommentParent parent;
-    public Post post;
-    public Author author;
-    public String date;
-    public String status;
-    public String content;
+    @Nullable public CommentParent parent;
+    @Nullable public Post post;
+    @Nullable public Author author;
+    @NonNull public String date;
+    @NonNull public String status;
+    @NonNull public String content;
     public boolean i_like;
-    public String URL;
+    @NonNull public String URL;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentWPComRestResponse.java
@@ -3,18 +3,18 @@ package org.wordpress.android.fluxc.network.rest.wpcom.comment;
 import java.util.List;
 
 public class CommentWPComRestResponse {
-    public class CommentsWPComRestResponse {
+    public static class CommentsWPComRestResponse {
         public List<CommentWPComRestResponse> comments;
     }
 
-    public class Post {
+    public static class Post {
         public long ID;
         public String title;
         public String type;
         public String link;
     }
 
-    public class Author {
+    public static class Author {
         public long ID;
         public String email; // can be boolean "false" if not set
         public String name;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentsRestClient.kt
@@ -22,6 +22,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
+@Suppress("LongParameterList")
 @Singleton
 class CommentsRestClient @Inject constructor(
     appContext: Context?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -297,7 +297,10 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         return comments;
     }
 
-    private CommentModel commentResponseToComment(Object commentObject, SiteModel site) {
+    @Nullable
+    private CommentModel commentResponseToComment(
+            @NonNull Object commentObject,
+            @NonNull SiteModel site) {
         if (!(commentObject instanceof HashMap)) {
             return null;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -243,6 +243,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
             case ALL:
             case UNSPAM:
             case UNTRASH:
+            case UNREPLIED:
                 return "approve";
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -279,7 +279,10 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         }
     }
 
-    private List<CommentModel> commentsResponseToCommentList(Object response, SiteModel site) {
+    @NonNull
+    private List<CommentModel> commentsResponseToCommentList(
+            @NonNull Object response,
+            @NonNull SiteModel site) {
         List<CommentModel> comments = new ArrayList<>();
         if (!(response instanceof Object[])) {
             return comments;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -249,18 +249,17 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
     }
 
     private CommentStatus getCommentStatusFromXMLRPCStatusString(String stringStatus) {
-        // Default
-        CommentStatus status = CommentStatus.APPROVED;
         if ("approve".equals(stringStatus)) {
-            status = CommentStatus.APPROVED;
+            return CommentStatus.APPROVED;
         } else if ("hold".equals(stringStatus)) {
-            status = CommentStatus.UNAPPROVED;
+            return CommentStatus.UNAPPROVED;
         } else if ("spam".equals(stringStatus)) {
-            status = CommentStatus.SPAM;
+            return CommentStatus.SPAM;
         } else if ("trash".equals(stringStatus)) {
-            status = CommentStatus.TRASH;
+            return CommentStatus.TRASH;
+        } else { // Defaults (don't exist in XMLRPC)
+            return CommentStatus.APPROVED;
         }
-        return status;
     }
 
     private List<CommentModel> commentsResponseToCommentList(Object response, SiteModel site) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -76,7 +76,9 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void pushComment(final SiteModel site, @NonNull final CommentModel comment) {
+    public void pushComment(
+            @NonNull final SiteModel site,
+            @NonNull final CommentModel comment) {
         List<Object> params = new ArrayList<>(5);
         Map<String, Object> commentParams = new HashMap<>();
         commentParams.put("content", comment.getContent());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -67,8 +67,9 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
                 site.getXmlRpcUrl(), XMLRPC.GET_COMMENTS, params,
                 (Listener<Object>) response -> {
                     List<CommentModel> comments = commentsResponseToCommentList(response, site);
-                    FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(comments, site, number,
-                            offset, status);
+                    FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(
+                            comments, site, number, offset, status
+                    );
                     mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentsAction(payload));
                 },
                 error -> mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentsAction(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -40,10 +40,11 @@ import javax.inject.Singleton;
 
 @Singleton
 public class CommentXMLRPCClient extends BaseXMLRPCClient {
-    @Inject public CommentXMLRPCClient(Dispatcher dispatcher,
-                               @Named("custom-ssl") RequestQueue requestQueue,
-                               UserAgent userAgent,
-                               HTTPAuthManager httpAuthManager) {
+    @Inject public CommentXMLRPCClient(
+            Dispatcher dispatcher,
+            @Named("custom-ssl") RequestQueue requestQueue,
+            UserAgent userAgent,
+            HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);
     }
 
@@ -77,8 +78,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
                         mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentsAction(
                                 CommentErrorUtils.commentErrorToFetchCommentsPayload(error, site)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -110,8 +110,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
                         mDispatcher.dispatch(CommentActionBuilder.newPushedCommentAction(
                                 CommentErrorUtils.commentErrorToPushCommentPayload(error, comment)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -142,8 +141,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
                         mDispatcher.dispatch(CommentActionBuilder.newFetchedCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -184,8 +182,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
                         mDispatcher.dispatch(CommentActionBuilder.newDeletedCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
-                }
-        );
+                });
         add(request);
     }
 
@@ -268,8 +265,7 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
                         mDispatcher.dispatch(CommentActionBuilder.newCreatedNewCommentAction(
                                 CommentErrorUtils.commentErrorToFetchCommentPayload(error, comment)));
                     }
-                }
-        );
+                });
         add(request);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -263,17 +263,19 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
     }
 
     @NonNull
+    @SuppressWarnings("DuplicateBranchesInSwitch")
     private CommentStatus getCommentStatusFromXMLRPCStatusString(@NonNull String stringStatus) {
-        if ("approve".equals(stringStatus)) {
-            return CommentStatus.APPROVED;
-        } else if ("hold".equals(stringStatus)) {
-            return CommentStatus.UNAPPROVED;
-        } else if ("spam".equals(stringStatus)) {
-            return CommentStatus.SPAM;
-        } else if ("trash".equals(stringStatus)) {
-            return CommentStatus.TRASH;
-        } else { // Defaults (don't exist in XMLRPC)
-            return CommentStatus.APPROVED;
+        switch (stringStatus) {
+            case "approve":
+                return CommentStatus.APPROVED;
+            case "hold":
+                return CommentStatus.UNAPPROVED;
+            case "spam":
+                return CommentStatus.SPAM;
+            case "trash":
+                return CommentStatus.TRASH;
+            default: // Defaults (don't exist in XMLRPC)
+                return CommentStatus.APPROVED;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -262,7 +262,8 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         }
     }
 
-    private CommentStatus getCommentStatusFromXMLRPCStatusString(String stringStatus) {
+    @NonNull
+    private CommentStatus getCommentStatusFromXMLRPCStatusString(@NonNull String stringStatus) {
         if ("approve".equals(stringStatus)) {
             return CommentStatus.APPROVED;
         } else if ("hold".equals(stringStatus)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -46,7 +46,11 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);
     }
 
-    public void fetchComments(final SiteModel site, final int number, final int offset, final CommentStatus status) {
+    public void fetchComments(
+            @NonNull final SiteModel site,
+            final int number,
+            final int offset,
+            @NonNull final CommentStatus status) {
         List<Object> params = new ArrayList<>(4);
         Map<String, Object> commentParams = new HashMap<>();
         commentParams.put("number", number);
@@ -227,7 +231,8 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    private String getXMLRPCCommentStatus(CommentStatus status) {
+    @NonNull
+    private String getXMLRPCCommentStatus(@NonNull CommentStatus status) {
         switch (status) {
             case APPROVED:
                 return "approve";

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -157,7 +157,10 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
     /**
      * Create a new reply to a Comment
      */
-    public void createNewReply(final SiteModel site, final CommentModel comment, final CommentModel reply) {
+    public void createNewReply(
+            @NonNull final SiteModel site,
+            @NonNull final CommentModel comment,
+            @NonNull final CommentModel reply) {
         // Comment parameters
         Map<String, Object> replyParams = new HashMap<>(5);
 
@@ -183,7 +186,10 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
     /**
      * Create a new comment to a Post
      */
-    public void createNewComment(final SiteModel site, final PostModel post, final CommentModel comment) {
+    public void createNewComment(
+            @NonNull final SiteModel site,
+            @NonNull final PostModel post,
+            @NonNull final CommentModel comment) {
         // Comment parameters
         Map<String, Object> commentParams = new HashMap<>(5);
         commentParams.put("content", comment.getContent());
@@ -204,8 +210,12 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
 
     // Private methods
 
-    private void newComment(final SiteModel site, long remotePostId, final CommentModel comment, final long parentId,
-                            Map<String, Object> commentParams) {
+    private void newComment(
+            @NonNull final SiteModel site,
+            long remotePostId,
+            @NonNull final CommentModel comment,
+            final long parentId,
+            @NonNull Map<String, Object> commentParams) {
         List<Object> params = new ArrayList<>(5);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -123,12 +123,10 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void deleteComment(final SiteModel site, long remoteCommentId, @Nullable final CommentModel comment) {
-        // Prioritize CommentModel over comment id.
-        if (comment != null) {
-            remoteCommentId = comment.getRemoteCommentId();
-        }
-
+    public void deleteComment(
+            @NonNull final SiteModel site,
+            long remoteCommentId,
+            @Nullable final CommentModel comment) {
         List<Object> params = new ArrayList<>(4);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java
@@ -102,12 +102,10 @@ public class CommentXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void fetchComment(final SiteModel site, long remoteCommentId, final CommentModel comment) {
-        // Prioritize CommentModel over comment id.
-        if (comment != null) {
-            remoteCommentId = comment.getRemoteCommentId();
-        }
-
+    public void fetchComment(
+            @NonNull final SiteModel site,
+            long remoteCommentId,
+            @Nullable final CommentModel comment) {
         List<Object> params = new ArrayList<>(4);
         params.add(site.getSelfHostedSiteId());
         params.add(site.getUsername());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -26,6 +26,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
+@Suppress("LongParameterList")
 @Singleton
 class CommentsXMLRPCClient @Inject constructor(
     dispatcher: Dispatcher?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentsXMLRPCClient.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 @Singleton
 class CommentsXMLRPCClient @Inject constructor(
     dispatcher: Dispatcher?,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.persistence;
 
 import android.database.sqlite.SQLiteDatabase;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.wellsql.generated.CommentModelTable;
@@ -163,7 +164,8 @@ public class CommentSqlUtils {
         return results.get(0);
     }
 
-    public static CommentModel getCommentBySiteAndRemoteId(SiteModel site, long remoteCommentId) {
+    @Nullable
+    public static CommentModel getCommentBySiteAndRemoteId(@NonNull SiteModel site, long remoteCommentId) {
         List<CommentModel> results = WellSql.select(CommentModel.class)
                                             .where()
                                             .equals(CommentModelTable.REMOTE_COMMENT_ID, remoteCommentId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.persistence;
 
 import android.database.sqlite.SQLiteDatabase;
 
+import androidx.annotation.Nullable;
+
 import com.wellsql.generated.CommentModelTable;
 import com.wellsql.generated.LikeModelTable;
 import com.yarolegovich.wellsql.ConditionClauseBuilder;
@@ -86,7 +88,7 @@ public class CommentSqlUtils {
     }
 
     public static int removeCommentGaps(SiteModel site, List<CommentModel> comments, int maxEntriesInResponse,
-                                        int requestOffset, CommentStatus... statuses) {
+                                        int requestOffset, @Nullable CommentStatus... statuses) {
         if (site == null || comments == null || comments.isEmpty()) {
             return 0;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -61,12 +61,6 @@ public class CommentSqlUtils {
         }
     }
 
-    public static CommentModel insertCommentForResult(CommentModel comment) {
-        WellSql.insert(comment).asSingleTransaction(true).execute();
-
-        return comment;
-    }
-
     public static int removeComment(CommentModel comment) {
         if (comment == null) {
             return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -520,11 +520,19 @@ public class CommentStore extends Store {
         emitChange(event);
     }
 
-    private void fetchComment(RemoteCommentPayload payload) {
+    private void fetchComment(@NonNull RemoteCommentPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
-            mCommentRestClient.fetchComment(payload.site, payload.remoteCommentId, payload.comment);
+            mCommentRestClient.fetchComment(payload.site, getPrioritizedRemoteCommentId(payload), payload.comment);
         } else {
-            mCommentXMLRPCClient.fetchComment(payload.site, payload.remoteCommentId, payload.comment);
+            mCommentXMLRPCClient.fetchComment(payload.site, getPrioritizedRemoteCommentId(payload), payload.comment);
+        }
+    }
+
+    private long getPrioritizedRemoteCommentId(@NonNull RemoteCommentPayload payload) {
+        if (payload.comment != null) {
+            return payload.comment.getRemoteCommentId();
+        } else {
+            return payload.remoteCommentId;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -258,8 +258,9 @@ public class CommentStore extends Store {
         return CommentSqlUtils.getCommentsCountForSite(site, statuses);
     }
 
+    @Nullable
     @SuppressWarnings("UnusedReturnValue")
-    public CommentModel getCommentBySiteAndRemoteId(SiteModel site, long remoteCommentId) {
+    public CommentModel getCommentBySiteAndRemoteId(@NonNull SiteModel site, long remoteCommentId) {
         return CommentSqlUtils.getCommentBySiteAndRemoteId(site, remoteCommentId);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -587,19 +587,17 @@ public class CommentStore extends Store {
                 payload.hasMore
         );
         if (!payload.isError()) {
-            if (payload.likes != null) {
-                if (!payload.isRequestNextPage) {
-                    CommentSqlUtils.deleteCommentLikesAndPurgeExpired(payload.siteId, payload.commentRemoteId);
-                }
-
-                for (LikeModel like : payload.likes) {
-                    CommentSqlUtils.insertOrUpdateCommentLikes(payload.siteId, payload.commentRemoteId, like);
-                }
-                event.commentLikes.addAll(CommentSqlUtils.getCommentLikesByCommentId(
-                        payload.siteId,
-                        payload.commentRemoteId
-                ));
+            if (!payload.isRequestNextPage) {
+                CommentSqlUtils.deleteCommentLikesAndPurgeExpired(payload.siteId, payload.commentRemoteId);
             }
+
+            for (LikeModel like : payload.likes) {
+                CommentSqlUtils.insertOrUpdateCommentLikes(payload.siteId, payload.commentRemoteId, like);
+            }
+            event.commentLikes.addAll(CommentSqlUtils.getCommentLikesByCommentId(
+                    payload.siteId,
+                    payload.commentRemoteId
+            ));
         } else {
             List<LikeModel> cachedLikes = CommentSqlUtils.getCommentLikesByCommentId(
                     payload.siteId,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -462,7 +462,7 @@ public class CommentStore extends Store {
         emitChange(event);
     }
 
-    private void fetchComments(FetchCommentsPayload payload) {
+    private void fetchComments(@NonNull FetchCommentsPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
             mCommentRestClient.fetchComments(payload.site, payload.number, payload.offset, payload.status);
         } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -584,7 +584,7 @@ public class CommentStore extends Store {
         emitChange(event);
     }
 
-    private void fetchCommentLikes(FetchCommentLikesPayload payload) {
+    private void fetchCommentLikes(@NonNull FetchCommentLikesPayload payload) {
         mCommentRestClient.fetchCommentLikes(
                 payload.siteId,
                 payload.remoteCommentId,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -55,6 +55,7 @@ public class CommentStore extends Store {
             this.offset = offset;
         }
 
+        @SuppressWarnings("unused")
         public FetchCommentsPayload(@NonNull SiteModel site, @NonNull CommentStatus status, int number, int offset) {
             this.site = site;
             this.status = status;
@@ -88,6 +89,7 @@ public class CommentStore extends Store {
             this.like = like;
         }
 
+        @SuppressWarnings("unused")
         public RemoteLikeCommentPayload(@NonNull SiteModel site, long remoteCommentId, boolean like) {
             super(site, remoteCommentId);
             this.like = like;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -273,6 +273,7 @@ public class CommentStore extends Store {
 
     @Override
     @Subscribe(threadMode = ThreadMode.ASYNC)
+    @SuppressWarnings("rawtypes")
     public void onAction(Action action) {
         IAction actionType = action.getType();
         if (!(actionType instanceof CommentAction)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -491,18 +491,18 @@ public class CommentStore extends Store {
         emitChange(event);
     }
 
-    private void pushComment(RemoteCommentPayload payload) {
-        if (payload.comment == null) {
+    private void pushComment(@NonNull RemoteCommentPayload payload) {
+        if (payload.comment != null) {
+            if (payload.site.isUsingWpComRestApi()) {
+                mCommentRestClient.pushComment(payload.site, payload.comment);
+            } else {
+                mCommentXMLRPCClient.pushComment(payload.site, payload.comment);
+            }
+        } else {
             OnCommentChanged event = new OnCommentChanged(0);
             event.causeOfChange = CommentAction.PUSH_COMMENT;
             event.error = new CommentError(CommentErrorType.INVALID_INPUT, "Comment can't be null");
             emitChange(event);
-            return;
-        }
-        if (payload.site.isUsingWpComRestApi()) {
-            mCommentRestClient.pushComment(payload.site, payload.comment);
-        } else {
-            mCommentXMLRPCClient.pushComment(payload.site, payload.comment);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -260,6 +260,7 @@ public class CommentStore extends Store {
         return CommentSqlUtils.getCommentsCountForSite(site, statuses);
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public CommentModel getCommentBySiteAndRemoteId(SiteModel site, long remoteCommentId) {
         return CommentSqlUtils.getCommentBySiteAndRemoteId(site, remoteCommentId);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -26,10 +26,8 @@ import org.wordpress.android.fluxc.network.xmlrpc.comment.CommentXMLRPCClient;
 import org.wordpress.android.fluxc.persistence.CommentSqlUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -341,27 +339,6 @@ public class CommentStore extends Store {
     @Override
     public void onRegister() {
         AppLog.d(T.API, this.getClass().getName() + ": onRegister");
-    }
-
-    public CommentModel instantiateCommentModel(SiteModel site) {
-        CommentModel comment = new CommentModel();
-        comment.setLocalSiteId(site.getId());
-        // Init with defaults
-        comment.setContent("");
-        comment.setDatePublished(DateTimeUtils.iso8601UTCFromDate(new Date()));
-        comment.setStatus(CommentStatus.APPROVED.toString());
-        comment.setAuthorName("");
-        comment.setAuthorEmail("");
-        comment.setAuthorUrl("");
-        comment.setUrl("");
-        // Insert in the DB
-        comment = CommentSqlUtils.insertCommentForResult(comment);
-
-        if (comment.getId() == -1) {
-            comment = null;
-        }
-
-        return comment;
     }
 
     // Private methods

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -427,7 +427,7 @@ public class CommentStore extends Store {
         emitChange(event);
     }
 
-    private void deleteComment(RemoteCommentPayload payload) {
+    private void deleteComment(@NonNull RemoteCommentPayload payload) {
         // If the comment is stored locally, we want to update it locally (needed because in some
         // cases we use this to update comments by remote id).
         CommentModel comment = payload.comment;
@@ -435,9 +435,9 @@ public class CommentStore extends Store {
             getCommentBySiteAndRemoteId(payload.site, payload.remoteCommentId);
         }
         if (payload.site.isUsingWpComRestApi()) {
-            mCommentRestClient.deleteComment(payload.site, payload.remoteCommentId, comment);
+            mCommentRestClient.deleteComment(payload.site, getPrioritizedRemoteCommentId(payload), comment);
         } else {
-            mCommentXMLRPCClient.deleteComment(payload.site, payload.remoteCommentId, comment);
+            mCommentXMLRPCClient.deleteComment(payload.site, getPrioritizedRemoteCommentId(payload), comment);
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -556,7 +556,7 @@ public class CommentStore extends Store {
         emitChange(event);
     }
 
-    private void likeComment(RemoteLikeCommentPayload payload) {
+    private void likeComment(@NonNull RemoteLikeCommentPayload payload) {
         // If the comment is stored locally, we want to update it locally (needed because in some
         // cases we use this to update comments by remote id).
         CommentModel comment = payload.comment;
@@ -564,7 +564,7 @@ public class CommentStore extends Store {
             getCommentBySiteAndRemoteId(payload.site, payload.remoteCommentId);
         }
         if (payload.site.isUsingWpComRestApi()) {
-            mCommentRestClient.likeComment(payload.site, payload.remoteCommentId, comment, payload.like);
+            mCommentRestClient.likeComment(payload.site, getPrioritizedRemoteCommentId(payload), comment, payload.like);
         } else {
             OnCommentChanged event = new OnCommentChanged(0);
             event.causeOfChange = CommentAction.LIKE_COMMENT;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -99,10 +99,10 @@ public class CommentStore extends Store {
         @NonNull public final SiteModel site;
         public final int number;
         public final int offset;
-        public final CommentStatus requestedStatus;
+        @Nullable public final CommentStatus requestedStatus;
 
         public FetchCommentsResponsePayload(@NonNull List<CommentModel> comments, @NonNull SiteModel site, int number,
-                                            int offset, CommentStatus status) {
+                                            int offset, @Nullable CommentStatus status) {
             this.comments = comments;
             this.site = site;
             this.number = number;
@@ -206,7 +206,7 @@ public class CommentStore extends Store {
         public int rowsAffected;
         public int offset;
         public CommentAction causeOfChange;
-        public CommentStatus requestedStatus;
+        @Nullable public CommentStatus requestedStatus;
         public List<Integer> changedCommentsLocalIds = new ArrayList<>();
         public OnCommentChanged(int rowsAffected) {
             this.rowsAffected = rowsAffected;
@@ -482,8 +482,8 @@ public class CommentStore extends Store {
         if (!payload.isError()) {
             // Find comments that were deleted or moved to a different status on the server and remove them from
             // local DB.
-            CommentSqlUtils.removeCommentGaps(payload.site, payload.comments, payload.number, payload.offset,
-                    payload.requestedStatus);
+            CommentSqlUtils.removeCommentGaps(
+                    payload.site, payload.comments, payload.number, payload.offset, payload.requestedStatus);
 
             for (CommentModel comment : payload.comments) {
                 rowsAffected += CommentSqlUtils.insertOrUpdateComment(comment);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.utils;
 import androidx.annotation.Nullable;
 
 import org.wordpress.android.fluxc.model.CommentModel;
-import org.wordpress.android.fluxc.model.LikeModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType;
@@ -42,7 +41,7 @@ public class CommentErrorUtils {
             boolean hasMore
     ) {
         FetchedCommentLikesResponsePayload payload = new FetchedCommentLikesResponsePayload(
-                new ArrayList<LikeModel>(),
+                new ArrayList<>(),
                 siteId,
                 commentId,
                 requestNextPage,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -27,8 +27,9 @@ public class CommentErrorUtils {
 
     public static FetchCommentsResponsePayload commentErrorToFetchCommentsPayload(BaseNetworkError error,
                                                                                   SiteModel site) {
-        FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(new ArrayList<CommentModel>(), site,
-                0, 0, null);
+        FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(
+                new ArrayList<CommentModel>(), site, 0, 0, null
+        );
         payload.error = new CommentError(genericToCommentError(error), getErrorMessage(error));
         return payload;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -28,7 +28,7 @@ public class CommentErrorUtils {
     public static FetchCommentsResponsePayload commentErrorToFetchCommentsPayload(BaseNetworkError error,
                                                                                   SiteModel site) {
         FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(
-                new ArrayList<CommentModel>(), site, 0, 0, null
+                new ArrayList<>(), site, 0, 0, null
         );
         payload.error = new CommentError(genericToCommentError(error), getErrorMessage(error));
         return payload;


### PR DESCRIPTION
Parent #2798

This PR adds any missing nullability annotation to [CommentRestClient.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ee1af4fea6995ca7a97e579a67942bf3ddfa1ec9/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentRestClient.java#L4) and [CommentXMLRPCClient.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ee1af4fea6995ca7a97e579a67942bf3ddfa1ec9/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/comment/CommentXMLRPCClient.java#L4), all its related response classes and anything in between (ie. `CommentStore`). See response classes below:
- [CommentWPComRestResponse.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ee1af4fea6995ca7a97e579a67942bf3ddfa1ec9/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentWPComRestResponse.java#L4)

FYI.1: This change is `safe`, meaning that there shouldn't be any (major) compile-time changes associated with this change. Having said that, testing is highly recommended since the changes in this PR can affect one or more clients (ie. [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), [WCAndroid](https://github.com/woocommerce/woocommerce-android), etc)

FYI.2: An analysis on `CommentStore` and its usages with our main clients suggests that this store is only being utilizing by [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android). AFAIA [WCAndroid](https://github.com/woocommerce/woocommerce-android) is not using that store and as such can be safely ignored from testing.

PS: Note that [CommentStore.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ee1af4fea6995ca7a97e579a67942bf3ddfa1ec9/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java#L4) and their respective network client classes, both `REST` and `XMLRPC`, seem to be deprecated. The [CommentsStore.kt](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ee1af4fea6995ca7a97e579a67942bf3ddfa1ec9/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt#L4) and their respective network client classes, both `REST` and `XMLRPC`, seem to be the ones that are actually being actively used atm. Also note that the [CommentWPComRestResponse.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ee1af4fea6995ca7a97e579a67942bf3ddfa1ec9/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/comment/CommentWPComRestResponse.java#L4) response is shared between those two stores. As such, it seems that all comment related API calls from JP/WPAndroid are currently flowing via the new [CommentsStore.kt](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ee1af4fea6995ca7a97e579a67942bf3ddfa1ec9/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt#L4), while only FluxC is using the deprecated [CommentStore.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/ee1af4fea6995ca7a97e579a67942bf3ddfa1ec9/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java#L4). Be mindful of all that when testing this PR. 🤷 

-----

@wzieba let me know how I did on this PR, that is, in terms of updating these network client classes and adding nullability annotations on them and their main `CommentWPComRestResponse` response class, in order to utilize the nullability annotations added on its fields and thus make its use null proof. If you also feel that this is a good way to proceed with such client PRs, I'll then use this pattern across the board and follow a similar approach on every such PR.

-----

Nullability Annotation List:

1. [Add missing nn-a to likes utils pvd field on cmt rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/9fef4111ea753d93ebf67662916e0d083e6795fd)
2. [Add missing n-a to fetch comments on comment clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/1c258619e392a03a31027ac072782d32858922ee)
3. [Add missing n-a to push comment on comment clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/de7f769a454ba426efd41693107bffe6eecc80b8)
4. [Add missing n-a to fetch comment on comment clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/9f6c87b5d493ad8813372a5d0b7034d11a0d3774)
5. [Add missing n-a to fetch comment likes on comment rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/14729c21d3d172a6d469e4a7f89c6e5fc9caa756)
6. [Add missing n-a to delete comment on comment clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/12fe3cfc80ec316ca2211924e0e498ae88722c1d)
7. [Add missing n-a to create new reply/comment on comment clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/53e14a0bde415d92fede132f261b3161f843e846)
8. [Add missing n-a to like comment on comment rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/d044e7519fd416ed476a422cd935f49db4333bc5)
9. [Add missing n-a to comments response to comment list](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/c9ccc7295366e3719075726327c38d37abbfa03d)
10. [Add missing nl-a to requested status field on payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/726ea21602596f2e9b118ace46d7ef4a01aee818)
11. [Add missing n-a to comment response to comment](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/057436b1bfbf2748c6f3f8151452a0400354ed42)
12. [Add missing n-a to get cmt status from xmlrpc status string](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/484463a62cebdfcfd230e5a7bbaa2a8408b549f8)
13. [Add missing n-a to comments response to comment list](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/c6d0db782e6bb39f362f197c15f9f6d93b07905a)
14. [Add missing n-a to comment response to comment](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/8b2e4ace98fd41ac91cc93e1370c961028a57fd9)
15. [Add missing n-a to comment wp com rest response fields](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/2e855cd8fca3e827ef0d3b23a4018254e40af44e)

Nullability Checks List:

1. [Remove unnecessary payload likes if condition on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/b73fbb0e48b212a11025043cfcdbb6daa21402f2)

Warnings Resolutions List:

1. [Create missing switch branch on comment xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/35d09356d308ead0619a10e0c3b519d4c298f51e)
2. [Remove complexity from get cmt status from xmlrpc status str](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/246005f0538f73a68105fef7ec32c5ade2fc625b)
3. [Replace explicit type argument with <> on payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/a736e7481727ea919217b736410aaffd967900e3)
4. [Replace if with switch on comment xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/41d27ca6bcaba71dd9fbb41bd19a8750a1369b15)
5. [Replace explicit type argument with <> on payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/816d1e3d83bce3ad6b41767feace4ede30eb66dd)
6. [Make inner classes static on comment wp com rest response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/85fa7bfcd30dfe407c056dfb5c4629f470ca11b2)

Warnings Suppression List:

1. [Suppress long parameter list warning on comments clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/fd0532864d540dea0318eeeeb06af5a8672898d3)
2. [Suppress too many functions warning on comments xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/d0df40f8166a7f0f124b22cb3b3e4b54c0d75362)
3. [Suppress unused warnings on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/0bc6ba314d9c040cd4a752911ac5ed646ec3640d)
4. [Suppress unused return value warning on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/fb46f9433b4e7352c9a694777a6c1ad6036a1795)
5. [Suppress raw types warning on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/f34249e0c5495e86159e04c99f02aade1331d5a0)

Refactor List:

1. [Reformat comment rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/13840f1a8419e6961d0854e025d7d05cde206b57)
2. [Reformat comment xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/ae9066ca1cb0b3f66e154bea20ce4fd0acff90e8)
3. [Replace anonymous classes with lambda on comment rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/a4c64eff1406fa6386bbcce94112d8f21d277274)
4. [Replace anonymous classes with lambda on comment xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/c6458944eeff0e395863858a175f9fe82de9051e)
5. [Remove test only comment store method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/6bdbfa424bc8e92935067d8a8ef5f4732601ce0f)

Test List:

1. [Suppress new class naming convention for connected tests](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/89c0d962ac16f60a79d4ee712f46875a5b060664)
2. [Remove interrupted exception from test method's throws list](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/0ba2a4d3787beddf858f9caba6837fea83e2526d)
3. [Simplify assert null assertion for connected tests](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/04d7934a3b2a1f0aa6adb859382fb100b37a666b)
4. [Resolve robolectric related application deprecation warnings](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/47d40ba5b027b8e4478fcdc5cc26fe2ddc7a6947)
5. [Guard usages of get comment by site and remote id method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/21ca96ece9ad12c067cd2dfcd7a289db07d0b237)
6. [Simplify assert null assertion for unit tests](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/048fe853d40c2b0114efdaa76b9d6017b7e95933)
7. [Remove unnecessary comment response local variable from unit test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/015f66438c755f918af85bd976df6a7238ef72f3)
8. [Fix typo with comments response on unit test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/2bab5c02435f82f025eac5ec30a397ad41ad9582)
9. [Suppress unchecked cast on unit test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/88d0a1e4bad9734b4bedd3c83c9560bf77bd555e)
10. [Fix typo with updated comment on unit test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868/commits/dd40ab2ccf66ffe75fed7fdf7150f3e5da6d0580)

-----

## Associated Clients

It is highly recommending that this change is being tested on the below associated clients:

- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android)

-----

## To Test (`REST`):

- Smoke test the `FluxC Example` app via the `COMMENTS` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any `CommentStore` related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

## To Test (`XMLRPC`):

- Create a new self-hosted WordPress site for XMLRPC testing purposes ([jurassic.ninja](https://jurassic.ninja/)).
- Smoke test the `FluxC Example` app via the `COMMENTS` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any `CommentStore` related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

<details>
    <summary>1. Comment Details Screen from Comments Screen [CommentDetailFragment.java]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Comments` screen and tap on any comment.
- Verify that the `Comment Details` screen is shown and functioning as expected.
- For example, try replying, approving, marking as spam, liking, trashing, editing or copying a comment's link address. Additionally, make sure to verify that you can still swipe left-right to navigate between comments.

</details>

<details>
    <summary>2. Comment Details Screen from Notification Tab [CommentDetailFragment.java]</summary>

ℹ️ This test applies to the `Jetpack` app only.

- Go to `Notifications` tab, then its `COMMENTS` sub-tab, and tap on any comment.
- Verify that the `Comment Details` screen is shown and functioning as expected.
- For example, try replying to a comment. Additionally, make sure to verify that you can still swipe left-right to navigate between comments.

</details>

<details>
    <summary>3. Edit Comment Screen from Comments Screen [UnifiedCommentsEditActivity.java]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Comments` screen and tap on any comment.
- From the `More` on the right side, at the bottom of the comment, select `Edit`.
- Verify that the `Edit Comment` screen is shown and functioning as expected.
- For example, try editing/adding the comment's `Name`, `Web address`, `Email address` and its `Comment` itself.

</details>

<details>
    <summary>4. Edit Comment Screen from Notification Tab [UnifiedCommentsEditActivity.java]</summary>

ℹ️ This test applies to the `Jetpack` app only.

- Go to `Notifications` tab, then its `COMMENTS` sub-tab, and tap on any comment.
- From the `More` on the right side, at the bottom of the comment, select `Edit`.
- Verify that the `Edit Comment` screen is shown and functioning as expected.
- For example, try editing/adding the comment's `Name`, `Web address`, `Email address` and its `Comment` itself.

</details>

<details>
    <summary>5. Reader Comments Screen [ReaderCommentListActivity.java]</summary>

ℹ️ This test applies to the `Jetpack` app only.

- Go to `Reader` tab, then its `DISCOVER` sub-tab, and tap on any post.
- Tap on the `Comments` button at the bottom of the post.
- Verify that the `Reader Comments` screen is shown and functioning as expected.
- For example, try (un)following, enabling/disabling in-app notifications, replying to post, and then sharing, replying or liking a specific comment.

</details>