### PR TITLE
Configurable field

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
@@ -19,3 +19,7 @@ class WCBundledProduct(
     @SerializedName("quantity_default") val quantityDefault: Long?,
     @SerializedName("optional") val isOptional: Boolean
 )
+
+fun WCBundledProduct.isConfigurable(): Boolean {
+    return (quantityMin != quantityMax) || (quantityMin == null) || isOptional
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.WCProductModel.AddOnsMetadataKeys.ADDONS_METADATA_KEY
 import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
 import org.wordpress.android.fluxc.model.addons.RemoteAddonDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
 import org.wordpress.android.fluxc.network.utils.getBoolean
 import org.wordpress.android.fluxc.network.utils.getLong
 import org.wordpress.android.fluxc.network.utils.getString
@@ -124,7 +125,17 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             ?.any { it.key == OtherKeys.HEAD_START_POST && it.value == "_hs_extra" }
             ?: false
 
-    @Suppress("SwallowedException", "TooGenericExceptionCaught") private val WCMetaData.addons
+    val isConfigurable: Boolean
+        get() = when (type) {
+            CoreProductType.BUNDLE.value -> {
+                Gson().fromJson(bundledItems, Array<WCBundledProduct>::class.java)
+                    ?.any { it.isConfigurable() } ?: false
+            }
+            else -> false
+        }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    private val WCMetaData.addons
         get() =
             try {
                 Gson().run {


### PR DESCRIPTION
### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow.

### Description
This PR moves the configuration validation to the DB, so after getting the cached products, we can check if a product is configurable or not.

### Testing
It is better to test these changes in the Woo PR