### PR TITLE
[Nullability Annotations to Java Classes] Add `wordpress.lint` Dependency

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -164,6 +164,8 @@ dependencies {
     // Coroutines
     implementation sharedLibs.kotlinx.coroutines.core
     implementation sharedLibs.kotlinx.coroutines.android
+
+    lintChecks sharedLibs.wordpress.lint
 }
 
 def loadPropertiesOrUseExampleProperties(fileName, warningDetail) {

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -130,6 +130,8 @@ dependencies {
     testImplementation sharedLibs.mockito.kotlin
     testImplementation sharedLibs.mockito.inline
     testImplementation sharedLibs.assertj.core
+
+    lintChecks sharedLibs.wordpress.lint
 }
 
 project.afterEvaluate {

--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -100,6 +100,8 @@ dependencies {
     androidTestImplementation sharedLibs.androidx.test.runner
     androidTestImplementation sharedLibs.androidx.test.ext.junit
     androidTestImplementation sharedLibs.assertj.core
+
+    lintChecks sharedLibs.wordpress.lint
 }
 
 project.afterEvaluate {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "28-97e5b1880ab308dedaba036cbe61458e2ac09520"
+def catalogVersion = "1.15.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.14.0"
+def catalogVersion = "28-97e5b1880ab308dedaba036cbe61458e2ac09520"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {


### PR DESCRIPTION
Parent #2795
Closes #2818

This PR adds `wordPress-lint` checks to the project ([2.0.0](https://github.com/wordpress-mobile/WordPress-Lint-Android/releases/tag/2.0.0)).

-----

## To test:

1. Verifying that all the CI checks are successful (focus on the `Lint` related [check](https://buildkite.com/automattic/wordpress-fluxc-android/builds/2981#018b616b-80a0-41fc-b926-b06feebf4812) and their reports: [fluxc](https://buildkiteartifacts.com/b26f1746-2f0c-49cc-bbd1-a45a5e24c351/32e7e20c-4c4c-43b8-a886-f43cec935749/018b616b-55d7-4c79-89fc-ed76bfba163b/018b616b-80a0-41fc-b926-b06feebf4812/fluxc/build/reports/lint-results-release.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LWTDXMND3%2F20231024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231024T113814Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEBkaCXVzLWVhc3QtMSJHMEUCIQCyTCAJ13hczKTiDzQ7MHFC40gKC744f6WoqGqhDcdyBwIgK1MLU4PoJO5kc9Lkxkab2J9QqnqxIOMU%2FWGN8LAwx9Qq8QMIQhAAGgwwMzIzNzk3MDUzMDMiDEDWAMLVCtKVIozAbCrOA9%2FpoScea2%2FJ0NDEXIU87xPRnTNic0R2ly5%2Fn2EjqJ4b63QWv11uzH1xxal3hucfDurywW1n%2BdegPXZ64x8x38IRa2%2FEUkRhx%2FvGyiiDnJ7cnsNPBjK1JNFuVcO6AGQLhPLXWAYStVal5VR2JTdga9RFhGjIwtxw7IhMMkqD7kRYt0xLIiAeFs6WHVfDqTbSaa%2B%2Fi3I3ROuFs8WLS%2FQWucHCczLOogzAE4cvToDT2Vpimq1TRyDEhZX37SdzcgqHw0Genucb5sbMQUNxVXvRyCd82WALaaXkShDL8fkDRud6ImK9i3hufnG1KHwSylYU6R7xNKJqcL8%2BPoDuYadskOrP0T2c4iz3TrGghaUK2gtWjTUZ7L5NAXZc5TeRvoDDlLbwwGFJZCz6nos9HuMHQJpNF4wd1AArhMx6XNxm%2FCRslUiNYB8B7n9YRS6RXL1hueB8Dr2DkgAc7pmEzZSVaO%2BUg9hG8ITyfDW1oyUfGRauuEq%2B14lN9etPxpptPLjsUJPSDARFUppbusyYLHhkjVWY2MhgTVF%2FyZ049%2FR86lbLEMu4JgzB%2BP87TGZ7JkTjA0CZUrR5Y062EUfQ%2BcPZGOBC2Yne71ApUer365wdGDChjt6pBjqlAajKgZOCgrcvPJMfRPynsfXVqSsGib%2B1p5Qyk00AxwseHWc2FhLZpR85DeUNrIVrP03DGoZmI9Gl0XRm3%2Fvy8%2B%2BtBBD6YaYw94JcR4o78tXuuKvaDcr%2FZGIXFxT99sf7LoT7ENtdZElrl7WnGVAhza2ianYZHGFj6nZKAE8rH7TEU7bRCRXdvP6CHInTfWPsogSFO78jrfISOEuIetArAjB%2FGPVvww%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=553bbb29bb0cfdd2aa2118ac33ba22c6f9007d9c4e63485ff9a4ea1dc8113767) + [plugins/woocommerce](https://buildkiteartifacts.com/b26f1746-2f0c-49cc-bbd1-a45a5e24c351/32e7e20c-4c4c-43b8-a886-f43cec935749/018b616b-55d7-4c79-89fc-ed76bfba163b/018b616b-80a0-41fc-b926-b06feebf4812/plugins/woocommerce/build/reports/lint-results-release.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LTQDBWZPJ%2F20231024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231024T113816Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEBkaCXVzLWVhc3QtMSJHMEUCIFZ1g9lN9%2BVN7Nuz9Hp1TjncyiZeDMnnK0xZ1Uxdo%2FVGAiEA%2Bz%2Fies%2Bl2%2FgZ2K89TuxN%2FQlsNhg3dzKL3jys8K939Ikq8QMIQhAAGgwwMzIzNzk3MDUzMDMiDM5EYNo%2BBIWxkHqehSrOA%2F3suNkJ5PjCNdzyGXGwzIBsKquYlCMxYlax0yMVfVzq4m6pNdITDYoLS7gDkDKZFeK%2BZkbagpoEZQqoTSs%2FwcHqj91%2Bd2j0jsCCw%2BMiFgR5GePy3cjoD4kqHpuiB2%2BoNidoYwmA4sMxUf5jwqW%2BHg80XivpQKB5SCXJaWRZbdDHpzXeKPu8GlT%2FZbCYvWUfILbqfx%2FCYc4fnWTqjYuORe6Efif1mOSjMfpOp25XianNaREx0SrzeNPKG43%2BxDsv3uLPbRUt0HzvNXO%2BcWjH9pXHWl%2BRt4T7Bbm74Zac288%2BVwd9u%2BxjHKqA%2FG5PVTda6%2BCnyxYgLY6Z%2F20EPrS%2B2ibWmLNPfe1kBG91BCCjkxP4Lnz2fjXmr7jAb4kukY7nYVJDFPLZfRHKnmdmTXtacmNpu4xiGdpHl%2FTpsdDp%2FEDK7TaxIv2tAT5z%2BkKaW2AZqREbwvG3N5CbiAR8v6oT3hVKfpNp8aIUWOVGcTMxpw2Askbm%2B6vLDQT9GBC1qICG59k7bNxnocaNisiDhj4YPHsj29dLkk6IVihmNWOc6ij1w34lR%2FTCAjp5ZjCzPTAknAnXmBY4mhkVpVV3JESJW5%2FIT2QlNJAdpn%2B1kymvMTD7jN6pBjqlAcjpH3sHT9RynQtpl7JEyk%2FW0avZ7aovR1mfGIMcwRYWKGhbdmhpn8w%2FboTERyGVdyzgXzpksw%2BRbebrLg1ohwQZbQ%2BClmXux7dKgfWmiOYQKrF1wlalXdEH8UlaNp%2F7VGnWUKDATacKPqJGC%2BnAyPfwV4fFx8bwXYv8B0T9wsmv0ZwFqA6EHQNLmswhJ9XOsXnTjSIr%2B1RvVThf9wBWfnmF%2Bhph3g%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=e4a4ceab886625e5aee70f71e0714b5443e8940e01658f5b12323b86b1b0e58f) + [example](https://buildkiteartifacts.com/b26f1746-2f0c-49cc-bbd1-a45a5e24c351/32e7e20c-4c4c-43b8-a886-f43cec935749/018b616b-55d7-4c79-89fc-ed76bfba163b/018b616b-80a0-41fc-b926-b06feebf4812/example/build/reports/lint-results-release.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LYVRUALSC%2F20231024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231024T113817Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEBkaCXVzLWVhc3QtMSJHMEUCIExiqiVFdN1BL0Z8RCPwkJx9JQ8VeciEpAHrJ%2BPHDcQjAiEAweAwVEg5qtn6AilyXzWD3WpGms%2Fk%2F5sJEq0iJsO5m4Iq8QMIQhAAGgwwMzIzNzk3MDUzMDMiDIyjMxlQJwzAxnWxCSrOA1biMcidRAxZgMRlrBLulv152%2BZk9uj1DkKQknKRTZBmoZHlx%2FyCg5%2Ffc5TxLMiU91YdYz5jTUMrJld8YTM96HN2i1LEpIs8KZxijp2iwv0iAGZBz2nlM5IP886Cxd3YwCfqEXfFoIZuvy83veQaKadfGo%2FK7yrUOBtTB5rktr1t1nilYy7bQ2OuXsNHB1%2Fok%2B0TQ0BPzO9HxjMARGTt9URYAA4PCcAr%2FQ12zJOv6TVxhC8ivJemHYN%2BaDDqZWWKrLvKr1taK0YAbXibRbjUgSKFFnDsKN%2Fs0q5B3TwJ4tjPxJQll4BUPMt3RToDxG%2BtPAVYCz%2FfjpbOwPAj78mw1thMaW6V7zh9GfUaoVBROkWKCSZdHA6IS5xU2jDUF8Bx4Ez5d%2FDBFXkMMumPI%2FPZ9F9lYDATNrlaYEwFdCCHbjM%2Bx%2BTrt81VaOWpuzYQYBze6YfWN%2FOqPV2huNhIKpPYAuHigTgdbz7TPjZCCOzy0MgPAZYrpkcJBpXz%2FgIMhb1JkpwU0%2Bnow99r4tOdEgEZYyaYJBdmi9yOtisOwp4wcEzeyTB%2F8tkI5Hmb2FO95HY%2Bk7UYNyx0CCWb1iQU7Agw7fPeVbb2bcBwq2zlINC5NDCgjt6pBjqlARVmwCTrq2IRuastqJmBSsDQnAwdLtwbyId937JBSIYTzoGL4WiRqK4%2Fiuwx2yC9uzwG4%2FpwOTKgwpUb7sDyxMbHM7iI1BSa5JriC8ng1z3mHkkzSPG2k%2FVrZOEGZfo0LzfNXt7xB%2BS2mJQAdJwMCXK%2FMI59CiRapPb%2BrZpXyIESlExegD%2BKnsiBFN68AdTd4Gltq5VSYMjEsmNiLJJiYEt%2F0gNZ1A%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=a0a2487145082fcaadc7f6a88bdba80864c342f155868ed00926cc610ed1211d)).
2. Verify that the new `MissingNullAnnotationOn*` correctness related rules are reporting as expected. For a reference, see screenshots below:

`fluxc` module:

![image](https://github.com/wordpress-mobile/WordPress-FluxC-Android/assets/9729923/766b807e-bdf4-4f59-a29d-45af1998403b)

`plugins/woocommerce` module:

![image](https://github.com/wordpress-mobile/WordPress-FluxC-Android/assets/9729923/38258f88-1253-4be3-8a8b-fb47a271354e)

`example` module:

![image](https://github.com/wordpress-mobile/WordPress-FluxC-Android/assets/9729923/a87b8f49-62fd-4c2b-8e4e-bce4852bbfdd)

-----

## Merge instructions:

- [x] Wait for the accompanying [Catalog#28](https://github.com/Automattic/android-dependency-catalog/pull/28) PR to be merged.
- [x] Release a [new catalog version](https://github.com/Automattic/android-dependency-catalog#releasing-a-new-catalog-version) (`1.15.0`).
- [x] Update `catalogVersion` to point to the new `1.15.0` release.
- [x] Remove the `[PR] Not Ready for Merge` label.
- [x] Merge this PR.