### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to `Theme` Network Client Classes (`safe`)

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -40,6 +40,7 @@ import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -423,7 +424,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             activateTheme(jetpackSite, otherThemeToActivate);
 
             // Make sure another theme is activated
-            assertFalse(theme.getThemeId().equals(mThemeStore.getActiveThemeForSite(jetpackSite).getThemeId()));
+            assertNotEquals(theme.getThemeId(), mThemeStore.getActiveThemeForSite(jetpackSite).getThemeId());
         }
         // delete existing theme from site
         deleteTheme(jetpackSite, theme);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     enum TestEvents {
         NONE,

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("NewClassNamingConvention")
@@ -253,7 +254,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
 
-        assertTrue(mNextEvent == TestEvents.FETCHED_CURRENT_THEME);
+        assertSame(mNextEvent, TestEvents.FETCHED_CURRENT_THEME);
         assertNotNull(event.theme);
         mCountDownLatch.countDown();
     }
@@ -264,7 +265,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mNextEvent == TestEvents.ACTIVATED_THEME);
+        assertSame(mNextEvent, TestEvents.ACTIVATED_THEME);
         mCountDownLatch.countDown();
     }
 
@@ -274,7 +275,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mNextEvent == TestEvents.INSTALLED_THEME);
+        assertSame(mNextEvent, TestEvents.INSTALLED_THEME);
         mCountDownLatch.countDown();
     }
 
@@ -284,7 +285,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         if (event.isError()) {
             throw new AssertionError("Unexpected error occurred with type: " + event.error.type);
         }
-        assertTrue(mNextEvent == TestEvents.DELETED_THEME);
+        assertSame(mNextEvent, TestEvents.DELETED_THEME);
         mCountDownLatch.countDown();
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -339,8 +339,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
     private SiteModel signIntoWpComAccountWithJetpackSite() throws InterruptedException {
         // sign into a WP.com account with a Jetpack site
-        authenticateWPComAndFetchSites(BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
-                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY);
+        authenticateWPComAndFetchSites();
 
         // verify Jetpack site is available
         final SiteModel jetpackSite = getJetpackSite();
@@ -348,9 +347,12 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         return jetpackSite;
     }
 
