### PR TITLE
[ WC Manual Taxes] Add customerId to OrderEntity

### DIFF
--- a/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
+++ b/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
@@ -244,6 +244,14 @@ class MigrationTests {
         }
     }
 
+    @Test
+    fun testMigration28to29() {
+        helper.apply {
+            createDatabase(TEST_DB, 28).close()
+            runMigrationsAndValidate(TEST_DB, 29, false)
+        }
+    }
+
     companion object {
         private const val TEST_DB = "migration-test"
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderEntity.kt
@@ -42,6 +42,8 @@ data class OrderEntity(
     val discountTotal: String = "",
     val discountCodes: String = "",
     val refundTotal: BigDecimal = BigDecimal.ZERO, // The total refund value for this order (usually a negative number)
+    @ColumnInfo(name = "customerId", defaultValue = "0")
+    val customerId: Long = 0,
     val billingFirstName: String = "",
     val billingLastName: String = "",
     val billingCompany: String = "",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDto.kt
@@ -39,6 +39,7 @@ class OrderDto : Response {
         val total: String? = null
     }
 
+    val customer_id: Long? = null
     val billing: Billing? = null
     val coupon_lines: List<CouponLine>? = null
     val currency: String? = null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapper.kt
@@ -49,6 +49,7 @@ class OrderDtoMapper @Inject internal constructor(
                         // store their sum as a 'Double'.
                         refunds.sumOf { it.total?.toBigDecimalOrNull() ?: BigDecimal.ZERO }
                     } ?: BigDecimal.ZERO,
+                    customerId = this.customer_id ?: 0,
                     billingFirstName = this.billing?.first_name ?: "",
                     billingLastName = this.billing?.last_name ?: "",
                     billingCompany = this.billing?.company ?: "",

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -57,7 +57,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_8_9
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
 
 @Database(
-    version = 28,
+    version = 29,
     entities = [
         AddonEntity::class,
         AddonOptionEntity::class,
@@ -84,6 +84,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
         AutoMigration(from = 23, to = 24, spec = AutoMigration23to24::class),
         AutoMigration(from = 25, to = 26),
         AutoMigration(from = 26, to = 27),
+        AutoMigration(from = 28, to = 29),
     ]
 )
 @TypeConverters(


### PR DESCRIPTION
This PR is part of the effort to fix the behaviour when we try to delete a customer from an order.

Right now we can’t remove customer details from the order in case there are one or more products added.

Context:
p1694438541127429-slack-C025A8VV728
https://github.com/woocommerce/woocommerce-android/pull/9518#issuecomment-1663878435

Further investigation and discussion:

p1697561882534789-slack-CGPNUU63E

This PR does not affect WC at this point. 