### PR TITLE
Avoid possibility to create BaseNetworkError with null message

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.network;
 
+import static org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.METHOD_NOT_ALLOWED;
+import static org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.NOT_SET;
+
 import android.net.Uri;
 import android.net.Uri.Builder;
 import android.util.Base64;
@@ -29,9 +32,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.net.ssl.SSLHandshakeException;
-
-import static org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.METHOD_NOT_ALLOWED;
-import static org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.NOT_SET;
 
 public abstract class BaseRequest<T> extends Request<T> {
     public static final int DEFAULT_REQUEST_TIMEOUT = 30000;
@@ -361,17 +361,21 @@ public abstract class BaseRequest<T> extends Request<T> {
         }
 
         // Get Error by HTTP response code
+        String errorMessage = "";
+        if (volleyError.getMessage() != null) {
+            errorMessage = volleyError.getMessage();
+        }
         switch (volleyError.networkResponse.statusCode) {
             case 404:
-                return new BaseNetworkError(GenericErrorType.NOT_FOUND, volleyError.getMessage(), volleyError);
+                return new BaseNetworkError(GenericErrorType.NOT_FOUND, errorMessage, volleyError);
             case 405:
                 return this instanceof XMLRPCRequest
                         ? new BaseNetworkError(volleyError, METHOD_NOT_ALLOWED)
                         : new BaseNetworkError(volleyError);
             case 451:
-                return new BaseNetworkError(GenericErrorType.CENSORED, volleyError.getMessage(), volleyError);
+                return new BaseNetworkError(GenericErrorType.CENSORED, errorMessage, volleyError);
             case 500:
-                return new BaseNetworkError(GenericErrorType.SERVER_ERROR, volleyError.getMessage(), volleyError);
+                return new BaseNetworkError(GenericErrorType.SERVER_ERROR, errorMessage, volleyError);
             default:
                 break;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java
@@ -1,8 +1,5 @@
 package org.wordpress.android.fluxc.network;
 
-import static org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.METHOD_NOT_ALLOWED;
-import static org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.NOT_SET;
-
 import android.net.Uri;
 import android.net.Uri.Builder;
 import android.util.Base64;
@@ -32,6 +29,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.net.ssl.SSLHandshakeException;
+
+import static org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.METHOD_NOT_ALLOWED;
+import static org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.NOT_SET;
 
 public abstract class BaseRequest<T> extends Request<T> {
     public static final int DEFAULT_REQUEST_TIMEOUT = 30000;


### PR DESCRIPTION
That is supposed to fix https://github.com/woocommerce/woocommerce-android/issues/10034 and other similar crashes where we expect not null `message`.

The crash in the mentioned issue happens on [this line ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/09842f3637ea26e0f2f8bcff62b2511c13257a7f/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt#L816), because the message that expected to be not null, apparently comes as null.