### PR TITLE
Float deserializer

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/JsonElementToFloatSerializerDeserializer.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/utils/JsonElementToFloatSerializerDeserializer.kt
@@ -1,0 +1,34 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import java.lang.Exception
+import java.lang.reflect.Type
+
+class JsonElementToFloatSerializerDeserializer : JsonSerializer<Float?>, JsonDeserializer<Float?> {
+    override fun serialize(
+        src: Float?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?
+    ): JsonElement {
+        return src?.let { JsonPrimitive(it) } ?: JsonNull.INSTANCE
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): Float? {
+        return try {
+            json?.asFloat
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToFloatSerializerDeserializerTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/utils/JsonElementToFloatSerializerDeserializerTest.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.fluxc.utils
+
+import com.google.gson.Gson
+import com.google.gson.JsonPrimitive
+import com.google.gson.annotations.JsonAdapter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class JsonElementToFloatSerializerDeserializerTest {
+    private val sut = JsonElementToFloatSerializerDeserializer()
+
+    @Test
+    fun `when value is true then null value is returned`() {
+        val jsonElement = JsonPrimitive(true)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is a valid string number then the value is returned`() {
+        val value = 12345f
+        val valueString = value.toString()
+        val jsonElement = JsonPrimitive(valueString)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isEqualTo(value)
+    }
+
+    @Test
+    fun `when value is an invalid string number then null is returned`() {
+        val jsonElement = JsonPrimitive("12345_test")
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when value is different number format then the value is parsed to long and returned`() {
+        val value = 12345f
+        val valueLong = value.toLong()
+        val jsonElement = JsonPrimitive(valueLong)
+        val result = sut.deserialize(
+            json = jsonElement,
+            typeOfT = null,
+            context = null
+        )
+        assertThat(result).isEqualTo(value)
+    }
+
+    @Test
+    fun `test serialization deserialization`() {
+        val gson = Gson()
+        val value = 12345f
+        val json = gson.toJson(TestData(value))
+        val deserialized = gson.fromJson(json, TestData::class.java)
+        assertThat(deserialized.value).isEqualTo(value)
+    }
+
+    data class TestData(
+        @JsonAdapter(JsonElementToFloatSerializerDeserializer::class)
+        val value: Float
+    )
+}


### PR DESCRIPTION
### Why
When getting float values from the API, if the value we are trying to fetch is `null`, the API will return an EMPTY string. This will throw an exception when trying to convert this value (empty string) to Float.

### Description
This PR introduces the `JsonElementToFloatSerializerDeserializer` a more reliable serializer that will try to convert JSON elements to Float or return null for cases it doesn't know how to handle.

### Testing
Unit test should cover all major scenarios