### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to All `Comment` SqlUtils & Model Classes (`breaking`)

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestWPCom.java
@@ -156,6 +156,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertTrue(comment.getContent().contains(mNewComment.getContent()));
     }
 
@@ -174,6 +175,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(firstComment.getId());
+        assertNotNull(comment);
         assertTrue(comment.getILike());
 
         // Unlike comment
@@ -185,6 +187,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
 
         // Check comment has been modified in the DB
         comment = mCommentStore.getCommentByLocalId(firstComment.getId());
+        assertNotNull(comment);
         assertFalse(comment.getILike());
     }
 
@@ -205,6 +208,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertTrue(comment.getContent().contains(mNewComment.getContent()));
 
         // Delete
@@ -216,6 +220,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
 
         // Make sure the comment is still here but state changed
         comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertEquals(CommentStatus.TRASH.toString(), comment.getStatus());
     }
 
@@ -236,6 +241,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertTrue(comment.getContent().contains(mNewComment.getContent()));
 
         // Delete once (ie. move to trash)
@@ -326,6 +332,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
 
         // Using .contains() in the assert below because server might wrap the response in <p>
+        assertNotNull(comment);
         assertTrue(comment.getContent().contains(mNewComment.getContent()));
         assertNotSame(mNewComment.getRemoteCommentId(), comment.getRemoteCommentId());
         assertNotSame(mNewComment.getRemoteSiteId(), comment.getRemoteSiteId());
@@ -415,6 +422,7 @@ public class ReleaseStack_CommentTestWPCom extends ReleaseStack_WPComBase {
 
         // Check the new comment response contains URL
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertNotNull(comment.getUrl());
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_CommentTestXMLRPC.java
@@ -109,6 +109,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertTrue(comment.getContent().contains(mNewComment.getContent()));
     }
 
@@ -172,6 +173,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertEquals(comment.getContent(), mNewComment.getContent());
         assertEquals(comment.getAuthorId(), firstComment.getAuthorId());
         assertEquals(comment.getParentId(), firstComment.getRemoteCommentId());
@@ -196,6 +198,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         CommentModel comment = mCommentStore.getCommentByLocalId(firstComment.getId());
+        assertNotNull(comment);
         assertEquals(comment.getContent(), firstComment.getContent());
     }
 
@@ -235,6 +238,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertTrue(comment.getContent().contains(mNewComment.getContent()));
 
         // Delete
@@ -246,6 +250,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Make sure the comment is still here but state changed
         comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertEquals(CommentStatus.TRASH.toString(), comment.getStatus());
     }
 
@@ -266,6 +271,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Check comment has been modified in the DB
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertTrue(comment.getContent().contains(mNewComment.getContent()));
 
         // Delete once (ie. move to trash)
@@ -302,6 +308,7 @@ public class ReleaseStack_CommentTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
         // Check the new comment response contains URL
         CommentModel comment = mCommentStore.getCommentByLocalId(mNewComment.getId());
+        assertNotNull(comment);
         assertNotNull(comment.getUrl());
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/common/CommentsMapperTest.kt
@@ -161,11 +161,11 @@ class CommentsMapperTest {
             authorEmail = entity.authorEmail
             authorProfileImageUrl = entity.authorProfileImageUrl
             postTitle = entity.postTitle
-            status = entity.status
-            datePublished = entity.datePublished
+            status = entity.status ?: ""
+            datePublished = entity.datePublished ?: ""
             publishedTimestamp = entity.publishedTimestamp
-            content = entity.content
-            url = entity.authorProfileImageUrl
+            content = entity.content ?: ""
+            url = entity.authorProfileImageUrl ?: ""
             hasParent = entity.hasParent
             parentId = entity.parentId
             iLike = entity.iLike

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
@@ -54,9 +54,6 @@ public class CommentModel extends Payload<BaseNetworkError> implements Identifia
         mId = id;
     }
 
-    // not stored in db - denotes the hierarchical level of this comment
-    public transient int level = 0;
-
     public long getRemoteCommentId() {
         return mRemoteCommentId;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.model;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
@@ -11,6 +14,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import java.io.Serializable;
 
 @Table
+@SuppressWarnings("NotNullFieldNotInitialized")
 public class CommentModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     private static final long serialVersionUID = 3454722213760369852L;
 
@@ -23,19 +27,19 @@ public class CommentModel extends Payload<BaseNetworkError> implements Identifia
     @Column private long mRemoteSiteId;
 
     // Comment author
-    @Column private String mAuthorUrl;
-    @Column private String mAuthorName;
-    @Column private String mAuthorEmail;
+    @Nullable @Column private String mAuthorUrl;
+    @Nullable @Column private String mAuthorName;
+    @Nullable @Column private String mAuthorEmail;
     @Column private long mAuthorId;
-    @Column private String mAuthorProfileImageUrl;
+    @Nullable @Column private String mAuthorProfileImageUrl;
 
     // Comment data
-    @Column private String mPostTitle;
-    @Column private String mStatus;
-    @Column private String mDatePublished;
+    @Nullable @Column private String mPostTitle;
+    @NonNull @Column private String mStatus;
+    @NonNull @Column private String mDatePublished;
     @Column private long mPublishedTimestamp;
-    @Column private String mContent;
-    @Column private String mUrl;
+    @NonNull @Column private String mContent;
+    @NonNull @Column private String mUrl;
 
     // Parent Comment Data
     @Column private boolean mHasParent;
@@ -70,67 +74,75 @@ public class CommentModel extends Payload<BaseNetworkError> implements Identifia
         mRemotePostId = remotePostId;
     }
 
