### PR TITLE
Configuration key

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
@@ -19,3 +19,7 @@ class WCBundledProduct(
     @SerializedName("quantity_default") val quantityDefault: Long?,
     @SerializedName("optional") val isOptional: Boolean
 )
+
+fun WCBundledProduct.isConfigurable(): Boolean {
+    return (quantityMin != quantityMax) || (quantityMin == null) || isOptional
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
@@ -17,9 +17,13 @@ data class WCMetaData(
         const val DISPLAY_VALUE = "display_value"
         val SUPPORTED_KEYS: Set<String> = buildSet {
             add(SubscriptionMetadataKeys.SUBSCRIPTION_RENEWAL)
+            add(BundleMetadataKeys.BUNDLED_ITEM_ID)
         }
     }
     object SubscriptionMetadataKeys {
         const val SUBSCRIPTION_RENEWAL = "_subscription_renewal"
+    }
+    object BundleMetadataKeys {
+        const val BUNDLED_ITEM_ID = "_bundled_item_id"
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.WCProductModel.AddOnsMetadataKeys.ADDONS_METADATA_KEY
 import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
 import org.wordpress.android.fluxc.model.addons.RemoteAddonDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
 import org.wordpress.android.fluxc.network.utils.getBoolean
 import org.wordpress.android.fluxc.network.utils.getLong
 import org.wordpress.android.fluxc.network.utils.getString
@@ -124,7 +125,17 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             ?.any { it.key == OtherKeys.HEAD_START_POST && it.value == "_hs_extra" }
             ?: false
 
-    @Suppress("SwallowedException", "TooGenericExceptionCaught") private val WCMetaData.addons
+    val isConfigurable: Boolean
+        get() = when (type) {
+            CoreProductType.BUNDLE.value -> {
+                Gson().fromJson(bundledItems, Array<WCBundledProduct>::class.java)
+                    ?.any { it.isConfigurable() } ?: false
+            }
+            else -> false
+        }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    private val WCMetaData.addons
         get() =
             try {
                 Gson().run {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -38,4 +38,17 @@ data class LineItem(
             Attribute(it.displayKey, it.displayValue as String)
         } ?: emptyList()
     }
+
+    fun getConfigurationKey(): Long? {
+        return when {
+            bundledBy.isNullOrBlank().not() -> {
+                (metaData?.first { meta ->
+                    meta.key == WCMetaData.BundleMetadataKeys.BUNDLED_ITEM_ID
+                }?.value.toString())
+                    .toLongOrNull()
+            }
+
+            else -> null
+        }
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -39,16 +39,10 @@ data class LineItem(
         } ?: emptyList()
     }
 
-    fun getConfigurationKey(): Long? {
-        return when {
-            bundledBy.isNullOrBlank().not() -> {
-                (metaData?.first { meta ->
-                    meta.key == WCMetaData.BundleMetadataKeys.BUNDLED_ITEM_ID
-                }?.value.toString())
-                    .toLongOrNull()
-            }
-
-            else -> null
-        }
+    val configurationKey
+        get() = bundledBy.takeIf { it.isNullOrBlank().not() }
+            ?.let { metaData }
+            ?.find { it.key == WCMetaData.BundleMetadataKeys.BUNDLED_ITEM_ID }
+            ?.value.toString().toLongOrNull()
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/order/LineItem.kt
@@ -44,5 +44,4 @@ data class LineItem(
             ?.let { metaData }
             ?.find { it.key == WCMetaData.BundleMetadataKeys.BUNDLED_ITEM_ID }
             ?.value.toString().toLongOrNull()
-    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import com.google.gson.Gson
 import org.wordpress.android.fluxc.model.OrderEntity
+import org.wordpress.android.fluxc.model.WCMetaData
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.RECEIPT_URL_KEY
@@ -15,7 +16,7 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                 lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItem ->
                     lineItemDto.copy(
                         metaData = lineItemDto.metaData
-                            ?.filter { it.isDisplayableAttribute }
+                            ?.filter { it.isDisplayableAttribute || it.key in WCMetaData.SUPPORTED_KEYS }
                     )
                 }),
                 shippingLines = gson.toJson(fatModel.getShippingLineList()),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/JsonElementToFloatSerializerDeserializer.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/JsonElementToFloatSerializerDeserializer.kt
@@ -1,0 +1,34 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import java.lang.Exception
+import java.lang.reflect.Type
+
+class JsonElementToFloatSerializerDeserializer : JsonSerializer<Float?>, JsonDeserializer<Float?> {
+    override fun serialize(
+        src: Float?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?
+    ): JsonElement {
+        return src?.let { JsonPrimitive(it) } ?: JsonNull.INSTANCE
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): Float? {
+        return try {
+            json?.asFloat
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToFloatSerializerDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToFloatSerializerDeserializerTest.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.Gson
+import com.google.gson.JsonPrimitive
+import com.google.gson.annotations.JsonAdapter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class JsonElementToFloatSerializerDeserializerTest {
+    private val sut = JsonElementToFloatSerializerDeserializer()
+
+    @Test
+    fun `when value is true then null value is returned`() {
+        val jsonElement = JsonPrimitive(true)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is a valid string number then the value is returned`() {
+        val value = 12345f
+        val valueString = value.toString()
+        val jsonElement = JsonPrimitive(valueString)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isEqualTo(value)
+    }
+
+    @Test
+    fun `when value is an invalid string number then null is returned`() {
+        val jsonElement = JsonPrimitive("12345_test")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is different number format then the value is parsed to long and returned`() {
+        val value = 12345f
+        val valueLong = value.toLong()
+        val jsonElement = JsonPrimitive(valueLong)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isEqualTo(value)
+    }
+
+    @Test
+    fun `test serialization deserialization`() {
+        val gson = Gson()
+        val value = 12345f
+        val json = gson.toJson(TestData(value))
+        val deserialized = gson.fromJson(json, TestData::class.java)
+        assertThat(deserialized.value).isEqualTo(value)
+    }
+
+    data class TestData(
+        @JsonAdapter(JsonElementToFloatSerializerDeserializer::class)
+        val value: Float
+    )
+}


### PR DESCRIPTION
### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow.

### Description
This PR updates the allowed line item metadata to cache the bundle item ID. It also adds the getConfigurationKey function to retrieve the lineItem configuration key (bundle item ID in the case of bundle products)

### Testing
It is better to test these changes in the Woo PR https://github.com/woocommerce/woocommerce-android/pull/9984