### PR TITLE
Update SiteModel: Add column isSingleUserSite 

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CheckStyle-IDEA" serialisationVersion="2">
-    <checkstyleVersion>8.2</checkstyleVersion>
-    <scanScope>AllSourcesWithTests</scanScope>
-    <option name="thirdPartyClasspath" />
-    <option name="activeLocationIds">
-      <option value="468a932a-c2aa-4b19-888b-8b818dcce6c6" />
-    </option>
-    <option name="locations">
-      <list>
-        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
-        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
-        <ConfigurationLocation id="468a932a-c2aa-4b19-888b-8b818dcce6c6" type="LOCAL_FILE" scope="All" description="a8c Style">$PROJECT_DIR$/config/checkstyle.xml</ConfigurationLocation>
-      </list>
+  <component name="CheckStyle-IDEA">
+    <option name="configuration">
+      <map>
+        <entry key="active-configuration" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="checkstyle-version" value="8.2" />
+        <entry key="copy-libs" value="false" />
+        <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
+        <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
+        <entry key="location-2" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="scan-before-checkin" value="false" />
+        <entry key="scanscope" value="AllSourcesWithTests" />
+        <entry key="suppress-errors" value="false" />
+      </map>
     </option>
   </component>
 </project>

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CheckStyle-IDEA">
-    <option name="configuration">
-      <map>
-        <entry key="active-configuration" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
-        <entry key="checkstyle-version" value="8.2" />
-        <entry key="copy-libs" value="false" />
-        <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
-        <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="LOCAL_FILE:$PROJECT_DIR$/config/checkstyle.xml:a8c Style" />
-        <entry key="scan-before-checkin" value="false" />
-        <entry key="scanscope" value="AllSourcesWithTests" />
-        <entry key="suppress-errors" value="false" />
-      </map>
+  <component name="CheckStyle-IDEA" serialisationVersion="2">
+    <checkstyleVersion>8.2</checkstyleVersion>
+    <scanScope>AllSourcesWithTests</scanScope>
+    <option name="thirdPartyClasspath" />
+    <option name="activeLocationIds">
+      <option value="468a932a-c2aa-4b19-888b-8b818dcce6c6" />
+    </option>
+    <option name="locations">
+      <list>
+        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="468a932a-c2aa-4b19-888b-8b818dcce6c6" type="LOCAL_FILE" scope="All" description="a8c Style">$PROJECT_DIR$/config/checkstyle.xml</ConfigurationLocation>
+      </list>
     </option>
   </component>
 </project>

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -93,7 +93,7 @@ class SiteRestClientTest {
                 mapOf(
                         "fields" to "ID,URL,name,description,jetpack,jetpack_connection," +
                                 "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
-                                "organization_id,was_ecommerce_trial"
+                                "organization_id,was_ecommerce_trial,single_user_site"
                 )
         )
     }
@@ -145,7 +145,7 @@ class SiteRestClientTest {
                         "filters" to "wpcom",
                         "fields" to "ID,URL,name,description,jetpack,jetpack_connection," +
                                 "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
-                                "organization_id,was_ecommerce_trial"
+                                "organization_id,was_ecommerce_trial,single_user_site"
                 )
         )
     }
@@ -174,7 +174,7 @@ class SiteRestClientTest {
             mapOf(
                 "fields" to "ID,URL,name,description,jetpack,jetpack_connection," +
                     "visible,is_private,options,plan,capabilities,quota,icon,meta,zendesk_site_meta," +
-                    "organization_id,was_ecommerce_trial"
+                    "organization_id,was_ecommerce_trial,single_user_site"
             )
         )
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1114,11 +1114,11 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         this.mPlanActiveFeatures = planActiveFeatures;
     }
 
