### PR TITLE
Bundle variable support

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/model/WCProductModelTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/WCProductModelTest.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.model
 
+import com.google.gson.Gson
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.wordpress.android.fluxc.JsonLoaderUtils.jsonFileAs
+import org.wordpress.android.fluxc.model.WCMetaData.BundleMetadataKeys
 import org.wordpress.android.fluxc.model.addons.RemoteAddonDto.RemotePriceType.FlatFee
 import org.wordpress.android.fluxc.model.addons.RemoteAddonDto.RemoteRestrictionsType.AnyText
 import org.wordpress.android.fluxc.model.addons.RemoteAddonDto.RemoteType.Checkbox
@@ -13,7 +15,7 @@ class WCProductModelTest {
     @Test
     fun `Product addons should be serialized correctly`() {
         val productModelUnderTest =
-                "wc/product-with-addons.json"
+            "wc/product-with-addons.json"
                 .jsonFileAs(ProductApiResponse::class.java)
                 ?.asProductModel()
 
@@ -25,9 +27,9 @@ class WCProductModelTest {
     @Test
     fun `Product addons should be serialized with enum values correctly`() {
         val productModelUnderTest =
-                "wc/product-with-addons.json"
-                        .jsonFileAs(ProductApiResponse::class.java)
-                        ?.asProductModel()
+            "wc/product-with-addons.json"
+                .jsonFileAs(ProductApiResponse::class.java)
+                ?.asProductModel()
 
         assertThat(productModelUnderTest).isNotNull
         assertThat(productModelUnderTest?.addons).isNotEmpty
@@ -42,12 +44,12 @@ class WCProductModelTest {
     @Test
     fun `Product addons should contain Addon options serialized correctly`() {
         val addonOptions = "wc/product-with-addons.json"
-                .jsonFileAs(ProductApiResponse::class.java)
-                ?.asProductModel()
-                ?.addons
-                ?.takeIf { it.isNotEmpty() }
-                ?.first()
-                ?.options
+            .jsonFileAs(ProductApiResponse::class.java)
+            ?.asProductModel()
+            ?.addons
+            ?.takeIf { it.isNotEmpty() }
+            ?.first()
+            ?.options
 
         assertThat(addonOptions).isNotNull
         assertThat(addonOptions).isNotEmpty
@@ -56,9 +58,9 @@ class WCProductModelTest {
     @Test
     fun `Product metadata is serialized correctly`() {
         val productModelUnderTest =
-                "wc/product-with-addons.json"
-                        .jsonFileAs(ProductApiResponse::class.java)
-                        ?.asProductModel()
+            "wc/product-with-addons.json"
+                .jsonFileAs(ProductApiResponse::class.java)
+                ?.asProductModel()
 
         assertThat(productModelUnderTest).isNotNull
         assertThat(productModelUnderTest?.metadata).isNotNull
@@ -67,12 +69,66 @@ class WCProductModelTest {
     @Test
     fun `Product addons with incorrect key should be null`() {
         val productModelUnderTest =
-                "wc/product-with-incorrect-addons-key.json"
-                        .jsonFileAs(ProductApiResponse::class.java)
-                        ?.asProductModel()
+            "wc/product-with-incorrect-addons-key.json"
+                .jsonFileAs(ProductApiResponse::class.java)
+                ?.asProductModel()
 
         assertThat(productModelUnderTest).isNotNull
         assertThat(productModelUnderTest?.metadata).isNotNull
         assertThat(productModelUnderTest?.addons).isNull()
+    }
+
+    @Test
+    fun `Bundled product with max size is serialized correctly`() {
+        val product = "wc/product-bundle-with-max-quantity.json"
+            .jsonFileAs(ProductApiResponse::class.java)
+            ?.asProductModel()
+
+        assertThat(product?.metadata).isNotNull
+        val map = Gson()
+            .fromJson(product?.metadata, Array<WCMetaData>::class.java).associateBy { it.key }
+
+        assertThat(map).containsKey(BundleMetadataKeys.BUNDLE_MAX_SIZE)
+        assertThat(map).doesNotContainKey(BundleMetadataKeys.BUNDLE_MIN_SIZE)
+        assertThat(map.getValue(BundleMetadataKeys.BUNDLE_MAX_SIZE).value).isEqualTo("5")
+    }
+    @Test
+    fun `Bundled product with min size is serialized correctly`() {
+        val product = "wc/product-bundle-with-min-quantity.json"
+            .jsonFileAs(ProductApiResponse::class.java)
+            ?.asProductModel()
+
+        assertThat(product?.metadata).isNotNull
+        val map = Gson()
+            .fromJson(product?.metadata, Array<WCMetaData>::class.java).associateBy { it.key }
+
+        assertThat(map).containsKey(BundleMetadataKeys.BUNDLE_MIN_SIZE)
+        assertThat(map).doesNotContainKey(BundleMetadataKeys.BUNDLE_MAX_SIZE)
+        assertThat(map.getValue(BundleMetadataKeys.BUNDLE_MIN_SIZE).value).isEqualTo("5")
+    }
+
+    @Test
+    fun `Bundled product with quantity rules is serialized correctly`() {
+        val product = "wc/product-bundle-with-quantity-rules.json"
+            .jsonFileAs(ProductApiResponse::class.java)
+            ?.asProductModel()
+
+        assertThat(product?.metadata).isNotNull
+        val map = Gson()
+            .fromJson(product?.metadata, Array<WCMetaData>::class.java).associateBy { it.key }
+
+        assertThat(map).containsKey(BundleMetadataKeys.BUNDLE_MIN_SIZE)
+        assertThat(map).containsKey(BundleMetadataKeys.BUNDLE_MAX_SIZE)
+        assertThat(map.getValue(BundleMetadataKeys.BUNDLE_MAX_SIZE).value).isEqualTo("5")
+        assertThat(map.getValue(BundleMetadataKeys.BUNDLE_MIN_SIZE).value).isEqualTo("5")
+    }
+
+    @Test
+    fun `Bundled product with special stock status is serialized correctly`() {
+        val product = "wc/product-bundle-with-max-quantity.json"
+            .jsonFileAs(ProductApiResponse::class.java)
+            ?.asProductModel()
+
+        assertThat(product?.specialStockStatus).isEqualTo("insufficientstock")
     }
 }

--- a/example/src/test/resources/wc/product-bundle-with-max-quantity.json
+++ b/example/src/test/resources/wc/product-bundle-with-max-quantity.json
@@ -1,0 +1,230 @@
+{
+  "id": 533,
+  "name": "Pizza",
+  "slug": "pizza",
+  "permalink": "https:\/\/mystagingwebsite.com\/product\/pizza\/",
+  "date_created": "2021-07-07T13:19:31",
+  "date_created_gmt": "2021-07-07T13:19:31",
+  "date_modified": "2021-07-22T01:57:18",
+  "date_modified_gmt": "2021-07-22T01:57:18",
+  "type": "bundle",
+  "status": "publish",
+  "featured": false,
+  "catalog_visibility": "visible",
+  "description": "",
+  "short_description": "",
+  "sku": "",
+  "price": "",
+  "regular_price": "",
+  "sale_price": "",
+  "date_on_sale_from": null,
+  "date_on_sale_from_gmt": null,
+  "date_on_sale_to": null,
+  "date_on_sale_to_gmt": null,
+  "on_sale": false,
+  "purchasable": false,
+  "total_sales": 0,
+  "virtual": false,
+  "downloadable": false,
+  "downloads": [
+  ],
+  "download_limit": -1,
+  "download_expiry": -1,
+  "external_url": "",
+  "button_text": "",
+  "tax_status": "none",
+  "tax_class": "",
+  "manage_stock": false,
+  "stock_quantity": null,
+  "backorders": "no",
+  "backorders_allowed": false,
+  "backordered": false,
+  "low_stock_amount": null,
+  "sold_individually": true,
+  "weight": "",
+  "dimensions": {
+    "length": "",
+    "width": "",
+    "height": ""
+  },
+  "shipping_required": true,
+  "shipping_taxable": false,
+  "shipping_class": "",
+  "shipping_class_id": 0,
+  "reviews_allowed": true,
+  "average_rating": "0",
+  "rating_count": 0,
+  "upsell_ids": [
+  ],
+  "cross_sell_ids": [
+  ],
+  "parent_id": 0,
+  "purchase_note": "",
+  "categories": [
+    {
+      "id": 15,
+      "name": "Uncategorized",
+      "slug": "uncategorized"
+    }
+  ],
+  "tags": [
+  ],
+  "images": [
+  ],
+  "attributes": [
+    {
+      "id": 1,
+      "name": "Color",
+      "position": 0,
+      "visible": true,
+      "variation": true,
+      "options": [
+        "Black",
+        "Blue",
+        "Green"
+      ]
+    }
+  ],
+  "default_attributes": [
+  ],
+  "variations": [
+  ],
+  "grouped_products": [
+  ],
+  "menu_order": 0,
+  "price_html": "",
+  "related_ids": [
+  ],
+  "bundle_stock_status": "insufficientstock",
+  "bundle_max_size": 5,
+  "meta_data": [
+    {
+      "id": 11116,
+      "key": "_last_editor_used_jetpack",
+      "value": "classic-editor"
+    },
+    {
+      "id": 11118,
+      "key": "_product_addons",
+      "value": [
+        {
+          "name": "Topping",
+          "title_format": "label",
+          "description_enable": 1,
+          "description": "Pizza topping",
+          "type": "checkbox",
+          "display": "select",
+          "position": 0,
+          "required": 0,
+          "restrictions": 0,
+          "restrictions_type": "any_text",
+          "adjust_price": 0,
+          "price_type": "flat_fee",
+          "price": "",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "Peperoni",
+              "price": "3",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Extra cheese",
+              "price": "4",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Salami",
+              "price": "3",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Ham",
+              "price": "3",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        },
+        {
+          "name": "Soda",
+          "title_format": "label",
+          "description_enable": 0,
+          "description": "",
+          "type": "input_multiplier",
+          "display": "select",
+          "position": 1,
+          "required": 0,
+          "restrictions": 1,
+          "restrictions_type": "any_text",
+          "adjust_price": 1,
+          "price_type": "flat_fee",
+          "price": "2",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        },
+        {
+          "name": "Delivery",
+          "title_format": "label",
+          "description_enable": 0,
+          "description": "",
+          "type": "multiple_choice",
+          "display": "radiobutton",
+          "position": 2,
+          "required": 1,
+          "restrictions": 0,
+          "restrictions_type": "any_text",
+          "adjust_price": 0,
+          "price_type": "flat_fee",
+          "price": "",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "Yes",
+              "price": "5",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "No",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 11119,
+      "key": "_product_addons_exclude_global",
+      "value": "0"
+    }
+  ],
+  "stock_status": "outofstock",
+  "_links": {
+    "self": [
+      {
+        "href": "https:\/\/mystagingwebsite.com\/wp-json\/wc\/v3\/products\/533"
+      }
+    ],
+    "collection": [
+      {
+        "href": "https:\/\/mystagingwebsite.com\/wp-json\/wc\/v3\/products"
+      }
+    ]
+  }
+}

--- a/example/src/test/resources/wc/product-bundle-with-min-quantity.json
+++ b/example/src/test/resources/wc/product-bundle-with-min-quantity.json
@@ -1,0 +1,230 @@
+{
+  "id": 533,
+  "name": "Pizza",
+  "slug": "pizza",
+  "permalink": "https:\/\/mystagingwebsite.com\/product\/pizza\/",
+  "date_created": "2021-07-07T13:19:31",
+  "date_created_gmt": "2021-07-07T13:19:31",
+  "date_modified": "2021-07-22T01:57:18",
+  "date_modified_gmt": "2021-07-22T01:57:18",
+  "type": "bundle",
+  "status": "publish",
+  "featured": false,
+  "catalog_visibility": "visible",
+  "description": "",
+  "short_description": "",
+  "sku": "",
+  "price": "",
+  "regular_price": "",
+  "sale_price": "",
+  "date_on_sale_from": null,
+  "date_on_sale_from_gmt": null,
+  "date_on_sale_to": null,
+  "date_on_sale_to_gmt": null,
+  "on_sale": false,
+  "purchasable": false,
+  "total_sales": 0,
+  "virtual": false,
+  "downloadable": false,
+  "downloads": [
+  ],
+  "download_limit": -1,
+  "download_expiry": -1,
+  "external_url": "",
+  "button_text": "",
+  "tax_status": "none",
+  "tax_class": "",
+  "manage_stock": false,
+  "stock_quantity": null,
+  "backorders": "no",
+  "backorders_allowed": false,
+  "backordered": false,
+  "low_stock_amount": null,
+  "sold_individually": true,
+  "weight": "",
+  "dimensions": {
+    "length": "",
+    "width": "",
+    "height": ""
+  },
+  "shipping_required": true,
+  "shipping_taxable": false,
+  "shipping_class": "",
+  "shipping_class_id": 0,
+  "reviews_allowed": true,
+  "average_rating": "0",
+  "rating_count": 0,
+  "upsell_ids": [
+  ],
+  "cross_sell_ids": [
+  ],
+  "parent_id": 0,
+  "purchase_note": "",
+  "categories": [
+    {
+      "id": 15,
+      "name": "Uncategorized",
+      "slug": "uncategorized"
+    }
+  ],
+  "tags": [
+  ],
+  "images": [
+  ],
+  "attributes": [
+    {
+      "id": 1,
+      "name": "Color",
+      "position": 0,
+      "visible": true,
+      "variation": true,
+      "options": [
+        "Black",
+        "Blue",
+        "Green"
+      ]
+    }
+  ],
+  "default_attributes": [
+  ],
+  "variations": [
+  ],
+  "grouped_products": [
+  ],
+  "menu_order": 0,
+  "price_html": "",
+  "related_ids": [
+  ],
+  "bundle_stock_status": "insufficientstock",
+  "bundle_min_size": 5,
+  "meta_data": [
+    {
+      "id": 11116,
+      "key": "_last_editor_used_jetpack",
+      "value": "classic-editor"
+    },
+    {
+      "id": 11118,
+      "key": "_product_addons",
+      "value": [
+        {
+          "name": "Topping",
+          "title_format": "label",
+          "description_enable": 1,
+          "description": "Pizza topping",
+          "type": "checkbox",
+          "display": "select",
+          "position": 0,
+          "required": 0,
+          "restrictions": 0,
+          "restrictions_type": "any_text",
+          "adjust_price": 0,
+          "price_type": "flat_fee",
+          "price": "",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "Peperoni",
+              "price": "3",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Extra cheese",
+              "price": "4",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Salami",
+              "price": "3",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Ham",
+              "price": "3",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        },
+        {
+          "name": "Soda",
+          "title_format": "label",
+          "description_enable": 0,
+          "description": "",
+          "type": "input_multiplier",
+          "display": "select",
+          "position": 1,
+          "required": 0,
+          "restrictions": 1,
+          "restrictions_type": "any_text",
+          "adjust_price": 1,
+          "price_type": "flat_fee",
+          "price": "2",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        },
+        {
+          "name": "Delivery",
+          "title_format": "label",
+          "description_enable": 0,
+          "description": "",
+          "type": "multiple_choice",
+          "display": "radiobutton",
+          "position": 2,
+          "required": 1,
+          "restrictions": 0,
+          "restrictions_type": "any_text",
+          "adjust_price": 0,
+          "price_type": "flat_fee",
+          "price": "",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "Yes",
+              "price": "5",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "No",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 11119,
+      "key": "_product_addons_exclude_global",
+      "value": "0"
+    }
+  ],
+  "stock_status": "outofstock",
+  "_links": {
+    "self": [
+      {
+        "href": "https:\/\/mystagingwebsite.com\/wp-json\/wc\/v3\/products\/533"
+      }
+    ],
+    "collection": [
+      {
+        "href": "https:\/\/mystagingwebsite.com\/wp-json\/wc\/v3\/products"
+      }
+    ]
+  }
+}

--- a/example/src/test/resources/wc/product-bundle-with-quantity-rules.json
+++ b/example/src/test/resources/wc/product-bundle-with-quantity-rules.json
@@ -1,0 +1,231 @@
+{
+  "id": 533,
+  "name": "Pizza",
+  "slug": "pizza",
+  "permalink": "https:\/\/mystagingwebsite.com\/product\/pizza\/",
+  "date_created": "2021-07-07T13:19:31",
+  "date_created_gmt": "2021-07-07T13:19:31",
+  "date_modified": "2021-07-22T01:57:18",
+  "date_modified_gmt": "2021-07-22T01:57:18",
+  "type": "bundle",
+  "status": "publish",
+  "featured": false,
+  "catalog_visibility": "visible",
+  "description": "",
+  "short_description": "",
+  "sku": "",
+  "price": "",
+  "regular_price": "",
+  "sale_price": "",
+  "date_on_sale_from": null,
+  "date_on_sale_from_gmt": null,
+  "date_on_sale_to": null,
+  "date_on_sale_to_gmt": null,
+  "on_sale": false,
+  "purchasable": false,
+  "total_sales": 0,
+  "virtual": false,
+  "downloadable": false,
+  "downloads": [
+  ],
+  "download_limit": -1,
+  "download_expiry": -1,
+  "external_url": "",
+  "button_text": "",
+  "tax_status": "none",
+  "tax_class": "",
+  "manage_stock": false,
+  "stock_quantity": null,
+  "backorders": "no",
+  "backorders_allowed": false,
+  "backordered": false,
+  "low_stock_amount": null,
+  "sold_individually": true,
+  "weight": "",
+  "dimensions": {
+    "length": "",
+    "width": "",
+    "height": ""
+  },
+  "shipping_required": true,
+  "shipping_taxable": false,
+  "shipping_class": "",
+  "shipping_class_id": 0,
+  "reviews_allowed": true,
+  "average_rating": "0",
+  "rating_count": 0,
+  "upsell_ids": [
+  ],
+  "cross_sell_ids": [
+  ],
+  "parent_id": 0,
+  "purchase_note": "",
+  "categories": [
+    {
+      "id": 15,
+      "name": "Uncategorized",
+      "slug": "uncategorized"
+    }
+  ],
+  "tags": [
+  ],
+  "images": [
+  ],
+  "attributes": [
+    {
+      "id": 1,
+      "name": "Color",
+      "position": 0,
+      "visible": true,
+      "variation": true,
+      "options": [
+        "Black",
+        "Blue",
+        "Green"
+      ]
+    }
+  ],
+  "default_attributes": [
+  ],
+  "variations": [
+  ],
+  "grouped_products": [
+  ],
+  "menu_order": 0,
+  "price_html": "",
+  "related_ids": [
+  ],
+  "bundle_stock_status": "insufficientstock",
+  "bundle_max_size": 5,
+  "bundle_min_size": 5,
+  "meta_data": [
+    {
+      "id": 11116,
+      "key": "_last_editor_used_jetpack",
+      "value": "classic-editor"
+    },
+    {
+      "id": 11118,
+      "key": "_product_addons",
+      "value": [
+        {
+          "name": "Topping",
+          "title_format": "label",
+          "description_enable": 1,
+          "description": "Pizza topping",
+          "type": "checkbox",
+          "display": "select",
+          "position": 0,
+          "required": 0,
+          "restrictions": 0,
+          "restrictions_type": "any_text",
+          "adjust_price": 0,
+          "price_type": "flat_fee",
+          "price": "",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "Peperoni",
+              "price": "3",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Extra cheese",
+              "price": "4",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Salami",
+              "price": "3",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "Ham",
+              "price": "3",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        },
+        {
+          "name": "Soda",
+          "title_format": "label",
+          "description_enable": 0,
+          "description": "",
+          "type": "input_multiplier",
+          "display": "select",
+          "position": 1,
+          "required": 0,
+          "restrictions": 1,
+          "restrictions_type": "any_text",
+          "adjust_price": 1,
+          "price_type": "flat_fee",
+          "price": "2",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        },
+        {
+          "name": "Delivery",
+          "title_format": "label",
+          "description_enable": 0,
+          "description": "",
+          "type": "multiple_choice",
+          "display": "radiobutton",
+          "position": 2,
+          "required": 1,
+          "restrictions": 0,
+          "restrictions_type": "any_text",
+          "adjust_price": 0,
+          "price_type": "flat_fee",
+          "price": "",
+          "min": 0,
+          "max": 0,
+          "options": [
+            {
+              "label": "Yes",
+              "price": "5",
+              "image": "",
+              "price_type": "flat_fee"
+            },
+            {
+              "label": "No",
+              "price": "",
+              "image": "",
+              "price_type": "flat_fee"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 11119,
+      "key": "_product_addons_exclude_global",
+      "value": "0"
+    }
+  ],
+  "stock_status": "outofstock",
+  "_links": {
+    "self": [
+      {
+        "href": "https:\/\/mystagingwebsite.com\/wp-json\/wc\/v3\/products\/533"
+      }
+    ],
+    "collection": [
+      {
+        "href": "https:\/\/mystagingwebsite.com\/wp-json\/wc\/v3\/products"
+      }
+    ]
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
@@ -24,5 +24,8 @@ class WCBundledProduct(
 )
 
 fun WCBundledProduct.isConfigurable(): Boolean {
-    return (quantityMin != quantityMax) || (quantityMin == null) || isOptional
+    return (quantityMin != quantityMax)
+            || (quantityMin == null)
+            || isOptional
+            || (variationIds?.size == 1 && attributesDefault.isNullOrEmpty())
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCBundledProduct.kt
@@ -17,7 +17,10 @@ class WCBundledProduct(
     @SerializedName("quantity_max") val quantityMax: Float?,
     @JsonAdapter(JsonElementToFloatSerializerDeserializer::class)
     @SerializedName("quantity_default") val quantityDefault: Float?,
-    @SerializedName("optional") val isOptional: Boolean
+    @SerializedName("optional") val isOptional: Boolean,
+    @SerializedName("default_variation_attributes")
+    val attributesDefault: List<WCProductVariationModel.ProductVariantOption>?,
+    @SerializedName("allowed_variations") val variationIds: List<Long>?
 )
 
 fun WCBundledProduct.isConfigurable(): Boolean {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -172,6 +172,7 @@ data class ProductApiResponse(
             groupedProductIds = response.grouped_products?.toString() ?: ""
             bundledItems = response.bundled_items?.toString() ?: ""
             compositeComponents = response.composite_components?.toString() ?: ""
+            metadata = response.metadata?.toString() ?: ""
 
             response.dimensions?.asJsonObject?.let { json ->
                 length = json.getString("length") ?: ""
@@ -192,16 +193,15 @@ data class ProductApiResponse(
             val hasBundleMaxQuantityRule = response.bundle_max_size.isNullOrEmpty().not()
             val hasBundleQuantityRules = hasBundleMinQuantityRule || hasBundleMaxQuantityRule
 
-            model.metadata = if (response.metadata != null && hasBundleQuantityRules) {
+            if (hasBundleQuantityRules) {
+                val metadata = response.metadata ?: JsonArray()
                 response.bundle_max_size?.let { value ->
-                    WCMetaData.addAsMetadata(response.metadata, BUNDLE_MAX_SIZE, value)
+                    WCMetaData.addAsMetadata(metadata, BUNDLE_MAX_SIZE, value)
                 }
                 response.bundle_min_size?.let { value ->
-                    WCMetaData.addAsMetadata(response.metadata, BUNDLE_MIN_SIZE, value)
+                    WCMetaData.addAsMetadata(metadata, BUNDLE_MIN_SIZE, value)
                 }
-                response.metadata.toString()
-            } else {
-                response.metadata?.toString() ?: ""
+                model.metadata = metadata.toString()
             }
         }
         return model


### PR DESCRIPTION
### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow.

### Description
This PR brings support to the bundle variable rules in the App. It fetches the default_variation_attributes and allowed_variations fields from the metadata and update the need configuration function to take variable products into account.

### Description
It is better to test these changes in the Woo PR