-    private void authenticateWPComAndFetchSites(String username, String password) throws InterruptedException {
+    private void authenticateWPComAndFetchSites() throws InterruptedException {
         // Authenticate a test user (actual credentials declared in gradle.properties)
-        AuthenticatePayload payload = new AuthenticatePayload(username, password);
+        AuthenticatePayload payload = new AuthenticatePayload(
+                BuildConfig.TEST_WPCOM_USERNAME_SINGLE_JETPACK_ONLY,
+                BuildConfig.TEST_WPCOM_PASSWORD_SINGLE_JETPACK_ONLY
+        );
         mCountDownLatch = new CountDownLatch(1);
 
         // Correct user we should get an OnAuthenticationChanged message

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -83,7 +83,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         final SiteModel jetpackSite = signIntoWpComAccountWithJetpackSite();
 
         // verify that installed themes list is empty first
-        assertTrue(mThemeStore.getThemesForSite(jetpackSite).size() == 0);
+        assertEquals(0, mThemeStore.getThemesForSite(jetpackSite).size());
 
         // fetch installed themes
         fetchInstalledThemes(jetpackSite);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("NewClassNamingConvention")
 public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
     enum TestEvents {
         NONE,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -194,7 +194,7 @@ class ThemeFragment : Fragment() {
         if (event.isError) {
             prependToLog("error: " + event.error.message)
         } else {
-            prependToLog("success: theme = " + event.theme.name)
+            prependToLog("success: theme = " + event.theme?.name)
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -13,6 +13,7 @@ import kotlinx.android.synthetic.main.fragment_themes.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.ThemeModel
@@ -30,6 +31,9 @@ class ThemeFragment : Fragment() {
     @Inject internal lateinit var siteStore: SiteStore
     @Inject internal lateinit var themeStore: ThemeStore
     @Inject internal lateinit var dispatcher: Dispatcher
+
+    private var selectedSite: SiteModel? = null
+    private var selectedPos: Int = -1
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -52,6 +56,20 @@ class ThemeFragment : Fragment() {
     @Suppress("LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        theme_select_site.setOnClickListener {
+            showSiteSelectorDialog(selectedPos, object : SiteSelectorDialog.Listener {
+                override fun onSiteSelected(site: SiteModel, pos: Int) {
+                    selectedSite = site
+                    selectedPos = pos
+                    val wpcomSite = if (site.isWPCom) "WP" else ""
+                    val jetpackSite = if (site.isJetpackConnected) "JP" else ""
+                    val siteName = site.name ?: site.displayName
+                    val selectedSite = "[$wpcomSite$jetpackSite] $siteName"
+                    theme_selected_site.text = selectedSite
+                }
+            })
+        }
 
         activate_theme_wpcom.setOnClickListener {
             val id = getThemeIdFromInput(view)
@@ -241,10 +259,18 @@ class ThemeFragment : Fragment() {
     }
 
     private fun getWpComSite(): SiteModel? {
-        return siteStore.sites.firstOrNull { it != null && it.isWPCom }
+        return if (selectedSite?.isWPCom == true) {
+            selectedSite
+        } else {
+            null
+        }
     }
 
     private fun getJetpackConnectedSite(): SiteModel? {
-        return siteStore.sites.firstOrNull { it != null && it.isJetpackConnected }
+        return if (selectedSite?.isJetpackConnected == true) {
+            selectedSite
+        } else {
+            null
+        }
     }
 }

--- a/example/src/main/res/layout/fragment_themes.xml
+++ b/example/src/main/res/layout/fragment_themes.xml
@@ -8,6 +8,32 @@
     android:orientation="vertical"
     tools:ignore="HardcodedText">
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/theme_select_site"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingStart="@dimen/activity_start_end_half_margin"
+            android:paddingEnd="@dimen/activity_start_end_half_margin"
+            android:text="Select Site" />
+
+        <TextView
+            android:id="@+id/theme_selected_site"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingStart="@dimen/activity_start_end_half_margin"
+            android:paddingEnd="@dimen/activity_start_end_half_margin"
+            android:textAppearance="@style/Base.TextAppearance.Widget.AppCompat.Toolbar.Subtitle"
+            android:textColor="@android:color/holo_blue_bright" />
+
+    </LinearLayout>
+
     <Button
         android:id="@+id/fetch_wpcom_themes"
         android:layout_width="match_parent"

--- a/example/src/main/res/layout/fragment_themes.xml
+++ b/example/src/main/res/layout/fragment_themes.xml
@@ -63,7 +63,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Enter the theme's id here"
-        android:inputType="number" />
+        android:inputType="text" />
 
     <Button
         android:id="@+id/activate_theme_wpcom"

--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class ThemeStoreUnitTest {
-    private ThemeStore mThemeStore = new ThemeStore(new Dispatcher(), Mockito.mock(ThemeRestClient.class));
+    private final ThemeStore mThemeStore = new ThemeStore(new Dispatcher(), Mockito.mock(ThemeRestClient.class));
 
     @Before
     public void setUp() {

--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class ThemeStoreUnitTest {
@@ -56,7 +55,7 @@ public class ThemeStoreUnitTest {
         mThemeStore.setActiveThemeForSite(site, firstTheme);
         List<ThemeModel> activeThemes = ThemeSqlUtils.getActiveThemeForSite(site);
         assertNotNull(activeThemes);
-        assertTrue(activeThemes.size() == 1);
+        assertEquals(1, activeThemes.size());
         ThemeModel firstActiveTheme = activeThemes.get(0);
         assertEquals(firstTheme.getThemeId(), firstActiveTheme.getThemeId());
         assertEquals(firstTheme.getName(), firstActiveTheme.getName());
@@ -65,7 +64,7 @@ public class ThemeStoreUnitTest {
         mThemeStore.setActiveThemeForSite(site, secondTheme);
         activeThemes = ThemeSqlUtils.getActiveThemeForSite(site);
         assertNotNull(activeThemes);
-        assertTrue(activeThemes.size() == 1);
+        assertEquals(1, activeThemes.size());
         ThemeModel secondActiveTheme = activeThemes.get(0);
         assertEquals(secondTheme.getThemeId(), secondActiveTheme.getThemeId());
         assertEquals(secondTheme.getName(), secondActiveTheme.getName());

--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -35,7 +35,7 @@ public class ThemeStoreUnitTest {
 
     @Before
     public void setUp() {
-        Context appContext = RuntimeEnvironment.application.getApplicationContext();
+        Context appContext = RuntimeEnvironment.getApplication().getApplicationContext();
         WellSqlConfig config = new WellSqlConfig(appContext);
         WellSql.init(config);
         config.reset();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/JetpackThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/JetpackThemeResponse.java
@@ -1,22 +1,24 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.theme;
 
+import androidx.annotation.NonNull;
+
 import java.util.List;
 
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({"WeakerAccess", "NotNullFieldNotInitialized"})
 public class JetpackThemeResponse {
     public static class JetpackThemeListResponse {
-        public List<JetpackThemeResponse> themes;
+        @NonNull public List<JetpackThemeResponse> themes;
         public int count;
     }
 
-    public String id;
-    public String screenshot;
-    public String name;
-    public String theme_uri;
-    public String description;
-    public String author;
-    public String author_uri;
-    public String version;
+    @NonNull public String id;
+    @NonNull public String screenshot;
+    @NonNull public String name;
+    @NonNull public String theme_uri;
+    @NonNull public String description;
+    @NonNull public String author;
+    @NonNull public String author_uri;
+    @NonNull public String version;
     public boolean active;
     public boolean autoupdate;
     public boolean autoupdate_translation;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/JetpackThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/JetpackThemeResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 @SuppressWarnings("WeakerAccess")
 public class JetpackThemeResponse {
-    public class JetpackThemeListResponse {
+    public static class JetpackThemeListResponse {
         public List<JetpackThemeResponse> themes;
         public int count;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -44,17 +44,24 @@ import javax.inject.Singleton;
 
 @Singleton
 public class ThemeRestClient extends BaseWPComRestClient {
-    /** Used by {@link #fetchWpComThemes()} request all themes in a single fetch. */
+    /**
+     * Used by {@link #fetchWpComThemes()} request all themes in a single fetch.
+     */
     private static final String WP_THEME_FETCH_NUMBER_PARAM = "number=500";
     private static final String WPCOM_MOBILE_FRIENDLY_TAXONOMY_SLUG = "mobile-friendly";
 
-    @Inject public ThemeRestClient(Context appContext, Dispatcher dispatcher,
-                           @Named("regular") RequestQueue requestQueue,
-                           AccessToken accessToken, UserAgent userAgent) {
+    @Inject public ThemeRestClient(
+            Context appContext,
+            Dispatcher dispatcher,
+            @Named("regular") RequestQueue requestQueue,
+            AccessToken accessToken,
+            UserAgent userAgent) {
         super(appContext, dispatcher, requestQueue, accessToken, userAgent);
     }
 
-    /** [Undocumented!] Endpoint: v1.1/sites/$siteId/themes/$themeId/delete */
+    /**
+     * [Undocumented!] Endpoint: v1.1/sites/$siteId/themes/$themeId/delete
+     */
     public void deleteTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(theme.getThemeId()).delete.getUrlV1_1();
         add(WPComGsonRequest.buildPostRequest(url, null, JetpackThemeResponse.class,
@@ -78,7 +85,9 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    /** [Undocumented!] Endpoint: v1.1/sites/$siteId/themes/$themeId/install */
+    /**
+     * [Undocumented!] Endpoint: v1.1/sites/$siteId/themes/$themeId/install
+     */
     public void installTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
         String themeId = getThemeIdWithWpComSuffix(theme);
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(themeId).install.getUrlV1_1();
@@ -104,6 +113,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     /**
      * Endpoint: v1.1/sites/$siteId/themes/mine
+     *
      * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/themes/mine/">Documentation</a>
      */
     public void activateTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
@@ -133,6 +143,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     /**
      * [Undocumented!] Endpoint: v1.2/themes
+     *
      * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/themes/">Previous version</a>
      */
     public void fetchWpComThemes() {
@@ -198,6 +209,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     /**
      * [Undocumented!] Endpoint: v1/sites/$siteId/themes
+     *
      * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/themes/">Similar endpoint</a>
      */
     public void fetchJetpackInstalledThemes(@NonNull final SiteModel site) {
@@ -224,6 +236,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     /**
      * Endpoint: v1.1/sites/$siteId/themes/mine; same endpoint for both Jetpack and WP.com sites!
+     *
      * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/themes/mine/">Documentation</a>
      */
     public void fetchCurrentTheme(@NonNull final SiteModel site) {
@@ -322,7 +335,9 @@ public class ThemeRestClient extends BaseWPComRestClient {
         return themeList;
     }
 
-    /** Creates a list of ThemeModels from the Jetpack /v1/sites/$siteId/themes REST response. */
+    /**
+     * Creates a list of ThemeModels from the Jetpack /v1/sites/$siteId/themes REST response.
+     */
     private static List<ThemeModel> createThemeListFromJetpackResponse(JetpackThemeListResponse response) {
         final List<ThemeModel> themeList = new ArrayList<>();
         for (JetpackThemeResponse item : response.themes) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -304,7 +304,8 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     /**
      * Must provide theme slug with -wpcom suffix to install a WP.com theme on a Jetpack site.
-     * Per documentation in the developer console: https://developer.wordpress.com/docs/api/console/
+     *
+     * @see <a href="https://developer.wordpress.com/docs/api/console/">Documentation</a>
      */
     private @NonNull String getThemeIdWithWpComSuffix(ThemeModel theme) {
         if (theme == null || theme.getThemeId() == null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -316,8 +316,9 @@ public class ThemeRestClient extends BaseWPComRestClient {
      *
      * @see <a href="https://developer.wordpress.com/docs/api/console/">Documentation</a>
      */
-    private @NonNull String getThemeIdWithWpComSuffix(ThemeModel theme) {
-        if (theme == null || theme.getThemeId() == null) {
+    @NonNull
+    private String getThemeIdWithWpComSuffix(@NonNull ThemeModel theme) {
+        if (theme.getThemeId() == null) {
             return "";
         } else if (theme.getThemeId().endsWith("-wpcom")) {
             return theme.getThemeId();

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -266,7 +266,8 @@ public class ThemeRestClient extends BaseWPComRestClient {
         return theme;
     }
 
-    private static ThemeModel createThemeFromJetpackResponse(JetpackThemeResponse response) {
+    @NonNull
+    private static ThemeModel createThemeFromJetpackResponse(@NonNull JetpackThemeResponse response) {
         ThemeModel theme = new ThemeModel();
         theme.setThemeId(response.id);
         theme.setName(response.name);
@@ -301,7 +302,8 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /**
      * Creates a list of ThemeModels from the Jetpack /v1/sites/$siteId/themes REST response.
      */
-    private static List<ThemeModel> createThemeListFromJetpackResponse(JetpackThemeListResponse response) {
+    @NonNull
+    private static List<ThemeModel> createThemeListFromJetpackResponse(@NonNull JetpackThemeListResponse response) {
         final List<ThemeModel> themeList = new ArrayList<>();
         for (JetpackThemeResponse item : response.themes) {
             themeList.add(createThemeFromJetpackResponse(item));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -222,7 +222,8 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 }));
     }
 
-    private static ThemeModel createThemeFromWPComResponse(WPComThemeResponse response) {
+    @NonNull
+    private static ThemeModel createThemeFromWPComResponse(@NonNull WPComThemeResponse response) {
         ThemeModel theme = new ThemeModel();
         theme.setThemeId(response.id);
         theme.setSlug(response.slug);
@@ -288,7 +289,8 @@ public class ThemeRestClient extends BaseWPComRestClient {
         return theme;
     }
 
-    private static List<ThemeModel> createThemeListFromArrayResponse(WPComThemeListResponse response) {
+    @NonNull
+    private static List<ThemeModel> createThemeListFromArrayResponse(@NonNull WPComThemeListResponse response) {
         final List<ThemeModel> themeList = new ArrayList<>();
         for (WPComThemeResponse item : response.themes) {
             themeList.add(createThemeFromWPComResponse(item));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.volley.RequestQueue;
 
@@ -145,7 +146,11 @@ public class ThemeRestClient extends BaseWPComRestClient {
     /**
      * Endpoint:  v2/common-starter-site-designs
      */
-    public void fetchStarterDesigns(Float previewWidth, Float previewHeight, Float scale, String[] groups) {
+    public void fetchStarterDesigns(
+            @Nullable Float previewWidth,
+            @Nullable Float previewHeight,
+            @Nullable Float scale,
+            @Nullable String[] groups) {
         Map<String, String> params = new HashMap<>();
         params.put("type", "mobile");
         if (previewWidth != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -282,7 +282,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
         // the screenshot field in Jetpack responses does not contain a protocol so we'll prepend 'https'
         String screenshotUrl = response.screenshot;
-        if (screenshotUrl != null && screenshotUrl.startsWith("//")) {
+        if (screenshotUrl.startsWith("//")) {
             screenshotUrl = "https:" + screenshotUrl;
         }
         theme.setScreenshotUrl(screenshotUrl);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
@@ -6,17 +6,17 @@ import java.util.List;
 
 @SuppressWarnings("WeakerAccess")
 public class WPComThemeResponse {
-    public class WPComThemeListResponse {
+    public static class WPComThemeListResponse {
         public List<WPComThemeResponse> themes;
     }
 
-    public class WPComThemeMobileFriendlyTaxonomy {
+    public static class WPComThemeMobileFriendlyTaxonomy {
         public String name;
         public String slug;
         public int term_id;
     }
 
-    public class WPComThemeTaxonomies {
+    public static class WPComThemeTaxonomies {
         @SerializedName("theme_mobile-friendly")
         public WPComThemeMobileFriendlyTaxonomy[] theme_mobile_friendly;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
@@ -1,37 +1,40 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.theme;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({"WeakerAccess", "NotNullFieldNotInitialized"})
 public class WPComThemeResponse {
     public static class WPComThemeListResponse {
-        public List<WPComThemeResponse> themes;
+        @NonNull public List<WPComThemeResponse> themes;
     }
 
     public static class WPComThemeMobileFriendlyTaxonomy {
-        public String name;
-        public String slug;
+        @NonNull public String name;
+        @NonNull public String slug;
     }
 
     public static class WPComThemeTaxonomies {
         @SerializedName("theme_mobile-friendly")
-        public WPComThemeMobileFriendlyTaxonomy[] theme_mobile_friendly;
+        @Nullable public WPComThemeMobileFriendlyTaxonomy[] theme_mobile_friendly;
     }
 
-    public String id;
-    public String slug;
-    public String stylesheet;
-    public String name;
-    public String author;
-    public String author_uri;
-    public String theme_uri;
-    public String demo_uri;
-    public String version;
-    public String screenshot;
-    public String description;
-    public String download_uri;
-    public String price;
-    public WPComThemeTaxonomies taxonomies;
+    @NonNull public String id;
+    @Nullable public String slug;
+    @Nullable public String stylesheet;
+    @NonNull public String name;
+    @Nullable public String author;
+    @Nullable public String author_uri;
+    @Nullable public String theme_uri;
+    @Nullable public String demo_uri;
+    @Nullable public String version;
+    @NonNull public String screenshot;
+    @NonNull public String description;
+    @Nullable public String download_uri;
+    @Nullable public String price;
+    @Nullable public WPComThemeTaxonomies taxonomies;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
@@ -13,7 +13,6 @@ public class WPComThemeResponse {
     public static class WPComThemeMobileFriendlyTaxonomy {
         public String name;
         public String slug;
-        public int term_id;
     }
 
     public static class WPComThemeTaxonomies {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -49,8 +49,8 @@ public class ThemeStore extends Store {
     }
 
     public static class FetchedSiteThemesPayload extends Payload<ThemesError> {
-        public SiteModel site;
-        public List<ThemeModel> themes;
+        @NonNull public SiteModel site;
+        @Nullable public List<ThemeModel> themes;
 
         public FetchedSiteThemesPayload(@NonNull SiteModel site, @NonNull ThemesError error) {
             this.site = site;
@@ -157,10 +157,10 @@ public class ThemeStore extends Store {
     // OnChanged events
     @SuppressWarnings("WeakerAccess")
     public static class OnSiteThemesChanged extends OnChanged<ThemesError> {
-        public SiteModel site;
-        public ThemeAction origin;
+        @NonNull public SiteModel site;
+        @NonNull public ThemeAction origin;
 
-        public OnSiteThemesChanged(SiteModel site, ThemeAction origin) {
+        public OnSiteThemesChanged(@NonNull SiteModel site, @NonNull ThemeAction origin) {
             this.site = site;
             this.origin = origin;
         }
@@ -378,7 +378,11 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            ThemeSqlUtils.insertOrReplaceInstalledThemes(payload.site, payload.themes);
+            if (payload.themes != null) {
+                ThemeSqlUtils.insertOrReplaceInstalledThemes(payload.site, payload.themes);
+            } else {
+                AppLog.w(AppLog.T.THEMES, "Fetched site themes payload themes is null.");
+            }
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -106,15 +106,18 @@ public class ThemeStore extends Store {
     }
 
     public static class FetchedStarterDesignsPayload extends Payload<ThemesError> {
-        public List<StarterDesign> designs;
-        public List<StarterDesignCategory> categories;
+        @NonNull public List<StarterDesign> designs;
+        @NonNull public List<StarterDesignCategory> categories;
 
         public FetchedStarterDesignsPayload(@NonNull ThemesError error) {
             this.error = error;
+            this.designs = new ArrayList<>();
+            this.categories = new ArrayList<>();
         }
 
-        public FetchedStarterDesignsPayload(@NonNull List<StarterDesign> designs,
-                                            @NonNull List<StarterDesignCategory> categories) {
+        public FetchedStarterDesignsPayload(
+                @NonNull List<StarterDesign> designs,
+                @NonNull List<StarterDesignCategory> categories) {
             this.designs = designs;
             this.categories = categories;
         }
@@ -227,11 +230,13 @@ public class ThemeStore extends Store {
     }
 
     public static class OnStarterDesignsFetched extends OnChanged<ThemesError> {
-        public List<StarterDesign> designs;
-        public List<StarterDesignCategory> categories;
+        @NonNull public List<StarterDesign> designs;
+        @NonNull public List<StarterDesignCategory> categories;
 
-        public OnStarterDesignsFetched(List<StarterDesign> designs, List<StarterDesignCategory> categories,
-                                       ThemesError error) {
+        public OnStarterDesignsFetched(
+                @NonNull List<StarterDesign> designs,
+                @NonNull List<StarterDesignCategory> categories,
+                @Nullable ThemesError error) {
             this.designs = designs;
             this.categories = categories;
             this.error = error;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.theme.ThemeRestClient;
 import org.wordpress.android.fluxc.persistence.ThemeSqlUtils;
 import org.wordpress.android.util.AppLog;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -64,10 +65,11 @@ public class ThemeStore extends Store {
     }
 
     public static class FetchedWpComThemesPayload extends Payload<ThemesError> {
-        public List<ThemeModel> themes;
+        @NonNull public List<ThemeModel> themes;
 
         public FetchedWpComThemesPayload(@NonNull ThemesError error) {
             this.error = error;
+            this.themes = new ArrayList<>();
         }
 
         public FetchedWpComThemesPayload(@NonNull List<ThemeModel> themes) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -76,8 +76,8 @@ public class ThemeStore extends Store {
     }
 
     public static class SiteThemePayload extends Payload<ThemesError> {
-        public SiteModel site;
-        public ThemeModel theme;
+        @NonNull public SiteModel site;
+        @NonNull public ThemeModel theme;
 
         public SiteThemePayload(@NonNull SiteModel site, @NonNull ThemeModel theme) {
             this.site = site;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -245,6 +245,7 @@ public class ThemeStore extends Store {
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
+    @SuppressWarnings("rawtypes")
     public void onAction(Action action) {
         IAction actionType = action.getType();
         if (!(actionType instanceof ThemeAction)) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -34,8 +34,8 @@ public class ThemeStore extends Store {
 
     // Payloads
     public static class FetchedCurrentThemePayload extends Payload<ThemesError> {
-        public SiteModel site;
-        public ThemeModel theme;
+        @NonNull public SiteModel site;
+        @Nullable public ThemeModel theme;
 
         public FetchedCurrentThemePayload(@NonNull SiteModel site, @NonNull ThemesError error) {
             this.site = site;
@@ -171,10 +171,10 @@ public class ThemeStore extends Store {
 
     @SuppressWarnings("WeakerAccess")
     public static class OnCurrentThemeFetched extends OnChanged<ThemesError> {
-        public SiteModel site;
-        public ThemeModel theme;
+        @NonNull public SiteModel site;
+        @Nullable public ThemeModel theme;
 
-        public OnCurrentThemeFetched(SiteModel site, ThemeModel theme) {
+        public OnCurrentThemeFetched(@NonNull SiteModel site, @Nullable ThemeModel theme) {
             this.site = site;
             this.theme = theme;
         }
@@ -398,7 +398,11 @@ public class ThemeStore extends Store {
         if (payload.isError()) {
             event.error = payload.error;
         } else {
-            ThemeSqlUtils.insertOrReplaceActiveThemeForSite(payload.site, payload.theme);
+            if (payload.theme != null) {
+                ThemeSqlUtils.insertOrReplaceActiveThemeForSite(payload.site, payload.theme);
+            } else {
+                AppLog.w(AppLog.T.THEMES, "Fetched current theme payload theme is null.");
+            }
         }
         emitChange(event);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -91,8 +91,11 @@ public class ThemeStore extends Store {
         @Nullable public Float scale;
         @Nullable public String[] groups;
 
-        public FetchStarterDesignsPayload(@Nullable Float previewWidth, @Nullable Float previewHeight,
-                                          @Nullable Float scale, @Nullable String... groups) {
+        public FetchStarterDesignsPayload(
+                @Nullable Float previewWidth,
+                @Nullable Float previewHeight,
+                @Nullable Float scale,
+                @Nullable String... groups) {
             this.previewWidth = previewWidth;
             this.previewHeight = previewHeight;
             this.scale = scale;
@@ -341,9 +344,12 @@ public class ThemeStore extends Store {
         mThemeRestClient.fetchWpComThemes();
     }
 
-    private void fetchStarterDesigns(FetchStarterDesignsPayload payload) {
-        mThemeRestClient.fetchStarterDesigns(payload.previewWidth, payload.previewHeight,
-                payload.scale, payload.groups);
+    private void fetchStarterDesigns(@NonNull FetchStarterDesignsPayload payload) {
+        mThemeRestClient.fetchStarterDesigns(
+                payload.previewWidth,
+                payload.previewHeight,
+                payload.scale,
+                payload.groups);
     }
 
     private void handleWpComThemesFetched(@NonNull FetchedWpComThemesPayload payload) {


### PR DESCRIPTION
Parent #2798
Accompanying [JP/WPAndroid#19529](https://github.com/wordpress-mobile/WordPress-Android/pull/19529)

This PR adds any missing nullability annotation to [ThemeRestClient.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/bf74da433541f7ce29faeeb281dd55ad6e806bd1/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java#L4), all its related response classes and anything in between (ie. `MediaStore`). See response classes below:

- [WPComThemeResponse.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/bf74da433541f7ce29faeeb281dd55ad6e806bd1/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java)
- [JetpackThemeResponse.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/bf74da433541f7ce29faeeb281dd55ad6e806bd1/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/JetpackThemeResponse.java)

FYI.1: This change is `safe`, meaning that there shouldn't be any (major) compile-time changes associated with this change. Having said that, testing is highly recommended since the changes in this PR can affect one or more clients (ie. [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), [WCAndroid](https://github.com/woocommerce/woocommerce-android), etc)

FYI.2: An analysis on `ThemeStore` and its usages with our main clients suggests that this store is only being utilizing by [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android). AFAIA [WCAndroid](https://github.com/woocommerce/woocommerce-android) is not using that store and as such can be safely ignored from testing.

-----

PS.1: @antonis I added you as the main reviewer, randomly so, since I just wanted someone from the Jetpack/WordPress mobile team to be aware of and sign-off on that change. Feel free to merge this PR directly yourself if you deem so.

-----

Nullability Annotation List (`Response`):

1. [Add missing n-a to comment wp com theme response fields](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/d2929d36d1f10cfce92730abb4f3b3e4d0cd5224)
2. [Add missing n-a to comment jetpack theme response fields](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/4d84b172fead6d2d3853b7afb02bbaae3c827aba)

Nullability Annotation List (`Client`):

1. [Add missing n-a to fetch starter designs on theme rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/9549d91b378d234e9582bcb88924ab9602fe30de)
2. [Add missing n-a to create theme from wpr on theme rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/e768a98d28b0c5591c4e3895b0c80aa4f92fa63c)
3. [Add missing n-a to create theme from jpr on theme rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/5bb58ade8db2f769a9926d0c0d0c185469090745)
4. [Add missing n-a to theme id with wp suffix on theme rest clt](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/c8351b542e4b4a604933aa44746bf78732437d3e)

Nullability Annotation List (`Store`):

1. [Add missing n-a to fetched current theme pl on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/63a11fdf809092ea886caa9d6aa78615da13a3d1)
2. [Add missing n-a to fetched site themes payload on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/0a3ec94c176b72e666ad714198683ffff44d5551)
3. [Add missing n-a to fetched wp com themes pl on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/93ae4b5309be58ad7613087f559a9529942e97cb)
4. [Add missing n-a to fetched starter designs pl on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/537cc68f59b44762e3129f00c6fc47cb8810b531)

Nullability Checks List:

1. [Un-guard usages of jetpack screenshot url on theme rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/9ee355f2cd4f7d1f4bfbb78ba9b55d969af64bc6)

Warnings Resolutions List:

1. [Make inner classes static on wp com theme response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/abfcf9d393142a94bb01366107292f119f1fd3f9)
2. [Make inner classes static on jetpack theme response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/a3f526b21bd5f5ee7d12c8fec873a403cd634959)
3. [Delete unused term id field on wp com theme response](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/295a4caa7a057cd5360f7302b262c64455c9903c)

Warnings Suppression List:

1. [Suppress raw types warning on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/8324b111c704512ec204fa594fa3d85789691083)

Refactor List:

1. [Reformat theme rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/4e053712ff6fe695d14dbf9e69e0661222112e42)
2. [Replace anonymous classes with lambda on theme rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/4a7097fd0157d2130a88131526587a76c1479cb6) 

Test List:

1. [Add missing final to theme store on theme store test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/d7a12a5984bd1deacc88c4b875888a7f3f9715e3)
2. [Resolve robolectric related application deprecation warning](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/977a2bfd9d1a34cd5eb5c0216dac8778d4e1d915)
3. [Simplify assert true assertions on theme store test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/a6b6d79130cd672579264b27c9746b9d1ccb26ca)
4. [Suppress new class naming convention for connected tests](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/8edff9217f2bb4ac4d9197481a545edb11819d31)
5. [Simplify assert true assertion on rs theme test jetpack](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/8ce72667231ed91dcae0625069daaf81640c3a30)
6. [Simplify assert true assertions on rs theme test jetpack](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/77e554cfec2557f28984069925fdf6dce9529e89)
7. [Simplify assert false assertion on rs theme test jetpack](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/b4b0766aeb5ad611b0d75fb3551988a5b4dc5217)
8. [Simplify authenticate wp com fetch sites on rs theme test jetpack](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/9fd1d4e527aa0c3f7cd6aa562d38fb1b977de651) 

Docs List:

1. [Replace url with html link on theme rest client](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/e81f5b4c8d1672e0533bfc4e93f5ce805b8fb384)

Demo List:

1. [Add select site functionality to theme screen on example app](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/c16ee3b1654735f1ce34e57f25a095cb8d7fae0a)
2. [Change theme id input type to text on theme screen of example app](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2893/commits/fdd0bc97140ae54f840d19da773b2f19a6cf415a)

-----

## Associated Clients

It is highly recommending that this change is being tested on the below associated clients:

- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android)

-----

## To Test (`REST`):

- Smoke test the `FluxC Example` app via the `THEME` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any theme related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

## To Test (`XMLRPC`):

N/A

<details>
    <summary>1. [JP/WP] Themes Screen [ThemeBrowserActivity.java + ThemeBrowserFragment.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` apps.

- Go to `Themes` screen, verify it is shown and functioning as expected.
- For example try scrolling up-and-down and searching for a theme.
- Check your current theme and tap on the `Customize`, `Details` and `Support` buttons. Verify that everything works as expected.
- From the themes list, find your current theme on top, click on its menu items and again tap on the `Customize`, `Details` and `Support` buttons. Verify that everything works as expected.
- From the themes list, find another theme, other than your current one, click on its menu items and again tap on the `Details` and `Support` buttons. Verify that everything works as expected.
- Then, tap on the `View` and `Try & Customize` buttons. Verify that everything works as expected.
- Finally, tap on `Activate` button. Verify that the selected theme is activated and that everything works as expected.

</details>

<details>
    <summary>2. [JP] Site Creation Screens [SiteCreationActivity.kt + HomePagePickerFragment.kt + DesignPreviewFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app only.

- From `Choose Site`, tap on the `+` button on top and via the `Create WordPress.com site`, go to `Site Creation` screen, verify it is shown and functioning as expected.
- For example, while on the `What's your website about?` screen, select a topic from the list of topics (ie. `Food`).
- Then, while on the `Choose a theme` screen, select a theme from the list of themes (per category, ie `About`).
- Finally, verify that the `Preview` screen is shown and functioning as expected.

</details>

-----

## Merge instructions:

1. [x] Wait for the accompanying [JP/WPAndroid#19529](https://github.com/wordpress-mobile/WordPress-Android/pull/19529) to be reviewed and approved.
2. [x] Remove the `[PR] Not Ready for Merge` label.
3. [x] Merge this PR.
4. [x] Follow-up with the merge instructions on the accompanying [JP/WPAndroid#19529](https://github.com/wordpress-mobile/WordPress-Android/pull/19529) client PR.