### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to `Discovery` Network Client Classes (`safe`)

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
@@ -17,7 +17,7 @@ public class DiscoveryRequest extends BaseRequest<String> {
 
     private final Listener<String> mListener;
 
-    public DiscoveryRequest(String url, Listener<String> listener, BaseErrorListener errorListener) {
+    public DiscoveryRequest(@NonNull String url, Listener<String> listener, BaseErrorListener errorListener) {
         super(Method.GET, url, errorListener);
         mListener = listener;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryRequest.java
@@ -15,20 +15,24 @@ public class DiscoveryRequest extends BaseRequest<String> {
     private static final String PROTOCOL_CHARSET = "utf-8";
     private static final String PROTOCOL_CONTENT_TYPE = String.format("text/xml; charset=%s", PROTOCOL_CHARSET);
 
-    private final Listener<String> mListener;
+    @NonNull private final Listener<String> mListener;
 
-    public DiscoveryRequest(@NonNull String url, Listener<String> listener, BaseErrorListener errorListener) {
+    public DiscoveryRequest(
+            @NonNull String url,
+            @NonNull Listener<String> listener,
+            @NonNull BaseErrorListener errorListener) {
         super(Method.GET, url, errorListener);
         mListener = listener;
     }
 
     @Override
-    protected void deliverResponse(String response) {
+    protected void deliverResponse(@NonNull String response) {
         mListener.onResponse(response);
     }
 
+    @NonNull
     @Override
-    protected Response<String> parseNetworkResponse(NetworkResponse response) {
+    protected Response<String> parseNetworkResponse(@NonNull NetworkResponse response) {
         String parsed;
         try {
             parsed = new String(response.data, HttpHeaderParser.parseCharset(response.headers));
@@ -38,12 +42,14 @@ public class DiscoveryRequest extends BaseRequest<String> {
         return Response.success(parsed, HttpHeaderParser.parseCacheHeaders(response));
     }
 
+    @NonNull
     @Override
     public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
         // no op
         return error;
     }
 
+    @NonNull
     @Override
     public String getBodyContentType() {
         return PROTOCOL_CONTENT_TYPE;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
@@ -3,6 +3,8 @@ package org.wordpress.android.fluxc.network.discovery;
 import android.text.TextUtils;
 import android.webkit.URLUtil;
 
+import androidx.annotation.NonNull;
+
 import org.wordpress.android.util.AppLog;
 
 import java.util.regex.Matcher;
@@ -51,7 +53,8 @@ public class DiscoveryUtils {
     /**
      * Append 'xmlrpc.php' if missing in the URL
      */
-    public static String appendXMLRPCPath(String url) {
+    @NonNull
+    public static String appendXMLRPCPath(@NonNull String url) {
         // Don't use 'ends' here! Some hosting wants parameters passed to baseURL/xmlrpc-php?my-authcode=XXX
         if (url.contains("xmlrpc.php")) {
             return url;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
@@ -102,7 +102,7 @@ public class DiscoveryUtils {
     /**
      * Check whether given network error is a 401 Unauthorized HTTP error
      */
-    public static boolean isHTTPAuthErrorMessage(Exception e) {
+    public static boolean isHTTPAuthErrorMessage(@Nullable Exception e) {
         return e != null && e.getMessage() != null && e.getMessage().contains("401");
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
@@ -111,7 +111,8 @@ public class DiscoveryUtils {
      *
      * @return XML-RPC endpoint for the specified site, or null if unable to discover endpoint.
      */
-    public static String getXMLRPCApiLink(String html) {
+    @Nullable
+    public static String getXMLRPCApiLink(@Nullable String html) {
         Pattern xmlrpcLink = Pattern.compile("<api\\s*?name=\"WordPress\".*?apiLink=\"(.*?)\"",
                 Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
         if (html != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
@@ -14,7 +14,8 @@ public class DiscoveryUtils {
     /**
      * Strip known unnecessary paths from XML-RPC URL and remove trailing slashes
      */
-    public static String stripKnownPaths(String url) {
+    @NonNull
+    public static String stripKnownPaths(@NonNull String url) {
         // Remove 'wp-login.php' if available in the URL
         String sanitizedURL = truncateUrl(url, "wp-login.php");
 
@@ -40,7 +41,8 @@ public class DiscoveryUtils {
      * @param marker the marker to begin the truncation from
      * @return new string truncated to the begining of the marker or the input string if marker is not found
      */
-    public static String truncateUrl(String url, String marker) {
+    @NonNull
+    public static String truncateUrl(@NonNull String url, @NonNull String marker) {
         if (TextUtils.isEmpty(marker) || !url.contains(marker)) {
             return url;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.wordpress.android.util.AppLog;
 
@@ -68,7 +69,7 @@ public class DiscoveryUtils {
     /**
      * Verify that the response of system.listMethods matches the expected list of available XML-RPC methods
      */
-    public static boolean validateListMethodsResponse(Object[] availableMethods) {
+    public static boolean validateListMethodsResponse(@Nullable Object[] availableMethods) {
         if (availableMethods == null) {
             AppLog.e(AppLog.T.NUX, "The response of system.listMethods was empty!");
             return false;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
@@ -129,7 +129,8 @@ public class DiscoveryUtils {
      *
      * @return String XML-RPC url
      */
-    public static String getXMLRPCPingback(String html) {
+    @Nullable
+    public static String getXMLRPCPingback(@Nullable String html) {
         Pattern pingbackLink = Pattern.compile(
                 "<link\\s*?rel=\"pingback\"\\s*?href=\"(.*?)\"",
                 Pattern.CASE_INSENSITIVE | Pattern.DOTALL);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryUtils.java
@@ -40,7 +40,7 @@ public class DiscoveryUtils {
      * Truncate a string beginning at the marker
      * @param url input string
      * @param marker the marker to begin the truncation from
-     * @return new string truncated to the begining of the marker or the input string if marker is not found
+     * @return new string truncated to the beginning of the marker or the input string if marker is not found
      */
     @NonNull
     public static String truncateUrl(@NonNull String url, @NonNull String marker) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
@@ -22,6 +22,7 @@ import javax.inject.Singleton;
 
 import static org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.TIMEOUT_MS;
 
+@SuppressWarnings("CommentedOutCode")
 @Singleton
 public class DiscoveryWPAPIRestClient extends BaseWPAPIRestClient {
     @Inject public DiscoveryWPAPIRestClient(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
@@ -23,9 +23,10 @@ import static org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFi
 
 @Singleton
 public class DiscoveryWPAPIRestClient extends BaseWPAPIRestClient {
-    @Inject public DiscoveryWPAPIRestClient(Dispatcher dispatcher,
-                                    @Named("custom-ssl") RequestQueue requestQueue,
-                                    UserAgent userAgent) {
+    @Inject public DiscoveryWPAPIRestClient(
+            Dispatcher dispatcher,
+            @Named("custom-ssl") RequestQueue requestQueue,
+            UserAgent userAgent) {
         super(dispatcher, requestQueue, userAgent);
     }
 
@@ -61,7 +62,7 @@ public class DiscoveryWPAPIRestClient extends BaseWPAPIRestClient {
             RootWPAPIRestResponse response = future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
             if (!response.getNamespaces().contains("wp/v2")) {
                 AppLog.i(AppLog.T.NUX, "Site does not have the full WP-API available "
-                        + "(missing wp/v2 namespace)");
+                                       + "(missing wp/v2 namespace)");
                 return null;
             } else {
                 AppLog.i(AppLog.T.NUX, "Found valid WP-API endpoint! - " + wpApiBaseUrl);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
@@ -55,8 +55,15 @@ public class DiscoveryWPAPIRestClient extends BaseWPAPIRestClient {
         BaseRequestFuture<RootWPAPIRestResponse> future = BaseRequestFuture.newFuture();
         OnWPAPIErrorListener errorListener = future::onErrorResponse;
 
-        WPAPIGsonRequest request = new WPAPIGsonRequest<>(Request.Method.GET, wpApiBaseUrl, null, null,
-                RootWPAPIRestResponse.class, future, errorListener);
+        WPAPIGsonRequest<RootWPAPIRestResponse> request = new WPAPIGsonRequest<>(
+                Request.Method.GET,
+                wpApiBaseUrl,
+                null,
+                null,
+                RootWPAPIRestResponse.class,
+                future,
+                errorListener
+        );
         add(request);
         try {
             RootWPAPIRestResponse response = future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
@@ -57,7 +57,8 @@ public class DiscoveryWPAPIRestClient extends BaseWPAPIRestClient {
         return null;
     }
 
-    public String verifyWPAPIV2Support(String wpApiBaseUrl) {
+    @Nullable
+    public String verifyWPAPIV2Support(@NonNull String wpApiBaseUrl) {
         BaseRequestFuture<RootWPAPIRestResponse> future = BaseRequestFuture.newFuture();
         OnWPAPIErrorListener errorListener = future::onErrorResponse;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
@@ -30,7 +30,7 @@ public class DiscoveryWPAPIRestClient extends BaseWPAPIRestClient {
         super(dispatcher, requestQueue, userAgent);
     }
 
-    public String discoverWPAPIBaseURL(String url) throws SelfHostedEndpointFinder.DiscoveryException {
+    public String discoverWPAPIBaseURL(String url) {
         BaseRequestFuture<String> future = BaseRequestFuture.newFuture();
         WPAPIHeadRequest request = new WPAPIHeadRequest(url, future, future);
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.OnWPAPIErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest;
 import org.wordpress.android.util.AppLog;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -67,7 +68,8 @@ public class DiscoveryWPAPIRestClient extends BaseWPAPIRestClient {
         add(request);
         try {
             RootWPAPIRestResponse response = future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-            if (!response.getNamespaces().contains("wp/v2")) {
+            List<String> namespaces = response.getNamespaces();
+            if (namespaces != null && !namespaces.contains("wp/v2")) {
                 AppLog.i(AppLog.T.NUX, "Site does not have the full WP-API available "
                                        + "(missing wp/v2 namespace)");
                 return null;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.network.discovery;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 
@@ -32,7 +35,8 @@ public class DiscoveryWPAPIRestClient extends BaseWPAPIRestClient {
         super(dispatcher, requestQueue, userAgent);
     }
 
-    public String discoverWPAPIBaseURL(String url) {
+    @Nullable
+    public String discoverWPAPIBaseURL(@NonNull String url) {
         BaseRequestFuture<String> future = BaseRequestFuture.newFuture();
         WPAPIHeadRequest request = new WPAPIHeadRequest(url, future, future);
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.network.discovery;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.android.volley.AuthFailureError;
 import com.android.volley.NetworkResponse;
 import com.android.volley.NoConnectionError;
@@ -42,7 +45,8 @@ public class DiscoveryXMLRPCClient extends BaseXMLRPCClient {
     /**
      * Obtain the HTML response from a GET request for the given URL.
      */
-    public String getResponse(String url) throws DiscoveryException {
+    @Nullable
+    public String getResponse(@NonNull String url) throws DiscoveryException {
         BaseRequestFuture<String> future = BaseRequestFuture.newFuture();
         DiscoveryRequest request = new DiscoveryRequest(url, future, future);
         add(request);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
@@ -31,10 +31,11 @@ import static org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFi
 
 @Singleton
 public class DiscoveryXMLRPCClient extends BaseXMLRPCClient {
-    @Inject public DiscoveryXMLRPCClient(Dispatcher dispatcher,
-                                 @Named("custom-ssl") RequestQueue requestQueue,
-                                 UserAgent userAgent,
-                                 HTTPAuthManager httpAuthManager) {
+    @Inject public DiscoveryXMLRPCClient(
+            Dispatcher dispatcher,
+            @Named("custom-ssl") RequestQueue requestQueue,
+            UserAgent userAgent,
+            HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);
     }
 
@@ -63,8 +64,8 @@ public class DiscoveryXMLRPCClient extends BaseXMLRPCClient {
                     throw new DiscoveryException(DiscoveryError.XMLRPC_FORBIDDEN, url);
                 }
             } else if (e.getCause() instanceof NoConnectionError
-                    && e.getCause().getCause() instanceof SSLHandshakeException
-                    && e.getCause().getCause().getCause() instanceof CertificateException) {
+                       && e.getCause().getCause() instanceof SSLHandshakeException
+                       && e.getCause().getCause().getCause() instanceof CertificateException) {
                 // In the event of an SSL handshake error we should stop attempting discovery
                 throw new DiscoveryException(DiscoveryError.ERRONEOUS_SSL_CERTIFICATE, url);
             }
@@ -104,8 +105,8 @@ public class DiscoveryXMLRPCClient extends BaseXMLRPCClient {
                     throw new DiscoveryException(DiscoveryError.XMLRPC_FORBIDDEN, url);
                 }
             } else if (e.getCause() instanceof NoConnectionError
-                    && e.getCause().getCause() instanceof SSLHandshakeException
-                    && e.getCause().getCause().getCause() instanceof CertificateException) {
+                       && e.getCause().getCause() instanceof SSLHandshakeException
+                       && e.getCause().getCause().getCause() instanceof CertificateException) {
                 // In the event of an SSL handshake error we should stop attempting discovery
                 throw new DiscoveryException(DiscoveryError.ERRONEOUS_SSL_CERTIFICATE, url);
             } else if (e.getCause() instanceof ServerError) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
@@ -80,7 +80,8 @@ public class DiscoveryXMLRPCClient extends BaseXMLRPCClient {
     /**
      * Peform a system.listMethods call on the given URL.
      */
-    public Object[] listMethods(String url) throws DiscoveryException {
+    @Nullable
+    public Object[] listMethods(@NonNull String url) throws DiscoveryException {
         if (!UrlUtils.isValidUrlAndHostNotNull(url)) {
             AppLog.e(AppLog.T.NUX, "Invalid URL: " + url);
             throw new DiscoveryException(DiscoveryError.INVALID_URL, url);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java
@@ -78,7 +78,7 @@ public class DiscoveryXMLRPCClient extends BaseXMLRPCClient {
     }
 
     /**
-     * Peform a system.listMethods call on the given URL.
+     * Perform a system.listMethods call on the given URL.
      */
     @Nullable
     public Object[] listMethods(@NonNull String url) throws DiscoveryException {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
@@ -13,11 +13,15 @@ import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
  * {@link AuthenticationAction#AUTHENTICATE_ERROR} events.
  */
 public class DiscoveryXMLRPCRequest extends XMLRPCRequest {
-    DiscoveryXMLRPCRequest(@NonNull String url, XMLRPC method, Listener<? super Object[]> listener,
-                           BaseErrorListener errorListener) {
+    DiscoveryXMLRPCRequest(
+            @NonNull String url,
+            @NonNull XMLRPC method,
+            @NonNull Listener<? super Object[]> listener,
+            @NonNull BaseErrorListener errorListener) {
         super(url, method, null, listener, errorListener);
     }
 
+    @NonNull
     @Override
     public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
         // no op

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCRequest.java
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
  * {@link AuthenticationAction#AUTHENTICATE_ERROR} events.
  */
 public class DiscoveryXMLRPCRequest extends XMLRPCRequest {
-    DiscoveryXMLRPCRequest(String url, XMLRPC method, Listener<? super Object[]> listener,
+    DiscoveryXMLRPCRequest(@NonNull String url, XMLRPC method, Listener<? super Object[]> listener,
                            BaseErrorListener errorListener) {
         super(url, method, null, listener, errorListener);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -79,7 +79,7 @@ public class SelfHostedEndpointFinder {
         mDiscoveryWPAPIRestClient = discoveryWPAPIRestClient;
     }
 
-    public void findEndpoint(final String url) {
+    public void findEndpoint(@NonNull final String url) {
         new Thread(() -> {
             try {
                 String wpRestEndpoint = "";
@@ -102,7 +102,8 @@ public class SelfHostedEndpointFinder {
         }).start();
     }
 
-    private String verifyOrDiscoverXMLRPCEndpoint(final String siteUrl) throws DiscoveryException {
+    @Nullable
+    private String verifyOrDiscoverXMLRPCEndpoint(@NonNull final String siteUrl) throws DiscoveryException {
         if (TextUtils.isEmpty(siteUrl)) {
             throw new DiscoveryException(DiscoveryError.INVALID_URL, siteUrl);
         }
@@ -158,6 +159,7 @@ public class SelfHostedEndpointFinder {
         return urlsToTry;
     }
 
+    @Nullable
     private String verifyXMLRPCUrl(@NonNull final String siteUrl) throws DiscoveryException {
         // Ordered set of Strings that contains the URLs we want to try
         final LinkedHashSet<String> urlsToTry = getOrderedVerifyUrlsToTry(siteUrl);
@@ -190,7 +192,8 @@ public class SelfHostedEndpointFinder {
     // Attempts to retrieve the XML-RPC url for a self-hosted site.
     // See diagrams here https://github.com/wordpress-mobile/WordPress-Android/issues/3805 for details about the
     // whole process.
-    private String discoverXMLRPCEndpoint(String siteUrl) throws DiscoveryException {
+    @Nullable
+    private String discoverXMLRPCEndpoint(@NonNull String siteUrl) throws DiscoveryException {
         // Ordered set of Strings that contains the URLs we want to try
         final Set<String> urlsToTry = new LinkedHashSet<>();
 
@@ -357,7 +360,8 @@ public class SelfHostedEndpointFinder {
         return false;
     }
 
-    private String discoverWPRESTEndpoint(String url) throws DiscoveryException {
+    @Nullable
+    private String discoverWPRESTEndpoint(@NonNull String url) throws DiscoveryException {
         if (TextUtils.isEmpty(url)) {
             throw new DiscoveryException(DiscoveryError.INVALID_URL, url);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -27,7 +27,7 @@ public class SelfHostedEndpointFinder {
 
     @NonNull private final Dispatcher mDispatcher;
     @NonNull private final DiscoveryXMLRPCClient mDiscoveryXMLRPCClient;
-    private final DiscoveryWPAPIRestClient mDiscoveryWPAPIRestClient;
+    @NonNull private final DiscoveryWPAPIRestClient mDiscoveryWPAPIRestClient;
 
     public enum DiscoveryError implements OnChangedError {
         INVALID_URL,
@@ -72,7 +72,7 @@ public class SelfHostedEndpointFinder {
     @Inject public SelfHostedEndpointFinder(
             @NonNull Dispatcher dispatcher,
             @NonNull DiscoveryXMLRPCClient discoveryXMLRPCClient,
-            DiscoveryWPAPIRestClient discoveryWPAPIRestClient) {
+            @NonNull DiscoveryWPAPIRestClient discoveryWPAPIRestClient) {
         mDispatcher = dispatcher;
         mDiscoveryXMLRPCClient = discoveryXMLRPCClient;
         mDiscoveryWPAPIRestClient = discoveryWPAPIRestClient;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -293,7 +293,8 @@ public class SelfHostedEndpointFinder {
         return null;
     }
 
-    private String sanitizeSiteUrl(String siteUrl, boolean addHttps) throws DiscoveryException {
+    @NonNull
+    private String sanitizeSiteUrl(@NonNull String siteUrl, boolean addHttps) throws DiscoveryException {
         // Remove padding whitespace
         String url = siteUrl.trim();
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -69,8 +69,9 @@ public class SelfHostedEndpointFinder {
         }
     }
 
-    @Inject public SelfHostedEndpointFinder(Dispatcher dispatcher, DiscoveryXMLRPCClient discoveryXMLRPCClient,
-                                    DiscoveryWPAPIRestClient discoveryWPAPIRestClient) {
+    @Inject public SelfHostedEndpointFinder(
+            Dispatcher dispatcher, DiscoveryXMLRPCClient discoveryXMLRPCClient,
+            DiscoveryWPAPIRestClient discoveryWPAPIRestClient) {
         mDispatcher = dispatcher;
         mDiscoveryXMLRPCClient = discoveryXMLRPCClient;
         mDiscoveryWPAPIRestClient = discoveryWPAPIRestClient;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -61,16 +61,16 @@ public class SelfHostedEndpointFinder {
     }
 
     public static class DiscoveryResultPayload extends Payload<DiscoveryError> {
-        public String xmlRpcEndpoint;
-        public String wpRestEndpoint;
-        public String failedEndpoint;
+        @Nullable public String xmlRpcEndpoint;
+        @Nullable public String wpRestEndpoint;
+        @Nullable public String failedEndpoint;
 
-        public DiscoveryResultPayload(String xmlRpcEndpoint, String wpRestEndpoint) {
+        public DiscoveryResultPayload(@NonNull String xmlRpcEndpoint, @Nullable String wpRestEndpoint) {
             this.xmlRpcEndpoint = xmlRpcEndpoint;
             this.wpRestEndpoint = wpRestEndpoint;
         }
 
-        public DiscoveryResultPayload(DiscoveryError discoveryError, String failedEndpoint) {
+        public DiscoveryResultPayload(@NonNull DiscoveryError discoveryError, @Nullable String failedEndpoint) {
             this.error = discoveryError;
             this.failedEndpoint = failedEndpoint;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -284,6 +284,7 @@ public class SelfHostedEndpointFinder {
     /**
      * Returns RSD URL based on regex match.
      */
+    @Nullable
     private String getRSDMetaTagHrefRegEx(@NonNull String html) {
         Matcher matcher = RSD_LINK.matcher(html);
         if (matcher.find()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -26,7 +26,7 @@ public class SelfHostedEndpointFinder {
     public static final int TIMEOUT_MS = 60000;
 
     @NonNull private final Dispatcher mDispatcher;
-    private final DiscoveryXMLRPCClient mDiscoveryXMLRPCClient;
+    @NonNull private final DiscoveryXMLRPCClient mDiscoveryXMLRPCClient;
     private final DiscoveryWPAPIRestClient mDiscoveryWPAPIRestClient;
 
     public enum DiscoveryError implements OnChangedError {
@@ -70,7 +70,8 @@ public class SelfHostedEndpointFinder {
     }
 
     @Inject public SelfHostedEndpointFinder(
-            @NonNull Dispatcher dispatcher, DiscoveryXMLRPCClient discoveryXMLRPCClient,
+            @NonNull Dispatcher dispatcher,
+            @NonNull DiscoveryXMLRPCClient discoveryXMLRPCClient,
             DiscoveryWPAPIRestClient discoveryWPAPIRestClient) {
         mDispatcher = dispatcher;
         mDiscoveryXMLRPCClient = discoveryXMLRPCClient;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -279,7 +279,7 @@ public class SelfHostedEndpointFinder {
     /**
      * Returns RSD URL based on regex match.
      */
-    private String getRSDMetaTagHrefRegEx(@NonNull String html) throws DiscoveryException {
+    private String getRSDMetaTagHrefRegEx(@NonNull String html) {
         Matcher matcher = RSD_LINK.matcher(html);
         if (matcher.find()) {
             return matcher.group(1);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -108,7 +108,7 @@ public class SelfHostedEndpointFinder {
         }).start();
     }
 
-    @Nullable
+    @NonNull
     private String verifyOrDiscoverXMLRPCEndpoint(@NonNull final String siteUrl) throws DiscoveryException {
         if (TextUtils.isEmpty(siteUrl)) {
             throw new DiscoveryException(DiscoveryError.INVALID_URL, siteUrl);
@@ -199,7 +199,7 @@ public class SelfHostedEndpointFinder {
     // Attempts to retrieve the XML-RPC url for a self-hosted site.
     // See diagrams here https://github.com/wordpress-mobile/WordPress-Android/issues/3805 for details about the
     // whole process.
-    @Nullable
+    @NonNull
     private String discoverXMLRPCEndpoint(@NonNull String siteUrl) throws DiscoveryException {
         // Ordered set of Strings that contains the URLs we want to try
         final Set<String> urlsToTry = new LinkedHashSet<>();
@@ -269,7 +269,7 @@ public class SelfHostedEndpointFinder {
         }
 
         if (URLUtil.isValidUrl(xmlrpcUrl)) {
-            if (checkXMLRPCEndpointValidity(xmlrpcUrl)) {
+            if (xmlrpcUrl != null && checkXMLRPCEndpointValidity(xmlrpcUrl)) {
                 // Endpoint found and works fine.
                 return xmlrpcUrl;
             }
@@ -322,7 +322,7 @@ public class SelfHostedEndpointFinder {
         return url;
     }
 
-    private boolean checkXMLRPCEndpointValidity(String url) throws DiscoveryException {
+    private boolean checkXMLRPCEndpointValidity(@NonNull String url) throws DiscoveryException {
         try {
             Object[] methods = mDiscoveryXMLRPCClient.listMethods(url);
             if (methods == null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -25,7 +25,7 @@ import javax.inject.Inject;
 public class SelfHostedEndpointFinder {
     public static final int TIMEOUT_MS = 60000;
 
-    private final Dispatcher mDispatcher;
+    @NonNull private final Dispatcher mDispatcher;
     private final DiscoveryXMLRPCClient mDiscoveryXMLRPCClient;
     private final DiscoveryWPAPIRestClient mDiscoveryWPAPIRestClient;
 
@@ -70,7 +70,7 @@ public class SelfHostedEndpointFinder {
     }
 
     @Inject public SelfHostedEndpointFinder(
-            Dispatcher dispatcher, DiscoveryXMLRPCClient discoveryXMLRPCClient,
+            @NonNull Dispatcher dispatcher, DiscoveryXMLRPCClient discoveryXMLRPCClient,
             DiscoveryWPAPIRestClient discoveryWPAPIRestClient) {
         mDispatcher = dispatcher;
         mDiscoveryXMLRPCClient = discoveryXMLRPCClient;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -129,7 +129,8 @@ public class SelfHostedEndpointFinder {
         return xmlrpcUrl;
     }
 
-    private LinkedHashSet<String> getOrderedVerifyUrlsToTry(String siteUrl) throws DiscoveryException {
+    @NonNull
+    private LinkedHashSet<String> getOrderedVerifyUrlsToTry(@NonNull String siteUrl) throws DiscoveryException {
         LinkedHashSet<String> urlsToTry = new LinkedHashSet<>();
         final String sanitizedSiteUrlHttps = sanitizeSiteUrl(siteUrl, true);
         final String sanitizedSiteUrlHttp = sanitizeSiteUrl(siteUrl, false);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -78,27 +78,24 @@ public class SelfHostedEndpointFinder {
     }
 
     public void findEndpoint(final String url) {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    String wpRestEndpoint = "";
-                    if (BuildConfig.ENABLE_WPAPI) {
-                        wpRestEndpoint = discoverWPRESTEndpoint(url);
-                    }
-                    // TODO: Eventually make the XML-RPC discovery only run if WP-API discovery fails
-                    String xmlRpcEndpoint = verifyOrDiscoverXMLRPCEndpoint(url);
-                    DiscoveryResultPayload payload = new DiscoveryResultPayload(xmlRpcEndpoint, wpRestEndpoint);
-                    mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoveryResultAction(payload));
-                } catch (DiscoveryException e) {
-                    // TODO: Handle tracking of XMLRPCDiscoveryException
-                    // If a DiscoveryException is caught this high up, it means that either:
-                    // 1. The discovery process has completed, and did not turn up a valid WordPress.com site
-                    // 2. Discovery was halted early because the given site requires SSL validation, or HTTP AUTH login,
-                    // or is a WordPress.com site, or is a completely invalid URL
-                    DiscoveryResultPayload payload = new DiscoveryResultPayload(e.discoveryError, e.failedUrl);
-                    mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoveryResultAction(payload));
+        new Thread(() -> {
+            try {
+                String wpRestEndpoint = "";
+                if (BuildConfig.ENABLE_WPAPI) {
+                    wpRestEndpoint = discoverWPRESTEndpoint(url);
                 }
+                // TODO: Eventually make the XML-RPC discovery only run if WP-API discovery fails
+                String xmlRpcEndpoint = verifyOrDiscoverXMLRPCEndpoint(url);
+                DiscoveryResultPayload payload = new DiscoveryResultPayload(xmlRpcEndpoint, wpRestEndpoint);
+                mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoveryResultAction(payload));
+            } catch (DiscoveryException e) {
+                // TODO: Handle tracking of XMLRPCDiscoveryException
+                // If a DiscoveryException is caught this high up, it means that either:
+                // 1. The discovery process has completed, and did not turn up a valid WordPress.com site
+                // 2. Discovery was halted early because the given site requires SSL validation, or HTTP AUTH login,
+                // or is a WordPress.com site, or is a completely invalid URL
+                DiscoveryResultPayload payload = new DiscoveryResultPayload(e.discoveryError, e.failedUrl);
+                mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoveryResultAction(payload));
             }
         }).start();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -25,6 +25,12 @@ import javax.inject.Inject;
 
 public class SelfHostedEndpointFinder {
     public static final int TIMEOUT_MS = 60000;
+    /**
+     * Regex pattern for matching the RSD link found in most WordPress sites.
+     */
+    private static final Pattern RSD_LINK = Pattern.compile(
+            "<link\\s*?rel=\"EditURI\"\\s*?type=\"application/rsd\\+xml\"\\s*?title=\"RSD\"\\s*?href=\"(.*?)\"",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     @NonNull private final Dispatcher mDispatcher;
     @NonNull private final DiscoveryXMLRPCClient mDiscoveryXMLRPCClient;
@@ -274,13 +280,6 @@ public class SelfHostedEndpointFinder {
             throw new DiscoveryException(DiscoveryError.MISSING_XMLRPC_METHOD, xmlrpcUrl);
         }
     }
-
-    /**
-     * Regex pattern for matching the RSD link found in most WordPress sites.
-     */
-    private static final Pattern RSD_LINK = Pattern.compile(
-            "<link\\s*?rel=\"EditURI\"\\s*?type=\"application/rsd\\+xml\"\\s*?title=\"RSD\"\\s*?href=\"(.*?)\"",
-            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     /**
      * Returns RSD URL based on regex match.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/SelfHostedEndpointFinder.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.wordpress.android.fluxc.BuildConfig;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -44,10 +45,10 @@ public class SelfHostedEndpointFinder {
     public static class DiscoveryException extends Exception {
         private static final long serialVersionUID = -300904137122546854L;
 
-        public final DiscoveryError discoveryError;
-        public final String failedUrl;
+        @NonNull public final DiscoveryError discoveryError;
+        @Nullable public final String failedUrl;
 
-        DiscoveryException(DiscoveryError failureType, String failedUrl) {
+        DiscoveryException(@NonNull DiscoveryError failureType, @Nullable String failedUrl) {
             this.discoveryError = failureType;
             this.failedUrl = failedUrl;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/WPAPIHeadRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/WPAPIHeadRequest.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.android.volley.NetworkResponse;
+import com.android.volley.ParseError;
 import com.android.volley.Response;
 import com.android.volley.Response.Listener;
 import com.android.volley.toolbox.HttpHeaderParser;
@@ -11,6 +12,7 @@ import com.android.volley.toolbox.HttpHeaderParser;
 import org.wordpress.android.fluxc.network.BaseRequest;
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError;
 
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,8 +38,13 @@ public class WPAPIHeadRequest extends BaseRequest<String> {
     @NonNull
     @Override
     protected Response<String> parseNetworkResponse(@NonNull NetworkResponse response) {
-        mResponseLinkHeader = response.headers.get("Link");
-        return Response.success("", HttpHeaderParser.parseCacheHeaders(response));
+        Map<String, String> headers = response.headers;
+        if (headers != null) {
+            mResponseLinkHeader = headers.get("Link");
+            return Response.success("", HttpHeaderParser.parseCacheHeaders(response));
+        } else {
+            return Response.error(new ParseError(new Exception("No headers in response")));
+        }
     }
 
     @NonNull

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/WPAPIHeadRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/WPAPIHeadRequest.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.discovery;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.volley.NetworkResponse;
 import com.android.volley.Response;
@@ -16,32 +17,38 @@ import java.util.regex.Pattern;
 public class WPAPIHeadRequest extends BaseRequest<String> {
     private static final Pattern LINK_PATTERN = Pattern.compile("^<(.*)>; rel=\"https://api.w.org/\"$");
 
-    private final Listener<String> mListener;
-    private String mResponseLinkHeader;
+    @NonNull private final Listener<String> mListener;
+    @Nullable private String mResponseLinkHeader;
 
-    public WPAPIHeadRequest(String url, Listener<String> listener, BaseErrorListener errorListener) {
+    public WPAPIHeadRequest(
+            @NonNull String url,
+            @NonNull Listener<String> listener,
+            @NonNull BaseErrorListener errorListener) {
         super(Method.HEAD, url, errorListener);
         mListener = listener;
     }
 
     @Override
-    protected void deliverResponse(String response) {
+    protected void deliverResponse(@NonNull String response) {
         mListener.onResponse(extractEndpointFromLinkHeader(mResponseLinkHeader));
     }
 
+    @NonNull
     @Override
-    protected Response<String> parseNetworkResponse(NetworkResponse response) {
+    protected Response<String> parseNetworkResponse(@NonNull NetworkResponse response) {
         mResponseLinkHeader = response.headers.get("Link");
         return Response.success("", HttpHeaderParser.parseCacheHeaders(response));
     }
 
+    @NonNull
     @Override
     public BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error) {
         // no op
         return new WPAPINetworkError(error, null);
     }
 
-    private static String extractEndpointFromLinkHeader(String linkHeader) {
+    @Nullable
+    private static String extractEndpointFromLinkHeader(@Nullable String linkHeader) {
         if (linkHeader != null) {
             Matcher matcher = LINK_PATTERN.matcher(linkHeader);
             if (matcher.find()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -48,7 +48,7 @@ public class XMLRPCRequest extends BaseRequest<Object> {
         AUTH_REQUIRED
     }
 
-    public XMLRPCRequest(String url, XMLRPC method, List<Object> params, Listener<? super Object[]> listener,
+    public XMLRPCRequest(@NonNull String url, XMLRPC method, List<Object> params, Listener<? super Object[]> listener,
                          BaseErrorListener errorListener) {
         super(Method.POST, url, errorListener);
         mListener = listener;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -1011,7 +1011,7 @@ public class AccountStore extends Store {
         emitChange(event);
     }
 
-    private void discoverEndPoint(String payload) {
+    private void discoverEndPoint(@NonNull String payload) {
         mSelfHostedEndpointFinder.findEndpoint(payload);
     }
 


### PR DESCRIPTION
Parent #2798

This PR adds any missing nullability annotation to [DiscoveryWPAPIRestClient.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/3caf1058bd9384da8a134cee9855c92e31e7ff5f/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryWPAPIRestClient.java#L4) and [DiscoveryXMLRPCClient.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/3caf1058bd9384da8a134cee9855c92e31e7ff5f/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/DiscoveryXMLRPCClient.java#L4), all its related response classes and anything in between (ie. `AccountStore`, `SiteWPAPIRestClient`).

FYI.1: This change is `safe`, meaning that there shouldn't be any (major) compile-time changes associated with this change. Having said that, testing is highly recommended since the changes in this PR can affect one or more clients (ie. [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), [WCAndroid](https://github.com/woocommerce/woocommerce-android), etc)

FYI.2: An analysis on `AccountStore`, `SiteWPAPIRestClient` and their usages with our main clients suggests that this store is being utilizing by both, the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and [WCAndroid](https://github.com/woocommerce/woocommerce-android) clients.

-----

PS.1: @hichamboushaba I added you as the main reviewer, randomly so, since I just wanted someone from the WooCommerce mobile team to be aware of and sign-off on that change for both. Feel free to merge this PR directly yourself if you deem so.

PS.2: @irfano I am also adding you as an extra reviewer, randomly so, since I want someone from the Jetpack/WordPress mobile team to be aware of this change as well. However, there is no need for you to review it as well, thus duplicating the review work. Having one team member from either of the mobile teams reviewing and testing this change is enough for this change.

-----

Nullability Annotation List:

1. [Add missing n-a to discover base url on discovery rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/2124dcf3c05a2f8da73f68f2ace65ec7686ea051)
2. [Add missing n-a to verify support on discovery rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/609c00f0ab263a1267b65610f0af9c017827a3ea)
3. [Add missing n-a to get response on discovery xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/7b8794992e80e2da4229e5bb9882e252ffbdedb9)
4. [Add missing n-a to list methods on discovery xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/15b8b431b8503f0e29f32e114cc2be7b6c3eb21d)
5. [Add missing nn-a to dispatcher field on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/d269f056ad6bba4aa234e13d8ca889ab58c003df)
6. [Add missing nn-a to xmlrpc client field on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/aa25c2b53579b4cb53f6318b85934eefb6e5f36c)
7. [Add missing nn-a to rest client field on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/947d25d3128b83538b30a4657dccb7008e45bab3)
8. [Add missing n-a to discovery exception on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/ec03e8b2c314090188d3f2a7114770b8bc1d73a2)
9. [Add missing n-a to find endpoint on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/9d2374eef746f637bb1e0103eb90c4395db58cbc)
10. [Add missing n-a to ordered verify urls to try on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/258c459f662458592f7b5c272a9c832c25269783)
11. [Add missing n-a to rsd metal tag href regex on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/ae9d0aceb9bc979c435d044904b9edf6045cfe29)
12. [Add missing n-a to sanitize site url on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/441205da6cb21efd2ee9f125f15a141b8556deb5)
13. [Add missing n-a to check xmlrpc ep validity on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/a4880a202aabcf71be6d56a18b874797d14b15e5)
14. [Add missing n-a to discovery result payload on sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/304dda36c3f6dbf7d7bf43657f77a9e089ceb229)
15. [Add missing n-a to strip known paths on discovery utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/f055d801bd08f9a256f51c4a00f726b53231cbb8)
16. [Add missing n-a to validate lm response on discovery utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/3534b59a99121bab0dc9282a8a5212e92da22541)
17. [Add missing n-a to is http auth em on discovery utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/a318e36083c39b81348e5c101e36696ef4219757)
18. [Add missing n-a to get xmlrpc api link on discovery utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/3ffcd6361c8cf87f02a7c954c10827b040f43d0e)
19. [Add missing n-a to get xmlrpc pingback on discovery utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/a5f001745d142b7e15fa4e9e222a3f5e1a05c254)
20. [Add missing n-a on discovery xmlrpc request](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/d966a54792acc3797456cfdb540fd5943fed2f78)
21. [Add missing n-a on discovery request](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/eef4c1080aaaf3bbe8e5e0dacaf2e75cde1478f4)
22. [Add missing n-a on wp api head request](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/1b547e52a11cfd5b70cb227d79f75dcac377fd74)

Nullability Checks List:

1. [Guard usages of response namespaces on discovery rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/ded97e474af743fe94bd71e35eaea79b6ffeb7df)
2. [Guard usages of response headers on wp api head request](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/2637e6a0d6ef9ef89831cec123e262f0dc7cfc68)

Warnings Resolutions List:

1. [Remove discovery exception from discover base url throws list](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/6433ad2fb054d43694e1da39d7213f4a0cdd9748)
2. [Change type of request to root wp api rest response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/a1d7fb577337764751c277ea8c3a09de31c72d28)
3. [Remove discovery exception from rsd url based throws list](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/3121ba97e84ce52c99e9dae1a4eec1cf25d25eed)

Warnings Suppression List:

1. [Suppress commented out code on discovery rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/331faf79a36f8dc1caa4ab98a9d17cba771e07af)

Refactor List:

1. [Reformat discovery wp api rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/44462cadf416113029ff6562a94e18cbde3191c6)
2. [Reformat discovery xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/bf88d6c9a3061c2cf991af4c8c0710d5dea9d6c4)
3. [Reformat self hosted endpoint finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/f76c5fa566de2f28e9fbd96241199acbd7b003c1)
4. [Replace anonymous classes with lambda](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/7612739229e6cdbd97f23cae57268ac895a41c91)
5. [Move static rsd link field to top of sh ep finder](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/e7b3709e8bc8090637d9cadb6cd836b591e983c6)

Docs List:

1. [Fix typo with perform on discovery xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/859cca25d5844ae8b870dd9efb8724c4105378eb)
2. [Fix typo with perform on discovery utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2872/commits/97370bd7fab48613e7ac01fe1aa564e955c91449)

-----

## Associated Clients

It is highly recommending that this change is being tested on the below associated clients:

- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android)
- [WCAndroid](https://github.com/woocommerce/woocommerce-android)

-----

## To Test (`REST`):

- Smoke test the `FluxC Example` app via the `SIGN IN & FETCH SITES`, `SIGH OUT` & `SIGNED OUT ACTIONS` screens. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any login/out and fetch site related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected.
- Furthermore, using [local-builds.gradle](https://github.com/woocommerce/woocommerce-android/blob/trunk/local-builds.gradle-example) on [WCAndroid](https://github.com/woocommerce/woocommerce-android), smoke test any login/out and fetch site related functionality and see if everything is working as expected.

## To Test (`XMLRPC`):

- Create a new self-hosted WordPress site for XMLRPC testing purposes ([jurassic.ninja](https://jurassic.ninja/)).
- Smoke test the `FluxC Example` app via the `SIGN IN & FETCH SITES`, `SIGH OUT` & `SIGNED OUT ACTIONS` screens. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any login/out and fetch site related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected.
- Furthermore, using [local-builds.gradle](https://github.com/woocommerce/woocommerce-android/blob/trunk/local-builds.gradle-example) on [WCAndroid](https://github.com/woocommerce/woocommerce-android), smoke test any login/out and fetch site related functionality and see if everything is working as expected.