-    public boolean isSingleUserSite() {
+    public Boolean isSingleUserSite() {
         return mIsSingleUserSite;
     }
 
-    public void setIsSingleUserSite(boolean isSingleUserSite) {
+    public void setIsSingleUserSite(Boolean isSingleUserSite) {
         mIsSingleUserSite = isSingleUserSite;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -258,6 +258,8 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     private String mPlanActiveFeatures;
     @Column
     private Boolean mWasEcommerceTrial;
+    @Column
+    private Boolean mIsSingleUserSite;
 
     @Override
     public int getId() {
@@ -1110,5 +1112,13 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public void setPlanActiveFeatures(final String planActiveFeatures) {
         this.mPlanActiveFeatures = planActiveFeatures;
+    }
+
+    public boolean isSingleUserSite() {
+        return mIsSingleUserSite;
+    }
+
+    public void setIsSingleUserSite(boolean isSingleUserSite) {
+        mIsSingleUserSite = isSingleUserSite;
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1203,7 +1203,6 @@ class SiteRestClient @Inject constructor(
         site.origin = SiteModel.ORIGIN_WPCOM_REST
         site.planActiveFeatures = (from.plan?.features?.active?.joinToString(",")).orEmpty()
         site.wasEcommerceTrial = from.was_ecommerce_trial
-        site.setIsSingleUserSite(from.single_user_site)
         return site
     }
 
@@ -1266,7 +1265,7 @@ class SiteRestClient @Inject constructor(
         private const val NEW_SITE_TIMEOUT_MS = 90000
         private const val SITE_FIELDS = "ID,URL,name,description,jetpack,jetpack_connection,visible,is_private," +
                 "options,plan,capabilities,quota,icon,meta,zendesk_site_meta,organization_id," +
-                "was_ecommerce_trial, single_user_site"
+                "was_ecommerce_trial"
         private const val FIELDS = "fields"
         private const val FILTERS = "filters"
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1203,6 +1203,7 @@ class SiteRestClient @Inject constructor(
         site.origin = SiteModel.ORIGIN_WPCOM_REST
         site.planActiveFeatures = (from.plan?.features?.active?.joinToString(",")).orEmpty()
         site.wasEcommerceTrial = from.was_ecommerce_trial
+        site.setIsSingleUserSite(from.single_user_site)
         return site
     }
 
@@ -1265,7 +1266,7 @@ class SiteRestClient @Inject constructor(
         private const val NEW_SITE_TIMEOUT_MS = 90000
         private const val SITE_FIELDS = "ID,URL,name,description,jetpack,jetpack_connection,visible,is_private," +
                 "options,plan,capabilities,quota,icon,meta,zendesk_site_meta,organization_id," +
-                "was_ecommerce_trial"
+                "was_ecommerce_trial,single_user_site"
         private const val FIELDS = "fields"
         private const val FILTERS = "filters"
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1203,6 +1203,7 @@ class SiteRestClient @Inject constructor(
         site.origin = SiteModel.ORIGIN_WPCOM_REST
         site.planActiveFeatures = (from.plan?.features?.active?.joinToString(",")).orEmpty()
         site.wasEcommerceTrial = from.was_ecommerce_trial
+        site.setIsSingleUserSite(from.single_user_site)
         return site
     }
 
@@ -1265,7 +1266,7 @@ class SiteRestClient @Inject constructor(
         private const val NEW_SITE_TIMEOUT_MS = 90000
         private const val SITE_FIELDS = "ID,URL,name,description,jetpack,jetpack_connection,visible,is_private," +
                 "options,plan,capabilities,quota,icon,meta,zendesk_site_meta,organization_id," +
-                "was_ecommerce_trial"
+                "was_ecommerce_trial, single_user_site"
         private const val FIELDS = "fields"
         private const val FILTERS = "filters"
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -125,4 +125,5 @@ public class SiteWPComRestResponse implements Response {
     public Quota quota;
     public ZendeskSiteMeta zendesk_site_meta;
     public boolean was_ecommerce_trial;
+    public boolean single_user_site;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -41,7 +41,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 196
+        return 197
     }
 
     override fun getDbName(): String {
@@ -1989,6 +1989,9 @@ open class WellSqlConfig : DefaultWellConfig {
                             "RANGE_ID TEXT NOT NULL," +
                             "_id INTEGER PRIMARY KEY AUTOINCREMENT)"
                     )
+                }
+                196 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD IS_SINGLE_USER_SITE BOOLEAN")
                 }
             }
         }


### PR DESCRIPTION
This PR adds a new column to SiteModel called `isSingleUserSite` which represents `(bool) Whether the site is single user. Only returned for [WP.com](http://wp.com/) sites and for Jetpack sites with version 3.4 or higher` (taken from rest api endpoint).

See WP Companion https://github.com/wordpress-mobile/WordPress-Android/pull/19404 for testing instructions.

**Updates include:**
- New column in SiteModel
- Update db version
- Add migration alter SQL statement
- Update site_fields to request the `single_user_site` in the fetch sites API request