+    @Nullable
     public String getAuthorUrl() {
         return mAuthorUrl;
     }
 
-    public void setAuthorUrl(String authorUrl) {
+    public void setAuthorUrl(@Nullable String authorUrl) {
         this.mAuthorUrl = authorUrl;
     }
 
+    @Nullable
     public String getAuthorName() {
         return mAuthorName;
     }
 
-    public void setAuthorName(String authorName) {
+    public void setAuthorName(@Nullable String authorName) {
         this.mAuthorName = authorName;
     }
 
+    @Nullable
     public String getAuthorEmail() {
         return mAuthorEmail;
     }
 
-    public void setAuthorEmail(String authorEmail) {
+    public void setAuthorEmail(@Nullable String authorEmail) {
         this.mAuthorEmail = authorEmail;
     }
 
+    @Nullable
     public String getAuthorProfileImageUrl() {
         return mAuthorProfileImageUrl;
     }
 
-    public void setAuthorProfileImageUrl(String authorProfileImageUrl) {
+    public void setAuthorProfileImageUrl(@Nullable String authorProfileImageUrl) {
         this.mAuthorProfileImageUrl = authorProfileImageUrl;
     }
 
+    @Nullable
     public String getPostTitle() {
         return mPostTitle;
     }
 
-    public void setPostTitle(String postTitle) {
+    public void setPostTitle(@Nullable String postTitle) {
         this.mPostTitle = postTitle;
     }
 
+    @NonNull
     public String getStatus() {
         return mStatus;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(@NonNull String status) {
         this.mStatus = status;
     }
 
+    @NonNull
     public String getDatePublished() {
         return mDatePublished;
     }
 
-    public void setDatePublished(String datePublished) {
+    public void setDatePublished(@NonNull String datePublished) {
         this.mDatePublished = datePublished;
     }
 
+    @NonNull
     public String getContent() {
         return mContent;
     }
 
-    public void setContent(String content) {
+    public void setContent(@NonNull String content) {
         this.mContent = content;
     }
 
@@ -166,11 +178,12 @@ public class CommentModel extends Payload<BaseNetworkError> implements Identifia
         mILike = iLike;
     }
 
+    @NonNull
     public String getUrl() {
         return mUrl;
     }
 
-    public void setUrl(String url) {
+    public void setUrl(@NonNull String url) {
         mUrl = url;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt
@@ -64,11 +64,11 @@ class CommentsMapper @Inject constructor(
             this.authorEmail = entity.authorEmail
             this.authorProfileImageUrl = entity.authorProfileImageUrl
             this.postTitle = entity.postTitle
-            this.status = entity.status
-            this.datePublished = entity.datePublished
+            this.status = entity.status ?: ""
+            this.datePublished = entity.datePublished ?: ""
             this.publishedTimestamp = entity.publishedTimestamp
-            this.content = entity.content
-            this.url = entity.url
+            this.content = entity.content ?: ""
+            this.url = entity.url ?: ""
             this.hasParent = entity.hasParent
             this.parentId = entity.parentId
             this.iLike = entity.iLike

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -155,6 +155,7 @@ public class CommentSqlUtils {
         return WellSql.delete(CommentModel.class).execute();
     }
 
+    @Nullable
     public static CommentModel getCommentByLocalCommentId(int localId) {
         List<CommentModel> results = WellSql.select(CommentModel.class)
                                             .where().equals(CommentModelTable.ID, localId).endWhere().getAsModel();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static org.wordpress.android.fluxc.model.LikeModel.TIMESTAMP_THRESHOLD;
 
 public class CommentSqlUtils {
-    public static int insertOrUpdateComment(CommentModel comment) {
+    public static int insertOrUpdateComment(@Nullable CommentModel comment) {
         if (comment == null) {
             return 0;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -88,7 +87,7 @@ public class CommentSqlUtils {
             return 0;
         }
 
-        Collections.sort(comments, new Comparator<CommentModel>() {
+        comments.sort(new Comparator<CommentModel>() {
             @Override
             public int compare(CommentModel o1, CommentModel o2) {
                 long x = o2.getPublishedTimestamp();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -77,9 +77,13 @@ public class CommentSqlUtils {
                       .execute();
     }
 
-    public static int removeCommentGaps(SiteModel site, List<CommentModel> comments, int maxEntriesInResponse,
-                                        int requestOffset, @Nullable CommentStatus... statuses) {
-        if (site == null || comments == null || comments.isEmpty()) {
+    public static int removeCommentGaps(
+            @NonNull SiteModel site,
+            @NonNull List<CommentModel> comments,
+            int maxEntriesInResponse,
+            int requestOffset,
+            @Nullable CommentStatus... statuses) {
+        if (comments.isEmpty()) {
             return 0;
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -71,11 +71,7 @@ public class CommentSqlUtils {
                       .execute();
     }
 
-    public static int removeComments(SiteModel site) {
-        if (site == null) {
-            return 0;
-        }
-
+    public static int removeComments(@NonNull SiteModel site) {
         return WellSql.delete(CommentModel.class)
                       .where().equals(CommentModelTable.LOCAL_SITE_ID, site.getId()).endWhere()
                       .execute();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -307,6 +307,7 @@ public class CommentSqlUtils {
         }
     }
 
+    @NonNull
     public static List<LikeModel> getCommentLikesByCommentId(long siteId, long remoteCommentId) {
         return WellSql.select(LikeModel.class)
                       .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -100,12 +101,18 @@ public class CommentSqlUtils {
         long startOfRange = comments.get(0).getPublishedTimestamp();
         long endOfRange = comments.get(comments.size() - 1).getPublishedTimestamp();
 
+        List<CommentStatus> sourceStatuses;
+        if (statuses != null) {
+            sourceStatuses = Arrays.asList(statuses);
+        } else {
+            sourceStatuses = Collections.emptyList();
+        }
         ArrayList<CommentStatus> targetStatuses = new ArrayList<>();
-        if (Arrays.asList(statuses).contains(CommentStatus.ALL)) {
+        if (sourceStatuses.contains(CommentStatus.ALL)) {
             targetStatuses.add(CommentStatus.APPROVED);
             targetStatuses.add(CommentStatus.UNAPPROVED);
         } else {
-            targetStatuses.addAll(Arrays.asList(statuses));
+            targetStatuses.addAll(sourceStatuses);
         }
 
         int numOfDeletedComments = 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -61,7 +61,7 @@ public class CommentSqlUtils {
         }
     }
 
-    public static int removeComment(CommentModel comment) {
+    public static int removeComment(@Nullable CommentModel comment) {
         if (comment == null) {
             return 0;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -177,16 +177,18 @@ public class CommentSqlUtils {
         return results.get(0);
     }
 
-    private static SelectQuery<CommentModel> getCommentsQueryForSite(SiteModel site, CommentStatus... statuses) {
+    @NonNull
+    private static SelectQuery<CommentModel> getCommentsQueryForSite(
+            @NonNull SiteModel site,
+            @NonNull CommentStatus... statuses) {
         return getCommentsQueryForSite(site, 0, statuses);
     }
 
-    private static SelectQuery<CommentModel> getCommentsQueryForSite(SiteModel site, int limit,
-                                                                     CommentStatus... statuses) {
-        if (site == null) {
-            return null;
-        }
-
+    @NonNull
+    private static SelectQuery<CommentModel> getCommentsQueryForSite(
+            @NonNull SiteModel site,
+            int limit,
+            @NonNull CommentStatus... statuses) {
         SelectQuery<CommentModel> query = WellSql.select(CommentModel.class);
 
         if (limit > 0) {
@@ -204,26 +206,28 @@ public class CommentSqlUtils {
         return selectQueryBuilder.endGroup().endWhere();
     }
 
-    public static List<CommentModel> getCommentsForSite(SiteModel site, @Order int order, CommentStatus... statuses) {
+    @NonNull
+    public static List<CommentModel> getCommentsForSite(
+            @NonNull SiteModel site,
+            @Order int order,
+            @NonNull CommentStatus... statuses) {
         return getCommentsForSite(site, order, 0, statuses);
     }
 
-    public static List<CommentModel> getCommentsForSite(SiteModel site, @Order int order, int limit,
-                                                        CommentStatus... statuses) {
-        if (site == null) {
-            return Collections.emptyList();
-        }
-
+    @NonNull
+    public static List<CommentModel> getCommentsForSite(
+            @NonNull SiteModel site,
+            @Order int order,
+            int limit,
+            @NonNull CommentStatus... statuses) {
         return getCommentsQueryForSite(site, limit, statuses)
                 .orderBy(CommentModelTable.DATE_PUBLISHED, order)
                 .getAsModel();
     }
 
-    public static int getCommentsCountForSite(SiteModel site, CommentStatus... statuses) {
-        if (site == null) {
-            return 0;
-        }
-
+    public static int getCommentsCountForSite(
+            @NonNull SiteModel site,
+            @NonNull CommentStatus... statuses) {
         return (int) getCommentsQueryForSite(site, statuses).count();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
@@ -87,13 +86,10 @@ public class CommentSqlUtils {
             return 0;
         }
 
-        comments.sort(new Comparator<CommentModel>() {
-            @Override
-            public int compare(CommentModel o1, CommentModel o2) {
-                long x = o2.getPublishedTimestamp();
-                long y = o1.getPublishedTimestamp();
-                return (x < y) ? -1 : ((x == y) ? 0 : 1);
-            }
+        comments.sort((o1, o2) -> {
+            long x = o2.getPublishedTimestamp();
+            long y = o1.getPublishedTimestamp();
+            return (x < y) ? -1 : ((x == y) ? 0 : 1);
         });
 
         ArrayList<Long> remoteIds = new ArrayList<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -280,11 +280,10 @@ public class CommentSqlUtils {
         return numDeleted;
     }
 
-    public static int insertOrUpdateCommentLikes(long siteId, long remoteCommentId, LikeModel like) {
-        if (null == like) {
-            return 0;
-        }
-
+    public static int insertOrUpdateCommentLikes(
+            long siteId,
+            long remoteCommentId,
+            @NonNull LikeModel like) {
         List<LikeModel> likeResult;
 
         // If the like already exists and has an id, we want to update it.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -89,7 +89,7 @@ public class CommentSqlUtils {
         comments.sort((o1, o2) -> {
             long x = o2.getPublishedTimestamp();
             long y = o1.getPublishedTimestamp();
-            return (x < y) ? -1 : ((x == y) ? 0 : 1);
+            return Long.compare(x, y);
         });
 
         ArrayList<Long> remoteIds = new ArrayList<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/CommentSqlUtils.java
@@ -227,6 +227,7 @@ public class CommentSqlUtils {
         return (int) getCommentsQueryForSite(site, statuses).count();
     }
 
+    @SuppressWarnings("resource")
     public static int deleteCommentLikesAndPurgeExpired(long siteId, long remoteCommentId) {
         int numDeleted = WellSql.delete(LikeModel.class)
                                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -380,7 +380,7 @@ public class CommentStore extends Store {
         }
     }
 
-    private void handleCreatedNewComment(RemoteCommentResponsePayload payload) {
+    private void handleCreatedNewComment(@NonNull RemoteCommentResponsePayload payload) {
         OnCommentChanged event = new OnCommentChanged(1, CommentAction.CREATE_NEW_COMMENT);
 
         // Update the comment from the DB
@@ -394,7 +394,7 @@ public class CommentStore extends Store {
         emitChange(event);
     }
 
-    private void updateComment(CommentModel payload) {
+    private void updateComment(@NonNull CommentModel payload) {
         int rowsAffected = 0;
         if (!payload.isError()) {
             rowsAffected = CommentSqlUtils.insertOrUpdateComment(payload);
@@ -404,14 +404,14 @@ public class CommentStore extends Store {
         emitChange(event);
     }
 
-    private void removeComment(CommentModel payload) {
+    private void removeComment(@NonNull CommentModel payload) {
         int rowsAffected = CommentSqlUtils.removeComment(payload);
         OnCommentChanged event = new OnCommentChanged(rowsAffected, CommentAction.REMOVE_COMMENT);
         event.changedCommentsLocalIds.add(payload.getId());
         emitChange(event);
     }
 
-    private void removeComments(SiteModel payload) {
+    private void removeComments(@NonNull SiteModel payload) {
         int rowsAffected = CommentSqlUtils.removeComments(payload);
         OnCommentChanged event = new OnCommentChanged(rowsAffected, CommentAction.REMOVE_COMMENTS);
         // Doesn't make sense to update here event.changedCommentsLocalIds
@@ -438,7 +438,7 @@ public class CommentStore extends Store {
         }
     }
 
-    private void handleDeletedCommentResponse(RemoteCommentResponsePayload payload) {
+    private void handleDeletedCommentResponse(@NonNull RemoteCommentResponsePayload payload) {
         OnCommentChanged event = new OnCommentChanged(0, CommentAction.DELETE_COMMENT);
         if (payload.comment != null) {
             event.changedCommentsLocalIds.add(payload.comment.getId());
@@ -466,7 +466,7 @@ public class CommentStore extends Store {
         }
     }
 
-    private void handleFetchCommentsResponse(FetchCommentsResponsePayload payload) {
+    private void handleFetchCommentsResponse(@NonNull FetchCommentsResponsePayload payload) {
         int rowsAffected = 0;
         OnCommentChanged event = new OnCommentChanged(rowsAffected, CommentAction.FETCH_COMMENTS);
         if (!payload.isError()) {
@@ -500,7 +500,7 @@ public class CommentStore extends Store {
         }
     }
 
-    private void handlePushCommentResponse(RemoteCommentResponsePayload payload) {
+    private void handlePushCommentResponse(@NonNull RemoteCommentResponsePayload payload) {
         int rowsAffected = 0;
         if (!payload.isError()) {
             rowsAffected = CommentSqlUtils.insertOrUpdateComment(payload.comment);
@@ -529,7 +529,7 @@ public class CommentStore extends Store {
         }
     }
 
-    private void handleFetchCommentResponse(RemoteCommentResponsePayload payload) {
+    private void handleFetchCommentResponse(@NonNull RemoteCommentResponsePayload payload) {
         int rowsAffected = 0;
         if (!payload.isError()) {
             rowsAffected = CommentSqlUtils.insertOrUpdateComment(payload.comment);
@@ -561,7 +561,7 @@ public class CommentStore extends Store {
         }
     }
 
-    private void handleLikedCommentResponse(RemoteCommentResponsePayload payload) {
+    private void handleLikedCommentResponse(@NonNull RemoteCommentResponsePayload payload) {
         int rowsAffected = 0;
         if (!payload.isError()) {
             rowsAffected = CommentSqlUtils.insertOrUpdateComment(payload.comment);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -277,6 +277,7 @@ public class CommentStore extends Store {
         return CommentSqlUtils.getCommentBySiteAndRemoteId(site, remoteCommentId);
     }
 
+    @Nullable
     public CommentModel getCommentByLocalId(int localId) {
         return CommentSqlUtils.getCommentByLocalCommentId(localId);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -215,16 +215,22 @@ public class CommentStore extends Store {
     }
 
     public static class OnCommentLikesChanged extends OnChanged<CommentError> {
-        public CommentAction causeOfChange;
+        @NonNull public CommentAction causeOfChange;
         public final long siteId;
         public final long commentId;
-        public List<LikeModel> commentLikes = new ArrayList<>();
+        @NonNull public List<LikeModel> commentLikes = new ArrayList<>();
         public final boolean hasMore;
 
-        public OnCommentLikesChanged(long siteId, long commentId, boolean hasMore) {
+        public OnCommentLikesChanged(
+                long siteId,
+                long commentId,
+                boolean hasMore,
+                @NonNull CommentAction causeOfChange
+        ) {
             this.siteId = siteId;
             this.commentId = commentId;
             this.hasMore = hasMore;
+            this.causeOfChange = causeOfChange;
         }
     }
 
@@ -570,11 +576,12 @@ public class CommentStore extends Store {
         );
     }
 
-    private void handleFetchedCommentLikes(FetchedCommentLikesResponsePayload payload) {
+    private void handleFetchedCommentLikes(@NonNull FetchedCommentLikesResponsePayload payload) {
         OnCommentLikesChanged event = new OnCommentLikesChanged(
                 payload.siteId,
                 payload.commentRemoteId,
-                payload.hasMore
+                payload.hasMore,
+                CommentAction.FETCHED_COMMENT_LIKES
         );
         if (!payload.isError()) {
             if (!payload.isRequestNextPage) {
@@ -596,7 +603,6 @@ public class CommentStore extends Store {
             event.commentLikes.addAll(cachedLikes);
         }
 
-        event.causeOfChange = CommentAction.FETCHED_COMMENT_LIKES;
         event.error = payload.error;
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -192,9 +192,9 @@ public class CommentStore extends Store {
     }
 
     public static class CommentError implements OnChangedError {
-        public CommentErrorType type;
-        public String message;
-        public CommentError(CommentErrorType type, @NonNull String message) {
+        @NonNull public CommentErrorType type;
+        @NonNull public String message;
+        public CommentError(@NonNull CommentErrorType type, @NonNull String message) {
             this.type = type;
             this.message = message;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentStore.java
@@ -254,14 +254,20 @@ public class CommentStore extends Store {
      * @param statuses Array of status or CommentStatus.ALL to get all of them.
      * @param limit Maximum number of comments to return. 0 is unlimited.
      */
+    @NonNull
     @SuppressLint("WrongConstant")
-    public List<CommentModel> getCommentsForSite(SiteModel site, boolean orderByDateAscending, int limit,
-                                                 CommentStatus... statuses) {
+    public List<CommentModel> getCommentsForSite(
+            @NonNull SiteModel site,
+            boolean orderByDateAscending,
+            int limit,
+            @NonNull CommentStatus... statuses) {
         @Order int order = orderByDateAscending ? SelectQuery.ORDER_ASCENDING : SelectQuery.ORDER_DESCENDING;
         return CommentSqlUtils.getCommentsForSite(site, order, limit, statuses);
     }
 
-    public int getNumberOfCommentsForSite(SiteModel site, CommentStatus... statuses) {
+    public int getNumberOfCommentsForSite(
+            @NonNull SiteModel site,
+            @NonNull CommentStatus... statuses) {
         return CommentSqlUtils.getCommentsCountForSite(site, statuses);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/CommentsStore.kt
@@ -654,8 +654,7 @@ class CommentsStore @Inject constructor(
     )
     private suspend fun onPushComment(payload: RemoteCommentPayload): OnCommentChanged {
         if (payload.comment == null) {
-            return OnCommentChanged(0).apply {
-                this.causeOfChange = CommentAction.PUSH_COMMENT
+            return OnCommentChanged(0, CommentAction.PUSH_COMMENT).apply {
                 this.error = CommentError(INVALID_INPUT, "Comment can't be null")
             }
         }
@@ -715,9 +714,8 @@ class CommentsStore @Inject constructor(
         status: CommentStatus? = null,
         offset: Int? = null
     ): OnCommentChanged {
-        return OnCommentChanged(rowsAffected).apply {
+        return OnCommentChanged(rowsAffected, actionType).apply {
             this.changedCommentsLocalIds.addAll(commentLocalIds)
-            this.causeOfChange = actionType
             this.error = error
             status?.let {
                 this.requestedStatus = it

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.utils;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.wordpress.android.fluxc.model.CommentModel;
@@ -17,8 +18,10 @@ import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentResponsePaylo
 import java.util.ArrayList;
 
 public class CommentErrorUtils {
-    public static RemoteCommentResponsePayload commentErrorToFetchCommentPayload(BaseNetworkError error,
-                                                                                 @Nullable CommentModel comment) {
+    @NonNull
+    public static RemoteCommentResponsePayload commentErrorToFetchCommentPayload(
+            @NonNull BaseNetworkError error,
+            @Nullable CommentModel comment) {
         RemoteCommentResponsePayload payload = new RemoteCommentResponsePayload(comment);
         payload.error = new CommentError(genericToCommentError(error), getErrorMessage(error));
         return payload;
@@ -58,11 +61,13 @@ public class CommentErrorUtils {
         return payload;
     }
 
-    public static CommentError networkToCommentError(BaseNetworkError error) {
+    @NonNull
+    public static CommentError networkToCommentError(@NonNull BaseNetworkError error) {
         return new CommentError(genericToCommentError(error), getErrorMessage(error));
     }
 
-    private static CommentErrorType genericToCommentError(BaseNetworkError error) {
+    @NonNull
+    private static CommentErrorType genericToCommentError(@NonNull BaseNetworkError error) {
         CommentErrorType errorType = CommentErrorType.GENERIC_ERROR;
         if (error.isGeneric()) {
             switch (error.type) {
@@ -101,7 +106,8 @@ public class CommentErrorUtils {
         return errorType;
     }
 
-    private static String getErrorMessage(BaseNetworkError error) {
+    @NonNull
+    private static String getErrorMessage(@NonNull BaseNetworkError error) {
         return error.message;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -74,6 +74,19 @@ public class CommentErrorUtils {
                 case INVALID_RESPONSE:
                     errorType = CommentErrorType.INVALID_RESPONSE;
                     break;
+                case TIMEOUT:
+                case NO_CONNECTION:
+                case NETWORK_ERROR:
+                case NOT_FOUND:
+                case CENSORED:
+                case SERVER_ERROR:
+                case INVALID_SSL_CERTIFICATE:
+                case HTTP_AUTH_ERROR:
+                case AUTHORIZATION_REQUIRED:
+                case NOT_AUTHENTICATED:
+                case PARSE_ERROR:
+                case UNKNOWN:
+                    break;
             }
         }
         if (error instanceof WPComGsonNetworkError) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -38,8 +38,9 @@ public class CommentErrorUtils {
         return payload;
     }
 
+    @NonNull
     public static FetchedCommentLikesResponsePayload commentErrorToFetchedCommentLikesPayload(
-            BaseNetworkError error,
+            @NonNull BaseNetworkError error,
             long siteId,
             long commentId,
             boolean requestNextPage,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -74,25 +74,8 @@ public class CommentErrorUtils {
     @NonNull
     private static CommentErrorType genericToCommentError(@NonNull BaseNetworkError error) {
         CommentErrorType errorType = CommentErrorType.GENERIC_ERROR;
-        if (error.isGeneric()) {
-            switch (error.type) {
-                case INVALID_RESPONSE:
-                    errorType = CommentErrorType.INVALID_RESPONSE;
-                    break;
-                case TIMEOUT:
-                case NO_CONNECTION:
-                case NETWORK_ERROR:
-                case NOT_FOUND:
-                case CENSORED:
-                case SERVER_ERROR:
-                case INVALID_SSL_CERTIFICATE:
-                case HTTP_AUTH_ERROR:
-                case AUTHORIZATION_REQUIRED:
-                case NOT_AUTHENTICATED:
-                case PARSE_ERROR:
-                case UNKNOWN:
-                    break;
-            }
+        if (error.isGeneric() && error.type == GenericErrorType.INVALID_RESPONSE) {
+            errorType = CommentErrorType.INVALID_RESPONSE;
         }
         if (error instanceof WPComGsonNetworkError) {
             WPComGsonNetworkError wpComGsonNetworkError = (WPComGsonNetworkError) error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -27,8 +27,10 @@ public class CommentErrorUtils {
         return payload;
     }
 
-    public static FetchCommentsResponsePayload commentErrorToFetchCommentsPayload(BaseNetworkError error,
-                                                                                  SiteModel site) {
+    @NonNull
+    public static FetchCommentsResponsePayload commentErrorToFetchCommentsPayload(
+            @NonNull BaseNetworkError error,
+            @NonNull SiteModel site) {
         FetchCommentsResponsePayload payload = new FetchCommentsResponsePayload(
                 new ArrayList<>(), site, 0, 0, null
         );

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/CommentErrorUtils.java
@@ -57,8 +57,10 @@ public class CommentErrorUtils {
         return payload;
     }
 
-    public static RemoteCommentResponsePayload commentErrorToPushCommentPayload(BaseNetworkError error,
-                                                                                CommentModel comment) {
+    @NonNull
+    public static RemoteCommentResponsePayload commentErrorToPushCommentPayload(
+            @NonNull BaseNetworkError error,
+            @NonNull CommentModel comment) {
         RemoteCommentResponsePayload payload = new RemoteCommentResponsePayload(comment);
         payload.error = new CommentError(genericToCommentError(error), getErrorMessage(error));
         return payload;


### PR DESCRIPTION
Parent #2799
Closes #2831

This PR adds any missing nullability annotation to all `Comment` related sql-util & model classes.

FYI.1: This change is `breaking`, meaning that any client that depended on the `Comment` model should update to the new APIs. As such, this change is inherently `risk`, meaning that there are compile-time changes associated with this change and thus needs testing to verify correctness, both on the library's and client's side.

FYI.2: Comparing to a [previous](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2851) such PR, in this PR there are no `non-default constructors` and `default constructor` changes. This is because of the fact that there are a couple of pseudo `Comment` model construction usages within the JP/WPAndroid repo ([here](https://github.com/wordpress-mobile/WordPress-Android/blob/1f67fab3cec29e0a96423985f5b9118084c246db/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java#L628-L630) and [here](https://github.com/wordpress-mobile/WordPress-Android/blob/1f67fab3cec29e0a96423985f5b9118084c246db/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java#L1149-L1151)), which makes it really hard to re-define and scope the `Comment` model. As such, and in order to avoid causing a larger refactor, adding `non-default constructors` constructors and deprecating the `default constructor` on `Comment` model was ignored.

PS.1: Any other changes on any other class are just some propagating missing nullability annotation changes, which stem from the main set of classes being updated, this PR's focus, plus, some other extra minor analysis, refactor and test related changes.

PS.2: As part of this 3821422ca9f71e4def3455ad021c729feb412680 commit, the [CommentsMapper.kt](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/21b9cb51949bff38713430b86c31e4620623dcf2/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt#L4) and its [commentEntityToLegacyModel(...)](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/21b9cb51949bff38713430b86c31e4620623dcf2/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt#L54-L76) function got updated to respect the updated nullability contract of the [CommentModel.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/21b9cb51949bff38713430b86c31e4620623dcf2/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java#L4) model class, which is no longer allowing for a nullable `mStatus`, `mDatePublished`, `mContent` and `mUrl` fields. From my understanding, the author of  [CommentsMapper.kt](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/21b9cb51949bff38713430b86c31e4620623dcf2/fluxc/src/main/java/org/wordpress/android/fluxc/model/comments/CommentsMapper.kt#L4) created those mappings and the [CommentEntity](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/21b9cb51949bff38713430b86c31e4620623dcf2/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/comments/CommentsDao.kt#L276C16-L306) database entity by defaulting all non primitive fields of the `Comment` model to being nullable. But, from my testing, and [this](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2868) related PR (its response) at least 4 of them can't and shouldn't be nullable, as in some cases, if those were to be defined as nullable, that would have caused a NPE. Be extra mindful of that when reviewing this PR.

-----

@wzieba let me know how I did on this PR, that is,  in terms of updating the store/sqlutils classes and adding nullability annotations on them and their main [CommentModel.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/21b9cb51949bff38713430b86c31e4620623dcf2/fluxc/src/main/java/org/wordpress/android/fluxc/model/CommentModel.java#L4) model class, in order to utilize the nullability annotations added on its fields and thus make its use null proof. If you also feel that this is a good way to proceed with such PRs, I'll then use this pattern across the board and follow a similar approach on every such PR.

-----

Nullability Annotations List (`Model`):

1. [Add missing n-a to comment model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/3821422ca9f71e4def3455ad021c729feb412680)

Nullability Annotations List (`SqlUtils`):

1. [Replace collections with cmt list sort on comments sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/8b52511b295bfc93078a87124db072a692ed4d16)
2. [Replace anonymous classes with lambda on comment sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/93ece6b5bb17d91789df593b089b8525a30bec9a)
3. [Add missing n-a to insert or update cmt on comment sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/dce9c685c0f0d60cdeef691251cd55ed13a31fb6)
4. [Add missing n-a to remove comment on comment sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/3585f82c33a251fe914d478a53024388dd75aea0)
5. [Add missing n-a to remove comments on comment sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/64a642b804893f22080f2e63afc3bd1d199a6ea7)
6. [Add missing n-a to remove comment gaps on comment sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/f2b5c5c8d6dc79b4276dc85f2884172538dca88b)
7. [Add missing n-a to insert or update cmt likes on cmt sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/d24959cdc8eb5e81173b8bae10426433a263be10)
8. [Add missing n-a to get cmt likes by cmt id on cmt sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/a164dd020a556a647fe3e66e2e5bd64a4d64080f)

Nullability Annotations List (`Store`):

1. [Add missing n-a to comment error on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/6e7364979bb01c240bd94436235300c4aa4d0b70)
2. [Add missing n-a to on comment changed on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/97617df3fcb45ba633e7a46f9251dd6dde4a6bff)
3. [Add missing n-a to on comment likes changed on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/4f45ac862f1a7dc4848a31a4c74c8bf7a0d6e28e)
4. [Add missing n-a to get comments for site on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/afe04d3cb7ef9d0ad5f45df5036eb7884620c33a)
5. [Add missing n-a to get comment by local id on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/6f6f78700a3f7b34d38fe2b68c31937cd27c89aa)
6. [Add missing n-a to all payload methods on comment store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/ad4e4fdb394a42439b3a3a3dc4b785010e650e7d)

Nullability Annotations List (`Utils`):

1. [Add missing n-a to comment error to fetch comments payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/0465dffc8bdc156c6d40f43b68035df42824c088)
2. [Add missing n-a to comment error to fetched cmt likes payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/3d476284fb5641f93e203dd6acdb73a8e1ddd335)
3. [Add missing n-a to comment error to push comment payload](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/bd52c7237b2166df5ae5def99ac01dee2bef9c4b)

Nullability Checks List:

1. [Guard usages of statuses on comment sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/e3dfdd553a8bd43c8afdba3c046e58b4ee1a195b)

Warnings Resolution List:

1. [Create missing switch branch on comment error utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/dfc9856a23ea7ea75493ea08a106a6d94309c635)
2. [Replace comments published timestamp with long compare](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/fe724caae5b2bd5e9d39d9b097a43b22ec495da2)

Warnings Suppression List:

1. [Suppress resource warning for well sql give me writable db](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/33328c951597dc88609c5bc69d8b14ccc6b583c3)

Refactor List:

1. [Remove unused transient level field from comment model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/54ffcc1c7e0f3b8c5d58c98fdd91ba7e1495c429)
2. [Replace anonymous classes with lambda on comment sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2870/commits/93ece6b5bb17d91789df593b089b8525a30bec9a)

-----

## Associated Clients

It is highly recommending that this change is being tested alongside the below associated clients and their accompanying PRs:

- [JP/WPAndroid#19389](https://github.com/wordpress-mobile/WordPress-Android/pull/19389)

-----

## To Test (`REST`):

- Smoke test the `FluxC Example` app via the `COMMENTS` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any `CommentStore` and `CommentsStore` related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

## To Test (`XMLRPC`):

- Create a new self-hosted WordPress site for XMLRPC testing purposes ([jurassic.ninja](https://jurassic.ninja/)).
- Smoke test the `FluxC Example` app via the `COMMENTS` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any `CommentStore` and `CommentsStore` related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

<details>
    <summary>1. Comment Details Screen from Comments Screen [CommentDetailFragment.java]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Comments` screen and tap on any comment.
- Verify that the `Comment Details` screen is shown and functioning as expected.
- For example, try replying, approving, marking as spam, liking, trashing, editing or copying a comment's link address. Additionally, make sure to verify that you can still swipe left-right to navigate between comments.

</details>

<details>
    <summary>2. Comment Details Screen from Notification Tab [CommentDetailFragment.java]</summary>

ℹ️ This test applies to the `Jetpack` app only.

- Go to `Notifications` tab, then its `COMMENTS` sub-tab, and tap on any comment.
- Verify that the `Comment Details` screen is shown and functioning as expected.
- For example, try replying to a comment. Additionally, make sure to verify that you can still swipe left-right to navigate between comments.

</details>

<details>
    <summary>3. Edit Comment Screen from Comments Screen [UnifiedCommentsEditActivity.java]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Comments` screen and tap on any comment.
- From the `More` on the right side, at the bottom of the comment, select `Edit`.
- Verify that the `Edit Comment` screen is shown and functioning as expected.
- For example, try editing/adding the comment's `Name`, `Web address`, `Email address` and its `Comment` itself.

</details>

<details>
    <summary>4. Edit Comment Screen from Notification Tab [UnifiedCommentsEditActivity.java]</summary>

ℹ️ This test applies to the `Jetpack` app only.

- Go to `Notifications` tab, then its `COMMENTS` sub-tab, and tap on any comment.
- From the `More` on the right side, at the bottom of the comment, select `Edit`.
- Verify that the `Edit Comment` screen is shown and functioning as expected.
- For example, try editing/adding the comment's `Name`, `Web address`, `Email address` and its `Comment` itself.

</details>

<details>
    <summary>5. Reader Comments Screen [ReaderCommentListActivity.java]</summary>

ℹ️ This test applies to the `Jetpack` app only.

- Go to `Reader` tab, then its `DISCOVER` sub-tab, and tap on any post.
- Tap on the `Comments` button at the bottom of the post.
- Verify that the `Reader Comments` screen is shown and functioning as expected.
- For example, try (un)following, enabling/disabling in-app notifications, replying to post, and then sharing, replying or liking a specific comment.

</details>

-----

## Merge instructions:

1. [x] Wait for the accompanying [JP/WPAndroid#19389](https://github.com/wordpress-mobile/WordPress-Android/pull/19389) to be reviewed and approved.
2. [x] Remove the `[PR] Not Ready for Merge` label.
3. [x] Merge this PR.
4. [x] Follow-up with the merge instructions on the accompanying [JP/WPAndroid#19389](https://github.com/wordpress-mobile/WordPress-Android/pull/19389) client PR.