### PR TITLE
Add theme_style data to ThemeModel

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -37,6 +37,7 @@ public class ThemeModel implements Identifiable, Serializable {
     @Column private boolean mAutoUpdateTranslation;
 
     // local use only
+    @Column private boolean mIsExternalTheme;
     @Column private boolean mIsWpComTheme;
 
     @Override
@@ -240,6 +241,14 @@ public class ThemeModel implements Identifiable, Serializable {
 
     public void setAutoUpdateTranslation(boolean autoUpdateTranslation) {
         mAutoUpdateTranslation = autoUpdateTranslation;
+    }
+
+    public boolean isExternalTheme() {
+        return mIsExternalTheme;
+    }
+
+    public void setIsExternalTheme(boolean isExternalTheme) {
+        mIsExternalTheme = isExternalTheme;
     }
 
     public boolean isWpComTheme() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -25,6 +25,7 @@ public class ThemeModel implements Identifiable, Serializable {
     @Column private String mAuthorUrl;
     @Column private String mThemeUrl;
     @Column private String mScreenshotUrl;
+    @Column private String mThemeType;
     @Column private String mDemoUrl;
     @Column private String mDownloadUrl;
     @Column private String mStylesheet;
@@ -155,6 +156,14 @@ public class ThemeModel implements Identifiable, Serializable {
 
     public void setScreenshotUrl(String screenshotUrl) {
         mScreenshotUrl = screenshotUrl;
+    }
+
+    public String getThemeType() {
+        return mThemeType;
+    }
+
+    public void setThemeType(String themeType) {
+        mThemeType = themeType;
     }
 
     public String getDemoUrl() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -47,6 +47,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /** Used by {@link #fetchWpComThemes()} request all themes in a single fetch. */
     private static final String WP_THEME_FETCH_NUMBER_PARAM = "number=500";
     private static final String WPCOM_MOBILE_FRIENDLY_TAXONOMY_SLUG = "mobile-friendly";
+    private static final String THEME_TYPE_EXTERNAL = "managed-external";
 
     @Inject public ThemeRestClient(Context appContext, Dispatcher dispatcher,
                            @Named("regular") RequestQueue requestQueue,
@@ -261,6 +262,9 @@ public class ThemeRestClient extends BaseWPComRestClient {
         theme.setVersion(response.version);
         theme.setScreenshotUrl(response.screenshot);
         theme.setThemeType(response.theme_type);
+        if (response.theme_type != null) {
+            theme.setIsExternalTheme(response.theme_type.equals(THEME_TYPE_EXTERNAL));
+        }
         theme.setDescription(response.description);
         theme.setDownloadUrl(response.download_uri);
         if (TextUtils.isEmpty(response.price)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -260,6 +260,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
         theme.setDemoUrl(response.demo_uri);
         theme.setVersion(response.version);
         theme.setScreenshotUrl(response.screenshot);
+        theme.setThemeType(response.theme_type);
         theme.setDescription(response.description);
         theme.setDownloadUrl(response.download_uri);
         if (TextUtils.isEmpty(response.price)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
@@ -31,6 +31,7 @@ public class WPComThemeResponse {
     public String demo_uri;
     public String version;
     public String screenshot;
+    public String theme_type;
     public String description;
     public String download_uri;
     public String price;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -41,7 +41,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 197
+        return 198
     }
 
     override fun getDbName(): String {
@@ -1992,6 +1992,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 196 -> migrate(version) {
                     db.execSQL("ALTER TABLE SiteModel ADD IS_SINGLE_USER_SITE BOOLEAN")
+                }
+                197 -> migrate(version) {
+                    db.execSQL("ALTER TABLE ThemeModel ADD THEME_TYPE TEXT")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -1995,6 +1995,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 197 -> migrate(version) {
                     db.execSQL("ALTER TABLE ThemeModel ADD THEME_TYPE TEXT")
+                    db.execSQL("ALTER TABLE ThemeModel ADD IS_EXTERNAL_THEME BOOLEAN")
                 }
             }
         }


### PR DESCRIPTION
This PR is to fix an issue on JPAndroid and can be tested via https://github.com/wordpress-mobile/WordPress-Android/pull/19497

We need `theme_style` data for themes to differ between internal (Automattic) and external (partner) themes. 
- For internal themes, the data is `"theme_type":"hosted-internal"`,
- For external themes, it is `"theme_type":"managed-external"`.

Example endpoint: https://public-api.wordpress.com/rest/v1.2/themes