### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to `Media` Model Classes (`breaking`)

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -67,7 +67,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
         interceptor.respondWithSticky("media-upload-response-success.json")
 
         // First, try canceling an image with the default behavior (canceled image is deleted from the store)
-        newMediaModel("Test Title", sampleImagePath).let { testMedia ->
+        newMediaModel("Test Title", sampleImagePath)?.let { testMedia ->
             countDownLatch = CountDownLatch(1)
             nextEvent = TestEvents.CANCELED_MEDIA
             val payload = UploadMediaPayload(testSite, testMedia, true)
@@ -83,7 +83,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
         }
 
         // Now, try canceling with delete=false (canceled image should be marked as failed and kept in the store)
-        newMediaModel("Test Title", sampleImagePath).let { testMedia ->
+        newMediaModel("Test Title", sampleImagePath)?.let { testMedia ->
             countDownLatch = CountDownLatch(1)
             nextEvent = TestEvents.CANCELED_MEDIA
             val payload = UploadMediaPayload(testSite, testMedia, true)
@@ -246,25 +246,25 @@ class MockedStack_MediaTest : MockedStack_Base() {
 
     private fun addMediaModelToUploadArray(title: String) {
         val mediaModel = newMediaModel(title, sampleImagePath)
-        uploadedMediaModels[mediaModel.id] = mediaModel
+        mediaModel?.let { uploadedMediaModels[mediaModel.id] = it }
     }
 
-    private fun newMediaModel(testTitle: String, mediaPath: String): MediaModel {
-        val testDescription = "Test Description"
-        val testCaption = "Test Caption"
-        val testAlt = "Test Alt"
+    private fun newMediaModel(testTitle: String, mediaPath: String): MediaModel? {
+        val testMedia = MediaModel(
+            testSite.id,
+            null,
+            mediaPath.substring(mediaPath.lastIndexOf("/")),
+            mediaPath,
+            mediaPath.substring(mediaPath.lastIndexOf(".") + 1),
+            "image/jpeg",
+            testTitle,
+            null
+        )
+        testMedia.description = "Test Description"
+        testMedia.caption = "Test Caption"
+        testMedia.alt = "Test Alt"
 
-        return mediaStore.instantiateMediaModel().apply {
-            filePath = mediaPath
-            fileExtension = mediaPath.substring(mediaPath.lastIndexOf(".") + 1)
-            this.mimeType = "image/jpeg"
-            fileName = mediaPath.substring(mediaPath.lastIndexOf("/"))
-            title = testTitle
-            description = testDescription
-            caption = testCaption
-            alt = testAlt
-            localSiteId = testSite.id
-        }
+        return mediaStore.instantiateMediaModel(testMedia)
     }
 
     private fun uploadMultipleMedia(

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -78,7 +78,12 @@ class MockedStack_MediaTest : MockedStack_Base() {
             val cancelPayload = CancelMediaPayload(testSite, testMedia)
             dispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload))
 
-            Assert.assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+            Assert.assertTrue(
+                countDownLatch.await(
+                    TestUtils.DEFAULT_TIMEOUT_MS.toLong(),
+                    TimeUnit.MILLISECONDS
+                )
+            )
             Assert.assertEquals(0, mediaStore.getSiteMediaCount(testSite))
         }
 
@@ -94,7 +99,12 @@ class MockedStack_MediaTest : MockedStack_Base() {
             val cancelPayload = CancelMediaPayload(testSite, testMedia, false)
             dispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(cancelPayload))
 
-            Assert.assertTrue(countDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+            Assert.assertTrue(
+                countDownLatch.await(
+                    TestUtils.DEFAULT_TIMEOUT_MS.toLong(),
+                    TimeUnit.MILLISECONDS
+                )
+            )
             Assert.assertEquals(1, mediaStore.getSiteMediaCount(testSite))
 
             val canceledMedia = mediaStore.getMediaWithLocalId(testMedia.id)
@@ -120,15 +130,17 @@ class MockedStack_MediaTest : MockedStack_Base() {
         // Verify all have been uploaded
         Assert.assertEquals(uploadedMediaModels.size, uploadedIds.size)
         Assert.assertEquals(
-                uploadedMediaModels.size,
-                mediaStore.getSiteMediaWithState(testSite, MediaUploadState.UPLOADED).size
+            uploadedMediaModels.size,
+            mediaStore.getSiteMediaWithState(testSite, MediaUploadState.UPLOADED).size
         )
 
         // Verify they exist in the MediaStore
         val iterator = uploadedMediaModels.values.iterator()
         while (iterator.hasNext()) {
             iterator.next().let { uploadedMediaModel ->
-                Assert.assertNotNull(mediaStore.getSiteMediaWithId(testSite, uploadedMediaModel.mediaId))
+                Assert.assertNotNull(
+                    mediaStore.getSiteMediaWithId(testSite, uploadedMediaModel.mediaId)
+                )
             }
         }
     }
@@ -164,8 +176,10 @@ class MockedStack_MediaTest : MockedStack_Base() {
         Assert.assertEquals(uploadedIds.size, mediaStore.getSiteMediaCount(testSite))
 
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        Assert.assertEquals(uploadedIds.size,
-                mediaStore.getSiteMediaWithState(testSite, MediaUploadState.UPLOADED).size)
+        Assert.assertEquals(
+            uploadedIds.size,
+            mediaStore.getSiteMediaWithState(testSite, MediaUploadState.UPLOADED).size
+        )
     }
 
     @Test
@@ -199,11 +213,16 @@ class MockedStack_MediaTest : MockedStack_Base() {
         Assert.assertEquals(uploadedMediaModels.size, mediaStore.getSiteMediaCount(testSite))
 
         // The number of uploaded media in the store should match our records of how many were not cancelled
-        Assert.assertEquals(uploadedIds.size, mediaStore.getSiteMediaWithState(testSite,
-                MediaUploadState.UPLOADED).size)
+        Assert.assertEquals(
+            uploadedIds.size,
+            mediaStore.getSiteMediaWithState(testSite, MediaUploadState.UPLOADED).size
+        )
 
         // All cancelled media should have a FAILED state
-        Assert.assertEquals(amountToCancel, mediaStore.getSiteMediaWithState(testSite, MediaUploadState.FAILED).size)
+        Assert.assertEquals(
+            amountToCancel,
+            mediaStore.getSiteMediaWithState(testSite, MediaUploadState.FAILED).size
+        )
     }
 
     @Subscribe
@@ -284,7 +303,8 @@ class MockedStack_MediaTest : MockedStack_Base() {
             // To imitate a real set of media upload requests as much as possible, each one should return a unique
             // remote media id. This also makes sure the MediaModel table doesn't treat these as duplicate entries and
             // deletes them, failing the test.
-            defaultId: String -> defaultId.replace("9999", remoteIdQueue.poll()?.toString() ?: "")
+            defaultId: String ->
+            defaultId.replace("9999", remoteIdQueue.poll()?.toString() ?: "")
         }
 
         countDownLatch = CountDownLatch(mediaList.size)
@@ -306,6 +326,11 @@ class MockedStack_MediaTest : MockedStack_Base() {
             }
         }
 
-        Assert.assertTrue(countDownLatch.await(TestUtils.MULTIPLE_UPLOADS_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+        Assert.assertTrue(
+            countDownLatch.await(
+                TestUtils.MULTIPLE_UPLOADS_TIMEOUT_MS.toLong(),
+                TimeUnit.MILLISECONDS
+            )
+        )
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_MediaTest.kt
@@ -108,7 +108,7 @@ class MockedStack_MediaTest : MockedStack_Base() {
             Assert.assertEquals(1, mediaStore.getSiteMediaCount(testSite))
 
             val canceledMedia = mediaStore.getMediaWithLocalId(testMedia.id)
-            Assert.assertEquals(MediaUploadState.FAILED.toString(), canceledMedia.uploadState)
+            Assert.assertEquals(MediaUploadState.FAILED.toString(), canceledMedia?.uploadState)
         }
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadStoreTest.java
@@ -91,21 +91,21 @@ public class MockedStack_UploadStoreTest extends MockedStack_Base {
     }
 
     private MediaModel newMediaModel(String mediaPath) {
-        final String testDescription = "Test Description";
-        final String testCaption = "Test Caption";
-        final String testAlt = "Test Alt";
+        MediaModel testMedia = new MediaModel(
+                0,
+                null,
+                mediaPath.substring(mediaPath.lastIndexOf("/")),
+                mediaPath,
+                mediaPath.substring(mediaPath.lastIndexOf(".") + 1),
+                "image/jpeg",
+                "Test Title",
+                null
+        );
+        testMedia.setDescription("Test Description");
+        testMedia.setCaption("Test Caption");
+        testMedia.setAlt("Test Alt");
 
-        MediaModel testMedia = mMediaStore.instantiateMediaModel();
-        testMedia.setFilePath(mediaPath);
-        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
-        testMedia.setMimeType("image/jpeg");
-        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
-        testMedia.setTitle("Test Title");
-        testMedia.setDescription(testDescription);
-        testMedia.setCaption(testCaption);
-        testMedia.setAlt(testAlt);
-
-        return testMedia;
+        return mMediaStore.instantiateMediaModel(testMedia);
     }
 
     private SiteModel getTestSite() {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_UploadTest.java
@@ -515,21 +515,21 @@ public class MockedStack_UploadTest extends MockedStack_Base {
     }
 
     private MediaModel newMediaModel(String mediaPath) {
-        final String testDescription = "Test Description";
-        final String testCaption = "Test Caption";
-        final String testAlt = "Test Alt";
+        MediaModel testMedia = new MediaModel(
+                0,
+                null,
+                mediaPath.substring(mediaPath.lastIndexOf("/")),
+                mediaPath,
+                mediaPath.substring(mediaPath.lastIndexOf(".") + 1),
+                "image/jpeg",
+                "Test Title",
+                null
+        );
+        testMedia.setDescription("Test Description");
+        testMedia.setCaption("Test Caption");
+        testMedia.setAlt("Test Alt");
 
-        MediaModel testMedia = mMediaStore.instantiateMediaModel();
-        testMedia.setFilePath(mediaPath);
-        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
-        testMedia.setMimeType("image/jpeg");
-        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
-        testMedia.setTitle("Test Title");
-        testMedia.setDescription(testDescription);
-        testMedia.setCaption(testCaption);
-        testMedia.setAlt(testAlt);
-
-        return testMedia;
+        return mMediaStore.instantiateMediaModel(testMedia);
     }
 
     private void createNewPost(SiteModel site) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestJetpack.java
@@ -148,23 +148,21 @@ public class ReleaseStack_MediaTestJetpack extends ReleaseStack_Base {
     }
 
     private MediaModel newMediaModel(SiteModel site, String mediaPath) {
-        final String testTitle = "Test Title";
-        final String testDescription = "Test Description";
-        final String testCaption = "Test Caption";
-        final String testAlt = "Test Alt";
+        MediaModel testMedia = new MediaModel(
+                site.getId(),
+                null,
+                mediaPath.substring(mediaPath.lastIndexOf("/")),
+                mediaPath,
+                mediaPath.substring(mediaPath.lastIndexOf(".") + 1),
+                "image/jpeg",
+                "Test Title",
+                null
+        );
+        testMedia.setDescription("Test Description");
+        testMedia.setCaption("Test Caption");
+        testMedia.setAlt("Test Alt");
 
-        MediaModel testMedia = mMediaStore.instantiateMediaModel();
-        testMedia.setFilePath(mediaPath);
-        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
-        testMedia.setMimeType("image/jpeg");
-        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
-        testMedia.setTitle(testTitle);
-        testMedia.setDescription(testDescription);
-        testMedia.setCaption(testCaption);
-        testMedia.setAlt(testAlt);
-        testMedia.setLocalSiteId(site.getId());
-
-        return testMedia;
+        return mMediaStore.instantiateMediaModel(testMedia);
     }
 
     private void uploadMedia(SiteModel site, MediaModel media) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -381,22 +381,21 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     }
 
     private MediaModel newMediaModel(String mediaPath, String mimeType) {
-        final String testDescription = "Test Description";
-        final String testCaption = "Test Caption";
-        final String testAlt = "Test Alt";
+        MediaModel testMedia = new MediaModel(
+                sSite.getId(),
+                null,
+                mediaPath.substring(mediaPath.lastIndexOf("/")),
+                mediaPath,
+                mediaPath.substring(mediaPath.lastIndexOf(".") + 1),
+                mimeType,
+                "Test Title",
+                null
+        );
+        testMedia.setDescription("Test Description");
+        testMedia.setCaption("Test Caption");
+        testMedia.setAlt("Test Alt");
 
-        MediaModel testMedia = mMediaStore.instantiateMediaModel();
-        testMedia.setFilePath(mediaPath);
-        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
-        testMedia.setMimeType(mimeType);
-        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
-        testMedia.setTitle("Test Title");
-        testMedia.setDescription(testDescription);
-        testMedia.setCaption(testCaption);
-        testMedia.setAlt(testAlt);
-        testMedia.setLocalSiteId(sSite.getId());
-
-        return testMedia;
+        return mMediaStore.instantiateMediaModel(testMedia);
     }
 
     private void pushMedia(MediaModel media) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -297,7 +297,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        if (event.completed) {
+        if (event.media != null && event.completed) {
             if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
                 mLastUploadedId = event.media.getMediaId();
             } else {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -370,7 +370,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     }
 
     private boolean eventHasKnownImages(OnMediaChanged event) {
-        if (event == null || event.mediaList == null || event.mediaList.isEmpty()) return false;
+        if (event == null || event.mediaList.isEmpty()) return false;
         String[] splitIds = BuildConfig.TEST_WPCOM_IMAGE_IDS_TEST1.split(",");
         if (splitIds.length != event.mediaList.size()) return false;
         for (MediaModel mediaItem : event.mediaList) {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestWPCom.java
@@ -351,8 +351,7 @@ public class ReleaseStack_MediaTestWPCom extends ReleaseStack_WPComBase {
     @Subscribe
     public void onStockMediaUploaded(OnStockMediaUploaded event) {
         if (event.isError()) {
-            throw new AssertionError("Unexpected error occurred with type: "
-                                     + event.error.type);
+            throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
 
         boolean isSingleUpload = mNextEvent == TestEvents.UPLOADED_STOCK_MEDIA_SINGLE;

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -96,10 +96,11 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
 
     @Test
     public void testDeleteMediaThatDoesNotExist() throws InterruptedException {
-        MediaModel testMedia = new MediaModel();
-        testMedia.setMediaId(9999999L);
         mNextEvent = TestEvents.NOT_FOUND_ERROR;
-        deleteMedia(testMedia);
+        deleteMedia(new MediaModel(
+                sSite.getId(),
+                9999999L
+        ));
     }
 
     @Test
@@ -148,9 +149,10 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         mediaIds.add(9999989L);
         mNextEvent = TestEvents.NOT_FOUND_ERROR;
         for (Long id : mediaIds) {
-            MediaModel media = new MediaModel();
-            media.setMediaId(id);
-            fetchMedia(media);
+            fetchMedia(new MediaModel(
+                    sSite.getId(),
+                    id
+            ));
         }
     }
 
@@ -404,22 +406,21 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
     }
 
     private MediaModel newMediaModel(String mediaPath, String mimeType) {
-        final String testDescription = "Test Description";
-        final String testCaption = "Test Caption";
-        final String testAlt = "Test Alt";
+        MediaModel testMedia = new MediaModel(
+                sSite.getId(),
+                null,
+                mediaPath.substring(mediaPath.lastIndexOf("/")),
+                mediaPath,
+                mediaPath.substring(mediaPath.lastIndexOf(".") + 1),
+                mimeType,
+                "Test Title",
+                null
+        );
+        testMedia.setDescription("Test Description");
+        testMedia.setCaption("Test Caption");
+        testMedia.setAlt("Test Alt");
 
-        MediaModel testMedia = mMediaStore.instantiateMediaModel();
-        testMedia.setFilePath(mediaPath);
-        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1));
-        testMedia.setMimeType(mimeType);
-        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/")));
-        testMedia.setTitle("Test Title");
-        testMedia.setDescription(testDescription);
-        testMedia.setCaption(testCaption);
-        testMedia.setAlt(testAlt);
-        testMedia.setLocalSiteId(sSite.getId());
-
-        return testMedia;
+        return mMediaStore.instantiateMediaModel(testMedia);
     }
 
     private void pushMedia(MediaModel media) throws InterruptedException {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_MediaTestXMLRPC.java
@@ -352,7 +352,7 @@ public class ReleaseStack_MediaTestXMLRPC extends ReleaseStack_XMLRPCBase {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        if (event.completed) {
+        if (event.media != null && event.completed) {
             if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
                 mLastUploadedId = event.media.getMediaId();
             } else {

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
@@ -321,18 +321,20 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
             }
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        if (event.completed) {
-             if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
-                mLastUploadedId = event.media.getMediaId();
+        if (event.media != null) {
+            if (event.completed) {
+                if (mNextEvent == TestEvents.UPLOADED_MEDIA) {
+                    mLastUploadedId = event.media.getMediaId();
+                } else {
+                    throw new AssertionError("Unexpected completion for media: " + event.media.getId());
+                }
+                mCountDownLatch.countDown();
             } else {
-                throw new AssertionError("Unexpected completion for media: " + event.media.getId());
-            }
-            mCountDownLatch.countDown();
-        } else {
-            // General checks that the UploadStore is keeping an updated progress value for the media
-            if (getMediaUploadModelForMediaModel(event.media) != null) {
-                assertTrue(mUploadStore.getUploadProgressForMedia(event.media) > 0F);
-                assertTrue(mUploadStore.getUploadProgressForMedia(event.media) < 1F);
+                // General checks that the UploadStore is keeping an updated progress value for the media
+                if (getMediaUploadModelForMediaModel(event.media) != null) {
+                    assertTrue(mUploadStore.getUploadProgressForMedia(event.media) > 0F);
+                    assertTrue(mUploadStore.getUploadProgressForMedia(event.media) < 1F);
+                }
             }
         }
     }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_UploadTest.java
@@ -419,22 +419,21 @@ public class ReleaseStack_UploadTest extends ReleaseStack_WPComBase {
     }
 
     private MediaModel newMediaModel(String testTitle, String mediaPath, String mimeType) {
-        final String testDescription = "Test Description";
-        final String testCaption = "Test Caption";
-        final String testAlt = "Test Alt";
+        MediaModel testMedia = new MediaModel(
+                sSite.getId(),
+                null,
+                mediaPath.substring(mediaPath.lastIndexOf("/")),
+                mediaPath,
+                mediaPath.substring(mediaPath.lastIndexOf(".") + 1),
+                mimeType,
+                testTitle,
+                null
+        );
+        testMedia.setDescription("Test Description");
+        testMedia.setCaption("Test Caption");
+        testMedia.setAlt("Test Alt");
 
-        MediaModel testMedia = mMediaStore.instantiateMediaModel();
-        testMedia.setFilePath(mediaPath);
-        testMedia.setFileExtension(mediaPath.substring(mediaPath.lastIndexOf(".") + 1, mediaPath.length()));
-        testMedia.setMimeType(mimeType);
-        testMedia.setFileName(mediaPath.substring(mediaPath.lastIndexOf("/"), mediaPath.length()));
-        testMedia.setTitle(testTitle);
-        testMedia.setDescription(testDescription);
-        testMedia.setCaption(testCaption);
-        testMedia.setAlt(testAlt);
-        testMedia.setLocalSiteId(sSite.getId());
-
-        return testMedia;
+        return mMediaStore.instantiateMediaModel(testMedia);
     }
 
     private void deleteMedia(MediaModel media) throws InterruptedException {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -249,7 +249,7 @@ public class MediaFragment extends Fragment {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaUploaded(OnMediaUploaded event) {
-        if (!event.isError()) {
+        if (event.media != null && !event.isError()) {
             if (event.canceled) {
                 prependToLog("Upload canceled: " + event.media.getFileName());
                 mCancelButton.setEnabled(false);

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MediaFragment.java
@@ -122,9 +122,10 @@ public class MediaFragment extends Fragment {
 
                 String[] ids = text1.split(",");
                 for (String id : ids) {
-                    MediaModel media = new MediaModel();
-                    media.setMediaId(Long.valueOf(id));
-                    fetchMedia(mSite, media);
+                    fetchMedia(mSite, new MediaModel(
+                            mSite.getId(),
+                            Long.parseLong(id)
+                    ));
                 }
             }, "comma-separate media IDs", "", "");
             dialog.show(getFragmentManager(), "media-ids-dialog");
@@ -289,17 +290,25 @@ public class MediaFragment extends Fragment {
     private void uploadMedia(@NonNull SiteModel site, @NonNull String mediaUri) {
         prependToLog("Uploading media to " + site.getName());
 
-        mCurrentUpload = mMediaStore.instantiateMediaModel();
-        mCurrentUpload.setFileName(MediaUtils.getFileName(mediaUri));
-        mCurrentUpload.setFilePath(mediaUri);
-        mCurrentUpload.setMimeType(MediaUtils.getMimeTypeForExtension(MediaUtils.getExtension(mediaUri)));
+        MediaModel media = new MediaModel(
+                site.getId(),
+                null,
+                MediaUtils.getFileName(mediaUri),
+                mediaUri,
+                null,
+                MediaUtils.getMimeTypeForExtension(MediaUtils.getExtension(mediaUri)),
+                "",
+                null
+        );
+        mCurrentUpload = mMediaStore.instantiateMediaModel(media);
+        if (mCurrentUpload != null) {
+            // Upload
+            UploadMediaPayload payload = new UploadMediaPayload(site, mCurrentUpload, true);
+            prependToLog("Dispatching upload event for media localId=" + mCurrentUpload.getId());
 
-        // Upload
-        UploadMediaPayload payload = new UploadMediaPayload(site, mCurrentUpload, true);
-        prependToLog("Dispatching upload event for media localId=" + mCurrentUpload.getId());
-
-        mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-        mCancelButton.setEnabled(true);
+            mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
+            mCancelButton.setEnabled(true);
+        }
     }
 
     private void deleteMedia(@NonNull SiteModel site, @NonNull MediaModel media) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/UploadsFragment.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/UploadsFragment.java
@@ -166,7 +166,7 @@ public class UploadsFragment extends Fragment {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaUploaded(OnMediaUploaded event) {
-        if (!event.isError()) {
+        if (event.media != null && !event.isError()) {
             if (event.canceled) {
                 prependToLog("Upload canceled: " + event.media.getFileName());
                 mUploadButton.setEnabled(true);

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaErrorTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaErrorTest.kt
@@ -5,16 +5,15 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.fluxc.store.MediaStore.MediaError
-import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
+import org.wordpress.android.fluxc.store.MediaStore
 
 @RunWith(MockitoJUnitRunner::class)
 class MediaErrorTest {
-    private lateinit var mediaError: MediaError
+    private lateinit var mediaError: MediaStore.MediaError
 
     @Before
     fun setUp() {
-        mediaError = MediaError(MediaErrorType.GENERIC_ERROR)
+        mediaError = MediaStore.MediaError(MediaStore.MediaErrorType.GENERIC_ERROR)
     }
 
     @Test
@@ -26,26 +25,26 @@ class MediaErrorTest {
 
     @Test
     fun `user message extracted on BAD_REQUEST and API user message available`() {
-        mediaError.type = MediaErrorType.BAD_REQUEST
+        mediaError.type = MediaStore.MediaErrorType.BAD_REQUEST
         mediaError.message = "rest_upload_user_quota_exceeded|You have used your space quota. " +
                 "Please delete files before uploading. Back"
 
         val userMessage = mediaError.apiUserMessageIfAvailable
 
-        assertThat(userMessage).isNotEmpty()
+        assertThat(userMessage).isNotEmpty
         assertThat(userMessage).isEqualTo("You have used your space quota. " +
                 "Please delete files before uploading. Back")
     }
 
     @Test
     fun `user message not extracted on BAD_REQUEST and API user message not available`() {
-        mediaError.type = MediaErrorType.BAD_REQUEST
+        mediaError.type = MediaStore.MediaErrorType.BAD_REQUEST
         mediaError.message = "You have used your space quota. " +
                 "Please delete files before uploading. Back"
 
         val userMessage = mediaError.apiUserMessageIfAvailable
 
-        assertThat(userMessage).isNotEmpty()
+        assertThat(userMessage).isNotEmpty
         assertThat(userMessage).isEqualTo("You have used your space quota. " +
                 "Please delete files before uploading. Back")
     }
@@ -57,7 +56,7 @@ class MediaErrorTest {
 
         val userMessage = mediaError.apiUserMessageIfAvailable
 
-        assertThat(userMessage).isNotEmpty()
+        assertThat(userMessage).isNotEmpty
         assertThat(userMessage).isEqualTo("rest_upload_user_quota_exceeded|You have used your space quota. " +
                 "Please delete files before uploading. Back")
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaErrorTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaErrorTest.kt
@@ -6,8 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.store.MediaStore.MediaError
-import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.BAD_REQUEST
-import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 
 @RunWith(MockitoJUnitRunner::class)
 class MediaErrorTest {
@@ -15,7 +14,7 @@ class MediaErrorTest {
 
     @Before
     fun setUp() {
-        mediaError = MediaError(GENERIC_ERROR)
+        mediaError = MediaError(MediaErrorType.GENERIC_ERROR)
     }
 
     @Test
@@ -27,7 +26,7 @@ class MediaErrorTest {
 
     @Test
     fun `user message extracted on BAD_REQUEST and API user message available`() {
-        mediaError.type = BAD_REQUEST
+        mediaError.type = MediaErrorType.BAD_REQUEST
         mediaError.message = "rest_upload_user_quota_exceeded|You have used your space quota. " +
                 "Please delete files before uploading. Back"
 
@@ -40,7 +39,7 @@ class MediaErrorTest {
 
     @Test
     fun `user message not extracted on BAD_REQUEST and API user message not available`() {
-        mediaError.type = BAD_REQUEST
+        mediaError.type = MediaErrorType.BAD_REQUEST
         mediaError.message = "You have used your space quota. " +
                 "Please delete files before uploading. Back"
 

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -31,7 +31,7 @@ public class MediaSqlUtilsTest {
     private static final int TEST_LOCAL_SITE_ID = 42;
     private static final int SMALL_TEST_POOL = 10;
 
-    private Random mRandom = new Random(System.currentTimeMillis());
+    private final Random mRandom = new Random(System.currentTimeMillis());
 
     @Before
     public void setUp() {

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -406,7 +406,7 @@ public class MediaSqlUtilsTest {
     }
 
     @Test
-    public void testPushAndFetchCollision() throws InterruptedException {
+        public void testPushAndFetchCollision() {
         // Test uploading media, fetching remote media and updating the db from the fetch first
 
         MediaModel mediaModel = getTestMedia(0);

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -229,67 +229,83 @@ public class MediaSqlUtilsTest {
         int testLength = 60;
         String testVideoPressGuid = "testVideoPressGuid";
         boolean testVideoPressProcessing = false;
-        String testUploadState = MediaUploadState.UPLOADING.toString();
+        MediaUploadState testUploadState = MediaUploadState.UPLOADING;
         int testHorizontalAlign = 500;
         boolean testVerticalAlign = false;
         boolean testFeatured = false;
         boolean testFeaturedInPost = false;
         boolean testMarkedLocallyAsFeatured = false;
-        MediaModel testModel = new MediaModel();
-        testModel.setMediaId(testId);
-        testModel.setPostId(testPostId);
-        testModel.setAuthorId(testAuthorId);
-        testModel.setGuid(testGuid);
-        testModel.setUploadDate(testUploadDate);
-        testModel.setUrl(testUrl);
-        testModel.setThumbnailUrl(testThumbnailUrl);
-        testModel.setFileName(testFileName);
+
+        MediaModel testModel = new MediaModel(
+                testLocalSiteId,
+                testId,
+                testPostId,
+                testAuthorId,
+                testGuid,
+                testUploadDate,
+                testUrl,
+                testThumbnailUrl,
+                testFileName,
+                testFileExt,
+                testMimeType,
+                testTitle,
+                testCaption,
+                testDescription,
+                testAlt,
+                testWidth,
+                testHeight,
+                testLength,
+                testVideoPressGuid,
+                testVideoPressProcessing,
+                testUploadState,
+                null,
+                null,
+                null,
+                false
+        );
         testModel.setFilePath(testPath);
-        testModel.setFileExtension(testFileExt);
-        testModel.setMimeType(testMimeType);
-        testModel.setTitle(testTitle);
-        testModel.setCaption(testCaption);
-        testModel.setDescription(testDescription);
-        testModel.setAlt(testAlt);
-        testModel.setWidth(testWidth);
-        testModel.setHeight(testHeight);
-        testModel.setLength(testLength);
-        testModel.setVideoPressGuid(testVideoPressGuid);
-        testModel.setVideoPressProcessingDone(testVideoPressProcessing);
-        testModel.setUploadState(testUploadState);
-        testModel.setLocalSiteId(testLocalSiteId);
         testModel.setHorizontalAlignment(testHorizontalAlign);
         testModel.setVerticalAlignment(testVerticalAlign);
         testModel.setFeatured(testFeatured);
         testModel.setFeaturedInPost(testFeaturedInPost);
         testModel.setMarkedLocallyAsFeatured(testMarkedLocallyAsFeatured);
         assertThat(1).isEqualTo(MediaSqlUtils.insertOrUpdateMedia(testModel));
-        testModel.setPostId(testPostId + 1);
-        testModel.setAuthorId(testAuthorId + 1);
-        testModel.setGuid(testGuid + 1);
-        testModel.setUploadDate(testUploadDate + 1);
-        testModel.setUrl(testUrl + 1);
-        testModel.setThumbnailUrl(testThumbnailUrl + 1);
-        testModel.setFileName(testFileName + 1);
-        testModel.setFilePath(testPath + 1);
-        testModel.setFileExtension(testFileExt + 1);
-        testModel.setMimeType(testMimeType + 1);
-        testModel.setTitle(testTitle + 1);
-        testModel.setCaption(testCaption + 1);
-        testModel.setDescription(testDescription + 1);
-        testModel.setAlt(testAlt + 1);
-        testModel.setWidth(testWidth + 1);
-        testModel.setHeight(testHeight + 1);
-        testModel.setLength(testLength + 1);
-        testModel.setVideoPressGuid(testVideoPressGuid + 1);
-        testModel.setVideoPressProcessingDone(!testVideoPressProcessing);
-        testModel.setUploadState(testUploadState + 1);
-        testModel.setHorizontalAlignment(testHorizontalAlign + 1);
-        testModel.setVerticalAlignment(!testVerticalAlign);
-        testModel.setFeatured(!testFeatured);
-        testModel.setFeaturedInPost(!testFeaturedInPost);
-        testModel.setMarkedLocallyAsFeatured(!testMarkedLocallyAsFeatured);
-        assertThat(MediaSqlUtils.insertOrUpdateMedia(testModel)).isEqualTo(1);
+
+        MediaModel testModelUpdated = new MediaModel(
+                testLocalSiteId,
+                testId,
+                testPostId + 1,
+                testAuthorId + 1,
+                testGuid + 1,
+                testUploadDate + 1,
+                testUrl + 1,
+                testThumbnailUrl + 1,
+                testFileName + 1,
+                testFileExt + 1,
+                testMimeType + 1,
+                testTitle + 1,
+                testCaption + 1,
+                testDescription + 1,
+                testAlt + 1,
+                testWidth + 1,
+                testHeight + 1,
+                testLength + 1,
+                testVideoPressGuid + 1,
+                !testVideoPressProcessing,
+                MediaUploadState.UPLOADED,
+                null,
+                null,
+                null,
+                false
+        );
+        testModelUpdated.setFilePath(testPath + 1);
+        testModelUpdated.setHorizontalAlignment(testHorizontalAlign + 1);
+        testModelUpdated.setVerticalAlignment(!testVerticalAlign);
+        testModelUpdated.setFeatured(!testFeatured);
+        testModelUpdated.setFeaturedInPost(!testFeaturedInPost);
+        testModelUpdated.setMarkedLocallyAsFeatured(!testMarkedLocallyAsFeatured);
+        assertThat(MediaSqlUtils.insertOrUpdateMedia(testModelUpdated)).isEqualTo(1);
+
         List<MediaModel> media = MediaSqlUtils.getAllSiteMedia(getTestSiteWithLocalId(testLocalSiteId));
         assertThat(media).hasSize(1);
         MediaModel testMedia = media.get(0);
@@ -313,7 +329,7 @@ public class MediaSqlUtilsTest {
         assertThat(testMedia.getLength()).isEqualTo(testLength + 1);
         assertThat(testMedia.getVideoPressGuid()).isEqualTo(testVideoPressGuid + 1);
         assertThat(testMedia.getVideoPressProcessingDone()).isEqualTo(!testVideoPressProcessing);
-        assertThat(testMedia.getUploadState()).isEqualTo(testUploadState + 1);
+        assertThat(MediaUploadState.fromString(testMedia.getUploadState())).isEqualTo(MediaUploadState.UPLOADED);
         assertThat(testMedia.getHorizontalAlignment()).isEqualTo(testHorizontalAlign + 1);
         assertThat(testMedia.getVerticalAlignment()).isEqualTo(!testVerticalAlign);
         assertThat(testMedia.getFeatured()).isEqualTo(!testFeatured);
@@ -450,16 +466,17 @@ public class MediaSqlUtilsTest {
     }
 
     private MediaModel getTestMedia(long mediaId) {
-        MediaModel media = new MediaModel();
-        media.setLocalSiteId(TEST_LOCAL_SITE_ID);
-        media.setMediaId(mediaId);
-        return media;
+        return new MediaModel(
+                TEST_LOCAL_SITE_ID,
+                mediaId
+        );
     }
 
     private MediaModel getTestMedia(long mediaId, String title, String description, String caption) {
-        MediaModel media = new MediaModel();
-        media.setLocalSiteId(TEST_LOCAL_SITE_ID);
-        media.setMediaId(mediaId);
+        MediaModel media = new MediaModel(
+                TEST_LOCAL_SITE_ID,
+                mediaId
+        );
         media.setTitle(title);
         media.setDescription(description);
         media.setCaption(caption);

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -70,7 +70,7 @@ public class MediaSqlUtilsTest {
     // Inserts 10 items with known IDs then retrieves all media and validates IDs
     @Test
     public void testGetAllSiteMedia() {
-        long[] testIds = insertBasicTestItems(SMALL_TEST_POOL);
+        long[] testIds = insertBasicTestItems();
         List<MediaModel> storedMedia = MediaSqlUtils.getAllSiteMedia(getTestSiteWithLocalId(TEST_LOCAL_SITE_ID));
         assertThat(storedMedia).hasSize(testIds.length);
         for (int i = 0; i < testIds.length; ++i) {
@@ -112,7 +112,7 @@ public class MediaSqlUtilsTest {
     // Inserts many media items then retrieves only some items and validates based on ID
     @Test
     public void testGetSpecifiedMedia() {
-        long[] testIds = insertBasicTestItems(SMALL_TEST_POOL);
+        long[] testIds = insertBasicTestItems();
         List<Long> mediaIds = new ArrayList<>();
         for (int i = 0; i < SMALL_TEST_POOL; i += 2) {
             mediaIds.add(testIds[i]);
@@ -152,7 +152,7 @@ public class MediaSqlUtilsTest {
     // Inserts many images then retrieves all images with a supplied exclusion filter
     @Test
     public void testGetSiteImagesExclusionFilter() {
-        long[] imageIds = insertImageTestItems(SMALL_TEST_POOL);
+        long[] imageIds = insertImageTestItems();
         List<Long> exclusion = new ArrayList<>();
         for (int i = 0; i < SMALL_TEST_POOL; i += 2) {
             exclusion.add(imageIds[i]);
@@ -353,7 +353,7 @@ public class MediaSqlUtilsTest {
         SiteModel site = getTestSiteWithLocalId(TEST_LOCAL_SITE_ID);
 
         // Insert media
-        insertBasicTestItems(SMALL_TEST_POOL);
+        insertBasicTestItems();
 
         // Insert one deleted media
         MediaModel image = getTestMedia(42);
@@ -369,7 +369,7 @@ public class MediaSqlUtilsTest {
         SiteModel site = getTestSiteWithLocalId(TEST_LOCAL_SITE_ID);
 
         // Insert media
-        insertBasicTestItems(SMALL_TEST_POOL);
+        insertBasicTestItems();
 
         // Insert one detached but deleted media
         MediaModel media = getTestMedia(42);
@@ -391,7 +391,7 @@ public class MediaSqlUtilsTest {
         SiteModel site = getTestSiteWithLocalId(TEST_LOCAL_SITE_ID);
 
         // Insert images
-        insertImageTestItems(SMALL_TEST_POOL);
+        insertImageTestItems();
 
         // Insert one deleted image
         MediaModel image = getTestMedia(42);
@@ -437,9 +437,9 @@ public class MediaSqlUtilsTest {
 
     // Utilities
 
-    private long[] insertBasicTestItems(int num) {
-        long[] testItemIds = new long[num];
-        for (int i = 0; i < num; ++i) {
+    private long[] insertBasicTestItems() {
+        long[] testItemIds = new long[MediaSqlUtilsTest.SMALL_TEST_POOL];
+        for (int i = 0; i < MediaSqlUtilsTest.SMALL_TEST_POOL; ++i) {
             testItemIds[i] = mRandom.nextLong();
             MediaModel media = getTestMedia(testItemIds[i]);
             media.setUploadState(MediaUploadState.UPLOADED);
@@ -448,9 +448,9 @@ public class MediaSqlUtilsTest {
         return testItemIds;
     }
 
-    private long[] insertImageTestItems(int num) {
-        long[] testItemIds = new long[num];
-        for (int i = 0; i < num; ++i) {
+    private long[] insertImageTestItems() {
+        long[] testItemIds = new long[MediaSqlUtilsTest.SMALL_TEST_POOL];
+        for (int i = 0; i < MediaSqlUtilsTest.SMALL_TEST_POOL; ++i) {
             testItemIds[i] = Math.abs(mRandom.nextInt());
             MediaModel image = getTestMedia(testItemIds[i]);
             image.setMimeType("image/jpg");

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -127,6 +127,7 @@ public class MediaSqlUtilsTest {
 
     // Inserts media of multiple MIME types then retrieves only images and verifies
     @Test
+    @SuppressWarnings("ConstantValue")
     public void testGetSiteImages() {
         List<Long> imageIds = new ArrayList<>(SMALL_TEST_POOL);
         List<Long> videoIds = new ArrayList<>(SMALL_TEST_POOL);

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaSqlUtilsTest.java
@@ -200,12 +200,6 @@ public class MediaSqlUtilsTest {
         }
     }
 
-    // Adds media with known post ID and title, deletes via postId and title, verifies
-    @Test
-    public void testMatchPostMedia() {
-        MediaModel testMedia = getTestMedia(1);
-    }
-
     // Adds a media item with known fields, updates all fields, retrieves and verifies
     @Test
     public void testUpdateExistingMedia() {

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -279,7 +279,7 @@ public class MediaStoreTest {
             insertMediaIntoDatabase(attached);
             insertMediaIntoDatabase(unattached);
         }
-        assertEquals(testPoolSize, mMediaStore.getUnattachedSiteMediaCount(getTestSiteWithLocalId(testSiteId)));
+        assertEquals(testPoolSize, mMediaStore.getUnattachedSiteMedia(getTestSiteWithLocalId(testSiteId)).size());
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaStoreTest.java
@@ -189,7 +189,7 @@ public class MediaStoreTest {
     public void testGetSiteImageCount() {
         final int testSiteId = 9001;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertEquals(0, mMediaStore.getSiteImageCount(testSite));
+        assertEquals(0, mMediaStore.getSiteImages(testSite).size());
 
         // insert both images and videos
         final int testListSize = 10;
@@ -207,14 +207,14 @@ public class MediaStoreTest {
         }
 
         assertEquals(mMediaStore.getSiteMediaCount(testSite), testImages.size() + testVideos.size());
-        assertEquals(mMediaStore.getSiteImageCount(testSite), testImages.size());
+        assertEquals(mMediaStore.getSiteImages(testSite).size(), testImages.size());
     }
 
     @Test
     public void testGetSiteImagesBlacklist() {
         final int testSiteId = 3;
         SiteModel testSite = getTestSiteWithLocalId(testSiteId);
-        assertEquals(0, mMediaStore.getSiteImageCount(testSite));
+        assertEquals(0, mMediaStore.getSiteImages(testSite).size());
 
         final int testListSize = 10;
         final List<MediaModel> testImages = new ArrayList<>(testListSize);
@@ -224,7 +224,7 @@ public class MediaStoreTest {
             assertEquals(1, insertMediaIntoDatabase(image));
             testImages.add(image);
         }
-        assertEquals(testListSize, mMediaStore.getSiteImageCount(testSite));
+        assertEquals(testListSize, mMediaStore.getSiteImages(testSite).size());
 
         // create blacklist
         List<Long> blacklist = new ArrayList<>(testListSize / 2);

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaTestUtils.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class MediaTestUtils {
     public static int insertMediaIntoDatabase(MediaModel media) {
@@ -18,7 +18,7 @@ public class MediaTestUtils {
     public static List<MediaModel> insertRandomMediaIntoDatabase(int localSiteId, int count) {
         List<MediaModel> insertedMedia = generateRandomizedMediaList(count, localSiteId);
         for (MediaModel media : insertedMedia) {
-            assertTrue(MediaSqlUtils.insertOrUpdateMedia(media) == 1);
+            assertEquals(1, MediaSqlUtils.insertOrUpdateMedia(media));
         }
         return insertedMedia;
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/media/MediaTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/media/MediaTestUtils.java
@@ -24,7 +24,10 @@ public class MediaTestUtils {
     }
 
     public static MediaModel generateMedia(String title, String desc, String caption, String alt) {
-        MediaModel media = new MediaModel();
+        MediaModel media = new MediaModel(
+                0,
+                0
+        );
         media.setTitle(title);
         media.setDescription(desc);
         media.setCaption(caption);
@@ -33,9 +36,10 @@ public class MediaTestUtils {
     }
 
     public static MediaModel generateMediaFromPath(int localSiteId, long mediaId, String filePath) {
-        MediaModel media = new MediaModel();
-        media.setLocalSiteId(localSiteId);
-        media.setMediaId(mediaId);
+        MediaModel media = new MediaModel(
+                localSiteId,
+                mediaId
+        );
         media.setFilePath(filePath);
         media.setFileName(MediaUtils.getFileName(filePath));
         media.setFileExtension(MediaUtils.getExtension(filePath));

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/UploadTestUtils.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/UploadTestUtils.java
@@ -11,16 +11,17 @@ class UploadTestUtils {
     private static final int TEST_LOCAL_SITE_ID = 42;
 
     static MediaModel getTestMedia(long mediaId) {
-        MediaModel media = new MediaModel();
-        media.setLocalSiteId(TEST_LOCAL_SITE_ID);
-        media.setMediaId(mediaId);
-        return media;
+        return new MediaModel(
+                TEST_LOCAL_SITE_ID,
+                mediaId
+        );
     }
 
     static MediaModel getLocalTestMedia() {
-        MediaModel media = new MediaModel();
-        media.setLocalSiteId(TEST_LOCAL_SITE_ID);
-        return media;
+        return new MediaModel(
+                TEST_LOCAL_SITE_ID,
+                0
+        );
     }
 
     static PostModel getTestPost() {

--- a/example/src/test/java/org/wordpress/android/fluxc/utils/MediaUtilsTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/utils/MediaUtilsTest.java
@@ -5,30 +5,30 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MediaUtilsTest {
-    private String[] mSupportedImageSubtypes = {
+    private final String[] mSupportedImageSubtypes = {
             "jpeg", "png", "gif"
     };
-    private String[] mSupportedVideoSubtypes = {
+    private final String[] mSupportedVideoSubtypes = {
             "mp4", "quicktime", "x-ms-wmv", "avi", "mpeg", "mp2p", "ogg", "3gpp", "3gpp2"
     };
-    private String[] mSupportedAudioSubtypes = {
+    private final String[] mSupportedAudioSubtypes = {
             "mpeg", "mp4", "ogg", "x-wav"
     };
-    private String[] mSupportedApplicationSubtypes = {
+    private final String[] mSupportedApplicationSubtypes = {
             "pdf", "msword", "vnd.openxmlformats-officedocument.wordprocessingml.document", "mspowerpoint",
             "vnd.openxmlformats-officedocument.presentationml.presentation", "vnd.oasis.opendocument.text",
             "vnd.ms-excel", "vnd.openxmlformats-officedocument.spreadsheetml.sheet", "keynote", "zip"
     };
-    private String[] mSupportedImageExtensions = {
+    private final String[] mSupportedImageExtensions = {
             "jpg", "jpeg", "png", "gif"
     };
-    private String[] mSupportedVideoExtensions = {
+    private final String[] mSupportedVideoExtensions = {
             "mp4", "m4v", "mov", "wmv", "avi", "mpg", "ogv", "3gp", "3g2"
     };
-    private String[] mSupportedAudioExtensions = {
+    private final String[] mSupportedAudioExtensions = {
             "mp3", "m4a", "ogg", "wav"
     };
-    private String[] mSupportedApplicationExtensions = {
+    private final String[] mSupportedApplicationExtensions = {
             "pdf", "doc", "ppt", "odt", "pptx", "docx", "xls", "xlsx", "key", "zip"
     };
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.model;
 
+import androidx.annotation.Nullable;
+
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
@@ -121,7 +123,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
 
     @Override
     @SuppressWarnings("ConditionCoveredByFurtherCondition")
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (this == other) return true;
         if (other == null || !(other instanceof MediaModel)) return false;
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -108,20 +108,21 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         CAPTION("caption"),
         ALT("alt");
 
-        private final String mFieldName;
+        @NonNull private final String mFieldName;
 
         // Constructor
-        MediaFields(String fieldName) {
+        MediaFields(@NonNull String fieldName) {
             this.mFieldName = fieldName;
         }
 
         // Getter
+        @NonNull
         public String getFieldName() {
             return this.mFieldName;
         }
     }
 
-    private MediaFields[] mFieldsToUpdate = MediaFields.values();
+    @NonNull private MediaFields[] mFieldsToUpdate = MediaFields.values();
 
     @Override
     @SuppressWarnings("ConditionCoveredByFurtherCondition")
@@ -360,12 +361,13 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         return mUploadState;
     }
 
+    @NonNull
     public MediaFields[] getFieldsToUpdate() {
         return mFieldsToUpdate;
     }
 
     @SuppressWarnings("unused")
-    public void setFieldsToUpdate(MediaFields[] fieldsToUpdate) {
+    public void setFieldsToUpdate(@NonNull MediaFields[] fieldsToUpdate) {
         this.mFieldsToUpdate = fieldsToUpdate;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -16,6 +16,7 @@ import org.wordpress.android.util.StringUtils;
 import java.io.Serializable;
 
 @Table
+@SuppressWarnings("NotNullFieldNotInitialized")
 public class MediaModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     private static final long serialVersionUID = -1396457338496002846L;
 
@@ -44,26 +45,26 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     @Column private long mMediaId; // The remote ID of the media
     @Column private long mPostId; // The remote post ID ('parent') of the media
     @Column private long mAuthorId;
-    @Column private String mGuid;
+    @NonNull @Column private String mGuid;
 
     // Upload date, ISO 8601-formatted date in UTC
-    @Column private String mUploadDate;
+    @Nullable @Column private String mUploadDate;
 
     // Remote Url's
-    @Column private String mUrl;
-    @Column private String mThumbnailUrl;
+    @NonNull @Column private String mUrl;
+    @Nullable @Column private String mThumbnailUrl;
 
     // File descriptors
-    @Column private String mFileName;
-    @Column private String mFilePath;
-    @Column private String mFileExtension;
-    @Column private String mMimeType;
+    @Nullable @Column private String mFileName;
+    @Nullable @Column private String mFilePath;
+    @Nullable @Column private String mFileExtension;
+    @Nullable @Column private String mMimeType;
 
     // Descriptive strings
-    @Column private String mTitle;
-    @Column private String mCaption;
-    @Column private String mDescription;
-    @Column private String mAlt;
+    @Nullable @Column private String mTitle;
+    @NonNull @Column private String mCaption;
+    @NonNull @Column private String mDescription;
+    @NonNull @Column private String mAlt;
 
     // Image and Video files only
     @Column private int mWidth;
@@ -73,7 +74,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     @Column private int mLength;
 
     // Video only
-    @Column private String mVideoPressGuid;
+    @Nullable @Column private String mVideoPressGuid;
     @Column private boolean mVideoPressProcessingDone;
 
     // Local only
@@ -81,9 +82,9 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     @Column private boolean mMarkedLocallyAsFeatured;
 
     // Other Sizes. Only available for images on self-hosted (xmlrpc layer) and Rest WPCOM sites
-    @Column private String mFileUrlMediumSize; // Self-hosted and wpcom
-    @Column private String mFileUrlMediumLargeSize; // Self-hosted only
-    @Column private String mFileUrlLargeSize; // Self-hosted and wpcom
+    @Nullable @Column private String mFileUrlMediumSize; // Self-hosted and wpcom
+    @Nullable @Column private String mFileUrlMediumLargeSize; // Self-hosted only
+    @Nullable @Column private String mFileUrlLargeSize; // Self-hosted and wpcom
 
     //
     // Legacy
@@ -212,98 +213,110 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         return mAuthorId;
     }
 
-    public void setGuid(String guid) {
+    public void setGuid(@NonNull String guid) {
         mGuid = guid;
     }
 
+    @NonNull
     public String getGuid() {
         return mGuid;
     }
 
-    public void setUploadDate(String uploadDate) {
+    public void setUploadDate(@Nullable String uploadDate) {
         mUploadDate = uploadDate;
     }
 
+    @Nullable
     public String getUploadDate() {
         return mUploadDate;
     }
 
-    public void setUrl(String url) {
+    public void setUrl(@NonNull String url) {
         mUrl = url;
     }
 
+    @NonNull
     public String getUrl() {
         return mUrl;
     }
 
-    public void setThumbnailUrl(String thumbnailUrl) {
+    public void setThumbnailUrl(@Nullable String thumbnailUrl) {
         mThumbnailUrl = thumbnailUrl;
     }
 
+    @Nullable
     public String getThumbnailUrl() {
         return mThumbnailUrl;
     }
 
-    public void setFileName(String fileName) {
+    public void setFileName(@Nullable String fileName) {
         mFileName = fileName;
     }
 
+    @Nullable
     public String getFileName() {
         return mFileName;
     }
 
-    public void setFilePath(String filePath) {
+    public void setFilePath(@Nullable String filePath) {
         mFilePath = filePath;
     }
 
+    @Nullable
     public String getFilePath() {
         return mFilePath;
     }
 
-    public void setFileExtension(String fileExtension) {
+    public void setFileExtension(@Nullable String fileExtension) {
         mFileExtension = fileExtension;
     }
 
+    @Nullable
     public String getFileExtension() {
         return mFileExtension;
     }
 
-    public void setMimeType(String mimeType) {
+    public void setMimeType(@Nullable String mimeType) {
         mMimeType = mimeType;
     }
 
+    @Nullable
     public String getMimeType() {
         return mMimeType;
     }
 
-    public void setTitle(String title) {
+    public void setTitle(@Nullable String title) {
         mTitle = title;
     }
 
+    @Nullable
     public String getTitle() {
         return mTitle;
     }
 
-    public void setCaption(String caption) {
+    public void setCaption(@NonNull String caption) {
         mCaption = caption;
     }
 
+    @NonNull
     public String getCaption() {
         return mCaption;
     }
 
-    public void setDescription(String description) {
+    public void setDescription(@NonNull String description) {
         mDescription = description;
     }
 
+    @NonNull
     public String getDescription() {
         return mDescription;
     }
 
-    public void setAlt(String alt) {
+    public void setAlt(@NonNull String alt) {
         mAlt = alt;
     }
 
+    @NonNull
     public String getAlt() {
         return mAlt;
     }
@@ -332,10 +345,11 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         return mLength;
     }
 
-    public void setVideoPressGuid(String videoPressGuid) {
+    public void setVideoPressGuid(@Nullable String videoPressGuid) {
         mVideoPressGuid = videoPressGuid;
     }
 
+    @Nullable
     public String getVideoPressGuid() {
         return mVideoPressGuid;
     }
@@ -427,26 +441,29 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         return mDeleted;
     }
 
-    public void setFileUrlMediumSize(String file) {
+    public void setFileUrlMediumSize(@Nullable String file) {
         mFileUrlMediumSize = file;
     }
 
+    @Nullable
     public String getFileUrlMediumSize() {
         return mFileUrlMediumSize;
     }
 
-    public void setFileUrlMediumLargeSize(String file) {
+    public void setFileUrlMediumLargeSize(@Nullable String file) {
         mFileUrlMediumLargeSize = file;
     }
 
+    @Nullable
     public String getFileUrlMediumLargeSize() {
         return mFileUrlMediumLargeSize;
     }
 
-    public void setFileUrlLargeSize(String file) {
+    public void setFileUrlLargeSize(@Nullable String file) {
         mFileUrlLargeSize = file;
     }
 
+    @Nullable
     public String getFileUrlLargeSize() {
         return mFileUrlLargeSize;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -16,7 +16,6 @@ import org.wordpress.android.util.StringUtils;
 import java.io.Serializable;
 
 @Table
-@SuppressWarnings("NotNullFieldNotInitialized")
 public class MediaModel extends Payload<BaseNetworkError> implements Identifiable, Serializable {
     private static final long serialVersionUID = -1396457338496002846L;
 
@@ -124,6 +123,200 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     }
 
     @NonNull private MediaFields[] mFieldsToUpdate = MediaFields.values();
+
+    @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    public MediaModel() {
+        this.mId = 0;
+        this.mLocalSiteId = 0;
+        this.mLocalPostId = 0;
+        this.mMediaId = 0;
+        this.mPostId = 0;
+        this.mAuthorId = 0;
+        this.mGuid = "";
+        this.mUploadDate = null;
+        this.mUrl = "";
+        this.mThumbnailUrl = null;
+        this.mFileName = null;
+        this.mFilePath = null;
+        this.mFileExtension = null;
+        this.mMimeType = null;
+        this.mTitle = null;
+        this.mCaption = "";
+        this.mDescription = "";
+        this.mAlt = "";
+        this.mWidth = 0;
+        this.mHeight = 0;
+        this.mLength = 0;
+        this.mVideoPressGuid = null;
+        this.mVideoPressProcessingDone = false;
+        this.mUploadState = null;
+        this.mMarkedLocallyAsFeatured = false;
+        this.mFileUrlMediumSize = null;
+        this.mFileUrlMediumLargeSize = null;
+        this.mFileUrlLargeSize = null;
+        this.mHorizontalAlignment = 0;
+        this.mVerticalAlignment = false;
+        this.mFeatured = false;
+        this.mFeaturedInPost = false;
+        this.mDeleted = false;
+    }
+
+    /**
+     * Use when getting an existing media.
+     */
+    public MediaModel(
+            int localSiteId,
+            long mediaId) {
+        this.mLocalSiteId = localSiteId;
+        this.mMediaId = mediaId;
+        this.mGuid = "";
+        this.mUrl = "";
+        this.mCaption = "";
+        this.mDescription = "";
+        this.mAlt = "";
+    }
+
+    /**
+     * Use when converting local uri into a media, and then, to upload a new or update an existing media.
+     */
+    public MediaModel(
+            int localSiteId,
+            @Nullable String uploadDate,
+            @Nullable String fileName,
+            @Nullable String filePath,
+            @Nullable String fileExtension,
+            @Nullable String mimeType,
+            @Nullable String title,
+            @Nullable MediaUploadState uploadState) {
+        this.mLocalSiteId = localSiteId;
+        this.mGuid = "";
+        this.mUploadDate = uploadDate;
+        this.mUrl = "";
+        this.mFileName = fileName;
+        this.mFilePath = filePath;
+        this.mFileExtension = fileExtension;
+        this.mMimeType = mimeType;
+        this.mTitle = title;
+        this.mCaption = "";
+        this.mDescription = "";
+        this.mAlt = "";
+        this.mUploadState = uploadState != null ? uploadState.toString() : null;
+    }
+
+    /**
+     * Use when converting editor image metadata into a media.
+     */
+    public MediaModel(
+            @NonNull String url,
+            @Nullable String fileName,
+            @Nullable String fileExtension,
+            @Nullable String title,
+            @NonNull String caption,
+            @NonNull String alt,
+            int width,
+            int height) {
+        this.mGuid = "";
+        this.mUrl = url;
+        this.mFileName = fileName;
+        this.mFileExtension = fileExtension;
+        this.mTitle = title;
+        this.mCaption = caption;
+        this.mDescription = "";
+        this.mAlt = alt;
+        this.mWidth = width;
+        this.mHeight = height;
+    }
+
+    /**
+     * Use when converting a media file into a media.
+     */
+    public MediaModel(
+            int id,
+            int localSiteId,
+            long mediaId,
+            @NonNull String url,
+            @Nullable String thumbnailUrl,
+            @Nullable String fileName,
+            @Nullable String filePath,
+            @Nullable String fileExtension,
+            @Nullable String mimeType,
+            @Nullable String title,
+            @NonNull String caption,
+            @NonNull String description,
+            @NonNull String alt,
+            @Nullable String videoPressGuid,
+            @NonNull MediaUploadState uploadState) {
+        this.mId = id;
+        this.mLocalSiteId = localSiteId;
+        this.mMediaId = mediaId;
+        this.mGuid = "";
+        this.mUrl = url;
+        this.mThumbnailUrl = thumbnailUrl;
+        this.mFileName = fileName;
+        this.mFilePath = filePath;
+        this.mFileExtension = fileExtension;
+        this.mMimeType = mimeType;
+        this.mTitle = title;
+        this.mCaption = caption;
+        this.mDescription = description;
+        this.mAlt = alt;
+        this.mVideoPressGuid = videoPressGuid;
+        this.mUploadState = uploadState.toString();
+    }
+
+    public MediaModel(
+            int localSiteId,
+            long mediaId,
+            long postId,
+            long authorId,
+            @NonNull String guid,
+            @Nullable String uploadDate,
+            @NonNull String url,
+            @Nullable String thumbnailUrl,
+            @Nullable String fileName,
+            @Nullable String fileExtension,
+            @Nullable String mimeType,
+            @Nullable String title,
+            @NonNull String caption,
+            @NonNull String description,
+            @NonNull String alt,
+            int width,
+            int height,
+            int length,
+            @Nullable String videoPressGuid,
+            boolean videoPressProcessingDone,
+            @NonNull MediaUploadState uploadState,
+            @Nullable String fileUrlMediumSize,
+            @Nullable String fileUrlMediumLargeSize,
+            @Nullable String fileUrlLargeSize,
+            boolean deleted) {
+        this.mLocalSiteId = localSiteId;
+        this.mMediaId = mediaId;
+        this.mPostId = postId;
+        this.mAuthorId = authorId;
+        this.mGuid = guid;
+        this.mUploadDate = uploadDate;
+        this.mUrl = url;
+        this.mThumbnailUrl = thumbnailUrl;
+        this.mFileName = fileName;
+        this.mFileExtension = fileExtension;
+        this.mMimeType = mimeType;
+        this.mTitle = title;
+        this.mCaption = caption;
+        this.mDescription = description;
+        this.mAlt = alt;
+        this.mWidth = width;
+        this.mHeight = height;
+        this.mLength = length;
+        this.mVideoPressGuid = videoPressGuid;
+        this.mVideoPressProcessingDone = videoPressProcessingDone;
+        this.mUploadState = uploadState.toString();
+        this.mFileUrlMediumSize = fileUrlMediumSize;
+        this.mFileUrlMediumLargeSize = fileUrlMediumLargeSize;
+        this.mFileUrlLargeSize = fileUrlLargeSize;
+        this.mDeleted = deleted;
+    }
 
     @Override
     @SuppressWarnings("ConditionCoveredByFurtherCondition")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -104,7 +104,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         CAPTION("caption"),
         ALT("alt");
 
-        private String mFieldName;
+        private final String mFieldName;
 
         // Constructor
         MediaFields(String fieldName) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -120,6 +120,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     private MediaFields[] mFieldsToUpdate = MediaFields.values();
 
     @Override
+    @SuppressWarnings("ConditionCoveredByFurtherCondition")
     public boolean equals(Object other) {
         if (this == other) return true;
         if (other == null || !(other instanceof MediaModel)) return false;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -359,6 +359,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         return mFieldsToUpdate;
     }
 
+    @SuppressWarnings("unused")
     public void setFieldsToUpdate(MediaFields[] fieldsToUpdate) {
         this.mFieldsToUpdate = fieldsToUpdate;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.model;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.yarolegovich.wellsql.core.Identifiable;
@@ -21,7 +22,8 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     public enum MediaUploadState {
         QUEUED, UPLOADING, DELETING, DELETED, FAILED, UPLOADED;
 
-        public static MediaUploadState fromString(String stringState) {
+        @NonNull
+        public static MediaUploadState fromString(@Nullable String stringState) {
             if (stringState != null) {
                 for (MediaUploadState state : MediaUploadState.values()) {
                     if (stringState.equalsIgnoreCase(state.toString())) {
@@ -75,7 +77,7 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
     @Column private boolean mVideoPressProcessingDone;
 
     // Local only
-    @Column private String mUploadState;
+    @Nullable @Column private String mUploadState;
     @Column private boolean mMarkedLocallyAsFeatured;
 
     // Other Sizes. Only available for images on self-hosted (xmlrpc layer) and Rest WPCOM sites
@@ -345,16 +347,17 @@ public class MediaModel extends Payload<BaseNetworkError> implements Identifiabl
         return mVideoPressProcessingDone;
     }
 
-    public void setUploadState(String uploadState) {
+    public void setUploadState(@Nullable String uploadState) {
         mUploadState = uploadState;
     }
 
-    public String getUploadState() {
-        return mUploadState;
+    public void setUploadState(@NonNull MediaUploadState uploadState) {
+        mUploadState = uploadState.toString();
     }
 
-    public void setUploadState(MediaUploadState uploadState) {
-        mUploadState = uploadState.toString();
+    @Nullable
+    public String getUploadState() {
+        return mUploadState;
     }
 
     public MediaFields[] getFieldsToUpdate() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -33,8 +33,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload
 import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
-import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.PARSE_ERROR
-import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.REQUEST_TOO_LARGE
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.MimeType
@@ -155,11 +153,11 @@ abstract class BaseWPV2MediaRestClient constructor(
                             }
                         } catch (e: JsonSyntaxException) {
                             AppLog.e(MEDIA, e)
-                            val error = MediaError(PARSE_ERROR)
+                            val error = MediaError(MediaErrorType.PARSE_ERROR)
                             handleFailure(media, error)
                         } catch (e: NullPointerException) {
                             AppLog.e(MEDIA, e)
-                            val error = MediaError(PARSE_ERROR)
+                            val error = MediaError(MediaErrorType.PARSE_ERROR)
                             handleFailure(media, error)
                         }
                     } else {
@@ -201,7 +199,7 @@ abstract class BaseWPV2MediaRestClient constructor(
             is WPAPIResponse.Error -> {
                 val errorMessage = "could not parse Fetch all media response: $response"
                 AppLog.w(MEDIA, errorMessage)
-                val error = MediaError(PARSE_ERROR)
+                val error = MediaError(MediaErrorType.PARSE_ERROR)
                 error.logMessage = errorMessage
                 FetchMediaListResponsePayload(site, error, mimeType)
             }
@@ -219,7 +217,7 @@ abstract class BaseWPV2MediaRestClient constructor(
         val mediaError = MediaError(MediaErrorType.fromHttpStatusCode(code))
         mediaError.statusCode = code
         mediaError.logMessage = message
-        if (mediaError.type == REQUEST_TOO_LARGE) {
+        if (mediaError.type == MediaErrorType.REQUEST_TOO_LARGE) {
             // 413 (Request too large) errors are coming from the web server and are not an API response like the rest
             mediaError.message = message
             return mediaError
@@ -228,7 +226,7 @@ abstract class BaseWPV2MediaRestClient constructor(
             val responseBody = body
             if (responseBody == null) {
                 AppLog.e(MEDIA, "error uploading media, response body was empty $this")
-                mediaError.type = PARSE_ERROR
+                mediaError.type = MediaErrorType.PARSE_ERROR
                 return mediaError
             }
             val jsonBody = JSONObject(responseBody.string())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WPRestUploadRequestBody.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WPRestUploadRequestBody.kt
@@ -39,18 +39,22 @@ class WPRestUploadRequestBody(
             }
         }
 
-        val mediaFile = File(media.filePath)
-        val body = mediaFile.asRequestBody(media.mimeType.toMediaType())
-        val fileName = URLEncoder.encode(media.fileName, "UTF-8")
-
         val builder: MultipartBody.Builder = MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
-                .addFormDataPart(FILE_FORM_KEY, fileName, body)
                 .addParamIfNotEmpty(TITLE_FORM_KEY, media.title)
                 .addParamIfNotEmpty(DESCRIPTION_FORM_KEY, media.description)
                 .addParamIfNotEmpty(CAPTION_FORM_KEY, media.caption)
                 .addParamIfNotEmpty(ALT_FORM_KEY, media.alt)
                 .addParamIfNotEmpty(POST_ID_FORM_KEY, media.postId.takeIf { it > 0L }?.toString())
+
+        val filePath = media.filePath
+        val mimeType = media.mimeType
+        if (filePath != null && mimeType != null) {
+            val mediaFile = File(filePath)
+            val body = mediaFile.asRequestBody(mimeType.toMediaType())
+            val fileName = URLEncoder.encode(media.fileName, "UTF-8")
+            builder.addFormDataPart(FILE_FORM_KEY, fileName, body)
+        }
 
         return builder.build()
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaResponseUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/MediaResponseUtils.kt
@@ -3,8 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.media
 import android.text.TextUtils
 import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.model.MediaModel
-import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.DELETED
-import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.UPLOADED
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaWPComRestResponse.MultipleMediaResponse
 import javax.inject.Inject
 
@@ -13,7 +12,10 @@ class MediaResponseUtils
     /**
      * Creates a [MediaModel] list from a WP.com REST response to a request for all media.
      */
-    fun getMediaListFromRestResponse(from: MultipleMediaResponse, localSiteId: Int): List<MediaModel> {
+    fun getMediaListFromRestResponse(
+        from: MultipleMediaResponse,
+        localSiteId: Int
+    ): List<MediaModel> {
         return from.media.mapNotNull {
             getMediaFromRestResponse(it).apply { this.localSiteId = localSiteId }
         }
@@ -22,45 +24,41 @@ class MediaResponseUtils
     /**
      * Creates a [MediaModel] from a WP.com REST response to a fetch request.
      */
-    fun getMediaFromRestResponse(from: MediaWPComRestResponse): MediaModel {
-        val media = MediaModel()
-        media.mediaId = from.ID
-        media.uploadDate = from.date
-        media.postId = from.post_ID
-        media.authorId = from.author_ID
-        media.url = from.URL
-        media.guid = from.guid
-        media.fileName = from.file
-        media.fileExtension = from.extension
-        media.mimeType = from.mime_type
-        media.title = StringEscapeUtils.unescapeHtml4(from.title)
-        media.caption = StringEscapeUtils.unescapeHtml4(from.caption)
-        media.description = StringEscapeUtils.unescapeHtml4(from.description)
-        media.alt = StringEscapeUtils.unescapeHtml4(from.alt)
+    fun getMediaFromRestResponse(from: MediaWPComRestResponse) = MediaModel(
+        0,
+        from.ID,
+        from.post_ID,
+        from.author_ID,
+        from.guid,
+        from.date,
+        from.URL,
         from.thumbnails?.let {
             if (!TextUtils.isEmpty(it.fmt_std)) {
-                media.thumbnailUrl = it.fmt_std
+                it.fmt_std
             } else {
-                media.thumbnailUrl = it.thumbnail
+                it.thumbnail
             }
-            if (!TextUtils.isEmpty(it.large)) {
-                media.fileUrlLargeSize = it.large
-            }
-            if (!TextUtils.isEmpty(it.medium)) {
-                media.fileUrlMediumSize = it.medium
-            }
-        }
-        media.height = from.height
-        media.width = from.width
-        media.length = from.length
-        media.videoPressGuid = from.videopress_guid
-        media.videoPressProcessingDone = from.videopress_processing_done
-        media.deleted = MediaWPComRestResponse.DELETED_STATUS == from.status
-        if (!media.deleted) {
-            media.setUploadState(UPLOADED)
+        },
+        from.file,
+        from.extension,
+        from.mime_type,
+        StringEscapeUtils.unescapeHtml4(from.title),
+        StringEscapeUtils.unescapeHtml4(from.caption),
+        StringEscapeUtils.unescapeHtml4(from.description),
+        StringEscapeUtils.unescapeHtml4(from.alt),
+        from.width,
+        from.height,
+        from.length,
+        from.videopress_guid,
+        from.videopress_processing_done,
+        if (MediaWPComRestResponse.DELETED_STATUS == from.status) {
+            MediaUploadState.DELETED
         } else {
-            media.setUploadState(DELETED)
-        }
-        return media
-    }
+            MediaUploadState.UPLOADED
+        },
+        from.thumbnails?.let { if (!TextUtils.isEmpty(it.medium)) it.medium else null },
+        null,
+        from.thumbnails?.let { if (!TextUtils.isEmpty(it.large)) it.large else null },
+        MediaWPComRestResponse.DELETED_STATUS == from.status
+    )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/RestUploadRequestBody.java
@@ -84,15 +84,19 @@ public class RestUploadRequestBody extends BaseUploadRequestBody {
         }
 
         // add media file data
-        File mediaFile = new File(media.getFilePath());
-        RequestBody body = RequestBody.create(MediaType.parse(media.getMimeType()), mediaFile);
-        String fileName = media.getFileName();
-        try {
-            fileName = URLEncoder.encode(media.getFileName(), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
+        String filePath = media.getFilePath();
+        String mimeType = media.getMimeType();
+        if (filePath != null && mimeType != null) {
+            File mediaFile = new File(filePath);
+            RequestBody body = RequestBody.create(MediaType.parse(mimeType), mediaFile);
+            String fileName = media.getFileName();
+            try {
+                fileName = URLEncoder.encode(media.getFileName(), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+            builder.addFormDataPart(MEDIA_DATA_KEY, fileName, body);
         }
-        builder.addFormDataPart(MEDIA_DATA_KEY, fileName, body);
 
         return builder.build();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -50,7 +50,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -544,35 +543,39 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
             return null;
         }
 
-        MediaModel media = new MediaModel();
-        media.setMediaId(MapUtils.getMapLong(response, "attachment_id"));
-        media.setPostId(MapUtils.getMapLong(response, "parent"));
-        media.setTitle(StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(response, "title")));
-        media.setCaption(StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(response, "caption")));
-        media.setDescription(StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(response, "description")));
-        media.setVideoPressGuid(MapUtils.getMapStr(response, "videopress_shortcode"));
-        media.setThumbnailUrl(MapUtils.getMapStr(response, "thumbnail"));
-        Date uploadDate = MapUtils.getMapDate(response, "date_created_gmt");
-        media.setUploadDate(DateTimeUtils.iso8601UTCFromDate(uploadDate));
         String link = MapUtils.getMapStr(response, "link");
         String fileExtension = MediaUtils.getExtension(link);
-        media.setUrl(link);
-        media.setFileName(MediaUtils.getFileName(link));
-        media.setFileExtension(fileExtension);
-        media.setMimeType(MediaUtils.getMimeTypeForExtension(fileExtension));
-
-        Object metadataObject = response.get("metadata");
-        if (metadataObject instanceof Map) {
-            Map metadataMap = (Map) metadataObject;
-            media.setWidth(MapUtils.getMapInt(metadataMap, "width"));
-            media.setHeight(MapUtils.getMapInt(metadataMap, "height"));
-            media.setFileUrlMediumSize(getFileUrlForSize(link, metadataMap, "medium"));
-            media.setFileUrlMediumLargeSize(getFileUrlForSize(link, metadataMap, "medium_large"));
-            media.setFileUrlLargeSize(getFileUrlForSize(link, metadataMap, "large"));
+        Map metadataMap = null;
+        if (response.get("metadata") instanceof Map) {
+            metadataMap = (Map) response.get("metadata");
         }
-
-        media.setUploadState(MediaUploadState.UPLOADED);
-        return media;
+        return new MediaModel(
+                0,
+                MapUtils.getMapLong(response, "attachment_id"),
+                MapUtils.getMapLong(response, "parent"),
+                0,
+                "",
+                DateTimeUtils.iso8601UTCFromDate(MapUtils.getMapDate(response, "date_created_gmt")),
+                link,
+                MapUtils.getMapStr(response, "thumbnail"),
+                MediaUtils.getFileName(link),
+                fileExtension,
+                MediaUtils.getMimeTypeForExtension(fileExtension),
+                StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(response, "title")),
+                StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(response, "caption")),
+                StringEscapeUtils.unescapeHtml4(MapUtils.getMapStr(response, "description")),
+                "",
+                metadataMap != null ? MapUtils.getMapInt(metadataMap, "width") : 0,
+                metadataMap != null ? MapUtils.getMapInt(metadataMap, "height") : 0,
+                0,
+                MapUtils.getMapStr(response, "videopress_shortcode"),
+                false,
+                MediaUploadState.UPLOADED,
+                metadataMap != null ? getFileUrlForSize(link, metadataMap, "medium") : null,
+                metadataMap != null ? getFileUrlForSize(link, metadataMap, "medium_large") : null,
+                metadataMap != null ? getFileUrlForSize(link, metadataMap, "large") : null,
+                false
+        );
     }
 
     @Nullable

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -414,8 +414,7 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
                 error -> {
                     String message = "Error response from XMLRPC.DELETE_MEDIA:" + error;
                     AppLog.e(T.MEDIA, message);
-                    MediaErrorType mediaErrorType = MediaErrorType.fromBaseNetworkError(error);
-                    MediaError mediaError = new MediaError(mediaErrorType);
+                    MediaError mediaError = new MediaError(MediaErrorType.fromBaseNetworkError(error));
                     mediaError.logMessage = "XMLRPC: " + message;
                     notifyMediaDeleted(site, media, mediaError);
                 }));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -55,7 +55,10 @@ public class MediaSqlUtils {
                 .getAsModel();
     }
 
-    public static WellCursor<MediaModel> getImagesWithStatesAsCursor(SiteModel site, List<String> uploadStates) {
+    @NonNull
+    public static WellCursor<MediaModel> getImagesWithStatesAsCursor(
+            @NonNull SiteModel site,
+            @NonNull List<String> uploadStates) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())
@@ -66,7 +69,10 @@ public class MediaSqlUtils {
                 .getAsCursor();
     }
 
-    public static WellCursor<MediaModel> getUnattachedMediaWithStates(SiteModel site, List<String> uploadStates) {
+    @NonNull
+    public static WellCursor<MediaModel> getUnattachedMediaWithStates(
+            @NonNull SiteModel site,
+            @NonNull List<String> uploadStates) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -298,7 +298,11 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
-    public static List<MediaModel> matchPostMedia(int localPostId, String column, Object value) {
+    @NonNull
+    public static List<MediaModel> matchPostMedia(
+            int localPostId,
+            @NonNull String column,
+            @NonNull Object value) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_POST_ID, localPostId)
@@ -308,6 +312,7 @@ public class MediaSqlUtils {
                 .getAsModel();
     }
 
+    @NonNull
     public static List<MediaModel> matchPostMedia(int localPostId) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -127,28 +127,45 @@ public class MediaSqlUtils {
         }
     }
 
-    public static List<MediaModel> searchSiteMedia(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public static List<MediaModel> searchSiteMedia(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return searchSiteMediaQuery(siteModel, searchTerm).getAsModel();
     }
 
-    public static List<MediaModel> searchSiteImages(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public static List<MediaModel> searchSiteImages(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return searchSiteMediaByMimeTypeQuery(siteModel, searchTerm, Type.IMAGE.getValue()).getAsModel();
     }
 
-    public static List<MediaModel> searchSiteAudio(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public static List<MediaModel> searchSiteAudio(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return searchSiteMediaByMimeTypeQuery(siteModel, searchTerm, Type.AUDIO.getValue()).getAsModel();
     }
 
-    public static List<MediaModel> searchSiteVideos(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public static List<MediaModel> searchSiteVideos(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return searchSiteMediaByMimeTypeQuery(siteModel, searchTerm, Type.VIDEO.getValue()).getAsModel();
     }
 
-    public static List<MediaModel> searchSiteDocuments(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public static List<MediaModel> searchSiteDocuments(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return searchSiteMediaByMimeTypeQuery(siteModel, searchTerm, Type.APPLICATION.getValue()).getAsModel();
     }
 
-    private static SelectQuery<MediaModel> searchSiteMediaQuery(SiteModel siteModel,
-                                                                String searchTerm) {
+    @NonNull
+    private static SelectQuery<MediaModel> searchSiteMediaQuery(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
@@ -162,9 +179,11 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
-    private static SelectQuery<MediaModel> searchSiteMediaByMimeTypeQuery(SiteModel siteModel,
-                                                                          String searchTerm,
-                                                                          String mimeTypePrefix) {
+    @NonNull
+    private static SelectQuery<MediaModel> searchSiteMediaByMimeTypeQuery(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm,
+            @NonNull String mimeTypePrefix) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -254,11 +254,19 @@ public class MediaSqlUtils {
         return getSiteMediaExcludingQuery(site, column, value).getAsModel();
     }
 
-    public static List<MediaModel> matchSiteMedia(SiteModel siteModel, String column, Object value) {
+    @NonNull
+    public static List<MediaModel> matchSiteMedia(
+            @NonNull SiteModel siteModel,
+            @NonNull String column,
+            @NonNull Object value) {
         return matchSiteMediaQuery(siteModel, column, value).getAsModel();
     }
 
-    private static SelectQuery<MediaModel> matchSiteMediaQuery(SiteModel siteModel, String column, Object value) {
+    @NonNull
+    private static SelectQuery<MediaModel> matchSiteMediaQuery(
+            @NonNull SiteModel siteModel,
+            @NonNull String column,
+            @NonNull Object value) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -188,7 +188,10 @@ public class MediaSqlUtils {
         return getSiteMediaByMimeTypeQuery(siteModel, Type.IMAGE.getValue());
     }
 
-    public static List<MediaModel> getSiteImagesExcluding(SiteModel siteModel, List<Long> filter) {
+    @NonNull
+    public static List<MediaModel> getSiteImagesExcluding(
+            @NonNull SiteModel siteModel,
+            @NonNull List<Long> filter) {
         return getSiteImagesExcludingQuery(siteModel, filter).getAsModel();
     }
 
@@ -207,7 +210,10 @@ public class MediaSqlUtils {
         return getSiteAudioQuery(siteModel).getAsModel();
     }
 
-    public static SelectQuery<MediaModel> getSiteImagesExcludingQuery(SiteModel siteModel, List<Long> filter) {
+    @NonNull
+    public static SelectQuery<MediaModel> getSiteImagesExcludingQuery(
+            @NonNull SiteModel siteModel,
+            @NonNull List<Long> filter) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -389,7 +389,7 @@ public class MediaSqlUtils {
         return media;
     }
 
-    public static int deleteMedia(MediaModel media) {
+    public static int deleteMedia(@Nullable MediaModel media) {
         if (media == null) return 0;
         if (media.getMediaId() == 0) {
             // If the remote media ID is 0, this is a local media file and we should only match by local ID
@@ -415,7 +415,10 @@ public class MediaSqlUtils {
         }
     }
 
-    public static int deleteMatchingSiteMedia(SiteModel siteModel, String column, Object value) {
+    public static int deleteMatchingSiteMedia(
+            @NonNull SiteModel siteModel,
+            @NonNull String column,
+            @NonNull Object value) {
         return WellSql.delete(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
@@ -424,18 +427,14 @@ public class MediaSqlUtils {
     }
 
     @SuppressWarnings("unused")
-    public static int deleteAllSiteMedia(SiteModel site) {
-        if (site == null) {
-            return 0;
-        }
-
+    public static int deleteAllSiteMedia(@NonNull SiteModel site) {
         return WellSql.delete(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())
                 .endGroup().endWhere().execute();
     }
 
-    public static void deleteAllUploadedSiteMedia(SiteModel siteModel) {
+    public static void deleteAllUploadedSiteMedia(@NonNull SiteModel siteModel) {
         WellSql.delete(MediaModel.class)
                .where().beginGroup()
                .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
@@ -443,7 +442,9 @@ public class MediaSqlUtils {
                .endGroup().endWhere().execute();
     }
 
-    public static void deleteAllUploadedSiteMediaWithMimeType(SiteModel siteModel, String mimeType) {
+    public static void deleteAllUploadedSiteMediaWithMimeType(
+            @NonNull SiteModel siteModel,
+            @NonNull String mimeType) {
         WellSql.delete(MediaModel.class)
                .where().beginGroup()
                .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
@@ -456,7 +457,10 @@ public class MediaSqlUtils {
         WellSql.delete(MediaModel.class).execute();
     }
 
-    public static void deleteUploadedSiteMediaNotInList(SiteModel site, List<MediaModel> mediaList, String mimeType) {
+    public static void deleteUploadedSiteMediaNotInList(
+            @NonNull SiteModel site,
+            @NonNull List<MediaModel> mediaList,
+            @NonNull String mimeType) {
         if (mediaList.isEmpty()) {
             if (!TextUtils.isEmpty(mimeType)) {
                 MediaSqlUtils.deleteAllUploadedSiteMediaWithMimeType(site, mimeType);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -339,7 +339,7 @@ public class MediaSqlUtils {
                 .getAsModel();
     }
 
-    public static int insertOrUpdateMedia(MediaModel media) {
+    public static int insertOrUpdateMedia(@Nullable MediaModel media) {
         if (media == null) return 0;
 
         List<MediaModel> existingMedia;
@@ -383,7 +383,8 @@ public class MediaSqlUtils {
         }
     }
 
-    public static MediaModel insertMediaForResult(MediaModel media) {
+    @NonNull
+    public static MediaModel insertMediaForResult(@NonNull MediaModel media) {
         WellSql.insert(media).asSingleTransaction(true).execute();
         return media;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -95,11 +95,17 @@ public class MediaSqlUtils {
                 .getAsModel();
     }
 
-    public static List<MediaModel> getSiteMediaWithIds(SiteModel siteModel, List<Long> mediaIds) {
+    @NonNull
+    public static List<MediaModel> getSiteMediaWithIds(
+            @NonNull SiteModel siteModel,
+            @NonNull List<Long> mediaIds) {
         return getSiteMediaWithIdsQuery(siteModel, mediaIds).getAsModel();
     }
 
-    private static SelectQuery<MediaModel> getSiteMediaWithIdsQuery(SiteModel siteModel, List<Long> mediaIds) {
+    @NonNull
+    private static SelectQuery<MediaModel> getSiteMediaWithIdsQuery(
+            @NonNull SiteModel siteModel,
+            @NonNull List<Long> mediaIds) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -26,17 +26,25 @@ public class MediaSqlUtils {
         return getAllSiteMediaQuery(siteModel).getAsModel();
     }
 
-    public static List<MediaModel> getMediaWithStates(SiteModel site, List<String> uploadStates) {
+    @NonNull
+    public static List<MediaModel> getMediaWithStates(
+            @NonNull SiteModel site,
+            @NonNull List<String> uploadStates) {
         return getMediaWithStatesQuery(site, uploadStates).getAsModel();
     }
 
-    public static WellCursor<MediaModel> getMediaWithStatesAsCursor(SiteModel site, List<String> uploadStates) {
+    @NonNull
+    public static WellCursor<MediaModel> getMediaWithStatesAsCursor(
+            @NonNull SiteModel site,
+            @NonNull List<String> uploadStates) {
         return getMediaWithStatesQuery(site, uploadStates).getAsCursor();
     }
 
-    public static List<MediaModel> getMediaWithStatesAndMimeType(SiteModel site,
-                                                                 List<String> uploadStates,
-                                                                 String mimeType) {
+    @NonNull
+    public static List<MediaModel> getMediaWithStatesAndMimeType(
+            @NonNull SiteModel site,
+            @NonNull List<String> uploadStates,
+            @NonNull String mimeType) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())
@@ -76,7 +84,10 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
-    private static SelectQuery<MediaModel> getMediaWithStatesQuery(SiteModel site, List<String> uploadStates) {
+    @NonNull
+    private static SelectQuery<MediaModel> getMediaWithStatesQuery(
+            @NonNull SiteModel site,
+            @NonNull List<String> uploadStates) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, site.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -405,6 +405,7 @@ public class MediaSqlUtils {
                 .endGroup().endWhere().execute();
     }
 
+    @SuppressWarnings("unused")
     public static int deleteAllSiteMedia(SiteModel site) {
         if (site == null) {
             return 0;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -84,7 +84,8 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
-    public static List<MediaModel> getSiteMediaWithId(SiteModel siteModel, long mediaId) {
+    @NonNull
+    public static List<MediaModel> getSiteMediaWithId(@NonNull SiteModel siteModel, long mediaId) {
         return WellSql.select(MediaModel.class).where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
                 .equals(MediaModelTable.MEDIA_ID, mediaId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.wellsql.generated.MediaModelTable;
 import com.yarolegovich.wellsql.ConditionClauseBuilder;
@@ -107,6 +108,7 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
+    @Nullable
     public static MediaModel getMediaWithLocalId(int localMediaId) {
         List<MediaModel> result = WellSql.select(MediaModel.class).where()
                 .equals(MediaModelTable.ID, localMediaId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -178,11 +178,13 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
-    public static List<MediaModel> getSiteImages(SiteModel siteModel) {
+    @NonNull
+    public static List<MediaModel> getSiteImages(@NonNull SiteModel siteModel) {
         return getSiteImagesQuery(siteModel).getAsModel();
     }
 
-    private static SelectQuery<MediaModel> getSiteImagesQuery(SiteModel siteModel) {
+    @NonNull
+    private static SelectQuery<MediaModel> getSiteImagesQuery(@NonNull SiteModel siteModel) {
         return getSiteMediaByMimeTypeQuery(siteModel, Type.IMAGE.getValue());
     }
 
@@ -190,15 +192,18 @@ public class MediaSqlUtils {
         return getSiteImagesExcludingQuery(siteModel, filter).getAsModel();
     }
 
-    public static List<MediaModel> getSiteVideos(SiteModel siteModel) {
+    @NonNull
+    public static List<MediaModel> getSiteVideos(@NonNull SiteModel siteModel) {
         return getSiteVideosQuery(siteModel).getAsModel();
     }
 
-    public static List<MediaModel> getSiteDocuments(SiteModel siteModel) {
+    @NonNull
+    public static List<MediaModel> getSiteDocuments(@NonNull SiteModel siteModel) {
         return getSiteDocumentsQuery(siteModel).getAsModel();
     }
 
-    public static List<MediaModel> getSiteAudio(SiteModel siteModel) {
+    @NonNull
+    public static List<MediaModel> getSiteAudio(@NonNull SiteModel siteModel) {
         return getSiteAudioQuery(siteModel).getAsModel();
     }
 
@@ -212,19 +217,25 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
-    private static SelectQuery<MediaModel> getSiteVideosQuery(SiteModel siteModel) {
+    @NonNull
+    private static SelectQuery<MediaModel> getSiteVideosQuery(@NonNull SiteModel siteModel) {
         return getSiteMediaByMimeTypeQuery(siteModel, Type.VIDEO.getValue());
     }
 
-    private static SelectQuery<MediaModel> getSiteAudioQuery(SiteModel siteModel) {
+    @NonNull
+    private static SelectQuery<MediaModel> getSiteAudioQuery(@NonNull SiteModel siteModel) {
         return getSiteMediaByMimeTypeQuery(siteModel, Type.AUDIO.getValue());
     }
 
-    private static SelectQuery<MediaModel> getSiteDocumentsQuery(SiteModel siteModel) {
+    @NonNull
+    private static SelectQuery<MediaModel> getSiteDocumentsQuery(@NonNull SiteModel siteModel) {
         return getSiteMediaByMimeTypeQuery(siteModel, Type.APPLICATION.getValue());
     }
 
-    private static SelectQuery<MediaModel> getSiteMediaByMimeTypeQuery(SiteModel siteModel, String mimeTypePrefix) {
+    @NonNull
+    private static SelectQuery<MediaModel> getSiteMediaByMimeTypeQuery(
+            @NonNull SiteModel siteModel,
+            @NonNull String mimeTypePrefix) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.persistence;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import com.wellsql.generated.MediaModelTable;
 import com.yarolegovich.wellsql.ConditionClauseBuilder;
 import com.yarolegovich.wellsql.DeleteQuery;
@@ -18,7 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MediaSqlUtils {
-    public static List<MediaModel> getAllSiteMedia(SiteModel siteModel) {
+    @NonNull
+    public static List<MediaModel> getAllSiteMedia(@NonNull SiteModel siteModel) {
         return getAllSiteMediaQuery(siteModel).getAsModel();
     }
 
@@ -65,7 +68,8 @@ public class MediaSqlUtils {
                 .getAsCursor();
     }
 
-    private static SelectQuery<MediaModel> getAllSiteMediaQuery(SiteModel siteModel) {
+    @NonNull
+    private static SelectQuery<MediaModel> getAllSiteMediaQuery(@NonNull SiteModel siteModel) {
         return WellSql.select(MediaModel.class)
                 .where().equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId()).endWhere()
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -250,7 +250,11 @@ public class MediaSqlUtils {
                 .orderBy(MediaModelTable.UPLOAD_DATE, SelectQuery.ORDER_DESCENDING);
     }
 
-    public static List<MediaModel> getSiteMediaExcluding(SiteModel site, String column, Object value) {
+    @NonNull
+    public static List<MediaModel> getSiteMediaExcluding(
+            @NonNull SiteModel site,
+            @NonNull String column,
+            @NonNull Object value) {
         return getSiteMediaExcludingQuery(site, column, value).getAsModel();
     }
 
@@ -436,7 +440,11 @@ public class MediaSqlUtils {
         return builder.endGroup().endWhere().execute();
     }
 
-    private static SelectQuery<MediaModel> getSiteMediaExcludingQuery(SiteModel site, String column, Object value) {
+    @NonNull
+    private static SelectQuery<MediaModel> getSiteMediaExcludingQuery(
+            @NonNull SiteModel site,
+            @NonNull String column,
+            @NonNull Object value) {
         return WellSql.select(MediaModel.class)
                 .where().beginGroup()
                 .not().equals(column, value)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/MediaSqlUtils.java
@@ -417,34 +417,35 @@ public class MediaSqlUtils {
                 .endGroup().endWhere().execute();
     }
 
-    public static int deleteAllUploadedSiteMedia(SiteModel siteModel) {
-        return WellSql.delete(MediaModel.class)
-                .where().beginGroup()
-                .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
-                .equals(MediaModelTable.UPLOAD_STATE, MediaUploadState.UPLOADED.toString())
-                .endGroup().endWhere().execute();
+    public static void deleteAllUploadedSiteMedia(SiteModel siteModel) {
+        WellSql.delete(MediaModel.class)
+               .where().beginGroup()
+               .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
+               .equals(MediaModelTable.UPLOAD_STATE, MediaUploadState.UPLOADED.toString())
+               .endGroup().endWhere().execute();
     }
 
-    public static int deleteAllUploadedSiteMediaWithMimeType(SiteModel siteModel, String mimeType) {
-        return WellSql.delete(MediaModel.class)
-                .where().beginGroup()
-                .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
-                .equals(MediaModelTable.UPLOAD_STATE, MediaUploadState.UPLOADED.toString())
-                .contains(MediaModelTable.MIME_TYPE, mimeType)
-                .endGroup().endWhere().execute();
+    public static void deleteAllUploadedSiteMediaWithMimeType(SiteModel siteModel, String mimeType) {
+        WellSql.delete(MediaModel.class)
+               .where().beginGroup()
+               .equals(MediaModelTable.LOCAL_SITE_ID, siteModel.getId())
+               .equals(MediaModelTable.UPLOAD_STATE, MediaUploadState.UPLOADED.toString())
+               .contains(MediaModelTable.MIME_TYPE, mimeType)
+               .endGroup().endWhere().execute();
     }
 
-    public static int deleteAllMedia() {
-        return WellSql.delete(MediaModel.class).execute();
+    public static void deleteAllMedia() {
+        WellSql.delete(MediaModel.class).execute();
     }
 
-    public static int deleteUploadedSiteMediaNotInList(SiteModel site, List<MediaModel> mediaList, String mimeType) {
+    public static void deleteUploadedSiteMediaNotInList(SiteModel site, List<MediaModel> mediaList, String mimeType) {
         if (mediaList.isEmpty()) {
             if (!TextUtils.isEmpty(mimeType)) {
-                return MediaSqlUtils.deleteAllUploadedSiteMediaWithMimeType(site, mimeType);
+                MediaSqlUtils.deleteAllUploadedSiteMediaWithMimeType(site, mimeType);
             } else {
-                return MediaSqlUtils.deleteAllUploadedSiteMedia(site);
+                MediaSqlUtils.deleteAllUploadedSiteMedia(site);
             }
+            return;
         }
 
         List<Integer> idList = new ArrayList<>();
@@ -462,7 +463,7 @@ public class MediaSqlUtils {
             builder.contains(MediaModelTable.MIME_TYPE, mimeType);
         }
 
-        return builder.endGroup().endWhere().execute();
+        builder.endGroup().endWhere().execute();
     }
 
     @NonNull

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -1083,8 +1083,7 @@ public class MediaStore extends Store {
         if (payload.mimeType != null) {
             mimeTypeValue = payload.mimeType.getValue();
         }
-        MediaSqlUtils.deleteUploadedSiteMediaNotInList(
-                payload.site, existingMediaList, mimeTypeValue);
+        MediaSqlUtils.deleteUploadedSiteMediaNotInList(payload.site, existingMediaList, mimeTypeValue);
 
         // add new media
         for (MediaModel media : newMediaList) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -756,7 +756,8 @@ public class MediaStore extends Store {
         return media.size() > 0 ? media.get(0).getUrl() : null;
     }
 
-    public String getThumbnailUrlForSiteMediaWithId(SiteModel siteModel, long mediaId) {
+    @Nullable
+    public String getThumbnailUrlForSiteMediaWithId(@NonNull SiteModel siteModel, long mediaId) {
         List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(siteModel, mediaId);
         return media.size() > 0 ? media.get(0).getThumbnailUrl() : null;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -692,7 +692,10 @@ public class MediaStore extends Store {
         return MediaSqlUtils.getMediaWithLocalId(localMediaId);
     }
 
-    public List<MediaModel> getSiteMediaWithIds(SiteModel siteModel, List<Long> mediaIds) {
+    @NonNull
+    public List<MediaModel> getSiteMediaWithIds(
+            @NonNull SiteModel siteModel,
+            @NonNull List<Long> mediaIds) {
         return MediaSqlUtils.getSiteMediaWithIds(siteModel, mediaIds);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -722,7 +722,10 @@ public class MediaStore extends Store {
         return MediaSqlUtils.getSiteDocuments(siteModel);
     }
 
-    public List<MediaModel> getSiteImagesExcludingIds(SiteModel siteModel, List<Long> filter) {
+    @NonNull
+    public List<MediaModel> getSiteImagesExcludingIds(
+            @NonNull SiteModel siteModel,
+            @NonNull List<Long> filter) {
         return MediaSqlUtils.getSiteImagesExcluding(siteModel, filter);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -379,17 +379,23 @@ public class MediaStore extends Store {
     }
 
     public static class OnMediaListFetched extends OnChanged<MediaError> {
-        public SiteModel site;
+        @NonNull public SiteModel site;
         public boolean canLoadMore;
-        public MimeType.Type mimeType;
+        @Nullable public MimeType.Type mimeType;
 
-        public OnMediaListFetched(SiteModel site, boolean canLoadMore, MimeType.Type mimeType) {
+        public OnMediaListFetched(
+                @NonNull SiteModel site,
+                boolean canLoadMore,
+                @Nullable MimeType.Type mimeType) {
             this.site = site;
             this.canLoadMore = canLoadMore;
             this.mimeType = mimeType;
         }
 
-        public OnMediaListFetched(SiteModel site, MediaError error, MimeType.Type mimeType) {
+        public OnMediaListFetched(
+                @NonNull SiteModel site,
+                @Nullable MediaError error,
+                @Nullable MimeType.Type mimeType) {
             this.site = site;
             this.error = error;
             this.mimeType = mimeType;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -337,10 +337,12 @@ public class MediaStore extends Store {
     }
 
     public static class UploadStockMediaError implements OnChangedError {
-        public UploadStockMediaErrorType type;
-        public String message;
+        @NonNull public UploadStockMediaErrorType type;
+        @Nullable public String message;
 
-        public UploadStockMediaError(UploadStockMediaErrorType type, String message) {
+        public UploadStockMediaError(
+                @NonNull UploadStockMediaErrorType type,
+                @Nullable String message) {
             this.type = type;
             this.message = message;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -618,9 +618,8 @@ public class MediaStore extends Store {
     // Getters
     //
 
-    public MediaModel instantiateMediaModel() {
-        MediaModel media = new MediaModel();
-
+    @Nullable
+    public MediaModel instantiateMediaModel(@NonNull MediaModel media) {
         MediaModel insertedMedia = MediaSqlUtils.insertMediaForResult(media);
 
         if (insertedMedia.getId() == -1) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -687,6 +687,7 @@ public class MediaStore extends Store {
         return media.size() > 0 ? media.get(0) : null;
     }
 
+    @Nullable
     public MediaModel getMediaWithLocalId(int localMediaId) {
         return MediaSqlUtils.getMediaWithLocalId(localMediaId);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -349,22 +349,29 @@ public class MediaStore extends Store {
     }
 
     public static class OnMediaChanged extends OnChanged<MediaError> {
-        public MediaAction cause;
-        public List<MediaModel> mediaList;
+        @NonNull public MediaAction cause;
+        @NonNull public List<MediaModel> mediaList;
 
-        public OnMediaChanged(MediaAction cause) {
+        public OnMediaChanged(@NonNull MediaAction cause) {
             this(cause, new ArrayList<>(), null);
         }
 
-        public OnMediaChanged(MediaAction cause, @NonNull List<MediaModel> mediaList) {
+        public OnMediaChanged(
+                @NonNull MediaAction cause,
+                @NonNull List<MediaModel> mediaList) {
             this(cause, mediaList, null);
         }
 
-        public OnMediaChanged(MediaAction cause, MediaError error) {
+        public OnMediaChanged(
+                @NonNull MediaAction cause,
+                @Nullable MediaError error) {
             this(cause, new ArrayList<>(), error);
         }
 
-        public OnMediaChanged(MediaAction cause, @NonNull List<MediaModel> mediaList, MediaError error) {
+        public OnMediaChanged(
+                @NonNull MediaAction cause,
+                @NonNull List<MediaModel> mediaList,
+                @Nullable MediaError error) {
             this.cause = cause;
             this.mediaList = mediaList;
             this.error = error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -403,12 +403,16 @@ public class MediaStore extends Store {
     }
 
     public static class OnMediaUploaded extends OnChanged<MediaError> {
-        public MediaModel media;
+        @Nullable public MediaModel media;
         public float progress;
         public boolean completed;
         public boolean canceled;
 
-        public OnMediaUploaded(MediaModel media, float progress, boolean completed, boolean canceled) {
+        public OnMediaUploaded(
+                @Nullable MediaModel media,
+                float progress,
+                boolean completed,
+                boolean canceled) {
             this.media = media;
             this.progress = progress;
             this.completed = completed;
@@ -992,15 +996,23 @@ public class MediaStore extends Store {
         if (payload.isError() || payload.canceled || payload.completed) {
             updateMedia(payload.media, false);
         }
-        OnMediaUploaded onMediaUploaded =
-                new OnMediaUploaded(payload.media, payload.progress, payload.completed, payload.canceled);
+        OnMediaUploaded onMediaUploaded = new OnMediaUploaded(
+                payload.media,
+                payload.progress,
+                payload.completed,
+                payload.canceled
+        );
         onMediaUploaded.error = payload.error;
         emitChange(onMediaUploaded);
     }
 
     private void handleMediaCanceled(@NonNull ProgressPayload payload) {
-        OnMediaUploaded onMediaUploaded =
-                new OnMediaUploaded(payload.media, payload.progress, payload.completed, payload.canceled);
+        OnMediaUploaded onMediaUploaded = new OnMediaUploaded(
+                payload.media,
+                payload.progress,
+                payload.completed,
+                payload.canceled
+        );
         onMediaUploaded.error = payload.error;
 
         emitChange(onMediaUploaded);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -797,19 +797,25 @@ public class MediaStore extends Store {
         return MediaSqlUtils.searchSiteDocuments(siteModel, searchTerm);
     }
 
-    public MediaModel getMediaForPostWithPath(PostImmutableModel postModel, String filePath) {
+    @Nullable
+    public MediaModel getMediaForPostWithPath(
+            @NonNull PostImmutableModel postModel,
+            @NonNull String filePath) {
         List<MediaModel> media = MediaSqlUtils.matchPostMedia(postModel.getId(), MediaModelTable.FILE_PATH, filePath);
         return media.size() > 0 ? media.get(0) : null;
     }
 
-    public List<MediaModel> getMediaForPost(PostImmutableModel postModel) {
+    @NonNull
+    public List<MediaModel> getMediaForPost(@NonNull PostImmutableModel postModel) {
         return MediaSqlUtils.matchPostMedia(postModel.getId());
     }
 
+    @NonNull
     @SuppressWarnings("unused")
-    public List<MediaModel> getMediaForPostWithState(PostImmutableModel postModel, MediaUploadState expectedState) {
-        return MediaSqlUtils.matchPostMedia(postModel.getId(), MediaModelTable.UPLOAD_STATE,
-                expectedState);
+    public List<MediaModel> getMediaForPostWithState(
+            @NonNull PostImmutableModel postModel,
+            @NonNull MediaUploadState expectedState) {
+        return MediaSqlUtils.matchPostMedia(postModel.getId(), MediaModelTable.UPLOAD_STATE, expectedState);
     }
 
     @Nullable

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -762,23 +762,38 @@ public class MediaStore extends Store {
         return media.size() > 0 ? media.get(0).getThumbnailUrl() : null;
     }
 
-    public List<MediaModel> searchSiteMedia(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public List<MediaModel> searchSiteMedia(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return MediaSqlUtils.searchSiteMedia(siteModel, searchTerm);
     }
 
-    public List<MediaModel> searchSiteImages(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public List<MediaModel> searchSiteImages(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return MediaSqlUtils.searchSiteImages(siteModel, searchTerm);
     }
 
-    public List<MediaModel> searchSiteVideos(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public List<MediaModel> searchSiteVideos(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return MediaSqlUtils.searchSiteVideos(siteModel, searchTerm);
     }
 
-    public List<MediaModel> searchSiteAudio(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public List<MediaModel> searchSiteAudio(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return MediaSqlUtils.searchSiteAudio(siteModel, searchTerm);
     }
 
-    public List<MediaModel> searchSiteDocuments(SiteModel siteModel, String searchTerm) {
+    @NonNull
+    public List<MediaModel> searchSiteDocuments(
+            @NonNull SiteModel siteModel,
+            @NonNull String searchTerm) {
         return MediaSqlUtils.searchSiteDocuments(siteModel, searchTerm);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -729,12 +729,9 @@ public class MediaStore extends Store {
         return MediaSqlUtils.getSiteImagesExcluding(siteModel, filter);
     }
 
-    public List<MediaModel> getUnattachedSiteMedia(SiteModel siteModel) {
+    @NonNull
+    public List<MediaModel> getUnattachedSiteMedia(@NonNull SiteModel siteModel) {
         return MediaSqlUtils.matchSiteMedia(siteModel, MediaModelTable.POST_ID, 0);
-    }
-
-    public int getUnattachedSiteMediaCount(SiteModel siteModel) {
-        return getUnattachedSiteMedia(siteModel).size();
     }
 
     public List<MediaModel> getLocalSiteMedia(SiteModel siteModel) {
@@ -742,11 +739,17 @@ public class MediaStore extends Store {
         return MediaSqlUtils.getSiteMediaExcluding(siteModel, MediaModelTable.UPLOAD_STATE, expectedState);
     }
 
-    public List<MediaModel> getSiteMediaWithState(SiteModel siteModel, MediaUploadState expectedState) {
+    @NonNull
+    public List<MediaModel> getSiteMediaWithState(
+            @NonNull SiteModel siteModel,
+            @NonNull MediaUploadState expectedState) {
         return MediaSqlUtils.matchSiteMedia(siteModel, MediaModelTable.UPLOAD_STATE, expectedState);
     }
 
-    public String getUrlForSiteVideoWithVideoPressGuid(SiteModel siteModel, String videoPressGuid) {
+    @Nullable
+    public String getUrlForSiteVideoWithVideoPressGuid(
+            @NonNull SiteModel siteModel,
+            @NonNull String videoPressGuid) {
         List<MediaModel> media =
                 MediaSqlUtils.matchSiteMedia(siteModel, MediaModelTable.VIDEO_PRESS_GUID, videoPressGuid);
         return media.size() > 0 ? media.get(0).getUrl() : null;
@@ -792,13 +795,14 @@ public class MediaStore extends Store {
                 expectedState);
     }
 
-    public MediaModel getNextSiteMediaToDelete(SiteModel siteModel) {
+    @Nullable
+    public MediaModel getNextSiteMediaToDelete(@NonNull SiteModel siteModel) {
         List<MediaModel> media = MediaSqlUtils.matchSiteMedia(siteModel,
                 MediaModelTable.UPLOAD_STATE, MediaUploadState.DELETING.toString());
         return media.size() > 0 ? media.get(0) : null;
     }
 
-    public boolean hasSiteMediaToDelete(SiteModel siteModel) {
+    public boolean hasSiteMediaToDelete(@NonNull SiteModel siteModel) {
         return getNextSiteMediaToDelete(siteModel) != null;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -1136,7 +1136,7 @@ public class MediaStore extends Store {
         emitChange(mediaChange);
     }
 
-    private void performUploadStockMedia(UploadStockMediaPayload payload) {
+    private void performUploadStockMedia(@NonNull UploadStockMediaPayload payload) {
         mMediaRestClient.uploadStockMedia(payload.site, payload.stockMediaList);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -50,6 +50,16 @@ import javax.inject.Singleton;
 public class MediaStore extends Store {
     public static final int DEFAULT_NUM_MEDIA_PER_FETCH = 50;
 
+    public static final List<String> NOT_DELETED_STATES = new ArrayList<>();
+
+    static {
+        NOT_DELETED_STATES.add(MediaUploadState.DELETING.toString());
+        NOT_DELETED_STATES.add(MediaUploadState.FAILED.toString());
+        NOT_DELETED_STATES.add(MediaUploadState.QUEUED.toString());
+        NOT_DELETED_STATES.add(MediaUploadState.UPLOADED.toString());
+        NOT_DELETED_STATES.add(MediaUploadState.UPLOADING.toString());
+    }
+
     //
     // Payloads
     //
@@ -661,16 +671,6 @@ public class MediaStore extends Store {
     @NonNull
     public List<MediaModel> getAllSiteMedia(@NonNull SiteModel siteModel) {
         return MediaSqlUtils.getAllSiteMedia(siteModel);
-    }
-
-    public static final List<String> NOT_DELETED_STATES = new ArrayList<>();
-
-    static {
-        NOT_DELETED_STATES.add(MediaUploadState.DELETING.toString());
-        NOT_DELETED_STATES.add(MediaUploadState.FAILED.toString());
-        NOT_DELETED_STATES.add(MediaUploadState.QUEUED.toString());
-        NOT_DELETED_STATES.add(MediaUploadState.UPLOADED.toString());
-        NOT_DELETED_STATES.add(MediaUploadState.UPLOADING.toString());
     }
 
     public int getSiteMediaCount(@NonNull SiteModel siteModel) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -699,27 +699,27 @@ public class MediaStore extends Store {
         return MediaSqlUtils.getSiteMediaWithIds(siteModel, mediaIds);
     }
 
-    public List<MediaModel> getSiteImages(SiteModel siteModel) {
+    @NonNull
+    public List<MediaModel> getSiteImages(@NonNull SiteModel siteModel) {
         return MediaSqlUtils.getSiteImages(siteModel);
     }
 
+    @NonNull
     @SuppressWarnings("unused")
-    public List<MediaModel> getSiteVideos(SiteModel siteModel) {
+    public List<MediaModel> getSiteVideos(@NonNull SiteModel siteModel) {
         return MediaSqlUtils.getSiteVideos(siteModel);
     }
 
+    @NonNull
     @SuppressWarnings("unused")
-    public List<MediaModel> getSiteAudio(SiteModel siteModel) {
+    public List<MediaModel> getSiteAudio(@NonNull SiteModel siteModel) {
         return MediaSqlUtils.getSiteAudio(siteModel);
     }
 
+    @NonNull
     @SuppressWarnings("unused")
-    public List<MediaModel> getSiteDocuments(SiteModel siteModel) {
+    public List<MediaModel> getSiteDocuments(@NonNull SiteModel siteModel) {
         return MediaSqlUtils.getSiteDocuments(siteModel);
-    }
-
-    public int getSiteImageCount(SiteModel siteModel) {
-        return getSiteImages(siteModel).size();
     }
 
     public List<MediaModel> getSiteImagesExcludingIds(SiteModel siteModel, List<Long> filter) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -734,7 +734,8 @@ public class MediaStore extends Store {
         return MediaSqlUtils.matchSiteMedia(siteModel, MediaModelTable.POST_ID, 0);
     }
 
-    public List<MediaModel> getLocalSiteMedia(SiteModel siteModel) {
+    @NonNull
+    public List<MediaModel> getLocalSiteMedia(@NonNull SiteModel siteModel) {
         MediaUploadState expectedState = MediaUploadState.UPLOADED;
         return MediaSqlUtils.getSiteMediaExcluding(siteModel, MediaModelTable.UPLOAD_STATE, expectedState);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -247,33 +247,38 @@ public class MediaStore extends Store {
             this.mediaList = new ArrayList<>();
         }
     }
+
     //
     // OnChanged events
     //
 
     public static class MediaError implements OnChangedError {
-        public MediaErrorType type;
-        public MediaErrorSubType mErrorSubType;
-        public String message;
+        @NonNull public MediaErrorType type;
+        @Nullable public MediaErrorSubType mErrorSubType;
+        @Nullable public String message;
         public int statusCode;
-        public String logMessage;
+        @Nullable public String logMessage;
 
-        public MediaError(MediaErrorType type) {
+        public MediaError(@NonNull MediaErrorType type) {
             this.type = type;
         }
 
-        public MediaError(MediaErrorType type, String message) {
+        public MediaError(@NonNull MediaErrorType type, @Nullable String message) {
             this.type = type;
             this.message = message;
         }
 
-        public MediaError(MediaErrorType type, String message, MediaErrorSubType errorSubType) {
+        public MediaError(
+                @NonNull MediaErrorType type,
+                @Nullable String message,
+                @NonNull MediaErrorSubType errorSubType) {
             this.type = type;
             this.message = message;
             this.mErrorSubType = errorSubType;
         }
 
-        public static MediaError fromIOException(IOException e) {
+        @NonNull
+        public static MediaError fromIOException(@NonNull IOException e) {
             MediaError mediaError = new MediaError(MediaErrorType.GENERIC_ERROR);
             mediaError.message = e.getLocalizedMessage();
             mediaError.logMessage = e.getMessage();
@@ -300,6 +305,7 @@ public class MediaStore extends Store {
             return mediaError;
         }
 
+        @NonNull
         public String getApiUserMessageIfAvailable() {
             if (TextUtils.isEmpty(message)) {
                 return "";
@@ -829,8 +835,12 @@ public class MediaStore extends Store {
     }
 
     @SuppressWarnings("SameParameterValue")
-    private void notifyMediaUploadError(MediaErrorType errorType, String errorMessage, MediaModel media,
-                                        String logMessage, MalformedMediaArgSubType argErrorType) {
+    private void notifyMediaUploadError(
+            @NonNull MediaErrorType errorType,
+            @Nullable String errorMessage,
+            @Nullable MediaModel media,
+            @NonNull String logMessage,
+            @NonNull MalformedMediaArgSubType argErrorType) {
         OnMediaUploaded onMediaUploaded = new OnMediaUploaded(media, 1, false, false);
         MediaError mediaError = new MediaError(errorType, errorMessage, argErrorType);
         mediaError.logMessage = logMessage;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -658,7 +658,8 @@ public class MediaStore extends Store {
         return insertedMedia;
     }
 
-    public List<MediaModel> getAllSiteMedia(SiteModel siteModel) {
+    @NonNull
+    public List<MediaModel> getAllSiteMedia(@NonNull SiteModel siteModel) {
         return MediaSqlUtils.getAllSiteMedia(siteModel);
     }
 
@@ -672,7 +673,7 @@ public class MediaStore extends Store {
         NOT_DELETED_STATES.add(MediaUploadState.UPLOADING.toString());
     }
 
-    public int getSiteMediaCount(SiteModel siteModel) {
+    public int getSiteMediaCount(@NonNull SiteModel siteModel) {
         return getAllSiteMedia(siteModel).size();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -445,7 +445,8 @@ public class MediaStore extends Store {
         // unknown/unspecified
         GENERIC_ERROR;
 
-        public static MediaErrorType fromBaseNetworkError(BaseNetworkError baseError) {
+        @NonNull
+        public static MediaErrorType fromBaseNetworkError(@NonNull BaseNetworkError baseError) {
             switch (baseError.type) {
                 case NOT_FOUND:
                     return MediaErrorType.NOT_FOUND;
@@ -471,6 +472,7 @@ public class MediaStore extends Store {
             }
         }
 
+        @NonNull
         public static MediaErrorType fromHttpStatusCode(int code) {
             switch (code) {
                 case 400:
@@ -488,7 +490,8 @@ public class MediaStore extends Store {
             }
         }
 
-        public static MediaErrorType fromString(String string) {
+        @NonNull
+        public static MediaErrorType fromString(@Nullable String string) {
             if (string != null) {
                 for (MediaErrorType v : MediaErrorType.values()) {
                     if (string.equalsIgnoreCase(v.name())) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -514,7 +514,8 @@ public class MediaStore extends Store {
         UNKNOWN,
         GENERIC_ERROR;
 
-        public static UploadStockMediaErrorType fromNetworkError(WPComGsonNetworkError wpError) {
+        @NonNull
+        public static UploadStockMediaErrorType fromNetworkError(@NonNull WPComGsonNetworkError wpError) {
             // invalid upload request
             if (wpError.apiError.equalsIgnoreCase("invalid_input")) {
                 return INVALID_INPUT;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -677,11 +677,12 @@ public class MediaStore extends Store {
         return getAllSiteMedia(siteModel).size();
     }
 
-    public boolean hasSiteMediaWithId(SiteModel siteModel, long mediaId) {
+    public boolean hasSiteMediaWithId(@NonNull SiteModel siteModel, long mediaId) {
         return getSiteMediaWithId(siteModel, mediaId) != null;
     }
 
-    public MediaModel getSiteMediaWithId(SiteModel siteModel, long mediaId) {
+    @Nullable
+    public MediaModel getSiteMediaWithId(@NonNull SiteModel siteModel, long mediaId) {
         List<MediaModel> media = MediaSqlUtils.getSiteMediaWithId(siteModel, mediaId);
         return media.size() > 0 ? media.get(0) : null;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -855,7 +855,7 @@ public class MediaStore extends Store {
         }
     }
 
-    private void removeMedia(MediaModel media) {
+    private void removeMedia(@Nullable MediaModel media) {
         OnMediaChanged event = new OnMediaChanged(MediaAction.REMOVE_MEDIA);
 
         if (media == null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -1140,7 +1140,7 @@ public class MediaStore extends Store {
         mMediaRestClient.uploadStockMedia(payload.site, payload.stockMediaList);
     }
 
-    private void handleStockMediaUploaded(UploadedStockMediaPayload payload) {
+    private void handleStockMediaUploaded(@NonNull UploadedStockMediaPayload payload) {
         OnStockMediaUploaded onStockMediaUploaded;
 
         if (payload.isError()) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -461,8 +461,10 @@ public class UploadStore extends Store {
         emitChange(new OnUploadChanged(UploadAction.CLEAR_MEDIA_FOR_POST));
     }
 
-    private @NonNull Set<MediaModel> getMediaForPostWithState(PostImmutableModel post,
-                                                              @MediaUploadModel.UploadState int state) {
+    @NonNull
+    private Set<MediaModel> getMediaForPostWithState(
+            PostImmutableModel post,
+            @MediaUploadModel.UploadState int state) {
         PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(post.getId());
         if (postUploadModel == null) {
             return Collections.emptySet();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -115,9 +115,8 @@ public class MediaUtils {
      * Removes location from the Exif information from an image
      *
      * @param imagePath image file path
-     * @return success
      */
-    public static boolean stripLocation(String imagePath) {
+    public static void stripLocation(String imagePath) {
         try {
             ExifInterface exifInterface = new ExifInterface(imagePath);
             exifInterface.setAttribute(ExifInterface.TAG_GPS_ALTITUDE, "0/0");
@@ -130,10 +129,8 @@ public class MediaUtils {
             exifInterface.setAttribute(ExifInterface.TAG_GPS_PROCESSING_METHOD, "0");
             exifInterface.setAttribute(ExifInterface.TAG_GPS_DATESTAMP, " ");
             exifInterface.saveAttributes();
-            return true;
         } catch (IOException e) {
             AppLog.e(T.MEDIA, "Removing of GPS info from image failed");
-            return false;
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -79,6 +79,7 @@ public class MediaUtils {
     /**
      * Queries filesystem to determine if a given file can be read.
      */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public static boolean canReadFile(String filePath) {
         if (filePath == null || TextUtils.isEmpty(filePath)) return false;
         File file = new File(filePath);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -101,7 +101,8 @@ public class MediaUtils {
     /**
      * Returns the substring of characters that follow the final '/' in the given string.
      */
-    public static String getFileName(String filePath) {
+    @Nullable
+    public static String getFileName(@Nullable String filePath) {
         if (TextUtils.isEmpty(filePath) || !filePath.contains("/")) return null;
         if (filePath.lastIndexOf("/") + 1 >= filePath.length()) return null;
         return filePath.substring(filePath.lastIndexOf("/") + 1);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -120,21 +120,25 @@ public class MediaUtils {
      *
      * @param imagePath image file path
      */
-    public static void stripLocation(String imagePath) {
-        try {
-            ExifInterface exifInterface = new ExifInterface(imagePath);
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_ALTITUDE, "0/0");
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_ALTITUDE_REF, "0");
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_LATITUDE, "0/0,0/0000,00000000/00000");
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_LATITUDE_REF, "0");
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_LONGITUDE, "0/0,0/0,000000/00000 ");
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_LONGITUDE_REF, "0");
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_TIMESTAMP, "00:00:00");
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_PROCESSING_METHOD, "0");
-            exifInterface.setAttribute(ExifInterface.TAG_GPS_DATESTAMP, " ");
-            exifInterface.saveAttributes();
-        } catch (IOException e) {
-            AppLog.e(T.MEDIA, "Removing of GPS info from image failed");
+    public static void stripLocation(@Nullable String imagePath) {
+        if (imagePath != null) {
+            try {
+                ExifInterface exifInterface = new ExifInterface(imagePath);
+                exifInterface.setAttribute(ExifInterface.TAG_GPS_ALTITUDE, "0/0");
+                exifInterface.setAttribute(ExifInterface.TAG_GPS_ALTITUDE_REF, "0");
+                exifInterface.setAttribute(ExifInterface.TAG_GPS_LATITUDE, "0/0,0/0000,00000000/00000");
+                exifInterface.setAttribute(ExifInterface.TAG_GPS_LATITUDE_REF, "0");
+                exifInterface.setAttribute(ExifInterface.TAG_GPS_LONGITUDE, "0/0,0/0,000000/00000 ");
+                exifInterface.setAttribute(ExifInterface.TAG_GPS_LONGITUDE_REF, "0");
+                exifInterface.setAttribute(ExifInterface.TAG_GPS_TIMESTAMP, "00:00:00");
+                exifInterface.setAttribute(ExifInterface.TAG_GPS_PROCESSING_METHOD, "0");
+                exifInterface.setAttribute(ExifInterface.TAG_GPS_DATESTAMP, " ");
+                exifInterface.saveAttributes();
+            } catch (IOException e) {
+                AppLog.e(T.MEDIA, "Removing of GPS info from image failed [IO Exception]");
+            }
+        } else {
+            AppLog.e(T.MEDIA, "Removing of GPS info from image failed [Null Image Path]");
         }
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -66,6 +66,7 @@ public class MediaUtils {
     //
 
     @NonNull
+    @SuppressWarnings("unused")
     public static String getMediaValidationError(@NonNull MediaModel media) {
         return BaseUploadRequestBody.hasRequiredData(media);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -91,7 +91,8 @@ public class MediaUtils {
     /**
      * Returns the substring of characters that follow the final '.' in the given string.
      */
-    public static String getExtension(String filePath) {
+    @Nullable
+    public static String getExtension(@Nullable String filePath) {
         if (TextUtils.isEmpty(filePath) || !filePath.contains(".")) return null;
         if (filePath.lastIndexOf(".") + 1 >= filePath.length()) return null;
         return filePath.substring(filePath.lastIndexOf(".") + 1);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -58,7 +58,8 @@ public class MediaUtils {
                 || isSupportedApplicationMimeType(type);
     }
 
-    public static String getMimeTypeForExtension(String extension) {
+    @Nullable
+    public static String getMimeTypeForExtension(@Nullable String extension) {
         return MIME_TYPES.getMimeTypeForExtension(extension);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -82,7 +82,7 @@ public class MediaUtils {
      * Queries filesystem to determine if a given file can be read.
      */
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    public static boolean canReadFile(String filePath) {
+    public static boolean canReadFile(@Nullable String filePath) {
         if (filePath == null || TextUtils.isEmpty(filePath)) return false;
         File file = new File(filePath);
         return file.canRead();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MediaUtils.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.utils;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.exifinterface.media.ExifInterface;
 
 import org.wordpress.android.fluxc.model.MediaModel;
@@ -18,39 +19,39 @@ public class MediaUtils {
     private static final MimeTypes MIME_TYPES = new MimeTypes();
     public static final double MEMORY_LIMIT_FILESIZE_MULTIPLIER = 0.75D;
 
-    public static boolean isImageMimeType(String type) {
+    public static boolean isImageMimeType(@Nullable String type) {
         return MIME_TYPES.isImageType(type);
     }
 
-    public static boolean isVideoMimeType(String type) {
+    public static boolean isVideoMimeType(@Nullable String type) {
         return MIME_TYPES.isVideoType(type);
     }
 
-    public static boolean isAudioMimeType(String type) {
+    public static boolean isAudioMimeType(@Nullable String type) {
         return MIME_TYPES.isAudioType(type);
     }
 
-    public static boolean isApplicationMimeType(String type) {
+    public static boolean isApplicationMimeType(@Nullable String type) {
         return MIME_TYPES.isApplicationType(type);
     }
 
-    public static boolean isSupportedImageMimeType(String type) {
+    public static boolean isSupportedImageMimeType(@Nullable String type) {
         return MIME_TYPES.isSupportedImageType(type);
     }
 
-    public static boolean isSupportedVideoMimeType(String type) {
+    public static boolean isSupportedVideoMimeType(@Nullable String type) {
         return MIME_TYPES.isSupportedVideoType(type);
     }
 
-    public static boolean isSupportedAudioMimeType(String type) {
+    public static boolean isSupportedAudioMimeType(@Nullable String type) {
         return MIME_TYPES.isSupportedAudioType(type);
     }
 
-    public static boolean isSupportedApplicationMimeType(String type) {
+    public static boolean isSupportedApplicationMimeType(@Nullable String type) {
         return MIME_TYPES.isSupportedApplicationType(type);
     }
 
-    public static boolean isSupportedMimeType(String type) {
+    public static boolean isSupportedMimeType(@Nullable String type) {
         return isSupportedImageMimeType(type)
                 || isSupportedVideoMimeType(type)
                 || isSupportedAudioMimeType(type)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductImageModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductImageModel.kt
@@ -13,8 +13,8 @@ class WCProductImageModel(val id: Long) {
         fun fromMediaModel(media: MediaModel): WCProductImageModel {
             with(WCProductImageModel(media.mediaId)) {
                 dateCreated = media.uploadDate ?: DateUtils.getCurrentDateString()
-                src = media.url ?: ""
-                alt = media.alt ?: ""
+                src = media.url
+                alt = media.alt
                 name = media.fileName ?: ""
                 return this
             }


### PR DESCRIPTION
Parent #2799
Closes #2832

This PR adds any missing nullability annotation to [MediaModel.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7fd7840a9bd900fde8e32ad8bd5632ad8f05dff3/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java#L4) model and all related store & sql-util classes.

FYI: This change is `breaking`, meaning that any client that depended on the [MediaModel.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7fd7840a9bd900fde8e32ad8bd5632ad8f05dff3/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java#L4) model should update to the new APIs (`non-default constructors`) as the existing API (`default constructor`) are now deprecated. As such, this change is inherently `risky`, meaning that there are compile-time changes associated with this change and thus needs testing to verify correctness, both on the library's and client's side.

PS: Any other changes on any other class are just some propagating missing nullability annotation changes, which stem from the main set of classes being updated, this PR's focus, plus, some other extra minor analysis, refactor and test related changes.

-----

PS.1: @AjeshRPai I added you as the main reviewer, not so randomly (it being a continuation of #2878), since I just wanted someone from the Jetpack/WordPress mobile team to be aware of and sign-off on that change. Feel free to merge this PR directly yourself if you deem so.

PS.2: @0nko I am also adding you as an extra reviewer, not so randomly (it being a continuation of #2878), since I want someone from the WooCommerce mobile team to be aware of this change as well. However, there is no need for you to review it as well, thus duplicating the review work. Having one team member from either of the mobile teams reviewing and testing this change is enough for this change.

-----

Nullability Annotations List (`Model`):

1. [Add missing final keyword to field name on media fields enum](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/07c5b4a66c357f1575a81ee383dad1572b94ece0)
2. [Add missing nl-a to equals parameter on media model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/71cd024084657b7b22875f6c85eb38376d82a450)
3. [Add missing nl-a to upload state field on media model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/cd2554992b0ef2a78bb4491492a7cded2d078cc6)
4. [Add missing nn-a to fields to update field on media model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/ed262b8e14efae280021c0c8902be662f034210f)
5. [Add missing n-a to media model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/00393cd777dbce27478de8b73de325c97578a5ab)
6. [Add default and non-default constructors for media model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/2c13cd47ffe713bdd21eeec868ea04c1ae085ada) (`breaking`)

Nullability Annotations List (`Store`):

1. [Add missing n-a to media error type enum on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/dea7a5337bcd0bd1faedb56f6a08994dbee09a00)
2. [Add missing n-a to media error on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/63d05c6137b822ad5767bfe34ecfb8108a9a2b83)
3. [Add missing n-a to upload stock me type enum on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/9e1a12e3b3f1339fadcd8f76d238fa8145093f2d)
4. [Add missing n-a to upload stock me on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/f1295c231039f9897131f4bbd666e15a248ac466)
5. [Add missing n-a to on media changed on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/991b061454c128a256ff3cc2f11a7cc091dbfcaa)
6. [Add missing n-a to on media list fetched on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/a32c193364f314877c2bb2d1ede0dbb687a4e213)
7. [Add missing n-a to on media uploaded on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/6232ab638ecd56f1c048793322028318356f0a52)
8. [Add missing n-a to get (all) site media (count) on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/f7a53ff9b1958d78064b9af8c736307b0ef60ded)
9. [Add missing n-a to has/get site media with id on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/9d81ae952546aaad51e8717d29735931d770d9b4)
10. [Add missing n-a to get media with local id on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/fae9905b25b7c04dfb9b9d0e9d5b1c12dad49b34)
11. [Add missing n-a to get site media with ids on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/b5991879c35cd29d84dcf29210a6590834c860ee)
12. [Add missing n-a to get images/videos/audio/docs on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/0b74851cee5a7abcf0fc7885cfbc4e66bda1712b)
13. [Add missing n-a to get site images excl. ids on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/07eb3b9d6f7f7479dfdd8b4284d0c411ab1a485a)
14. [Add missing n-a to match site media related on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/b2bc82313ff0c7b47157289b3bcddbba50f5a7f7)
15. [Add missing n-a to get local site media on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/2c4ae2b04a04adb8da174cf715b47af7abafb306)
16. [Add missing n-a to get thumbnail url for smi on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/9c2ec88d4af6a751138dd3d9c326f40ff5547d16)
17. [Add missing n-a to search site related on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/7a0f04279f93b4f4cbfbc6908403252fbfd6cd60)
18. [Add missing n-a to match post media related on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/3627104206fd934ff1dad3a38238378b7bb37a06)
19. [Add missing n-a to remove media on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/b0e273d7e0c326598c7b2c44f585ff481320a0e1)
20. [Add missing n-a to perform upload stock media on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/a3168f28ece91993497b2f9486aae5077334d870)
21. [Add missing n-a to handle stock media uploaded on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/dcac956f473d0d7254b957255605652cb86905e0)

Nullability Annotations List (`SqlUtils`):

1. [Add missing n-a to get media with sq on media sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/4edf1c93d2e8c7dd884616c21890119a98e8dcf6)
2. [Add missing n-a to get with states related on media sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/c476f0ee1251c871fc5e29f79ce0685137781adc)
3. [Add missing n-a to get insert media related on media sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/90215b94213e282df4435ef7da49118479243d39)
4. [Add missing n-a to get delete media related on media sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/ea0f8f1f3dd6d33e4ac5f1d3d46e7be0552aba51)

Nullability Annotations List (`Utils`):

1. [Add missing n-a to is (supported) related on media utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/639fbf398496c9a2999a2b14ca46297399b53052)
2. [Add missing n-a to get mime type for extension on media utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/1579f612112879be5e3205ceeac20f84f1767ece)
3. [Add missing n-a to can read file on media utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/e425e8d4b86b31d8223c37ea61ff40b81e9e3516)
4. [Add missing n-a to get extension on media utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/1aa94c82ce06142c9d8729a752c78e5ad03d5180)
5. [Add missing n-a to get file name on media utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/beb0a2624845409e035bfacd03f912e4827076b6)
6. [Add missing n-a to strip location on media utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/d0c01974ed8a93421228505521ae2f3c1278b2f5)

Warnings Resolution List:

1. [Make strip location method void on media utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/8cefe9d31ca641481236fed29c6bd8992ef78cb2)
2. [Make delete related methods void on media sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/d88035220b6419a045e63f22a8f8731cf11e542c)

Warnings Suppression List:

1. [Suppress condition covered by further condition warning](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/9b0c22b71643232212001bfa2d427e334cf31b0c)
2. [Suppress unused warning on media model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/f7809a32009b3eb82579bacf7a7c8fde7018d2e0)
3. [Suppress unused warning on media utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/3add2d49b2aba082fd11bac21c2f6165b6deae29)
4. [Suppress boolean method is always inverted warn on media utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/b10ff95844694fab99688c41d3f836f7dc656f2e)
5. [Suppress unused warning on media sql utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/db4c0f6a9648e12a3f50ebdb5880afbbf9c5b427)

Refactor List:

1. [Move static not deleted states field to top on media store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/297ba53bc19b28f22e570a66d6f569f2cc4eb619)

Test List:

1. [Use property access syntax on media error test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/dc8d65c552db8007a3383e3674790b08b6123b99)
2. [Simplify assert true assertion on media test utils](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/cc7928c52a902341da1346f9a75c6c17dbca5518)
3. [Reformat mocked stack media test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/d54040e68b41b8c6e829fa0246cc2cf4f45126b2)
4. [Add missing final to media store on media utils test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/b8b71f9a47cf7cbff502aed3bddfce7a5fbb6645)
5. [Add missing final to media store on media sql utils test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/999c1a9c0316d8c2d33f82bd66e7af5bb22bec93)
6. [Suppress constant value warning on media sql utils test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/1759268b2a22e237e582572dbbc8e892b40fa57e)
7. [Delete unneeded test match post media test on media sql utils test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/ec188d7042e059d385397cf5bfe6568a2b82c765)
8. [Remove interrupted exception from throws list on media su test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/7ec75fb0c3c14448288f28f98dda513f63c9c68d)
9. [Simplify insert helper functions on on media sql utils test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886/commits/e47338a4c9cc68b15d2a0618e4ef4d9e120bd34d)

-----

## Associated Clients

It is highly recommending that this change is being tested on the below associated clients:

- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android)
- [WCAndroid](https://github.com/woocommerce/woocommerce-android)

-----

## To Test (`REST`):

- Smoke test the `FluxC Example` app via the `MEDIA` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any media related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:
- Furthermore, using [local-builds.gradle](https://github.com/woocommerce/woocommerce-android/blob/trunk/local-builds.gradle-example) on [WCAndroid](https://github.com/woocommerce/woocommerce-android), smoke test any media related functionality and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

## To Test (`XMLRPC`):

- Create a new self-hosted WordPress site for XMLRPC testing purposes ([jurassic.ninja](https://jurassic.ninja/)).
- Smoke test the `FluxC Example` app via the `MEDIA` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any media related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:
- Furthermore, using [local-builds.gradle](https://github.com/woocommerce/woocommerce-android/blob/trunk/local-builds.gradle-example) on [WCAndroid](https://github.com/woocommerce/woocommerce-android), smoke test any media related functionality and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

<details>
    <summary>[JP/WP] Media Screens [MediaBrowserActivity.java + MediaGridFragment.kt + MediaSettingsActivity.java + MediaPreviewActivity.java + MediaPreviewFragment.java]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Media` screen, verify it is shown and functioning as expected.
- For example try changing tabs, searching and adding a new media.
- Tap on any media and verify that the `Media Settings` screen is shown and functioning as expected.
- For example try updating the media title or adding a media description.
- Tap on the media preview and verify that the `Media Preview` screen is shown and functioning as expected.
- For example try swipe left-right to navigate between media previews.

</details>

<details>
    <summary>[WC] Photos Screens [ProductDetailFragment.java + ProductImagesFragment.kt + ProductImageViewerFragment.kt]</summary>

- Go to `Products` tab and tap on any product.
- Tap on any photo on top and verify that the `Photos` screen is shown and functioning as expected.
- For example try adding a new photo, select an upload method, and wait for the photo to be uploaded.
- Tap on the photo preview and verify that the `Photo Preview` screen is shown and functioning as expected.
- For example try swipe left-right to navigate between photo previews.

</details>

-----

## Merge instructions:

1. [x] Wait for the accompanying [JP/WPAndroid#19506](https://github.com/wordpress-mobile/WordPress-Android/pull/19506) to be reviewed and approved.
2. [x] Wait for the accompanying [WCAndroid#10078](https://github.com/woocommerce/woocommerce-android/pull/10078) to be reviewed and approved.
3. [x] Remove the `[PR] Not Ready for Merge` label.
4. [x] Merge this PR.
5. [x] Follow-up with the merge instructions on the accompanying [JP/WPAndroid#19506](https://github.com/wordpress-mobile/WordPress-Android/pull/19506) client PR.
6. [x] Follow-up with the merge instructions on the accompanying [WCAndroid#10078](https://github.com/woocommerce/woocommerce-android/pull/10078) client PR.