### PR TITLE
Makes site model optional in the cart creation

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsFixtures.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsFixtures.kt
@@ -28,6 +28,15 @@ val CREATE_SHOPPING_CART_WITH_PLAN_RESPONSE = CreateShoppingCartResponse(
     )
 )
 
+val CREATE_SHOPPING_CART_WITH_NO_SITE_RESPONSE = CreateShoppingCartResponse(
+    0,
+    22.toString(),
+    listOf(
+        Product(76, "superraredomainname156726.blog", Extra(true)),
+        Product(1001, "other product", Extra(true))
+    )
+)
+
 val DOMAIN_CONTACT_INFORMATION = DomainContactModel(
         "Wapu",
         "Wordpress",

--- a/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -28,6 +28,7 @@
 /me/transactions/supported-countries/
 /me/transactions/
 /me/shopping-cart/$site
+/me/shopping-cart/no-site
 
 /me/account/close
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/transactions/TransactionsRestClient.kt
@@ -55,14 +55,15 @@ class TransactionsRestClient @Inject constructor(
     }
 
     suspend fun createShoppingCart(
-        site: SiteModel,
+        site: SiteModel?,
         domainProductId: Int,
         domainName: String,
         isDomainPrivacyProtectionEnabled: Boolean,
         isTemporary: Boolean,
         planProductId: Int? = null
     ): CreatedShoppingCartPayload {
-        val url = WPCOMREST.me.shopping_cart.site(site.siteId).urlV1_1
+        val url = site?.let { WPCOMREST.me.shopping_cart.site(it.siteId).urlV1_1 }
+            ?: WPCOMREST.me.shopping_cart.no_site.urlV1_1
 
         val domainProduct = mapOf(
                 "product_id" to domainProductId,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/TransactionsStore.kt
@@ -169,7 +169,7 @@ class TransactionsStore @Inject constructor(
     }
 
     class CreateShoppingCartWithDomainAndPlanPayload(
-        val site: SiteModel,
+        val site: SiteModel?,
         val domainProductId: Int,
         val domainName: String,
         val isDomainPrivacyEnabled: Boolean,


### PR DESCRIPTION
Part of: https://github.com/wordpress-mobile/WordPress-Android/issues/19382

**WordPress-Android PR:** https://github.com/wordpress-mobile/WordPress-Android/pull/19527

## Description
This PR allows adding a domain to the cart without passing a site parameter. In that case the `/me/shopping-cart/no-site` endpoint is called.

## To test
1. Use the Jetpack build from https://github.com/wordpress-mobile/WordPress-Android/pull/19527
2. Go to Me>Domain>Add(+)
3. Search for a domain and tap on it
4. Tap the `Get Domain` option
5. **Verify** that the domain you selected is visible in the checkout step
