### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to `Media` Network Client Classes (`safe`)

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -293,7 +293,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
             // Wait a bit and issue the cancel command
             TestUtils.waitFor(300)
 
-            // We'e only cancelling the first n=howManyFirstToCancel uploads
+            // We're only cancelling the first n=howManyFirstToCancel uploads
             for (i in 0 until howManyFirstToCancel) {
                 val media = mediaList[i]
                 val payload = CancelMediaPayload(testSite, media, delete)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.properties.Delegates.notNull
 
+@Suppress("ClassNaming")
 @SuppressLint("UseSparseArrays")
 class MockedStack_MediaTest : MockedStack_Base() {
     @Inject lateinit var dispatcher: Dispatcher

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -67,7 +67,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
         interceptor.respondWithSticky("media-upload-response-success.json")
 
         // First, try canceling an image with the default behavior (canceled image is deleted from the store)
-        newMediaModel("Test Title", sampleImagePath, "image/jpeg").let { testMedia ->
+        newMediaModel("Test Title", sampleImagePath).let { testMedia ->
             countDownLatch = CountDownLatch(1)
             nextEvent = TestEvents.CANCELED_MEDIA
             val payload = UploadMediaPayload(testSite, testMedia, true)
@@ -83,7 +83,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
         }
 
         // Now, try canceling with delete=false (canceled image should be marked as failed and kept in the store)
-        newMediaModel("Test Title", sampleImagePath, "image/jpeg").let { testMedia ->
+        newMediaModel("Test Title", sampleImagePath).let { testMedia ->
             countDownLatch = CountDownLatch(1)
             nextEvent = TestEvents.CANCELED_MEDIA
             val payload = UploadMediaPayload(testSite, testMedia, true)
@@ -245,11 +245,11 @@ class MockedStack_MediaTest : MockedStack_Base() {
     }
 
     private fun addMediaModelToUploadArray(title: String) {
-        val mediaModel = newMediaModel(title, sampleImagePath, "image/jpeg")
+        val mediaModel = newMediaModel(title, sampleImagePath)
         uploadedMediaModels[mediaModel.id] = mediaModel
     }
 
-    private fun newMediaModel(testTitle: String, mediaPath: String, mimeType: String): MediaModel {
+    private fun newMediaModel(testTitle: String, mediaPath: String): MediaModel {
         val testDescription = "Test Description"
         val testCaption = "Test Caption"
         val testAlt = "Test Alt"
@@ -257,7 +257,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
         return mediaStore.instantiateMediaModel().apply {
             filePath = mediaPath
             fileExtension = mediaPath.substring(mediaPath.lastIndexOf(".") + 1)
-            this.mimeType = mimeType
+            this.mimeType = "image/jpeg"
             fileName = mediaPath.substring(mediaPath.lastIndexOf("/"))
             title = testTitle
             description = testDescription

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -206,7 +206,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
         Assert.assertEquals(amountToCancel, mediaStore.getSiteMediaWithState(testSite, MediaUploadState.FAILED).size)
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "ThrowsCount")
     @Subscribe
     fun onMediaUploaded(event: OnMediaUploaded) {
         if (event.isError) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -279,7 +279,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
             // To imitate a real set of media upload requests as much as possible, each one should return a unique
             // remote media id. This also makes sure the MediaModel table doesn't treat these as duplicate entries and
             // deletes them, failing the test.
-            defaultId: String -> defaultId.replace("9999", remoteIdQueue.poll().toString())
+            defaultId: String -> defaultId.replace("9999", remoteIdQueue.poll()?.toString() ?: "")
         }
 
         countDownLatch = CountDownLatch(mediaList.size)

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
@@ -97,9 +97,9 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
 
         MediaModel testMedia = mMediaStore.instantiateMediaModel();
         testMedia.setFilePath(mediaPath);
-        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1, mediaPath.length()));
+        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
         testMedia.setMimeType("image/jpeg");
-        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/"), mediaPath.length()));
+        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
         testMedia.setTitle("Test Title");
         testMedia.setDescription(testDescription);
         testMedia.setCaption(testCaption);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
  * Tests the interactions between the MediaStore/PostStore and the UploadStore, without directly injecting the
  * UploadStore in the test class.
  */
+@SuppressWarnings("NewClassNamingConvention")
 public class MockedStack_UploadStoreTest extends MockedStack_Base {
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
@@ -59,7 +59,7 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
 
     @Test
     public void testUploadMedia() throws InterruptedException {
-        MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(getSampleImagePath());
         startSuccessfulMediaUpload(testMedia, getTestSite());
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -90,11 +90,7 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
         }
     }
 
-    private MediaModel newMediaModel(String mediaPath, String mimeType) {
-        return newMediaModel("Test Title", mediaPath, mimeType);
-    }
-
-    private MediaModel newMediaModel(String testTitle, String mediaPath, String mimeType) {
+    private MediaModel newMediaModel(String mediaPath) {
         final String testDescription = "Test Description";
         final String testCaption = "Test Caption";
         final String testAlt = "Test Alt";
@@ -102,9 +98,9 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
         MediaModel testMedia = mMediaStore.instantiateMediaModel();
         testMedia.setFilePath(mediaPath);
         testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1, mediaPath.length()));
-        testMedia.setMimeType(mimeType);
+        testMedia.setMimeType("image/jpeg");
         testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/"), mediaPath.length()));
-        testMedia.setTitle(testTitle);
+        testMedia.setTitle("Test Title");
         testMedia.setDescription(testDescription);
         testMedia.setCaption(testCaption);
         testMedia.setAlt(testAlt);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Tests using a Mocked Network app component. Test the Store itself and not the underlying network component(s).
- *
+ * <p>
  * Tests the interactions between the MediaStore/PostStore and the UploadStore, without directly injecting the
  * UploadStore in the test class.
  */

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests using a Mocked Network app component. Test the Store itself and not the underlying network component(s).
  */
+@SuppressWarnings("NewClassNamingConvention")
 public class MockedStack_UploadTest extends MockedStack_Base {
     private static final String POST_DEFAULT_TITLE = "UploadTest base post";
     private static final String POST_DEFAULT_DESCRIPTION = "Hi there, I'm a post from FluxC!";

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -532,7 +532,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         return testMedia;
     }
 
-    private void createNewPost(SiteModel site) throws InterruptedException {
+    private void createNewPost(SiteModel site) {
         mPost = mPostStore.instantiatePostModel(site, false);
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -532,9 +532,8 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         return testMedia;
     }
 
-    private PostModel createNewPost(SiteModel site) throws InterruptedException {
+    private void createNewPost(SiteModel site) throws InterruptedException {
         mPost = mPostStore.instantiatePostModel(site, false);
-        return mPost;
     }
 
     private void setupPostAttributes() {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -521,9 +521,9 @@ public class MockedStack_UploadTest extends MockedStack_Base {
 
         MediaModel testMedia = mMediaStore.instantiateMediaModel();
         testMedia.setFilePath(mediaPath);
-        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1, mediaPath.length()));
+        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
         testMedia.setMimeType("image/jpeg");
-        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/"), mediaPath.length()));
+        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
         testMedia.setTitle("Test Title");
         testMedia.setDescription(testDescription);
         testMedia.setCaption(testCaption);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -89,7 +89,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
 
     @Test
     public void testUploadMedia() throws InterruptedException {
-        MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(getSampleImagePath());
         startSuccessfulMediaUpload(testMedia, getTestSite());
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -102,7 +102,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
 
     @Test
     public void testUploadMediaError() throws InterruptedException {
-        MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(getSampleImagePath());
         startFailingMediaUpload(testMedia, getTestSite());
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
@@ -121,7 +121,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         mInterceptor.respondWithSticky("media-upload-response-success.json", 1000L, null);
 
         // First, try canceling an image with the default behavior (canceled image is deleted from the store)
-        MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(getSampleImagePath());
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.CANCELED_MEDIA;
         UploadMediaPayload payload = new UploadMediaPayload(getTestSite(), testMedia, true);
@@ -142,7 +142,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         assertNull(mediaUploadModel);
 
         // Now, try canceling with delete=false (canceled image should be marked as failed and kept in the store)
-        testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        testMedia = newMediaModel(getSampleImagePath());
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.CANCELED_MEDIA;
         payload = new UploadMediaPayload(getTestSite(), testMedia, true);
@@ -175,7 +175,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         setupPostAttributes();
 
         // Start uploading media
-        MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(getSampleImagePath());
         testMedia.setLocalPostId(mPost.getId());
         startFailingMediaUpload(testMedia, site);
 
@@ -272,7 +272,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         setupPostAttributes();
 
         // Start uploading media
-        MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(getSampleImagePath());
         testMedia.setLocalPostId(mPost.getId());
         startSuccessfulMediaUpload(testMedia, site);
 
@@ -342,7 +342,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         setupPostAttributes();
 
         // Start uploading media
-        MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(getSampleImagePath());
         testMedia.setLocalPostId(mPost.getId());
         startFailingMediaUpload(testMedia, site);
 
@@ -373,7 +373,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         clearMedia(mPost, mUploadStore.getFailedMediaForPost(mPost));
 
         // Upload a new media item to the cancelled post
-        testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        testMedia = newMediaModel(getSampleImagePath());
         testMedia.setLocalPostId(mPost.getId());
         startFailingMediaUpload(testMedia, site);
 
@@ -399,7 +399,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         setupPostAttributes();
 
         // Start uploading media
-        MediaModel testMedia = newMediaModel(getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(getSampleImagePath());
         testMedia.setLocalPostId(mPost.getId());
         startSuccessfulMediaUpload(testMedia, site);
 
@@ -514,11 +514,7 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         }
     }
 
-    private MediaModel newMediaModel(String mediaPath, String mimeType) {
-        return newMediaModel("Test Title", mediaPath, mimeType);
-    }
-
-    private MediaModel newMediaModel(String testTitle, String mediaPath, String mimeType) {
+    private MediaModel newMediaModel(String mediaPath) {
         final String testDescription = "Test Description";
         final String testCaption = "Test Caption";
         final String testAlt = "Test Alt";
@@ -526,9 +522,9 @@ public class MockedStack_UploadTest extends MockedStack_Base {
         MediaModel testMedia = mMediaStore.instantiateMediaModel();
         testMedia.setFilePath(mediaPath);
         testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1, mediaPath.length()));
-        testMedia.setMimeType(mimeType);
+        testMedia.setMimeType("image/jpeg");
         testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/"), mediaPath.length()));
-        testMedia.setTitle(testTitle);
+        testMedia.setTitle("Test Title");
         testMedia.setDescription(testDescription);
         testMedia.setCaption(testCaption);
         testMedia.setAlt(testAlt);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -155,9 +155,9 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
 
         MediaModel testMedia = mMediaStore.instantiateMediaModel();
         testMedia.setFilePath(mediaPath);
-        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1, mediaPath.length()));
+        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
         testMedia.setMimeType("image/jpeg");
-        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/"), mediaPath.length()));
+        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
         testMedia.setTitle(testTitle);
         testMedia.setDescription(testDescription);
         testMedia.setCaption(testCaption);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -71,7 +71,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         site = mSiteStore.getSites().get(0);
 
         // Attempt to upload an image that exceeds the site's maximum upload_max_filesize or post_max_size
-        MediaModel testMedia = newMediaModel(site, getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(site, getSampleImagePath());
         mNextEvent = TestEvents.ERROR_EXCEEDS_FILESIZE_LIMIT;
         uploadMedia(site, testMedia);
 
@@ -91,7 +91,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         site.setMemoryLimit(1985); // Artificially set the site's memory limit, in bytes
 
         // Attempt to upload an image that exceeds the site's memory limit
-        MediaModel testMedia = newMediaModel(site, getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(site, getSampleImagePath());
         mNextEvent = TestEvents.ERROR_EXCEEDS_MEMORY_LIMIT;
         uploadMedia(site, testMedia);
 
@@ -115,7 +115,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         site.setSpaceUsed(50);
 
         // Attempt to upload an image that exceeds the site's memory limit
-        MediaModel testMedia = newMediaModel(site, getSampleImagePath(), "image/jpeg");
+        MediaModel testMedia = newMediaModel(site, getSampleImagePath());
         mNextEvent = TestEvents.ERROR_EXCEEDS_SITE_SPACE_QUOTA_LIMIT;
         uploadMedia(site, testMedia);
 
@@ -147,7 +147,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         }
     }
 
-    private MediaModel newMediaModel(SiteModel site, String mediaPath, String mimeType) {
+    private MediaModel newMediaModel(SiteModel site, String mediaPath) {
         final String testTitle = "Test Title";
         final String testDescription = "Test Description";
         final String testCaption = "Test Caption";
@@ -156,7 +156,7 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
         MediaModel testMedia = mMediaStore.instantiateMediaModel();
         testMedia.setFilePath(mediaPath);
         testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1, mediaPath.length()));
-        testMedia.setMimeType(mimeType);
+        testMedia.setMimeType("image/jpeg");
         testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/"), mediaPath.length()));
         testMedia.setTitle(testTitle);
         testMedia.setDescription(testDescription);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -10,7 +10,6 @@ import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
@@ -36,7 +35,6 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
     @Inject SiteStore mSiteStore;
-    @Inject AccountStore mAccountStore;
     @Inject MediaStore mMediaStore;
 
     private enum TestEvents {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -33,6 +33,7 @@ import javax.inject.Inject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
     @Inject SiteStore mSiteStore;
     @Inject AccountStore mAccountStore;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @SuppressLint("UseSparseArrays")
+@SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     @Inject MediaStore mMediaStore;
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -381,10 +381,6 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     }
 
     private MediaModel newMediaModel(String mediaPath, String mimeType) {
-        return newMediaModel("Test Title", mediaPath, mimeType);
-    }
-
-    private MediaModel newMediaModel(String testTitle, String mediaPath, String mimeType) {
         final String testDescription = "Test Description";
         final String testCaption = "Test Caption";
         final String testAlt = "Test Alt";
@@ -394,7 +390,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
         testMedia.setMimeType(mimeType);
         testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
-        testMedia.setTitle(testTitle);
+        testMedia.setTitle("Test Title");
         testMedia.setDescription(testDescription);
         testMedia.setCaption(testCaption);
         testMedia.setAlt(testAlt);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -404,10 +404,6 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     private MediaModel newMediaModel(String mediaPath, String mimeType) {
-        return newMediaModel("Test Title", mediaPath, mimeType);
-    }
-
-    private MediaModel newMediaModel(String testTitle, String mediaPath, String mimeType) {
         final String testDescription = "Test Description";
         final String testCaption = "Test Caption";
         final String testAlt = "Test Alt";
@@ -417,7 +413,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
         testMedia.setMimeType(mimeType);
         testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
-        testMedia.setTitle(testTitle);
+        testMedia.setTitle("Test Title");
         testMedia.setDescription(testDescription);
         testMedia.setCaption(testCaption);
         testMedia.setAlt(testAlt);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @SuppressLint("UseSparseArrays")
+@SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     @SuppressWarnings("unused")
     @Inject AccountStore mAccountStore;

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -18,6 +18,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -266,8 +267,10 @@ public class MediaFragment extends Fragment {
         }
     }
 
-    private void prependToLog(final String s) {
-        ((MainExampleActivity) getActivity()).prependToLog(s);
+    private void prependToLog(@Nullable final String s) {
+        if (s != null) {
+            ((MainExampleActivity) getActivity()).prependToLog(s);
+        }
     }
 
     private void fetchMediaList(@NonNull SiteModel site) {

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -35,7 +35,7 @@ public class MediaSqlUtilsTest {
 
     @Before
     public void setUp() {
-        Context appContext = RuntimeEnvironment.application.getApplicationContext();
+        Context appContext = RuntimeEnvironment.getApplication().getApplicationContext();
 
         WellSqlConfig config = new SingleStoreWellSqlConfigForTests(appContext, MediaModel.class);
         WellSql.init(config);

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -81,19 +81,19 @@ public class MediaStoreTest {
     public void testMediaCount() {
         final int testSiteId = 2;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 0);
+        assertEquals(0, mMediaStore.getSiteMediaCount(testSite));
 
         // count after insertion
         insertRandomMediaIntoDatabase(testSiteId, 5);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 5);
+        assertEquals(5, mMediaStore.getSiteMediaCount(testSite));
 
         // count after inserting with different site ID
         final int wrongSiteId = testSiteId + 1;
         SiteModel wrongSite = getTestSiteWithLocalId(wrongSiteId);
-        assertTrue(mMediaStore.getSiteMediaCount(wrongSite) == 0);
+        assertEquals(0, mMediaStore.getSiteMediaCount(wrongSite));
         insertRandomMediaIntoDatabase(wrongSiteId, 1);
-        assertTrue(mMediaStore.getSiteMediaCount(wrongSite) == 1);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 5);
+        assertEquals(1, mMediaStore.getSiteMediaCount(wrongSite));
+        assertEquals(5, mMediaStore.getSiteMediaCount(testSite));
     }
 
     @Test
@@ -101,17 +101,17 @@ public class MediaStoreTest {
         final int testSiteId = 24;
         final long testMediaId = 22;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 0);
+        assertEquals(0, mMediaStore.getSiteMediaCount(testSite));
         assertFalse(mMediaStore.hasSiteMediaWithId(testSite, testMediaId));
 
         // add test media
         MediaModel testMedia = getBasicMedia();
         testMedia.setLocalSiteId(testSiteId);
         testMedia.setMediaId(testMediaId);
-        assertTrue(insertMediaIntoDatabase(testMedia) == 1);
+        assertEquals(1, insertMediaIntoDatabase(testMedia));
 
         // verify store has inserted media
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == 1);
+        assertEquals(1, mMediaStore.getSiteMediaCount(testSite));
         assertTrue(mMediaStore.hasSiteMediaWithId(testSite, testMediaId));
     }
 
@@ -126,7 +126,7 @@ public class MediaStoreTest {
         MediaModel testMedia = getBasicMedia();
         testMedia.setLocalSiteId(testSiteId);
         testMedia.setMediaId(testMediaId);
-        assertTrue(insertMediaIntoDatabase(testMedia) == 1);
+        assertEquals(1, insertMediaIntoDatabase(testMedia));
 
         // cannot get media with incorrect site ID
         final int wrongSiteId = testSiteId + 1;
@@ -146,7 +146,7 @@ public class MediaStoreTest {
         final int testSiteId = 55;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
         List<MediaModel> insertedMedia = insertRandomMediaIntoDatabase(testSiteId, testListSize);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == testListSize);
+        assertEquals(testListSize, mMediaStore.getSiteMediaCount(testSite));
 
         // create whitelist
         List<Long> whitelist = new ArrayList<>(testListSize / 2);
@@ -156,7 +156,7 @@ public class MediaStoreTest {
 
         final List<MediaModel> storeMedia = mMediaStore.getSiteMediaWithIds(testSite, whitelist);
         assertNotNull(storeMedia);
-        assertTrue(storeMedia.size() == whitelist.size());
+        assertEquals(storeMedia.size(), whitelist.size());
         for (MediaModel media : storeMedia) {
             assertTrue(whitelist.contains(media.getMediaId()));
         }
@@ -180,7 +180,7 @@ public class MediaStoreTest {
 
         final List<MediaModel> storeImages = mMediaStore.getSiteImages(getTestSiteWithLocalId(testSiteId));
         assertNotNull(storeImages);
-        assertTrue(storeImages.size() == 1);
+        assertEquals(1, storeImages.size());
         assertEquals(testImageId, storeImages.get(0).getMediaId());
         assertTrue(MediaUtils.isImageMimeType(storeImages.get(0).getMimeType()));
     }
@@ -189,7 +189,7 @@ public class MediaStoreTest {
     public void testGetSiteImageCount() {
         final int testSiteId = 9001;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertTrue(mMediaStore.getSiteImageCount(testSite) == 0);
+        assertEquals(0, mMediaStore.getSiteImageCount(testSite));
 
         // insert both images and videos
         final int testListSize = 10;
@@ -200,31 +200,31 @@ public class MediaStoreTest {
         for (int i = 0; i < testListSize; ++i) {
             MediaModel testImage = generateMediaFromPath(testSiteId, i, String.format(testImagePath, i));
             MediaModel testVideo = generateMediaFromPath(testSiteId, i + testListSize, String.format(testVideoPath, i));
-            assertTrue(insertMediaIntoDatabase(testImage) == 1);
-            assertTrue(insertMediaIntoDatabase(testVideo) == 1);
+            assertEquals(1, insertMediaIntoDatabase(testImage));
+            assertEquals(1, insertMediaIntoDatabase(testVideo));
             testImages.add(testImage);
             testVideos.add(testVideo);
         }
 
-        assertTrue(mMediaStore.getSiteMediaCount(testSite) == testImages.size() + testVideos.size());
-        assertTrue(mMediaStore.getSiteImageCount(testSite) == testImages.size());
+        assertEquals(mMediaStore.getSiteMediaCount(testSite), testImages.size() + testVideos.size());
+        assertEquals(mMediaStore.getSiteImageCount(testSite), testImages.size());
     }
 
     @Test
     public void testGetSiteImagesBlacklist() {
         final int testSiteId = 3;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertTrue(mMediaStore.getSiteImageCount(testSite) == 0);
+        assertEquals(0, mMediaStore.getSiteImageCount(testSite));
 
         final int testListSize = 10;
         final List<MediaModel> testImages = new ArrayList<>(testListSize);
         final String testImagePath = "/test/test_image%d.png";
         for (int i = 0; i < testListSize; ++i) {
             MediaModel image = generateMediaFromPath(testSiteId, i, String.format(testImagePath, i));
-            assertTrue(insertMediaIntoDatabase(image) == 1);
+            assertEquals(1, insertMediaIntoDatabase(image));
             testImages.add(image);
         }
-        assertTrue(mMediaStore.getSiteImageCount(testSite) == testListSize);
+        assertEquals(testListSize, mMediaStore.getSiteImageCount(testSite));
 
         // create blacklist
         List<Long> blacklist = new ArrayList<>(testListSize / 2);
@@ -259,7 +259,7 @@ public class MediaStoreTest {
 
         final List<MediaModel> storeMedia = mMediaStore.getUnattachedSiteMedia(getTestSiteWithLocalId(testSiteId));
         assertNotNull(storeMedia);
-        assertTrue(storeMedia.size() == unattachedMedia.size());
+        assertEquals(storeMedia.size(), unattachedMedia.size());
         for (int i = 0; i < storeMedia.size(); ++i) {
             assertTrue(storeMedia.contains(unattachedMedia.get(i)));
         }
@@ -279,7 +279,7 @@ public class MediaStoreTest {
             insertMediaIntoDatabase(attached);
             insertMediaIntoDatabase(unattached);
         }
-        assertTrue(mMediaStore.getUnattachedSiteMediaCount(getTestSiteWithLocalId(testSiteId)) == testPoolSize);
+        assertEquals(testPoolSize, mMediaStore.getUnattachedSiteMediaCount(getTestSiteWithLocalId(testSiteId)));
     }
 
     @Test
@@ -333,7 +333,7 @@ public class MediaStoreTest {
         final String testVideoPressGuid = "thisisonlyatest";
         testVideo.setUrl(testUrl);
         testVideo.setVideoPressGuid(testVideoPressGuid);
-        assertTrue(insertMediaIntoDatabase(testVideo) == 1);
+        assertEquals(1, insertMediaIntoDatabase(testVideo));
 
         // retrieve video and verify
         final String storeUrl = mMediaStore
@@ -351,7 +351,7 @@ public class MediaStoreTest {
         final String testUrl = "http://notarealurl.testfluxc.org/not/a/real/resource/path.mp4";
         testMedia.setThumbnailUrl(testUrl);
         testMedia.setMediaId(testMediaId);
-        assertTrue(insertMediaIntoDatabase(testMedia) == 1);
+        assertEquals(1, insertMediaIntoDatabase(testMedia));
 
         // retrieve media and verify
         final String storeUrl = mMediaStore
@@ -372,7 +372,7 @@ public class MediaStoreTest {
             MediaModel testMedia = generateMedia(baseString, null, null, null);
             testMedia.setLocalSiteId(testSiteId);
             testMedia.setMediaId(i);
-            assertTrue(insertMediaIntoDatabase(testMedia) == 1);
+            assertEquals(1, insertMediaIntoDatabase(testMedia));
             baseString += String.valueOf(i);
         }
 
@@ -380,7 +380,7 @@ public class MediaStoreTest {
             List<MediaModel> storeMedia = mMediaStore
                     .searchSiteMedia(getTestSiteWithLocalId(testSiteId), testTitles[i]);
             assertNotNull(storeMedia);
-            assertTrue(storeMedia.size() == testPoolSize - i);
+            assertEquals(storeMedia.size(), testPoolSize - i);
         }
     }
 
@@ -420,7 +420,7 @@ public class MediaStoreTest {
                 .searchSiteImages(getTestSiteWithLocalId(testSiteId), "test");
 
         assertNotNull(storeImages);
-        assertTrue(storeImages.size() == 1);
+        assertEquals(1, storeImages.size());
         assertEquals(testImageId, storeImages.get(0).getMediaId());
         assertTrue(MediaUtils.isImageMimeType(storeImages.get(0).getMimeType()));
         assertEquals(testSiteId, storeImages.get(0).getLocalSiteId());
@@ -459,7 +459,7 @@ public class MediaStoreTest {
         final List<MediaModel> storeVideos = mMediaStore
                 .searchSiteVideos(getTestSiteWithLocalId(testSiteId), "test");
         assertNotNull(storeVideos);
-        assertTrue(storeVideos.size() == 1);
+        assertEquals(1, storeVideos.size());
         assertEquals(testVideoId2, storeVideos.get(0).getMediaId());
         assertTrue(MediaUtils.isVideoMimeType(storeVideos.get(0).getMimeType()));
         assertEquals(testSiteId, storeVideos.get(0).getLocalSiteId());
@@ -507,7 +507,7 @@ public class MediaStoreTest {
         final List<MediaModel> storeAudio = mMediaStore
                 .searchSiteAudio(getTestSiteWithLocalId(testSiteId), "test");
         assertNotNull(storeAudio);
-        assertTrue(storeAudio.size() == 2);
+        assertEquals(2, storeAudio.size());
         assertEquals(testAudioId1, storeAudio.get(0).getMediaId());
         assertEquals(testAudioId2, storeAudio.get(1).getMediaId());
 
@@ -571,7 +571,7 @@ public class MediaStoreTest {
         final List<MediaModel> storeDocuments = mMediaStore
                 .searchSiteDocuments(getTestSiteWithLocalId(testSiteId), "test");
         assertNotNull(storeDocuments);
-        assertTrue(storeDocuments.size() == 2);
+        assertEquals(2, storeDocuments.size());
         assertEquals(testDocumentId2, storeDocuments.get(0).getMediaId());
         assertEquals(testDocumentId3, storeDocuments.get(1).getMediaId());
 
@@ -708,16 +708,16 @@ public class MediaStoreTest {
     public void testRemoveAllMedia() {
         SiteModel testSite1 = getTestSiteWithLocalId(1);
         insertRandomMediaIntoDatabase(testSite1.getId(), 5);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite1) == 5);
+        assertEquals(5, mMediaStore.getSiteMediaCount(testSite1));
 
         SiteModel testSite2 = getTestSiteWithLocalId(2);
         insertRandomMediaIntoDatabase(testSite2.getId(), 7);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite2) == 7);
+        assertEquals(7, mMediaStore.getSiteMediaCount(testSite2));
 
         MediaSqlUtils.deleteAllMedia();
 
-        assertTrue(mMediaStore.getSiteMediaCount(testSite1) == 0);
-        assertTrue(mMediaStore.getSiteMediaCount(testSite2) == 0);
+        assertEquals(0, mMediaStore.getSiteMediaCount(testSite1));
+        assertEquals(0, mMediaStore.getSiteMediaCount(testSite2));
     }
 
     private MediaModel getBasicMedia() {

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -43,7 +43,7 @@ import static org.wordpress.android.fluxc.media.MediaTestUtils.insertRandomMedia
 @RunWith(RobolectricTestRunner.class)
 public class MediaStoreTest {
     @SuppressWarnings("KotlinInternalInJava")
-    private MediaStore mMediaStore = new MediaStore(new Dispatcher(),
+    private final MediaStore mMediaStore = new MediaStore(new Dispatcher(),
             Mockito.mock(MediaRestClient.class),
             Mockito.mock(MediaXMLRPCClient.class),
             Mockito.mock(WPComV2MediaRestClient.class),

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration;
 import org.wordpress.android.fluxc.network.rest.wpapi.media.ApplicationPasswordsMediaRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaRestClient;
 import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient;
@@ -43,12 +42,15 @@ import static org.wordpress.android.fluxc.media.MediaTestUtils.insertRandomMedia
 
 @RunWith(RobolectricTestRunner.class)
 public class MediaStoreTest {
+    @SuppressWarnings("KotlinInternalInJava")
     private MediaStore mMediaStore = new MediaStore(new Dispatcher(),
             Mockito.mock(MediaRestClient.class),
             Mockito.mock(MediaXMLRPCClient.class),
             Mockito.mock(WPComV2MediaRestClient.class),
             Mockito.mock(ApplicationPasswordsMediaRestClient.class),
-            Mockito.mock(ApplicationPasswordsConfiguration.class));
+            Mockito.mock(org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
+                    .ApplicationPasswordsConfiguration.class)
+    );
 
     @Before
     public void setUp() {

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -54,7 +54,7 @@ public class MediaStoreTest {
 
     @Before
     public void setUp() {
-        Context context = RuntimeEnvironment.application.getApplicationContext();
+        Context context = RuntimeEnvironment.getApplication().getApplicationContext();
         WellSqlConfig config = new SingleStoreWellSqlConfigForTests(context, MediaModel.class);
         WellSql.init(config);
         config.reset();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseUploadRequestBody.java
@@ -19,10 +19,10 @@ import okio.Sink;
 
 /**
  * Wrapper for {@link okhttp3.MultipartBody} that reports upload progress as body data is written.
- *
+ * <p>
  * A {@link ProgressListener} is required, use {@link okhttp3.MultipartBody} if progress is not needed.
- *
- * ref http://stackoverflow.com/questions/35528751/okhttp-3-tracking-multipart-upload-progress
+ * <p>
+ * @see <a href="http://stackoverflow.com/questions/35528751/okhttp-3-tracking-multipart-upload-progress">doc</a>
  */
 public abstract class BaseUploadRequestBody extends RequestBody {
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseUploadRequestBody.java
@@ -29,7 +29,7 @@ public abstract class BaseUploadRequestBody extends RequestBody {
      * Callback to report upload progress as body data is written to the sink for network delivery.
      */
     public interface ProgressListener {
-        void onProgress(MediaModel media, float progress);
+        void onProgress(@NonNull MediaModel media, float progress);
     }
 
     /**
@@ -40,15 +40,15 @@ public abstract class BaseUploadRequestBody extends RequestBody {
      *     <li>define a file path to a valid local file</li>
      * </ul>
      *
-     * @return null if {@code media} is valid, otherwise a string describing why it's invalid
+     * @return a string describing why {@code media} is invalid
      */
-    public static String hasRequiredData(MediaModel media) {
+    @NonNull
+    public static String hasRequiredData(@NonNull MediaModel media) {
         return checkMediaArg(media).getType().getErrorLogDescription();
     }
 
-    public static MalformedMediaArgSubType checkMediaArg(MediaModel media) {
-        if (media == null) return new MalformedMediaArgSubType(Type.MEDIA_WAS_NULL);
-
+    @NonNull
+    public static MalformedMediaArgSubType checkMediaArg(@NonNull MediaModel media) {
         // validate MIME type is recognized
         String mimeType = media.getMimeType();
         if (!MediaUtils.isSupportedMimeType(mimeType)) {
@@ -72,25 +72,19 @@ public abstract class BaseUploadRequestBody extends RequestBody {
         return new MalformedMediaArgSubType(Type.NO_ERROR);
     }
 
-    private final MediaModel mMedia;
-    private final ProgressListener mListener;
+    @NonNull private final MediaModel mMedia;
+    @NonNull private final ProgressListener mListener;
 
-    public BaseUploadRequestBody(MediaModel media, ProgressListener listener) {
-        // validate arguments
-        if (listener == null) {
-            throw new IllegalArgumentException("progress listener cannot be null");
-        }
-        String mediaError = hasRequiredData(media);
-        if (mediaError != null) {
-            throw new IllegalArgumentException(mediaError);
-        }
-
+    public BaseUploadRequestBody(
+            @NonNull MediaModel media,
+            @NonNull ProgressListener listener) {
         mMedia = media;
         mListener = listener;
     }
 
     protected abstract float getProgress(long bytesWritten);
 
+    @NonNull
     public MediaModel getMedia() {
         return mMedia;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseUploadRequestBody.java
@@ -97,7 +97,7 @@ public abstract class BaseUploadRequestBody extends RequestBody {
         private long mBytesWritten = 0;
         private long mLastTimeOnProgressCalled = 0;
 
-        public CountingSink(Sink delegate) {
+        public CountingSink(@NonNull Sink delegate) {
             super(delegate);
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaResponseUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaResponseUtils.kt
@@ -37,17 +37,17 @@ class MediaResponseUtils
         media.caption = StringEscapeUtils.unescapeHtml4(from.caption)
         media.description = StringEscapeUtils.unescapeHtml4(from.description)
         media.alt = StringEscapeUtils.unescapeHtml4(from.alt)
-        if (from.thumbnails != null) {
-            if (!TextUtils.isEmpty(from.thumbnails.fmt_std)) {
-                media.thumbnailUrl = from.thumbnails.fmt_std
+        from.thumbnails?.let {
+            if (!TextUtils.isEmpty(it.fmt_std)) {
+                media.thumbnailUrl = it.fmt_std
             } else {
-                media.thumbnailUrl = from.thumbnails.thumbnail
+                media.thumbnailUrl = it.thumbnail
             }
-            if (!TextUtils.isEmpty(from.thumbnails.large)) {
-                media.fileUrlLargeSize = from.thumbnails.large
+            if (!TextUtils.isEmpty(it.large)) {
+                media.fileUrlLargeSize = it.large
             }
-            if (!TextUtils.isEmpty(from.thumbnails.medium)) {
-                media.fileUrlMediumSize = from.thumbnails.medium
+            if (!TextUtils.isEmpty(it.medium)) {
+                media.fileUrlMediumSize = it.medium
             }
         }
         media.height = from.height

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaResponseUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaResponseUtils.kt
@@ -13,15 +13,16 @@ class MediaResponseUtils
     /**
      * Creates a [MediaModel] list from a WP.com REST response to a request for all media.
      */
-    fun getMediaListFromRestResponse(from: MultipleMediaResponse?, localSiteId: Int): List<MediaModel>? {
-        return from?.media?.mapNotNull { getMediaFromRestResponse(it)?.apply { this.localSiteId = localSiteId } }
+    fun getMediaListFromRestResponse(from: MultipleMediaResponse, localSiteId: Int): List<MediaModel> {
+        return from.media.mapNotNull {
+            getMediaFromRestResponse(it).apply { this.localSiteId = localSiteId }
+        }
     }
 
     /**
      * Creates a [MediaModel] from a WP.com REST response to a fetch request.
      */
-    fun getMediaFromRestResponse(from: MediaWPComRestResponse?): MediaModel? {
-        if (from == null) return null
+    fun getMediaFromRestResponse(from: MediaWPComRestResponse): MediaModel {
         val media = MediaModel()
         media.mediaId = from.ID
         media.uploadDate = from.date

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -455,8 +455,16 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                     // response is a list of media, exactly like that of MediaRestClient.fetchMediaList()
                     List<MediaModel> mediaList =
                             mMediaResponseUtils.getMediaListFromRestResponse(response, site.getId());
-                    UploadedStockMediaPayload payload = new UploadedStockMediaPayload(site, mediaList);
-                    mDispatcher.dispatch(MediaActionBuilder.newUploadedStockMediaAction(payload));
+                    if (mediaList != null) {
+                        UploadedStockMediaPayload payload = new UploadedStockMediaPayload(site, mediaList);
+                        mDispatcher.dispatch(MediaActionBuilder.newUploadedStockMediaAction(payload));
+                    } else {
+                        AppLog.e(T.MEDIA, "Media list is null: " + response);
+                        UploadStockMediaError mediaError = new UploadStockMediaError(
+                                UploadStockMediaErrorType.GENERIC_ERROR, "Media list is null");
+                        UploadedStockMediaPayload payload = new UploadedStockMediaPayload(site, mediaError);
+                        mDispatcher.dispatch(MediaActionBuilder.newUploadedStockMediaAction(payload));
+                    }
                 }, error -> {
                     AppLog.e(T.MEDIA, "VolleyError uploading stock media: " + error);
                     UploadStockMediaError mediaError = new UploadStockMediaError(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -81,7 +81,7 @@ import okhttp3.ResponseBody;
 @Singleton
 public class MediaRestClient extends BaseWPComRestClient implements ProgressListener {
     @NonNull private final OkHttpClient mOkHttpClient;
-    private final MediaResponseUtils mMediaResponseUtils;
+    @NonNull private final MediaResponseUtils mMediaResponseUtils;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads
     private final ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
@@ -93,7 +93,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
             @NonNull @Named("regular") OkHttpClient okHttpClient,
             AccessToken accessToken,
             UserAgent userAgent,
-            MediaResponseUtils mediaResponseUtils) {
+            @NonNull MediaResponseUtils mediaResponseUtils) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
         mOkHttpClient = okHttpClient;
         mMediaResponseUtils = mediaResponseUtils;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -413,7 +413,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                 }));
     }
 
-    public void cancelUpload(final MediaModel media) {
+    public void cancelUpload(@Nullable final MediaModel media) {
         if (media == null) {
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
             error.logMessage = "Null media on cancel upload";
@@ -605,7 +605,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(MediaActionBuilder.newDeletedMediaAction(payload));
     }
 
-    private void notifyMediaUploadCanceled(MediaModel media) {
+    private void notifyMediaUploadCanceled(@NonNull MediaModel media) {
         ProgressPayload payload = new ProgressPayload(media, 0.f, false, true);
         mDispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -130,7 +130,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         error.logMessage = "Parsed media is null";
                         notifyMediaPushed(site, media, error);
                     }
-                }, error -> {
+                },
+                error -> {
                     String errorMessage = "error editing remote media: " + error;
                     AppLog.e(T.MEDIA, errorMessage);
                     MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
@@ -324,7 +325,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         error.logMessage = errorMessage;
                         notifyMediaListFetched(site, error, mimeType);
                     }
-                }, error -> {
+                },
+                error -> {
                     String errorMessage = "VolleyError Fetching media: " + error;
                     AppLog.e(T.MEDIA, errorMessage);
                     MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
@@ -361,7 +363,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         error.logMessage = message;
                         notifyMediaFetched(site, media, error);
                     }
-                }, error -> {
+                },
+                error -> {
                     AppLog.e(T.MEDIA, "VolleyError Fetching media: " + error);
                     MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                     mediaError.message = error.message;
@@ -396,7 +399,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         error.logMessage = message;
                         notifyMediaDeleted(site, media, error);
                     }
-                }, error -> {
+                },
+                error -> {
                     AppLog.e(T.MEDIA, "VolleyError deleting media (ID=" + media.getMediaId() + "): " + error);
                     MediaErrorType mediaErrorType = MediaErrorType.fromBaseNetworkError(error);
                     if (mediaErrorType == MediaErrorType.NOT_FOUND) {
@@ -470,7 +474,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         UploadedStockMediaPayload payload = new UploadedStockMediaPayload(site, mediaError);
                         mDispatcher.dispatch(MediaActionBuilder.newUploadedStockMediaAction(payload));
                     }
-                }, error -> {
+                },
+                error -> {
                     AppLog.e(T.MEDIA, "VolleyError uploading stock media: " + error);
                     UploadStockMediaError mediaError = new UploadStockMediaError(
                             UploadStockMediaErrorType.fromNetworkError(error), error.message);
@@ -607,6 +612,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * The current REST API call (v1.1) accepts 'title', 'description', 'caption', 'alt',
      * and 'parent_id' for all media. Audio media also accepts 'artist' and 'album' attributes.
      * <p>
+     *
      * @see <a href="https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/">documentation</a>
      */
     @NonNull

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -376,7 +376,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     /**
      * Deletes media from a WP.com site whose media ID is in the provided list.
      */
-    public void deleteMedia(final SiteModel site, final MediaModel media) {
+    public void deleteMedia(@NonNull final SiteModel site, @Nullable final MediaModel media) {
         if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
@@ -597,7 +597,10 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaAction(payload));
     }
 
-    private void notifyMediaDeleted(SiteModel site, MediaModel media, MediaError error) {
+    private void notifyMediaDeleted(
+            @NonNull SiteModel site,
+            @Nullable MediaModel media,
+            @Nullable MediaError error) {
         MediaPayload payload = new MediaPayload(site, media, error);
         mDispatcher.dispatch(MediaActionBuilder.newDeletedMediaAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -80,7 +80,7 @@ import okhttp3.ResponseBody;
  */
 @Singleton
 public class MediaRestClient extends BaseWPComRestClient implements ProgressListener {
-    private OkHttpClient mOkHttpClient;
+    private final OkHttpClient mOkHttpClient;
     private MediaResponseUtils mMediaResponseUtils;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -80,7 +80,7 @@ import okhttp3.ResponseBody;
  */
 @Singleton
 public class MediaRestClient extends BaseWPComRestClient implements ProgressListener {
-    private final OkHttpClient mOkHttpClient;
+    @NonNull private final OkHttpClient mOkHttpClient;
     private final MediaResponseUtils mMediaResponseUtils;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads
@@ -90,7 +90,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
             Context appContext,
             Dispatcher dispatcher,
             @Named("regular") RequestQueue requestQueue,
-            @Named("regular") OkHttpClient okHttpClient,
+            @NonNull @Named("regular") OkHttpClient okHttpClient,
             AccessToken accessToken,
             UserAgent userAgent,
             MediaResponseUtils mediaResponseUtils) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -81,7 +81,7 @@ import okhttp3.ResponseBody;
 @Singleton
 public class MediaRestClient extends BaseWPComRestClient implements ProgressListener {
     private final OkHttpClient mOkHttpClient;
-    private MediaResponseUtils mMediaResponseUtils;
+    private final MediaResponseUtils mMediaResponseUtils;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads
     private ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -263,7 +263,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
 
                     MediaError error = parseUploadError(response, site);
 
-                    if (null != error && error.type == MediaErrorType.BAD_REQUEST) {
+                    if (error.type == MediaErrorType.BAD_REQUEST) {
                         AppLog.e(T.MEDIA, "media upload error message: " + error.message);
                     }
 
@@ -468,7 +468,10 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     //
     // Helper methods to dispatch media actions
     //
-    private MediaError parseUploadError(Response response, SiteModel siteModel) {
+    @NonNull
+    private MediaError parseUploadError(
+            @NonNull Response response,
+            @NonNull SiteModel siteModel) {
         MediaError mediaError = new MediaError(MediaErrorType.fromHttpStatusCode(response.code()));
         mediaError.statusCode = response.code();
         mediaError.logMessage = response.message();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -142,7 +142,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     /**
      * Uploads a single media item to a WP.com site.
      */
-    public void uploadMedia(final SiteModel site, final MediaModel media) {
+    public void uploadMedia(@NonNull final SiteModel site, @Nullable final MediaModel media) {
         if (media == null || media.getId() == 0) {
             // we can't have a MediaModel without an ID - otherwise we can't keep track of them.
             MediaError error = new MediaError(MediaErrorType.INVALID_ID);
@@ -551,7 +551,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(UploadActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaUploaded(MediaModel media, MediaError error) {
+    private void notifyMediaUploaded(@Nullable MediaModel media, @Nullable MediaError error) {
         if (media != null) {
             media.setUploadState(error == null ? MediaUploadState.UPLOADED : MediaUploadState.FAILED);
             removeCallFromCurrentUploadsMap(media.getId());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -89,13 +89,14 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     // to monitor multiple uploads
     private ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
 
-    @Inject public MediaRestClient(Context appContext,
-                           Dispatcher dispatcher,
-                           @Named("regular") RequestQueue requestQueue,
-                           @Named("regular") OkHttpClient okHttpClient,
-                           AccessToken accessToken,
-                           UserAgent userAgent,
-                           MediaResponseUtils mediaResponseUtils) {
+    @Inject public MediaRestClient(
+            Context appContext,
+            Dispatcher dispatcher,
+            @Named("regular") RequestQueue requestQueue,
+            @Named("regular") OkHttpClient okHttpClient,
+            AccessToken accessToken,
+            UserAgent userAgent,
+            MediaResponseUtils mediaResponseUtils) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
         mOkHttpClient = okHttpClient;
         mMediaResponseUtils = mediaResponseUtils;
@@ -143,8 +144,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         mediaError.logMessage = errorMessage;
                         notifyMediaPushed(site, media, mediaError);
                     }
-                }
-        ));
+                }));
     }
 
     /**
@@ -176,7 +176,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         // Abort upload if it exceeds the site upload limit
         if (site.hasMaxUploadSize() && body.contentLength() > site.getMaxUploadSize()) {
             String errorMessage = "Media size of " + body.contentLength() + " exceeds site limit of "
-                             + site.getMaxUploadSize();
+                                  + site.getMaxUploadSize();
             AppLog.d(T.MEDIA, errorMessage);
             MediaError error = new MediaError(MediaErrorType.EXCEEDS_FILESIZE_LIMIT);
             error.logMessage = errorMessage;
@@ -188,7 +188,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         double maxFilesizeForMemoryLimit = MediaUtils.getMaxFilesizeForMemoryLimit(site.getMemoryLimit());
         if (site.hasMemoryLimit() && body.contentLength() > maxFilesizeForMemoryLimit) {
             String errorMessage = "Media size of " + body.contentLength() + " exceeds safe memory limit of "
-                             + maxFilesizeForMemoryLimit + " for this site";
+                                  + maxFilesizeForMemoryLimit + " for this site";
             AppLog.d(T.MEDIA, errorMessage);
             MediaError error = new MediaError(MediaErrorType.EXCEEDS_MEMORY_LIMIT);
             error.logMessage = errorMessage;
@@ -199,7 +199,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         // Abort upload if it exceeds the space quota limit for the site
         if (site.hasDiskSpaceQuotaInformation() && body.contentLength() > site.getSpaceAvailable()) {
             String errorMessage = "Media size of " + body.contentLength() + " exceeds disk space quota remaining  "
-                             + site.getSpaceAvailable() + " for this site";
+                                  + site.getSpaceAvailable() + " for this site";
             AppLog.d(T.MEDIA, errorMessage);
             MediaError error = new MediaError(MediaErrorType.EXCEEDS_SITE_SPACE_QUOTA_LIMIT);
             error.logMessage = errorMessage;
@@ -299,7 +299,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
 
     /**
      * Gets a list of media items given the offset on a WP.com site.
-     *
+     * <p>
      * NOTE: Only media item data is gathered, the actual media file can be downloaded from the URL
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).
      */
@@ -341,8 +341,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         mediaError.logMessage = error.apiError;
                         notifyMediaListFetched(site, mediaError, mimeType);
                     }
-                }
-        ));
+                }));
     }
 
     /**
@@ -384,8 +383,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         mediaError.logMessage = error.apiError;
                         notifyMediaFetched(site, media, mediaError);
                     }
-                }
-            ));
+                }));
     }
 
     /**
@@ -430,8 +428,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
                         mediaError.logMessage = error.apiError;
                         notifyMediaDeleted(site, media, mediaError);
                     }
-                }
-            ));
+                }));
     }
 
     public void cancelUpload(final MediaModel media) {
@@ -457,7 +454,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     private void removeCallFromCurrentUploadsMap(int id) {
         mCurrentUploadCalls.remove(id);
         AppLog.d(T.MEDIA, "mediaRestClient: removed id: " + id + " from current uploads, remaining: "
-                + mCurrentUploadCalls.size());
+                          + mCurrentUploadCalls.size());
     }
 
     public void uploadStockMedia(@NonNull final SiteModel site,
@@ -616,11 +613,13 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     /**
      * The current REST API call (v1.1) accepts 'title', 'description', 'caption', 'alt',
      * and 'parent_id' for all media. Audio media also accepts 'artist' and 'album' attributes.
-     *
+     * <p>
      * ref https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/
      */
     private Map<String, Object> getEditRequestParams(final MediaModel media) {
-        if (media == null) return null;
+        if (media == null) {
+            return null;
+        }
 
         MediaFields[] fieldsToUpdate = media.getFieldsToUpdate();
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -84,7 +84,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     private final MediaResponseUtils mMediaResponseUtils;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads
-    private ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
 
     @Inject public MediaRestClient(
             Context appContext,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -84,7 +84,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     @NonNull private final MediaResponseUtils mMediaResponseUtils;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads
-    private final ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
+    @NonNull private final ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
 
     @Inject public MediaRestClient(
             Context appContext,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -100,7 +100,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     }
 
     @Override
-    public void onProgress(MediaModel media, float progress) {
+    public void onProgress(@NonNull MediaModel media, float progress) {
         if (mCurrentUploadCalls.containsKey(media.getId())) {
             notifyMediaProgress(media, Math.min(progress, 0.99f));
         }
@@ -542,7 +542,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(MediaActionBuilder.newPushedMediaAction(payload));
     }
 
-    private void notifyMediaProgress(MediaModel media, float progress) {
+    private void notifyMediaProgress(@NonNull MediaModel media, float progress) {
         ProgressPayload payload = new ProgressPayload(media, progress, false, null);
         mDispatcher.dispatch(UploadActionBuilder.newUploadedMediaAction(payload));
     }
@@ -597,11 +597,8 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * <p>
      * @see <a href="https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/">documentation</a>
      */
-    private Map<String, Object> getEditRequestParams(final MediaModel media) {
-        if (media == null) {
-            return null;
-        }
-
+    @NonNull
+    private Map<String, Object> getEditRequestParams(@NonNull final MediaModel media) {
         MediaFields[] fieldsToUpdate = media.getFieldsToUpdate();
 
         final Map<String, Object> params = new HashMap<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -587,7 +587,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * The current REST API call (v1.1) accepts 'title', 'description', 'caption', 'alt',
      * and 'parent_id' for all media. Audio media also accepts 'artist' and 'album' attributes.
      * <p>
-     * ref https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/
+     * @see <a href="https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/">documentation</a>
      */
     private Map<String, Object> getEditRequestParams(final MediaModel media) {
         if (media == null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -295,7 +295,11 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
      * NOTE: Only media item data is gathered, the actual media file can be downloaded from the URL
      * provided in the response {@link MediaModel}'s (via {@link MediaModel#getUrl()}).
      */
-    public void fetchMediaList(final SiteModel site, final int number, final int offset, final MimeType.Type mimeType) {
+    public void fetchMediaList(
+            @NonNull final SiteModel site,
+            final int number,
+            final int offset,
+            @Nullable final MimeType.Type mimeType) {
         final Map<String, String> params = new HashMap<>();
         params.put("number", String.valueOf(number));
         if (offset > 0) {
@@ -561,17 +565,21 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(UploadActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site,
-                                        @NonNull List<MediaModel> media,
-                                        boolean loadedMore,
-                                        boolean canLoadMore,
-                                        MimeType.Type mimeType) {
+    private void notifyMediaListFetched(
+            @NonNull SiteModel site,
+            @NonNull List<MediaModel> media,
+            boolean loadedMore,
+            boolean canLoadMore,
+            @Nullable MimeType.Type mimeType) {
         FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media,
                 loadedMore, canLoadMore, mimeType);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, MediaError error, MimeType.Type mimeType) {
+    private void notifyMediaListFetched(
+            @NonNull SiteModel site,
+            @NonNull MediaError error,
+            @Nullable MimeType.Type mimeType) {
         FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, error, mimeType);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -447,7 +447,10 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         body.put("service", "pexels");
         body.put("external_ids", jsonBody);
 
-        WPComGsonRequest request = WPComGsonRequest.buildPostRequest(url, body, MultipleMediaResponse.class,
+        WPComGsonRequest<MultipleMediaResponse> request = WPComGsonRequest.buildPostRequest(
+                url,
+                body,
+                MultipleMediaResponse.class,
                 response -> {
                     // response is a list of media, exactly like that of MediaRestClient.fetchMediaList()
                     List<MediaModel> mediaList =

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -339,7 +339,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
     /**
      * Gets a list of media items whose media IDs match the provided list.
      */
-    public void fetchMedia(final SiteModel site, final MediaModel media) {
+    public void fetchMedia(@NonNull final SiteModel site, @Nullable final MediaModel media) {
         if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
@@ -589,7 +589,10 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 
-    private void notifyMediaFetched(SiteModel site, MediaModel media, MediaError error) {
+    private void notifyMediaFetched(
+            @NonNull SiteModel site,
+            @Nullable MediaModel media,
+            @Nullable MediaError error) {
         MediaPayload payload = new MediaPayload(site, media, error);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.volley.RequestQueue;
 import com.google.gson.Gson;
@@ -106,7 +107,7 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         }
     }
 
-    public void pushMedia(final SiteModel site, final MediaModel media) {
+    public void pushMedia(@NonNull final SiteModel site, @Nullable final MediaModel media) {
         if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
@@ -537,7 +538,10 @@ public class MediaRestClient extends BaseWPComRestClient implements ProgressList
         return mediaError;
     }
 
-    private void notifyMediaPushed(SiteModel site, MediaModel media, MediaError error) {
+    private void notifyMediaPushed(
+            @NonNull SiteModel site,
+            @Nullable MediaModel media,
+            @Nullable MediaError error) {
         MediaPayload payload = new MediaPayload(site, media, error);
         mDispatcher.dispatch(MediaActionBuilder.newPushedMediaAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.media;
 
+import androidx.annotation.NonNull;
+
 import org.wordpress.android.fluxc.network.Response;
 
 import java.util.List;
@@ -9,11 +11,12 @@ import java.util.List;
  * <p>
  * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/media/%24media_ID/">doc</a>
  */
+@SuppressWarnings("NotNullFieldNotInitialized")
 public class MediaWPComRestResponse implements Response {
     public static final String DELETED_STATUS = "deleted";
 
     public static class MultipleMediaResponse {
-        public List<MediaWPComRestResponse> media;
+        @NonNull public List<MediaWPComRestResponse> media;
     }
 
     public static class Thumbnails {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
@@ -12,13 +12,13 @@ import java.util.List;
 public class MediaWPComRestResponse implements Response {
     public static final String DELETED_STATUS = "deleted";
 
-    public class MultipleMediaResponse {
+    public static class MultipleMediaResponse {
         public List<MediaWPComRestResponse> media;
         public List<String> errors;
         public int found;
     }
 
-    public class Thumbnails {
+    public static class Thumbnails {
         public String thumbnail;
         public String medium;
         public String large;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
@@ -22,7 +22,6 @@ public class MediaWPComRestResponse implements Response {
         public String thumbnail;
         public String medium;
         public String large;
-        public String post_thumbnail;
         public String fmt_std;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
@@ -14,8 +14,6 @@ public class MediaWPComRestResponse implements Response {
 
     public static class MultipleMediaResponse {
         public List<MediaWPComRestResponse> media;
-        public List<String> errors;
-        public int found;
     }
 
     public static class Thumbnails {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 /**
  * Response to GET request for media items
- *
- * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/media/%24media_ID/
+ * <p>
+ * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/media/%24media_ID/">doc</a>
  */
 public class MediaWPComRestResponse implements Response {
     public static final String DELETED_STATUS = "deleted";

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.media;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.wordpress.android.fluxc.network.Response;
 
@@ -20,30 +21,30 @@ public class MediaWPComRestResponse implements Response {
     }
 
     public static class Thumbnails {
-        public String thumbnail;
-        public String medium;
-        public String large;
-        public String fmt_std;
+        @Nullable public String thumbnail;
+        @Nullable public String medium;
+        @Nullable public String large;
+        @Nullable public String fmt_std;
     }
 
     public long ID;
-    public String date;
+    @NonNull public String date;
     public long post_ID;
     public long author_ID;
-    public String URL;
-    public String guid;
-    public String file;
-    public String extension;
-    public String mime_type;
-    public String title;
-    public String caption;
-    public String description;
-    public String alt;
-    public Thumbnails thumbnails;
+    @NonNull public String URL;
+    @NonNull public String guid;
+    @NonNull public String file;
+    @NonNull public String extension;
+    @NonNull public String mime_type;
+    @NonNull public String title;
+    @NonNull public String caption;
+    @NonNull public String description;
+    @NonNull public String alt;
+    @Nullable public Thumbnails thumbnails;
     public int height;
     public int width;
     public int length;
-    public String videopress_guid;
+    @Nullable public String videopress_guid;
     public boolean videopress_processing_done;
-    public String status;
+    @Nullable public String status;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
@@ -76,7 +76,10 @@ public class RestUploadRequestBody extends BaseUploadRequestBody {
 
         // add media attributes
         for (String key : params.keySet()) {
-            builder.addFormDataPart(String.format(MEDIA_PARAM_FORMAT, key), params.get(key).toString());
+            Object value = params.get(key);
+            if (value != null) {
+                builder.addFormDataPart(String.format(MEDIA_PARAM_FORMAT, key), value.toString());
+            }
         }
 
         // add media file data

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
@@ -70,6 +70,7 @@ public class RestUploadRequestBody extends BaseUploadRequestBody {
     }
 
     @NonNull
+    @SuppressWarnings("deprecation")
     private MultipartBody buildMultipartBody(@NonNull Map<String, Object> params) {
         MediaModel media = getMedia();
         MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
@@ -30,9 +30,12 @@ public class RestUploadRequestBody extends BaseUploadRequestBody {
     private static final String MEDIA_ATTRIBUTES_KEY = "attrs[0]";
     private static final String MEDIA_PARAM_FORMAT = MEDIA_ATTRIBUTES_KEY + "[%s]";
 
-    private final MultipartBody mMultipartBody;
+    @NonNull private final MultipartBody mMultipartBody;
 
-    public RestUploadRequestBody(MediaModel media, Map<String, Object> params, ProgressListener listener) {
+    public RestUploadRequestBody(
+            @NonNull MediaModel media,
+            @NonNull Map<String, Object> params,
+            @NonNull ProgressListener listener) {
         super(media, listener);
         mMultipartBody = buildMultipartBody(params);
     }
@@ -52,6 +55,7 @@ public class RestUploadRequestBody extends BaseUploadRequestBody {
         return -1L;
     }
 
+    @NonNull
     @Override
     public MediaType contentType() {
         return mMultipartBody.contentType();
@@ -65,7 +69,8 @@ public class RestUploadRequestBody extends BaseUploadRequestBody {
         bufferedSink.flush();
     }
 
-    private MultipartBody buildMultipartBody(Map<String, Object> params) {
+    @NonNull
+    private MultipartBody buildMultipartBody(@NonNull Map<String, Object> params) {
         MediaModel media = getMedia();
         MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
@@ -20,10 +20,10 @@ import okio.Okio;
 
 /**
  * Wrapper for {@link MultipartBody} that reports upload progress as body data is written.
- *
+ * <p>
  * A {@link ProgressListener} is required, use {@link MultipartBody} if progress is not needed.
- *
- * ref http://stackoverflow.com/questions/35528751/okhttp-3-tracking-multipart-upload-progress
+ * <p>
+ * @see <a href="http://stackoverflow.com/questions/35528751/okhttp-3-tracking-multipart-upload-progress">doc</a>
  */
 public class RestUploadRequestBody extends BaseUploadRequestBody {
     private static final String MEDIA_DATA_KEY = "media[0]";

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stockmedia/StockMediaRestClient.kt
@@ -110,7 +110,7 @@ class StockMediaRestClient @Inject constructor(
                 val mediaList: List<MediaModel> = mediaResponseUtils.getMediaListFromRestResponse(
                         response.data,
                         site.id
-                ) ?: listOf()
+                )
                 UploadedStockMediaPayload(site, mediaList)
             }
             is Error -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -416,7 +416,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 }));
     }
 
-    public void cancelUpload(final MediaModel media) {
+    public void cancelUpload(@Nullable final MediaModel media) {
         if (media == null) {
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
             error.logMessage = "XMLRPC: empty media on cancel upload";
@@ -504,7 +504,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newDeletedMediaAction(payload));
     }
 
-    private void notifyMediaUploadCanceled(MediaModel media) {
+    private void notifyMediaUploadCanceled(@NonNull MediaModel media) {
         ProgressPayload payload = new ProgressPayload(media, 0.f, false, true);
         mDispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -216,13 +216,21 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                                 fetchMedia(site, media, true);
                             } else {
                                 MediaModel responseMedia = getMediaFromXmlrpcResponse(responseMap);
-                                // Retain local IDs
-                                responseMedia.setId(media.getId());
-                                responseMedia.setLocalSiteId(site.getId());
-                                responseMedia.setLocalPostId(media.getLocalPostId());
-                                responseMedia.setMarkedLocallyAsFeatured(media.getMarkedLocallyAsFeatured());
+                                if (responseMedia != null) {
+                                    // Retain local IDs
+                                    responseMedia.setId(media.getId());
+                                    responseMedia.setLocalSiteId(site.getId());
+                                    responseMedia.setLocalPostId(media.getLocalPostId());
+                                    responseMedia.setMarkedLocallyAsFeatured(media.getMarkedLocallyAsFeatured());
 
-                                notifyMediaUploaded(responseMedia, null);
+                                    notifyMediaUploaded(responseMedia, null);
+                                } else {
+                                    String message = "could not parse Upload media response, ID: " + media.getMediaId();
+                                    AppLog.w(T.MEDIA, message);
+                                    MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
+                                    error.logMessage = "XMLRPC: " + message;
+                                    notifyMediaUploaded(media, error);
+                                }
                             }
                         } else {
                             String message = "error uploading media - malformed response: " + response.message();
@@ -521,9 +529,10 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return responseMedia;
     }
 
+    @Nullable
     @SuppressWarnings("rawtypes")
-    private MediaModel getMediaFromXmlrpcResponse(Map response) {
-        if (response == null || response.isEmpty()) {
+    private MediaModel getMediaFromXmlrpcResponse(@NonNull Map response) {
+        if (response.isEmpty()) {
             return null;
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -77,7 +77,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     private final OkHttpClient mOkHttpClient;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads
-    private ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
 
     @Inject public MediaXMLRPCClient(
             Dispatcher dispatcher,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -115,7 +115,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                     // success!
                     AppLog.i(T.MEDIA, "Media updated on remote: " + media.getTitle());
                     notifyMediaPushed(site, media, null);
-                }, error -> {
+                },
+                error -> {
                     String errorMessage = "error response to XMLRPC.EDIT_MEDIA request: " + error;
                     AppLog.e(T.MEDIA, errorMessage);
                     if (is404Response(error)) {
@@ -298,7 +299,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         error.logMessage = "XMLRPC: " + message;
                         notifyMediaListFetched(site, error, mimeType);
                     }
-                }, error -> {
+                },
+                error -> {
                     String message = "XMLRPC.GET_MEDIA_LIBRARY error response:";
                     AppLog.e(T.MEDIA, message, error.volleyError);
                     MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
@@ -361,7 +363,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                             notifyMediaFetched(site, media, error);
                         }
                     }
-                }, error -> {
+                },
+                error -> {
                     String message = "XMLRPC.GET_MEDIA_ITEM error response: " + error;
                     AppLog.e(T.MEDIA, message);
                     if (isFreshUpload) {
@@ -402,7 +405,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
                     AppLog.v(T.MEDIA, "Successful response from XMLRPC.DELETE_MEDIA");
                     notifyMediaDeleted(site, media, null);
-                }, error -> {
+                },
+                error -> {
                     String message = "Error response from XMLRPC.DELETE_MEDIA:" + error;
                     AppLog.e(T.MEDIA, message);
                     MediaErrorType mediaErrorType = MediaErrorType.fromBaseNetworkError(error);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -50,7 +50,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -287,18 +286,9 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         add(new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.GET_MEDIA_LIBRARY, params,
                 response -> {
                     List<MediaModel> mediaList = getMediaListFromXmlrpcResponse(response, site.getId());
-                    if (mediaList != null) {
-                        AppLog.v(T.MEDIA, "Fetched media list for site via XMLRPC.GET_MEDIA_LIBRARY");
-                        boolean canLoadMore = mediaList.size() == number;
-                        notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore, mimeType);
-                    } else {
-                        String message = "could not parse XMLRPC.GET_MEDIA_LIBRARY response: "
-                                         + Arrays.toString(response);
-                        AppLog.w(T.MEDIA, message);
-                        MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
-                        error.logMessage = "XMLRPC: " + message;
-                        notifyMediaListFetched(site, error, mimeType);
-                    }
+                    AppLog.v(T.MEDIA, "Fetched media list for site via XMLRPC.GET_MEDIA_LIBRARY");
+                    boolean canLoadMore = mediaList.size() == number;
+                    notifyMediaListFetched(site, mediaList, offset > 0, canLoadMore, mimeType);
                 },
                 error -> {
                     String message = "XMLRPC.GET_MEDIA_LIBRARY error response:";
@@ -514,12 +504,9 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     //
 
     // media list responses should be of type Object[] with each media item in the array represented by a HashMap
+    @NonNull
     @SuppressWarnings("rawtypes")
-    private List<MediaModel> getMediaListFromXmlrpcResponse(Object[] response, int localSiteId) {
-        if (response == null) {
-            return null;
-        }
-
+    private List<MediaModel> getMediaListFromXmlrpcResponse(@NonNull Object[] response, int localSiteId) {
         List<MediaModel> responseMedia = new ArrayList<>();
         for (Object mediaObject : response) {
             if (!(mediaObject instanceof HashMap)) {
@@ -531,7 +518,6 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 responseMedia.add(media);
             }
         }
-
         return responseMedia;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -692,15 +692,13 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     @NonNull
-    private List<Object> getBasicParams(final SiteModel site, final MediaModel media) {
+    private List<Object> getBasicParams(@NonNull final SiteModel site, @Nullable final MediaModel media) {
         List<Object> params = new ArrayList<>();
-        if (site != null) {
-            params.add(site.getSelfHostedSiteId());
-            params.add(site.getUsername());
-            params.add(site.getPassword());
-            if (media != null) {
-                params.add(media.getMediaId());
-            }
+        params.add(site.getSelfHostedSiteId());
+        params.add(site.getUsername());
+        params.add(site.getPassword());
+        if (media != null) {
+            params.add(media.getMediaId());
         }
         return params;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -197,7 +197,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         AppLog.d(T.MEDIA, "starting upload for: " + media.getId());
         call.enqueue(new Callback() {
             @Override
-            public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
+            public void onResponse(@NonNull Call call, @NonNull Response response) {
                 if (response.code() == HttpURLConnection.HTTP_OK) {
                     // HTTP_OK code doesn't mean the upload is successful, XML-RPC API returns code 200 with an
                     // xml field "faultCode" on error.

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -47,7 +47,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -615,8 +615,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 AppLog.e(T.MEDIA, "Failed to parse XMLRPC.wpUploadFile response - body was empty: " + response);
                 return null;
             }
-            String data = new String(responseBody.bytes(), "UTF-8");
-            InputStream is = new ByteArrayInputStream(data.getBytes(Charset.forName("UTF-8")));
+            String data = new String(responseBody.bytes(), StandardCharsets.UTF_8);
+            InputStream is = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
             Object responseObject = XMLSerializerUtils.deserialize(XMLSerializerUtils.scrubXmlResponse(is));
             if (responseObject instanceof Map) {
                 return (Map) responseObject;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -80,11 +80,12 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     // to monitor multiple uploads
     private ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
 
-    @Inject public MediaXMLRPCClient(Dispatcher dispatcher,
-                             @Named("custom-ssl") RequestQueue requestQueue,
-                             @Named("custom-ssl") OkHttpClient okHttpClient,
-                             UserAgent userAgent,
-                             HTTPAuthManager httpAuthManager) {
+    @Inject public MediaXMLRPCClient(
+            Dispatcher dispatcher,
+            @Named("custom-ssl") RequestQueue requestQueue,
+            @Named("custom-ssl") OkHttpClient okHttpClient,
+            UserAgent userAgent,
+            HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);
         mOkHttpClient = okHttpClient;
     }
@@ -118,22 +119,21 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         notifyMediaPushed(site, media, null);
                     }
                 }, new BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        String errorMessage = "error response to XMLRPC.EDIT_MEDIA request: " + error;
-                        AppLog.e(T.MEDIA, errorMessage);
-                        if (is404Response(error)) {
-                            AppLog.e(T.MEDIA, "media does not exist, no need to report error");
-                            notifyMediaPushed(site, media, null);
-                        } else {
-                            MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
-                            mediaError.message = error.message;
-                            mediaError.logMessage = errorMessage;
-                            notifyMediaPushed(site, media, mediaError);
-                        }
-                    }
+            @Override
+            public void onErrorResponse(@NonNull BaseNetworkError error) {
+                String errorMessage = "error response to XMLRPC.EDIT_MEDIA request: " + error;
+                AppLog.e(T.MEDIA, errorMessage);
+                if (is404Response(error)) {
+                    AppLog.e(T.MEDIA, "media does not exist, no need to report error");
+                    notifyMediaPushed(site, media, null);
+                } else {
+                    MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
+                    mediaError.message = error.message;
+                    mediaError.logMessage = errorMessage;
+                    notifyMediaPushed(site, media, mediaError);
                 }
-        ));
+            }
+        }));
     }
 
     /**
@@ -303,16 +303,15 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         }
                     }
                 }, new BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        String message = "XMLRPC.GET_MEDIA_LIBRARY error response:";
-                        AppLog.e(T.MEDIA, message, error.volleyError);
-                        MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
-                        mediaError.logMessage = "XMLRPC: " + message;
-                        notifyMediaListFetched(site, mediaError, mimeType);
-                    }
-                }
-        ));
+            @Override
+            public void onErrorResponse(@NonNull BaseNetworkError error) {
+                String message = "XMLRPC.GET_MEDIA_LIBRARY error response:";
+                AppLog.e(T.MEDIA, message, error.volleyError);
+                MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
+                mediaError.logMessage = "XMLRPC: " + message;
+                notifyMediaListFetched(site, mediaError, mimeType);
+            }
+        }));
     }
 
     public void fetchMedia(final SiteModel site, final MediaModel media) {
@@ -369,24 +368,23 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         }
                     }
                 }, new BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        String message = "XMLRPC.GET_MEDIA_ITEM error response: " + error;
-                        AppLog.e(T.MEDIA, message);
-                        if (isFreshUpload) {
-                            // we tried to fetch a media that's just uploaded but failed, so we should return
-                            // an upload error and not a fetch error as initially parsing the upload response failed
-                            MediaError mediaError = new MediaError(MediaErrorType.PARSE_ERROR);
-                            mediaError.logMessage = "XMLRPC: " + message;
-                            notifyMediaUploaded(media, mediaError);
-                        } else {
-                            MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
-                            mediaError.logMessage = "XMLRPC: " + message;
-                            notifyMediaFetched(site, media, mediaError);
-                        }
-                    }
+            @Override
+            public void onErrorResponse(@NonNull BaseNetworkError error) {
+                String message = "XMLRPC.GET_MEDIA_ITEM error response: " + error;
+                AppLog.e(T.MEDIA, message);
+                if (isFreshUpload) {
+                    // we tried to fetch a media that's just uploaded but failed, so we should return
+                    // an upload error and not a fetch error as initially parsing the upload response failed
+                    MediaError mediaError = new MediaError(MediaErrorType.PARSE_ERROR);
+                    mediaError.logMessage = "XMLRPC: " + message;
+                    notifyMediaUploaded(media, mediaError);
+                } else {
+                    MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
+                    mediaError.logMessage = "XMLRPC: " + message;
+                    notifyMediaFetched(site, media, mediaError);
                 }
-            ));
+            }
+        }));
     }
 
     public void deleteMedia(final SiteModel site, final MediaModel media) {
@@ -417,17 +415,16 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                         notifyMediaDeleted(site, media, null);
                     }
                 }, new BaseErrorListener() {
-                    @Override
-                    public void onErrorResponse(@NonNull BaseNetworkError error) {
-                        String message = "Error response from XMLRPC.DELETE_MEDIA:" + error;
-                        AppLog.e(T.MEDIA, message);
-                        MediaErrorType mediaErrorType = MediaErrorType.fromBaseNetworkError(error);
-                        MediaError mediaError = new MediaError(mediaErrorType);
-                        mediaError.logMessage = "XMLRPC: " + message;
-                        notifyMediaDeleted(site, media, mediaError);
-                    }
-                }
-            ));
+            @Override
+            public void onErrorResponse(@NonNull BaseNetworkError error) {
+                String message = "Error response from XMLRPC.DELETE_MEDIA:" + error;
+                AppLog.e(T.MEDIA, message);
+                MediaErrorType mediaErrorType = MediaErrorType.fromBaseNetworkError(error);
+                MediaError mediaError = new MediaError(mediaErrorType);
+                mediaError.logMessage = "XMLRPC: " + message;
+                notifyMediaDeleted(site, media, mediaError);
+            }
+        }));
     }
 
     public void cancelUpload(final MediaModel media) {
@@ -453,7 +450,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     private void removeCallFromCurrentUploadsMap(int id) {
         mCurrentUploadCalls.remove(id);
         AppLog.d(T.MEDIA, "mediaXMLRPCClient: removed id: " + id + " from current uploads, remaining: "
-                + mCurrentUploadCalls.size());
+                          + mCurrentUploadCalls.size());
     }
 
     //
@@ -516,11 +513,15 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
 
     // media list responses should be of type Object[] with each media item in the array represented by a HashMap
     private List<MediaModel> getMediaListFromXmlrpcResponse(Object[] response, int localSiteId) {
-        if (response == null) return null;
+        if (response == null) {
+            return null;
+        }
 
         List<MediaModel> responseMedia = new ArrayList<>();
         for (Object mediaObject : response) {
-            if (!(mediaObject instanceof HashMap)) continue;
+            if (!(mediaObject instanceof HashMap)) {
+                continue;
+            }
             MediaModel media = getMediaFromXmlrpcResponse((HashMap) mediaObject);
             if (media != null) {
                 media.setLocalSiteId(localSiteId);
@@ -532,7 +533,9 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     private MediaModel getMediaFromXmlrpcResponse(Map response) {
-        if (response == null || response.isEmpty()) return null;
+        if (response == null || response.isEmpty()) {
+            return null;
+        }
 
         MediaModel media = new MediaModel();
         media.setMediaId(MapUtils.getMapLong(response, "attachment_id"));
@@ -576,7 +579,9 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         }
 
         // make sure the path to the original image is a valid path to a file
-        if (mediaUrl.lastIndexOf("/") + 1 >= mediaUrl.length()) return null;
+        if (mediaUrl.lastIndexOf("/") + 1 >= mediaUrl.length()) {
+            return null;
+        }
 
         String baseURL = mediaUrl.substring(0, mediaUrl.lastIndexOf("/") + 1);
         return baseURL + fileName;
@@ -651,7 +656,9 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     private Map<String, Object> getEditMediaFields(final MediaModel media) {
-        if (media == null) return null;
+        if (media == null) {
+            return null;
+        }
         Map<String, Object> mediaFields = new HashMap<>();
         mediaFields.put("post_title", media.getTitle());
         mediaFields.put("post_content", media.getDescription());
@@ -667,7 +674,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         if (error.hasVolleyError() && error.volleyError != null) {
             VolleyError volleyError = error.volleyError;
             if (volleyError.networkResponse != null
-                    && volleyError.networkResponse.statusCode == HttpURLConnection.HTTP_NOT_FOUND) {
+                && volleyError.networkResponse.statusCode == HttpURLConnection.HTTP_NOT_FOUND) {
                 return true;
             }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -567,9 +567,13 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return media;
     }
 
+    @Nullable
     @SuppressWarnings("rawtypes")
-    private String getFileUrlForSize(String mediaUrl, Map metadataMap, String size) {
-        if (metadataMap == null || TextUtils.isEmpty(mediaUrl) || !mediaUrl.contains("/")) {
+    private String getFileUrlForSize(
+            @NonNull String mediaUrl,
+            @NonNull Map metadataMap,
+            @NonNull String size) {
+        if (TextUtils.isEmpty(mediaUrl) || !mediaUrl.contains("/")) {
             return null;
         }
 
@@ -587,11 +591,11 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return baseURL + fileName;
     }
 
+    @Nullable
     @SuppressWarnings("rawtypes")
-    private String getFileForSize(Map metadataMap, String size) {
-        if (metadataMap == null) {
-            return null;
-        }
+    private String getFileForSize(
+            @NonNull Map metadataMap,
+            @NonNull String size) {
         Object sizesObject = metadataMap.get("sizes");
         if (sizesObject instanceof Map) {
             Map sizesMap = (Map) sizesObject;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -90,7 +90,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     @Override
-    public void onProgress(MediaModel media, float progress) {
+    public void onProgress(@NonNull MediaModel media, float progress) {
         if (mCurrentUploadCalls.containsKey(media.getId())) {
             notifyMediaProgress(media, Math.min(progress, 0.99f));
         }
@@ -439,7 +439,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newPushedMediaAction(payload));
     }
 
-    private void notifyMediaProgress(MediaModel media, float progress) {
+    private void notifyMediaProgress(@NonNull MediaModel media, float progress) {
         ProgressPayload payload = new ProgressPayload(media, progress, false, null);
         mDispatcher.dispatch(UploadActionBuilder.newUploadedMediaAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -74,7 +74,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     private static final String[] REQUIRED_UPLOAD_RESPONSE_FIELDS = {
             "attachment_id", "parent", "title", "caption", "description", "thumbnail", "date_created_gmt", "link"};
 
-    private final OkHttpClient mOkHttpClient;
+    @NonNull private final OkHttpClient mOkHttpClient;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads
     private final ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
@@ -82,7 +82,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     @Inject public MediaXMLRPCClient(
             Dispatcher dispatcher,
             @Named("custom-ssl") RequestQueue requestQueue,
-            @Named("custom-ssl") OkHttpClient okHttpClient,
+            @NonNull @Named("custom-ssl") OkHttpClient okHttpClient,
             UserAgent userAgent,
             HTTPAuthManager httpAuthManager) {
         super(dispatcher, requestQueue, userAgent, httpAuthManager);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -381,7 +381,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 }));
     }
 
-    public void deleteMedia(final SiteModel site, final MediaModel media) {
+    public void deleteMedia(@NonNull final SiteModel site, @Nullable final MediaModel media) {
         if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
@@ -496,7 +496,10 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaAction(payload));
     }
 
-    private void notifyMediaDeleted(SiteModel site, MediaModel media, MediaError error) {
+    private void notifyMediaDeleted(
+            @NonNull SiteModel site,
+            @Nullable MediaModel media,
+            @Nullable MediaError error) {
         MediaPayload payload = new MediaPayload(site, media, error);
         mDispatcher.dispatch(MediaActionBuilder.newDeletedMediaAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -74,7 +74,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     private static final String[] REQUIRED_UPLOAD_RESPONSE_FIELDS = {
             "attachment_id", "parent", "title", "caption", "description", "thumbnail", "date_created_gmt", "link"};
 
-    private OkHttpClient mOkHttpClient;
+    private final OkHttpClient mOkHttpClient;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads
     private ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -618,8 +618,9 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return mediaError;
     }
 
+    @Nullable
     @SuppressWarnings("rawtypes")
-    private static Map getMapFromUploadResponse(Response response) throws XMLRPCException {
+    private static Map getMapFromUploadResponse(@NonNull Response response) throws XMLRPCException {
         try {
             ResponseBody responseBody = response.body();
             if (responseBody == null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -309,7 +309,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 }));
     }
 
-    public void fetchMedia(final SiteModel site, final MediaModel media) {
+    public void fetchMedia(@NonNull final SiteModel site, @Nullable final MediaModel media) {
         fetchMedia(site, media, false);
     }
 
@@ -488,7 +488,10 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 
-    private void notifyMediaFetched(SiteModel site, MediaModel media, MediaError error) {
+    private void notifyMediaFetched(
+            @NonNull SiteModel site,
+            @Nullable MediaModel media,
+            @Nullable MediaError error) {
         MediaPayload payload = new MediaPayload(site, media, error);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -77,7 +77,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     @NonNull private final OkHttpClient mOkHttpClient;
     // this will hold which media is being uploaded by which call, in order to be able
     // to monitor multiple uploads
-    private final ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
+    @NonNull private final ConcurrentHashMap<Integer, Call> mCurrentUploadCalls = new ConcurrentHashMap<>();
 
     @Inject public MediaXMLRPCClient(
             Dispatcher dispatcher,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -133,7 +133,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     /**
      * @see <a href="https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.uploadFile">documentation</a>
      */
-    public void uploadMedia(final SiteModel site, final MediaModel media) {
+    public void uploadMedia(@NonNull final SiteModel site, @Nullable final MediaModel media) {
         URL xmlrpcUrl;
         try {
             xmlrpcUrl = new URL(site.getXmlRpcUrl());
@@ -311,7 +311,10 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
      * @see <a href="https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaItem">documentation</a>
      */
     @SuppressWarnings("rawtypes")
-    private void fetchMedia(final SiteModel site, final MediaModel media, final boolean isFreshUpload) {
+    private void fetchMedia(
+            @NonNull final SiteModel site,
+            @Nullable final MediaModel media,
+            final boolean isFreshUpload) {
         if (media == null) {
             // caller may be expecting a notification
             MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
@@ -448,7 +451,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(UploadActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaUploaded(MediaModel media, MediaError error) {
+    private void notifyMediaUploaded(@Nullable MediaModel media, @Nullable MediaError error) {
         if (media != null) {
             media.setUploadState(error == null ? MediaUploadState.UPLOADED : MediaUploadState.FAILED);
             removeCallFromCurrentUploadsMap(media.getId());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -604,7 +604,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return null;
     }
 
-    private MediaError getMediaErrorFromXMLRPCException(XMLRPCException exception) {
+    @NonNull
+    private MediaError getMediaErrorFromXMLRPCException(@NonNull XMLRPCException exception) {
         MediaError mediaError = new MediaError(MediaErrorType.GENERIC_ERROR);
         mediaError.message = exception.getLocalizedMessage();
         mediaError.logMessage = exception.getMessage();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -130,7 +130,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     /**
-     * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.uploadFile
+     * @see <a href="https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.uploadFile">documentation</a>
      */
     public void uploadMedia(final SiteModel site, final MediaModel media) {
         URL xmlrpcUrl;
@@ -263,7 +263,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     /**
-     * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
+     * @see <a href="https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary">documentation</a>
      */
     public void fetchMediaList(final SiteModel site, final int number, final int offset, final MimeType.Type mimeType) {
         List<Object> params = getBasicParams(site, null);
@@ -306,7 +306,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     /**
-     * ref: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaItem
+     * @see <a href="https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaItem">documentation</a>
      */
     private void fetchMedia(final SiteModel site, final MediaModel media, final boolean isFreshUpload) {
         if (media == null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 import android.util.Base64;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.Response.Listener;
@@ -96,7 +97,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         }
     }
 
-    public void pushMedia(final SiteModel site, final MediaModel media) {
+    public void pushMedia(@NonNull final SiteModel site, @Nullable final MediaModel media) {
         List<Object> params = getBasicParams(site, media);
         params.add(getEditMediaFields(media));
         add(new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.EDIT_POST, params,
@@ -434,7 +435,10 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     // Helper methods to dispatch media actions
     //
 
-    private void notifyMediaPushed(SiteModel site, MediaModel media, MediaError error) {
+    private void notifyMediaPushed(
+            @NonNull SiteModel site,
+            @Nullable MediaModel media,
+            @Nullable MediaError error) {
         MediaPayload payload = new MediaPayload(site, media, error);
         mDispatcher.dispatch(MediaActionBuilder.newPushedMediaAction(payload));
     }
@@ -638,7 +642,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return false;
     }
 
-    private Map<String, Object> getEditMediaFields(final MediaModel media) {
+    @Nullable
+    private Map<String, Object> getEditMediaFields(@Nullable final MediaModel media) {
         if (media == null) {
             return null;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -671,7 +671,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return mediaFields;
     }
 
-    private boolean is404Response(BaseNetworkError error) {
+    private boolean is404Response(@NonNull BaseNetworkError error) {
         if (error.isGeneric() && error.type == BaseRequest.GenericErrorType.NOT_FOUND) {
             return true;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -267,7 +267,11 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     /**
      * @see <a href="https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary">documentation</a>
      */
-    public void fetchMediaList(final SiteModel site, final int number, final int offset, final MimeType.Type mimeType) {
+    public void fetchMediaList(
+            @NonNull final SiteModel site,
+            final int number,
+            final int offset,
+            @Nullable final MimeType.Type mimeType) {
         List<Object> params = getBasicParams(site, null);
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("number", number);
@@ -461,17 +465,21 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         mDispatcher.dispatch(UploadActionBuilder.newUploadedMediaAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site,
-                                        @NonNull List<MediaModel> media,
-                                        boolean loadedMore,
-                                        boolean canLoadMore,
-                                        MimeType.Type mimeType) {
+    private void notifyMediaListFetched(
+            @NonNull SiteModel site,
+            @NonNull List<MediaModel> media,
+            boolean loadedMore,
+            boolean canLoadMore,
+            @Nullable MimeType.Type mimeType) {
         FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, media,
                 loadedMore, canLoadMore, mimeType);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }
 
-    private void notifyMediaListFetched(SiteModel site, MediaError error, MimeType.Type mimeType) {
+    private void notifyMediaListFetched(
+            @NonNull SiteModel site,
+            @NonNull MediaError error,
+            @Nullable MimeType.Type mimeType) {
         FetchMediaListResponsePayload payload = new FetchMediaListResponsePayload(site, error, mimeType);
         mDispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload));
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -662,9 +662,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             }
 
             if (volleyError.getCause() instanceof XMLRPCFault) {
-                if (((XMLRPCFault) volleyError.getCause()).getFaultCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-                    return true;
-                }
+                return ((XMLRPCFault) volleyError.getCause()).getFaultCode() == HttpURLConnection.HTTP_NOT_FOUND;
             }
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -97,6 +97,14 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     public void pushMedia(@NonNull final SiteModel site, @Nullable final MediaModel media) {
+        if (media == null) {
+            // caller may be expecting a notification
+            MediaError error = new MediaError(MediaErrorType.NULL_MEDIA_ARG);
+            error.logMessage = "Pushed media is null";
+            notifyMediaPushed(site, null, error);
+            return;
+        }
+
         List<Object> params = getBasicParams(site, media);
         params.add(getEditMediaFields(media));
         add(new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.EDIT_POST, params,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -102,7 +102,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         add(new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.EDIT_POST, params,
                 (Listener<Object>) response -> {
                     // response should be a boolean indicating result of push request
-                    if (response == null || !(response instanceof Boolean) || !(Boolean) response) {
+                    if (!(response instanceof Boolean) || !(Boolean) response) {
                         String message = "could not parse XMLRPC.EDIT_MEDIA response: " + response;
                         AppLog.w(T.MEDIA, message);
                         MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);
@@ -381,7 +381,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         add(new XMLRPCRequest(site.getXmlRpcUrl(), XMLRPC.DELETE_POST, params,
                 (Listener<Object>) response -> {
                     // response should be a boolean indicating result of push request
-                    if (response == null || !(response instanceof Boolean) || !(Boolean) response) {
+                    if (!(response instanceof Boolean) || !(Boolean) response) {
                         String message = "could not parse XMLRPC.DELETE_MEDIA response: " + response;
                         AppLog.w(T.MEDIA, message);
                         MediaError error = new MediaError(MediaErrorType.PARSE_ERROR);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -641,7 +641,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     }
 
     @SuppressWarnings("rawtypes")
-    private static boolean isDeprecatedUploadResponse(Map responseMap) {
+    private static boolean isDeprecatedUploadResponse(@NonNull Map responseMap) {
         for (String requiredResponseField : REQUIRED_UPLOAD_RESPONSE_FIELDS) {
             if (!responseMap.containsKey(requiredResponseField)) {
                 return true;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -197,6 +197,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         AppLog.d(T.MEDIA, "starting upload for: " + media.getId());
         call.enqueue(new Callback() {
             @Override
+            @SuppressWarnings("rawtypes")
             public void onResponse(@NonNull Call call, @NonNull Response response) {
                 if (response.code() == HttpURLConnection.HTTP_OK) {
                     // HTTP_OK code doesn't mean the upload is successful, XML-RPC API returns code 200 with an
@@ -308,6 +309,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     /**
      * @see <a href="https://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaItem">documentation</a>
      */
+    @SuppressWarnings("rawtypes")
     private void fetchMedia(final SiteModel site, final MediaModel media, final boolean isFreshUpload) {
         if (media == null) {
             // caller may be expecting a notification
@@ -487,6 +489,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
     //
 
     // media list responses should be of type Object[] with each media item in the array represented by a HashMap
+    @SuppressWarnings("rawtypes")
     private List<MediaModel> getMediaListFromXmlrpcResponse(Object[] response, int localSiteId) {
         if (response == null) {
             return null;
@@ -507,6 +510,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return responseMedia;
     }
 
+    @SuppressWarnings("rawtypes")
     private MediaModel getMediaFromXmlrpcResponse(Map response) {
         if (response == null || response.isEmpty()) {
             return null;
@@ -543,6 +547,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return media;
     }
 
+    @SuppressWarnings("rawtypes")
     private String getFileUrlForSize(String mediaUrl, Map metadataMap, String size) {
         if (metadataMap == null || TextUtils.isEmpty(mediaUrl) || !mediaUrl.contains("/")) {
             return null;
@@ -562,6 +567,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return baseURL + fileName;
     }
 
+    @SuppressWarnings("rawtypes")
     private String getFileForSize(Map metadataMap, String size) {
         if (metadataMap == null) {
             return null;
@@ -601,6 +607,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return mediaError;
     }
 
+    @SuppressWarnings("rawtypes")
     private static Map getMapFromUploadResponse(Response response) throws XMLRPCException {
         try {
             ResponseBody responseBody = response.body();
@@ -621,6 +628,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         return null;
     }
 
+    @SuppressWarnings("rawtypes")
     private static boolean isDeprecatedUploadResponse(Map responseMap) {
         for (String requiredResponseField : REQUIRED_UPLOAD_RESPONSE_FIELDS) {
             if (!responseMap.containsKey(requiredResponseField)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
@@ -39,12 +39,15 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
     private static final String APPEND_XML =
             "</base64></value></member></struct></value></param></params></methodCall>";
 
-    private final String mPrependString;
+    @NonNull private final String mPrependString;
     private long mMediaSize;
     private long mContentSize = -1;
     private long mMediaBytesWritten = 0;
 
-    public XmlrpcUploadRequestBody(MediaModel media, ProgressListener listener, SiteModel site) {
+    public XmlrpcUploadRequestBody(
+            @NonNull MediaModel media,
+            @NonNull ProgressListener listener,
+            @NonNull SiteModel site) {
         super(media, listener);
 
         // TODO: we should use the XMLRPCSerializer instead of doing this
@@ -69,6 +72,7 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
         return (float) mMediaBytesWritten / mMediaSize;
     }
 
+    @NonNull
     @Override
     public MediaType contentType() {
         return MEDIA_TYPE;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
@@ -114,8 +114,7 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
 
         // write file to xml
 
-        FileInputStream fis = new FileInputStream(getMedia().getFilePath());
-        try {
+        try (FileInputStream fis = new FileInputStream(getMedia().getFilePath())) {
             byte[] buffer = new byte[3600]; // you must use a 24bit multiple
             int length;
             String chunk;
@@ -124,8 +123,6 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
                 mMediaBytesWritten += length;
                 bufferedSink.writeUtf8(chunk);
             }
-        } finally {
-            fis.close();
         }
 
         // write remainder or XML

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/XmlrpcUploadRequestBody.java
@@ -44,6 +44,7 @@ public class XmlrpcUploadRequestBody extends BaseUploadRequestBody {
     private long mContentSize = -1;
     private long mMediaBytesWritten = 0;
 
+    @SuppressWarnings("deprecation")
     public XmlrpcUploadRequestBody(
             @NonNull MediaModel media,
             @NonNull ProgressListener listener,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -78,12 +78,19 @@ public class MediaStore extends Store {
     public static class UploadMediaPayload extends MediaPayload {
         public final boolean stripLocation;
 
-        public UploadMediaPayload(SiteModel site, MediaModel media, boolean stripLocation) {
+        public UploadMediaPayload(
+                @NonNull SiteModel site,
+                @Nullable MediaModel media,
+                boolean stripLocation) {
             super(site, media, null);
             this.stripLocation = stripLocation;
         }
 
-        public UploadMediaPayload(SiteModel site, MediaModel media, MediaError error, boolean stripLocation) {
+        public UploadMediaPayload(
+                @NonNull SiteModel site,
+                @Nullable MediaModel media,
+                @Nullable MediaError error,
+                boolean stripLocation) {
             super(site, media, error);
             this.stripLocation = stripLocation;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -816,7 +816,7 @@ public class MediaStore extends Store {
         }
     }
 
-    private void performFetchMediaList(FetchMediaListPayload payload) {
+    private void performFetchMediaList(@NonNull FetchMediaListPayload payload) {
         int offset = 0;
         if (payload.loadMore) {
             List<String> list = new ArrayList<>();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -504,6 +504,7 @@ public class MediaStore extends Store {
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
+    @SuppressWarnings("rawtypes")
     public void onAction(Action action) {
         IAction actionType = action.getType();
         if (!(actionType instanceof MediaAction)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -779,7 +779,7 @@ public class MediaStore extends Store {
         emitChange(onMediaUploaded);
     }
 
-    private void performUploadMedia(UploadMediaPayload payload) {
+    private void performUploadMedia(@NonNull UploadMediaPayload payload) {
         MalformedMediaArgSubType argError = MediaUtils.getMediaValidationErrorType(payload.media);
 
         if (argError.getType() != Type.NO_ERROR) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -752,7 +752,7 @@ public class MediaStore extends Store {
     // Helper methods that choose the appropriate network client to perform an action
     //
 
-    private void performPushMedia(MediaPayload payload) {
+    private void performPushMedia(@NonNull MediaPayload payload) {
         if (payload.media == null) {
             // null or empty media list -or- list contains a null value
             notifyMediaError(MediaErrorType.NULL_MEDIA_ARG, MediaAction.PUSH_MEDIA, null);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -169,15 +169,25 @@ public class MediaStore extends Store {
      * Actions: UPLOADED_MEDIA, CANCELED_MEDIA_UPLOAD
      */
     public static class ProgressPayload extends Payload<MediaError> {
-        public MediaModel media;
+        @Nullable public MediaModel media;
         public float progress;
         public boolean completed;
         public boolean canceled;
-        public ProgressPayload(MediaModel media, float progress, boolean completed, boolean canceled) {
+
+        public ProgressPayload(
+                @NonNull MediaModel media,
+                float progress,
+                boolean completed,
+                boolean canceled) {
             this(media, progress, completed, null);
             this.canceled = canceled;
         }
-        public ProgressPayload(MediaModel media, float progress, boolean completed, MediaError error) {
+
+        public ProgressPayload(
+                @Nullable MediaModel media,
+                float progress,
+                boolean completed,
+                @Nullable MediaError error) {
             this.media = media;
             this.progress = progress;
             this.completed = completed;
@@ -753,7 +763,7 @@ public class MediaStore extends Store {
     // Action implementations
     //
 
-    void updateMedia(MediaModel media, boolean emit) {
+    void updateMedia(@Nullable MediaModel media, boolean emit) {
         OnMediaChanged event = new OnMediaChanged(MediaAction.UPDATE_MEDIA);
 
         if (media == null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -100,23 +100,30 @@ public class MediaStore extends Store {
      * Actions: FETCH_MEDIA_LIST
      */
     public static class FetchMediaListPayload extends Payload<BaseNetworkError> {
-        public SiteModel site;
+        @NonNull public SiteModel site;
         public boolean loadMore;
-        public MimeType.Type mimeType;
+        @Nullable public MimeType.Type mimeType;
         public int number = DEFAULT_NUM_MEDIA_PER_FETCH;
 
         @SuppressWarnings("unused")
-        public FetchMediaListPayload(SiteModel site) {
+        public FetchMediaListPayload(@NonNull SiteModel site) {
             this.site = site;
         }
 
-        public FetchMediaListPayload(SiteModel site, int number, boolean loadMore) {
+        public FetchMediaListPayload(
+                @NonNull SiteModel site,
+                int number,
+                boolean loadMore) {
             this.site = site;
             this.loadMore = loadMore;
             this.number = number;
         }
 
-        public FetchMediaListPayload(SiteModel site, int number, boolean loadMore, MimeType.Type mimeType) {
+        public FetchMediaListPayload(
+                @NonNull SiteModel site,
+                int number,
+                boolean loadMore,
+                @NonNull MimeType.Type mimeType) {
             this.site = site;
             this.loadMore = loadMore;
             this.mimeType = mimeType;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -274,7 +274,7 @@ public class MediaStore extends Store {
             if (type == MediaErrorType.BAD_REQUEST) {
                 String[] splitMsg = message.split("\\|", 2);
 
-                if (null != splitMsg && splitMsg.length > 1) {
+                if (splitMsg.length > 1) {
                     String userMessage = splitMsg[1];
 
                     if (TextUtils.isEmpty(userMessage)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -135,16 +135,18 @@ public class MediaStore extends Store {
      * Actions: FETCHED_MEDIA_LIST
      */
     public static class FetchMediaListResponsePayload extends Payload<MediaError> {
-        public SiteModel site;
-        public List<MediaModel> mediaList;
+        @NonNull public SiteModel site;
+        @NonNull public List<MediaModel> mediaList;
         public boolean loadedMore;
         public boolean canLoadMore;
-        public MimeType.Type mimeType;
-        public FetchMediaListResponsePayload(SiteModel site,
-                                             @NonNull List<MediaModel> mediaList,
-                                             boolean loadedMore,
-                                             boolean canLoadMore,
-                                             MimeType.Type mimeType) {
+        @Nullable public MimeType.Type mimeType;
+
+        public FetchMediaListResponsePayload(
+                @NonNull SiteModel site,
+                @NonNull List<MediaModel> mediaList,
+                boolean loadedMore,
+                boolean canLoadMore,
+                @Nullable MimeType.Type mimeType) {
             this.site = site;
             this.mediaList = mediaList;
             this.loadedMore = loadedMore;
@@ -152,7 +154,10 @@ public class MediaStore extends Store {
             this.mimeType = mimeType;
         }
 
-        public FetchMediaListResponsePayload(SiteModel site, MediaError error, MimeType.Type mimeType) {
+        public FetchMediaListResponsePayload(
+                @NonNull SiteModel site,
+                @NonNull MediaError error,
+                @Nullable MimeType.Type mimeType) {
             this.mediaList = new ArrayList<>();
             this.site = site;
             this.error = error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -840,7 +840,7 @@ public class MediaStore extends Store {
         }
     }
 
-    private void performFetchMedia(MediaPayload payload) {
+    private void performFetchMedia(@NonNull MediaPayload payload) {
         if (payload.site == null || payload.media == null) {
             // null or empty media list -or- list contains a null value
             notifyMediaError(MediaErrorType.NULL_MEDIA_ARG, MediaAction.FETCH_MEDIA, payload.media);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -416,6 +416,13 @@ public class MediaStore extends Store {
                     return MediaErrorType.SERVER_ERROR;
                 case TIMEOUT:
                     return MediaErrorType.TIMEOUT;
+                case NO_CONNECTION:
+                case NETWORK_ERROR:
+                case CENSORED:
+                case INVALID_SSL_CERTIFICATE:
+                case HTTP_AUTH_ERROR:
+                case INVALID_RESPONSE:
+                case UNKNOWN:
                 default:
                     return MediaErrorType.GENERIC_ERROR;
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -783,6 +783,7 @@ public class MediaStore extends Store {
         }
     }
 
+    @SuppressWarnings("SameParameterValue")
     private void notifyMediaUploadError(MediaErrorType errorType, String errorMessage, MediaModel media,
                                         String logMessage, MalformedMediaArgSubType argErrorType) {
         OnMediaUploaded onMediaUploaded = new OnMediaUploaded(media, 1, false, false);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -257,9 +257,11 @@ public class MediaStore extends Store {
         public String message;
         public int statusCode;
         public String logMessage;
+
         public MediaError(MediaErrorType type) {
             this.type = type;
         }
+
         public MediaError(MediaErrorType type, String message) {
             this.type = type;
             this.message = message;
@@ -331,6 +333,7 @@ public class MediaStore extends Store {
     public static class UploadStockMediaError implements OnChangedError {
         public UploadStockMediaErrorType type;
         public String message;
+
         public UploadStockMediaError(UploadStockMediaErrorType type, String message) {
             this.type = type;
             this.message = message;
@@ -340,15 +343,19 @@ public class MediaStore extends Store {
     public static class OnMediaChanged extends OnChanged<MediaError> {
         public MediaAction cause;
         public List<MediaModel> mediaList;
+
         public OnMediaChanged(MediaAction cause) {
             this(cause, new ArrayList<>(), null);
         }
+
         public OnMediaChanged(MediaAction cause, @NonNull List<MediaModel> mediaList) {
             this(cause, mediaList, null);
         }
+
         public OnMediaChanged(MediaAction cause, MediaError error) {
             this(cause, new ArrayList<>(), error);
         }
+
         public OnMediaChanged(MediaAction cause, @NonNull List<MediaModel> mediaList, MediaError error) {
             this.cause = cause;
             this.mediaList = mediaList;
@@ -360,11 +367,13 @@ public class MediaStore extends Store {
         public SiteModel site;
         public boolean canLoadMore;
         public MimeType.Type mimeType;
+
         public OnMediaListFetched(SiteModel site, boolean canLoadMore, MimeType.Type mimeType) {
             this.site = site;
             this.canLoadMore = canLoadMore;
             this.mimeType = mimeType;
         }
+
         public OnMediaListFetched(SiteModel site, MediaError error, MimeType.Type mimeType) {
             this.site = site;
             this.error = error;
@@ -377,6 +386,7 @@ public class MediaStore extends Store {
         public float progress;
         public boolean completed;
         public boolean canceled;
+
         public OnMediaUploaded(MediaModel media, float progress, boolean completed, boolean canceled) {
             this.media = media;
             this.progress = progress;
@@ -394,6 +404,7 @@ public class MediaStore extends Store {
             this.site = site;
             this.mediaList = mediaList;
         }
+
         public OnStockMediaUploaded(@NonNull SiteModel site, @NonNull UploadStockMediaError error) {
             this.site = site;
             this.error = error;
@@ -624,6 +635,7 @@ public class MediaStore extends Store {
     }
 
     public static final List<String> NOT_DELETED_STATES = new ArrayList<>();
+
     static {
         NOT_DELETED_STATES.add(MediaUploadState.DELETING.toString());
         NOT_DELETED_STATES.add(MediaUploadState.FAILED.toString());
@@ -843,8 +855,7 @@ public class MediaStore extends Store {
                     argError.getType().getErrorLogDescription(),
                     payload.media,
                     message,
-                    argError
-            );
+                    argError);
             return;
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -626,14 +626,17 @@ public class MediaStore extends Store {
         return MediaSqlUtils.getSiteImages(siteModel);
     }
 
+    @SuppressWarnings("unused")
     public List<MediaModel> getSiteVideos(SiteModel siteModel) {
         return MediaSqlUtils.getSiteVideos(siteModel);
     }
 
+    @SuppressWarnings("unused")
     public List<MediaModel> getSiteAudio(SiteModel siteModel) {
         return MediaSqlUtils.getSiteAudio(siteModel);
     }
 
+    @SuppressWarnings("unused")
     public List<MediaModel> getSiteDocuments(SiteModel siteModel) {
         return MediaSqlUtils.getSiteDocuments(siteModel);
     }
@@ -703,6 +706,7 @@ public class MediaStore extends Store {
         return MediaSqlUtils.matchPostMedia(postModel.getId());
     }
 
+    @SuppressWarnings("unused")
     public List<MediaModel> getMediaForPostWithState(PostImmutableModel postModel, MediaUploadState expectedState) {
         return MediaSqlUtils.matchPostMedia(postModel.getId(), MediaModelTable.UPLOAD_STATE,
                 expectedState);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -199,15 +199,15 @@ public class MediaStore extends Store {
      * Actions: CANCEL_MEDIA_UPLOAD
      */
     public static class CancelMediaPayload extends Payload<BaseNetworkError> {
-        public SiteModel site;
-        public MediaModel media;
+        @NonNull public SiteModel site;
+        @NonNull public MediaModel media;
         public boolean delete;
 
-        public CancelMediaPayload(SiteModel site, MediaModel media) {
+        public CancelMediaPayload(@NonNull SiteModel site, @NonNull MediaModel media) {
             this(site, media, true);
         }
 
-        public CancelMediaPayload(SiteModel site, MediaModel media, boolean delete) {
+        public CancelMediaPayload(@NonNull SiteModel site, @NonNull MediaModel media, boolean delete) {
             this.site = site;
             this.media = media;
             this.delete = delete;
@@ -919,10 +919,6 @@ public class MediaStore extends Store {
     }
 
     private void performCancelUpload(@NonNull CancelMediaPayload payload) {
-        if (payload.media == null) {
-            return;
-        }
-
         MediaModel media = payload.media;
         if (payload.delete) {
             MediaSqlUtils.deleteMedia(media);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -96,6 +96,7 @@ public class MediaStore extends Store {
         public MimeType.Type mimeType;
         public int number = DEFAULT_NUM_MEDIA_PER_FETCH;
 
+        @SuppressWarnings("unused")
         public FetchMediaListPayload(SiteModel site) {
             this.site = site;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -578,13 +578,13 @@ public class MediaStore extends Store {
     public MediaModel instantiateMediaModel() {
         MediaModel media = new MediaModel();
 
-        media = MediaSqlUtils.insertMediaForResult(media);
+        MediaModel insertedMedia = MediaSqlUtils.insertMediaForResult(media);
 
-        if (media.getId() == -1) {
-            media = null;
+        if (insertedMedia.getId() == -1) {
+            return null;
         }
 
-        return media;
+        return insertedMedia;
     }
 
     public List<MediaModel> getAllSiteMedia(SiteModel siteModel) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -309,13 +309,13 @@ public class MediaStore extends Store {
         public MediaAction cause;
         public List<MediaModel> mediaList;
         public OnMediaChanged(MediaAction cause) {
-            this(cause, new ArrayList<MediaModel>(), null);
+            this(cause, new ArrayList<>(), null);
         }
         public OnMediaChanged(MediaAction cause, @NonNull List<MediaModel> mediaList) {
             this(cause, mediaList, null);
         }
         public OnMediaChanged(MediaAction cause, MediaError error) {
-            this(cause, new ArrayList<MediaModel>(), error);
+            this(cause, new ArrayList<>(), error);
         }
         public OnMediaChanged(MediaAction cause, @NonNull List<MediaModel> mediaList, MediaError error) {
             this.cause = cause;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -329,10 +329,6 @@ public class UploadStore extends Store {
     }
 
     private void handleCancelMedia(@NonNull CancelMediaPayload payload) {
-        if (payload.media == null) {
-            return;
-        }
-
         // If the cancel action has the delete flag, the corresponding MediaModel will be deleted once this action
         // reaches the MediaStore, along with the MediaUploadModel (because of the FOREIGN KEY association)
         // Otherwise, we should mark the MediaUploadModel as FAILED

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -131,7 +131,7 @@ public class UploadStore extends Store {
     }
 
     @SuppressWarnings("EnumSwitchStatementWhichMissesCases")
-    private void onMediaAction(MediaAction actionType, Object payload) {
+    private void onMediaAction(MediaAction actionType, @NonNull Object payload) {
         switch (actionType) {
             case UPLOAD_MEDIA:
                 handleUploadMedia((MediaPayload) payload);
@@ -267,7 +267,10 @@ public class UploadStore extends Store {
         return 0;
     }
 
-    private void handleUploadMedia(MediaPayload payload) {
+    private void handleUploadMedia(@NonNull MediaPayload payload) {
+        if (payload.media == null) {
+            return;
+        }
         MediaUploadModel mediaUploadModel = new MediaUploadModel(payload.media.getId());
         MalformedMediaArgSubType argError = MediaUtils.getMediaValidationErrorType(payload.media);
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -65,10 +65,12 @@ public class MediaUtils {
     // File operations
     //
 
+    @NonNull
     public static String getMediaValidationError(@NonNull MediaModel media) {
         return BaseUploadRequestBody.hasRequiredData(media);
     }
 
+    @NonNull
     public static MalformedMediaArgSubType getMediaValidationErrorType(@NonNull MediaModel media) {
         return BaseUploadRequestBody.checkMediaArg(media);
     }


### PR DESCRIPTION
Parent #2798
Accompanying [JP/WPAndroid#19428](https://github.com/wordpress-mobile/WordPress-Android/pull/19428)

This PR adds any missing nullability annotation to [MediaRestClient.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/93445417d78612cabc3e8dc75df4ad708f3d6020/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaRestClient.java#L4) and [MediaXMLRPCClient.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/93445417d78612cabc3e8dc75df4ad708f3d6020/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java#L4), all its related response classes and anything in between (ie. `MediaStore`). See response classes below:

- [MediaWPComRestResponse.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/93445417d78612cabc3e8dc75df4ad708f3d6020/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaWPComRestResponse.java#L4)

FYI.1: This change is `safe`, meaning that there shouldn't be any (major) compile-time changes associated with this change. Having said that, testing is highly recommended since the changes in this PR can affect one or more clients (ie. [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), [WCAndroid](https://github.com/woocommerce/woocommerce-android), etc)

FYI.2: An analysis on `MediaStore` and their usages with our main clients suggests that this store is being utilizing by both, the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and [WCAndroid](https://github.com/woocommerce/woocommerce-android) clients.

-----

PS.1: @AjeshRPai I added you as the main reviewer, randomly so, since I just wanted someone from the Jetpack/WordPress mobile team to be aware of and sign-off on that change for both. Feel free to merge this PR directly yourself if you deem so.

PS.2: @0nko I am also adding you as an extra reviewer, randomly so, since I want someone from the WooCommerce mobile team to be aware of this change as well. However, there is no need for you to review it as well, thus duplicating the review work. Having one team member from either of the mobile teams reviewing and testing this change is enough for this change.

-----

Nullability Annotation List:

1. [Add missing nn-a to ok http client field on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/24f609316f9601934b9898d6daf5514e00ffd39f)
2. [Add missing nn-a to media response utils field on media rest](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/e06b98624e400a98f53c2d7f9efea0d660e96e5d)
3. [Add missing nn-a to current upload calls field on media clts](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/3db2009965d3cd016a080f6e73ed5b7881203126)
4. [Add missing n-a to on progress on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/1f879abf1372fe7f2db1a22b5146242409eae1fc)
5. [Add missing n-a to push media on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/02345c96eb1f827966271d6395bcfeaee3da4701)
6. [Add missing n-a to upload media on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/806ae6e718138138decd70a374de3a1112652b22)
7. [Add missing n-a to fetch media list on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/95eb024cc0c56e61a256cfce6539607658db4775)
8. [Add missing n-a to fetch media on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/b9c247b776a2cf60d09fe8b5f56504d93c462ddd)
9. [Add missing n-a to delete media on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/2175a474e2925da2c23fbb7162a764bfe94f303e)
10. [Add missing n-a to cancel upload on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/03a3cbeb30ea78c0d97cd6565ce99daef2be6138)
11. [Add missing n-a to get media list frm response on media xmlrpc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/605dad921760386f42a7d5b2758a3b3cada3338a)
12. [Add missing n-a to get map frm upload response on media xmlrpc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/1b14ce10b26da30f69bc02ec95dbd3cfffe9579f)
13. [Add missing n-a to deprecated upload response on media xmlrpc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/5a21c037aa15d68cb72d1d377808a9820f7fb289)
14. [Add missing n-a to media from xmlrpc response on media xmlrpc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/a8480342d0493d2ae9a0d09318d34081e83b1b28)
15. [Add missing n-a to get basic params on media xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/79bd324af358bec2afaa44a15302dbfd12d0a294)
16. [Add missing n-a to is 404 response on media xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/3f3b66492786e421ab6b87c6716ea66a3a3d752f)
17. [Add missing n-a to media error from exception on media xmlrpc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/e7500da6e4eafbe529e855af8951ff589bcd7c6c)
18. [Add missing n-a to get file (url) for size on media xmlrpc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/c00fa5ca98c77a6d2cc8ebfe97e691a398a76e32)
19. [Add missing n-a to media payload on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/339e9091f202c1172e952f5ac1339e8d4327e50c)
20. [Add missing n-a to upload mediaPayload on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/48d95acf120ebc6b2b93cbf73eb75cbed5381209)
21. [Add missing n-a to fetch media list payload on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/0adabd367c01a25d0e96500613e86fa4d2850ba7)
22. [Add missing n-a to fetch media list response pl on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/208574228b1127857a64504d66f5d0fa0344a9b2)
23. [Add missing n-a to progress payload on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/01894777992ee4ab51d071b8143f28417b28f5c1)
24. [Add missing n-a to cancel media payload on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/7d49bffe7eccb0a1d6fba18d04ee7c5b942f6a99)
25. [Add missing n-a to counting sink on base upload request body](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/e145b90e20087ea3948582f8edb1ce380c86e7fa)
26. [Add missing nl-a to s method parameter on media fragment](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/a12ad85713a34b75498b3380c603e39de9757211)
27. [Add missing nn-a to multi field on media wp com rest response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/e57e2277ce52e90a0543b264c5c704fdc3756c8e)
28. [Add missing n-a to media wp com rest response fields](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/3334cf0e27dfb7c2eb9021a7e09700dbc49645bf)

Nullability Checks List:

1. [Un-guard usages of media error on media rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/05c2fb5a9630512d6fb8792c29b34a76dbf00924)
2. [Guard usages of media list on media rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/0381ccc9f8306ea14d15586922f1637acdb00ebe)
3. [Guard usages of media title on media xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/2a6e10e0eceabc680557768ace3f7057acf29767)
4. [Guard usages of params get key on rest upload request body](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/3db2be480483ab0fbcab0ce38147389b17db6bf5) 

Warnings Resolutions List:

1. [Add missing final to ok http client field on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/8afc67a50ac001a01edf518aea7c07cc4d5fb09a)
2. [Add missing final to media response utils field on media rest](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/b7c74c1a55781cef476f5cc197ae1280d8d0c9c5)
3. [Add missing final to cnt upload calls field on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/224c637f66df88092b09bae4f65837e055d618d0)
4. [Change type of request to include the missing generic type](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/db21abff8fe8e0fdd5e2636ab48b3d873fcdb8e7)
5. [Remove unnecessary is response null checks on media xmlrpc clt](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/ea3a3fd5a2242073341007b2a0f7a178d8d2ea5c)
6. [Remove io exception from throws list on media xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/54b6c24d83cb0fbee46ab806ac8434cde6f3810b)
7. [Replace string/charset with std charsets utf8 on media xmlrpc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/d87de3d495d7fe9fe65ddb8ff5ba9da53c27d5fa)
8. [Simplify if/else on media xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/78538652775b8e3c6c800ffa029244319eea9eab)
9. [Create missing switch cases for media store errors](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/315a7ccb92d3d3d41ed875960677a274ae239a0a)
10. [Remove unnecessary is split msg null checks on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/1679912dc538be0ba8fcc381560986bd5ee6ed53)
11. [Replace explicit type argument with <> on on media changed](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/69ef729f2e575dbb82ce246aa181436ea9912b8e)
12. [Use inserted media on instantiate media model store method](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/26ecb150b2e71b0bf7cafa96f1f63b38b2e103d8)
13. [Replace fi stream with try with resource on xmlrpc upload rb](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/007716e339cc09481aa6eaa8e7cb6fa58824a8fd)
14. [Make inner classes static on media wp com rest response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/61b71b45ff038a137ab272465556e77ab074eda2)
15. [Delete unused thumbnails field on media wp com rest response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/8b8c7aeb495c5c98cea53f204c171eda07730058)
16. [Delete unused multiple fields on media wp com rest response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/971a8bc299dd46e5d279c260150af36caf627750)

Warnings Suppression List:

1. [Suppress use of parameterized class map on media xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/8e4e95cd9a9367c6c91cc8b78961438b400e0d20)
2. [Suppress raw types warning on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/ed685c15109d8d402e9112f0d316e03c49c7cb02)
3. [Suppress unused warning on media related payload constructor](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/590c55d860870657918c5d73fd507cda2ca3f9b4)
4. [Suppress unused warnings on get related media methods](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/3501ffbde52952fc025bd12ca9f75aaba6a6e740)
5. [Suppress same parameter value warning on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/0bfd72c69854685570b34f43cea00de87ac0acc8)
6. [Suppress request body create deprecation on rest upload rb](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/17118eea95ded117fe8d01f5082c80b8877b1dd8)
7. [Suppress string escape utils deprecation on xmlrpc upload rb](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/2f2875a976acd35a187632dafc2e163e07e8c2dd)

Refactor List:

1. [Reformat media rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/af01ceb670a4fc8c6b09a537aef6872bea980ede)
2. [Reformat media xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/dff7ec59ba7ccb91115741a7fb4ddca005545ff9)
3. [Replace anonymous classes with lambda on media rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/b2e3a7ceca82a8f99aa481eb56f3593b10b76686)
4. [Replace anonymous classes with lambda on media xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/68aedbf998db2a41591e475fc3f731f39c373a87)
5. [Reformat error responses on media clients](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/e01e7c1db772106edad7789ed8952e521fb9f01b)
6. [Reformat media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/da9a621efa50e50e2577231fc18301b8bbe5facf)

Test List:

1. [Suppress kotlin internal in java on media store test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/9ddce58d1347b8534664338d0f8b583fa763e9bc)
2. [Add missing final to media store on media store test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/88f415fc8397f526c81c1096458c307045dc71d8)
3. [Resolve robolectric related application deprecation warnings](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/572bf851658e15359882563cef39a1fd913ca745)
4. [Simplify assert true assertions on media store test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/ad21ea5ef68e7e0a5ab4a1c357bd1b4e52b8577b)
5. [Suppress new class naming convention for connected tests](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/af02aff38ed7a4874270d29f76caf09222b64efd)
8. [Suppress throws count for ms media test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/8f235d62f457b4e320a2804cdac7d67438223b8b)
9. [Simplify new media model helper func. on ms media test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/7d2084e46cb0a727890f2cd3cc2f7192b590f7bf)
10. [Guard usages of remote id queue poll on ms media test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/6a652a523ab4979dc3e13434fe4cdb97a1c223cd)
11. [Fix typo with we're on ms media test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/e370b8456f63e9d366a84bc389b3205097b46774)
12. [Simplify new media model helper function on ms upload test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/448539587552ce725341f2fac62032524256a8d9)
13. [Remove unnecessary media path length on ms upload test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/e4c6d1fe88314060408f153912c2998b3e258e71)
14. [Make create new post method void on ms upload test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/280025233ac999662f24f7cdcd86019cd3905a50)
15. [Remove interrupted exception from throws list on ms upload test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/68151b6576dfd9625c48f3a68fade983fd236092)
16. [Insert `<p>` on ms upload store test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/66b4d279cff9b1d7c5eec7726c3b9ef412a4405a)
17. [Simplify new media model helper function on ms upload store test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/c9d440d9f368867ab20e3efbf948ee82d159208d)
18. [Remove unnecessary media path length on ms upload store test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/034f80045cf871ea25287b169b531aed3888b389)
19. [Delete unused account store file on rs media test jetpack](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/e28b96050732232efaa1af1119d32eed53b3682b)
20. [Simplify new media model helper function on rs media test jetpack](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/61deec7a4f6c50ab574431a5398ecfeb9e26f6f2)
21. [Remove unnecessary media path length on rs media test jetpack](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/3be1fc6bec78500365d0bdc114c414dd6b1488fb)
22. [Simplify new media model helper function on rs media test wp com](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/6c96bcac32b7f578435dbbf50a6c7cca2c5f0da7)
23. [Simplify new media model helper function on rs media test xmlrpc](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/d3c81462ff5cb97dcca100dc94c0705e160e71b2)

Docs List:

1. [Replace url with html link on media rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/46901f1588f2614822a3506fce7978dc0db54d38)
2. [Replace urls with html links on media xmlrpc client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/935071b93a4d80ee3b3fdc13aa3a38f093a491a1)
3. [Improve documentation on rest upload request body](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/ec6e158c1050ecb73c9459232255ded5d8ea831b)
4. [Improve documentation on base upload request body](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/b54bd63949d2d05275889b47d1ca8a79ffccfabf)
5. [Improve documentation on media wp com rest response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2878/commits/1b6399da43bdc09c40343808de789fae81b5c4f4)

-----

## Associated Clients

It is highly recommending that this change is being tested on the below associated clients:

- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android)
- [WCAndroid](https://github.com/woocommerce/woocommerce-android)

-----

## To Test (`REST`):

- Smoke test the `FluxC Example` app via the `MEDIA` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any media related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:
- Furthermore, using [local-builds.gradle](https://github.com/woocommerce/woocommerce-android/blob/trunk/local-builds.gradle-example) on [WCAndroid](https://github.com/woocommerce/woocommerce-android), smoke test any media related functionality and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

## To Test (`XMLRPC`):

- Create a new self-hosted WordPress site for XMLRPC testing purposes ([jurassic.ninja](https://jurassic.ninja/)).
- Smoke test the `FluxC Example` app via the `MEDIA` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any media related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:
- Furthermore, using [local-builds.gradle](https://github.com/woocommerce/woocommerce-android/blob/trunk/local-builds.gradle-example) on [WCAndroid](https://github.com/woocommerce/woocommerce-android), smoke test any media related functionality and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

<details>
    <summary>[JP/WP] Media Screens [MediaBrowserActivity.java + MediaGridFragment.kt + MediaSettingsActivity.java + MediaPreviewActivity.java + MediaPreviewFragment.java]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Media` screen, verify it is shown and functioning as expected.
- For example try changing tabs, searching and adding a new media.
- Tap on any media and verify that the `Media Settings` screen is shown and functioning as expected.
- For example try updating the media title or adding a media description.
- Tap on the media preview and verify that the `Media Preview` screen is shown and functioning as expected.
- For example try swipe left-right to navigate between media previews.

</details>

<details>
    <summary>[WC] Photos Screens [ProductDetailFragment.java + ProductImagesFragment.kt + ProductImageViewerFragment.kt]</summary>

- Go to `Products` tab and tap on any product.
- Tap on any photo on top and verify that the `Photos` screen is shown and functioning as expected.
- For example try adding a new photo, select an upload method, and wait for the photo to be uploaded.
- Tap on the photo preview and verify that the `Photo Preview` screen is shown and functioning as expected.
- For example try swipe left-right to navigate between photo previews.

</details>


-----

## Merge instructions:

1. [x] Wait for the accompanying [JP/WPAndroid#19428](https://github.com/wordpress-mobile/WordPress-Android/pull/19428) to be reviewed and approved.
2. [x] Remove the `[PR] Not Ready for Merge` label.
3. [x] Merge this PR.
4. [x] Follow-up with the merge instructions on the accompanying [JP/WPAndroid#19428](https://github.com/wordpress-mobile/WordPress-Android/pull/19428) client PR.