### PR TITLE
Enhances the fetch all-domains api call to resolve domain status

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/DomainsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/DomainsFragment.kt
@@ -70,7 +70,8 @@ class DomainsFragment : StoreSelectingFragment() {
 
         fetch_all_domains.setOnClickListener {
             lifecycleScope.launch {
-                val result = store.fetchAllDomains(noWpCom = false) // fetching wpcom too for debugging purposes
+                // fetching wpcom too for debugging purposes
+                val result = store.fetchAllDomains(noWpCom = false, resolveStatus = true)
                 when {
                     result.isError -> {
                         prependToLog("Error fetching all domains: ${result.error.message}")
@@ -79,7 +80,8 @@ class DomainsFragment : StoreSelectingFragment() {
                         prependToLog("All domains count: ${result.domains?.size}")
                         val domains = result.domains
                             ?.joinToString(separator = "\n") {
-                                "${it.domain} (type: ${it.type}), expiry: ${it.expiry}"
+                                "${it.domain} (type: ${it.type}, expiry: ${it.expiry}, " +
+                                    "status: ${it.domainStatus?.statusType.toString()})"
                             }
                         prependToLog("Domains:\n$domains")
                     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -31,6 +31,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
 import org.wordpress.android.fluxc.network.rest.wpcom.site.NewSiteResponse.BlogDetails
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteWPComRestResponse.SitesResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.site.StatusType.ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.site.StatusType.SUCCESS
 import org.wordpress.android.fluxc.store.SiteStore.PostFormatsErrorType
 import org.wordpress.android.fluxc.store.SiteStore.SiteFilter.WPCOM
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
@@ -538,14 +540,26 @@ class SiteRestClientTest {
 
         initAllDomainsResponse(data = response)
 
-        val responseModel = restClient.fetchAllDomains(noWpCom = true)
+        val responseModel = restClient.fetchAllDomains()
         assert(responseModel is Success)
         with((responseModel as Success).data) {
-            assertThat(domains).hasSize(2)
+            assertThat(domains).hasSize(4)
             assertThat(domains[0].domain).isEqualTo("some.test.domain")
             assertThat(domains[0].wpcomDomain).isFalse
-            assertThat(domains[1].domain).isEqualTo("some.test.domain 2")
+            assertThat(domains[0].domainStatus).isNotNull
+            assertThat(domains[0].domainStatus?.status).isEqualTo("Active")
+            assertThat(domains[0].domainStatus?.statusType).isEqualTo(SUCCESS)
+            assertThat(domains[1].domain).isEqualTo("some.test.domain.with.status.weight")
             assertThat(domains[1].wpcomDomain).isTrue
+            assertThat(domains[1].domainStatus).isNotNull
+            assertThat(domains[1].domainStatus?.status).isEqualTo("Expiring soon")
+            assertThat(domains[1].domainStatus?.statusType).isEqualTo(ERROR)
+            assertThat(domains[1].domainStatus?.statusWeight).isEqualTo(1000)
+            assertThat(domains[2].domain).isEqualTo("some.test.domain.with.action.required")
+            assertThat(domains[2].domainStatus).isNotNull
+            assertThat(domains[2].domainStatus?.actionRequired).isTrue
+            assertThat(domains[3].domain).isEqualTo("some.test.domain.no.domain.status")
+            assertThat(domains[3].domainStatus).isNull()
         }
     }
 
@@ -554,7 +568,7 @@ class SiteRestClientTest {
         val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NETWORK_ERROR))
         initAllDomainsResponse(error = error)
 
-        val response = restClient.fetchAllDomains(noWpCom = true)
+        val response = restClient.fetchAllDomains()
         assert(response is Response.Error)
         with((response as Response.Error).error) {
             assertThat(type).isEqualTo(GenericErrorType.NETWORK_ERROR)
@@ -567,7 +581,7 @@ class SiteRestClientTest {
         val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.TIMEOUT))
         initAllDomainsResponse(error = error)
 
-        val response = restClient.fetchAllDomains(noWpCom = true)
+        val response = restClient.fetchAllDomains()
         assert(response is Response.Error)
         with((response as Response.Error).error) {
             assertThat(type).isEqualTo(GenericErrorType.TIMEOUT)
@@ -581,7 +595,7 @@ class SiteRestClientTest {
         val error = WPComGsonNetworkError(BaseNetworkError(GenericErrorType.NOT_AUTHENTICATED, tokenErrorMessage))
         initAllDomainsResponse(error = error)
 
-        val response = restClient.fetchAllDomains(noWpCom = true)
+        val response = restClient.fetchAllDomains()
         assert(response is Response.Error)
         with((response as Response.Error).error) {
             assertThat(type).isEqualTo(GenericErrorType.NOT_AUTHENTICATED)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.COMING_SOON
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import org.wordpress.android.fluxc.test
+import org.wordpress.android.util.DateTimeUtils
 import kotlin.test.assertNotNull
 
 @RunWith(MockitoJUnitRunner::class)
@@ -546,6 +547,12 @@ class SiteRestClientTest {
             assertThat(domains).hasSize(4)
             assertThat(domains[0].domain).isEqualTo("some.test.domain")
             assertThat(domains[0].wpcomDomain).isFalse
+            assertThat(domains[0].registrationDate).isEqualTo(
+                DateTimeUtils.dateUTCFromIso8601("2009-03-26T21:20:53+00:00")
+            )
+            assertThat(domains[0].expiry).isEqualTo(
+                DateTimeUtils.dateUTCFromIso8601("2024-03-24T00:00:00+00:00")
+            )
             assertThat(domains[0].domainStatus).isNotNull
             assertThat(domains[0].domainStatus?.status).isEqualTo("Active")
             assertThat(domains[0].domainStatus?.statusType).isEqualTo(SUCCESS)

--- a/example/src/test/resources/wp/all-domains/all-domains.json
+++ b/example/src/test/resources/wp/all-domains/all-domains.json
@@ -12,12 +12,55 @@
       "expiry": "2024-03-24T00:00:00+00:00",
       "wpcom_domain": false,
       "current_user_is_owner": true,
-      "site_slug": "test slug"
+      "site_slug": "test slug",
+      "domain_status": {
+        "status": "Active",
+        "status_type": "success"
+      }
     },
     {
-      "domain": "some.test.domain 2",
+      "domain": "some.test.domain.with.status.weight",
       "blog_id": 22222,
-      "blog_name": "some test blog 2",
+      "blog_name": "some test blog with status_weight",
+      "type": "mapping",
+      "is_domain_only_site": false,
+      "is_wpcom_staging_domain": false,
+      "has_registration": false,
+      "registration_date": "2009-03-26T21:20:53+00:00",
+      "expiry": "2024-03-24T00:00:00+00:00",
+      "wpcom_domain": true,
+      "current_user_is_owner": false,
+      "site_slug": "test slug 2",
+      "domain_status": {
+        "status": "Expiring soon",
+        "status_type": "error",
+        "status_weight": 1000
+      }
+    },
+    {
+      "domain": "some.test.domain.with.action.required",
+      "blog_id": 22222,
+      "blog_name": "some test blog with action_required",
+      "type": "mapping",
+      "is_domain_only_site": false,
+      "is_wpcom_staging_domain": false,
+      "has_registration": false,
+      "registration_date": "2009-03-26T21:20:53+00:00",
+      "expiry": "2024-03-24T00:00:00+00:00",
+      "wpcom_domain": true,
+      "current_user_is_owner": false,
+      "site_slug": "test slug 2",
+      "domain_status": {
+        "status": "Expiring soon",
+        "status_type": "error",
+        "status_weight": 1000,
+        "action_required": true
+      }
+    },
+    {
+      "domain": "some.test.domain.no.domain.status",
+      "blog_id": 22222,
+      "blog_name": "some test blog no domain status",
       "type": "mapping",
       "is_domain_only_site": false,
       "is_wpcom_staging_domain": false,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AllDomainsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AllDomainsResponse.kt
@@ -1,7 +1,12 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.site
 
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
 import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import java.lang.reflect.Type
 
 data class AllDomainsResponse(val domains: List<AllDomainsDomain>)
 
@@ -35,4 +40,56 @@ data class AllDomainsDomain(
     val currentUserIsOwner: Boolean = false,
     @SerializedName("site_slug")
     val siteSlug: String? = null,
+    @SerializedName("domain_status")
+    val domainStatus: DomainStatus? = null,
 )
+
+data class DomainStatus(
+    @SerializedName("status")
+    val status: String? = null,
+    @SerializedName("status_type")
+    @JsonAdapter(StatusTypeAdapter::class)
+    val statusType: StatusType? = null,
+    @SerializedName("status_weight")
+    val statusWeight: Long? = 0,
+    @SerializedName("action_required")
+    @JsonAdapter(BooleanTypeAdapter::class)
+    val actionRequired: Boolean? = false,
+)
+
+enum class StatusType(private val stringValue: String) {
+    SUCCESS("success"),
+    NEUTRAL("neutral"),
+    ALERT("alert"),
+    WARNING("warning"),
+    ERROR("error"),
+    UNKNOWN("unknown");
+
+    override fun toString() = stringValue
+
+    companion object {
+        fun fromString(string: String): StatusType {
+            for (item in values()) {
+                if (item.stringValue == string) {
+                    return item
+                }
+            }
+            return UNKNOWN
+        }
+    }
+}
+
+internal class StatusTypeAdapter : JsonDeserializer<StatusType> {
+    @Throws(JsonParseException::class)
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): StatusType {
+        val jsonPrimitive = json.asJsonPrimitive
+        return when {
+            jsonPrimitive.isString -> StatusType.fromString(jsonPrimitive.asString)
+            else -> StatusType.UNKNOWN
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AllDomainsResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/AllDomainsResponse.kt
@@ -6,7 +6,9 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonParseException
 import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import org.wordpress.android.util.DateTimeUtils
 import java.lang.reflect.Type
+import java.util.Date
 
 data class AllDomainsResponse(val domains: List<AllDomainsDomain>)
 
@@ -29,9 +31,11 @@ data class AllDomainsDomain(
     @JsonAdapter(BooleanTypeAdapter::class)
     val hasRegistration: Boolean = false,
     @SerializedName("registration_date")
-    val registrationDate: String? = null,
+    @JsonAdapter(AllDomainsDateAdapter::class)
+    val registrationDate: Date? = null,
     @SerializedName("expiry")
-    val expiry: String? = null,
+    @JsonAdapter(AllDomainsDateAdapter::class)
+    val expiry: Date? = null,
     @SerializedName("wpcom_domain")
     @JsonAdapter(BooleanTypeAdapter::class)
     val wpcomDomain: Boolean = false,
@@ -90,6 +94,21 @@ internal class StatusTypeAdapter : JsonDeserializer<StatusType> {
         return when {
             jsonPrimitive.isString -> StatusType.fromString(jsonPrimitive.asString)
             else -> StatusType.UNKNOWN
+        }
+    }
+}
+
+internal class AllDomainsDateAdapter : JsonDeserializer<Date?> {
+    @Throws(JsonParseException::class)
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): Date? {
+        val jsonPrimitive = json.asJsonPrimitive
+        return when {
+            jsonPrimitive.isString -> DateTimeUtils.dateUTCFromIso8601(jsonPrimitive.asString)
+            else -> null
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -837,9 +837,12 @@ class SiteRestClient @Inject constructor(
         add(request)
     }
 
-    suspend fun fetchAllDomains(noWpCom: Boolean = true): Response<AllDomainsResponse> {
+    suspend fun fetchAllDomains(noWpCom: Boolean = true, resolveStatus: Boolean = true): Response<AllDomainsResponse> {
         val url = WPCOMREST.all_domains.urlV1_1
-        val params = mapOf("no_wpcom" to noWpCom.toString())
+        val params = mapOf(
+            "no_wpcom" to noWpCom.toString(),
+            "resolve_status" to resolveStatus.toString()
+        )
         return wpComGsonRequestBuilder.syncGetRequest(this, url, params, AllDomainsResponse::class.java)
     }
     suspend fun fetchSiteDomains(site: SiteModel): Response<DomainsResponse> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -2098,10 +2098,13 @@ open class SiteStore @Inject constructor(
         emitChange(event)
     }
 
-    suspend fun fetchAllDomains(noWpCom: Boolean = true): FetchedAllDomainsPayload =
+    suspend fun fetchAllDomains(
+        noWpCom: Boolean = true,
+        resolveStatus: Boolean = true
+    ): FetchedAllDomainsPayload =
         coroutineEngine.withDefaultContext(T.API, this, "Fetch all domains") {
             return@withDefaultContext when (val response =
-                siteRestClient.fetchAllDomains(noWpCom)) {
+                siteRestClient.fetchAllDomains(noWpCom, resolveStatus)) {
                 is Success -> {
                     val domains = response.data.domains
                     FetchedAllDomainsPayload(domains)


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-Android/issues/19165

**Based on:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2867

This PR adds the `resolve_status` parameter in the all-domains api call as introduced in the updated spec (internal ref: pc8HXX-1gR-p2#comment-1182).
It also converts string date to object in the all-domains response model for easier handling.

Note: The `locale` parameter [is already passed by the client implementation](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/trunk/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java#L30).

**To test:**

1. Start the example app and sign in (note: [setup oauth first](https://github.com/wordpress-mobile/WordPress-FluxC-Android#oauth2-authentication))
2. Tap on the DOMAINS button
3. Tap on the FETCH ALL DOMAINS button
4. Verify that your domains are listed and the `status` is printed for each domain
5. Verify that the domains count is correct