### PR TITLE
Support webauthn nonce during Social login

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountRestClient.java
@@ -100,6 +100,7 @@ public class AccountRestClient extends BaseWPComRestClient {
             this.twoStepNonceAuthenticator = response.two_step_nonce_authenticator;
             this.twoStepNonceBackup = response.two_step_nonce_backup;
             this.twoStepNonceSms = response.two_step_nonce_sms;
+            this.twoStepNonceWebauthn = response.two_step_nonce_webauthn;
             this.twoStepNotificationSent = response.two_step_notification_sent;
             this.twoStepTypes = convertJsonArrayToStringList(response.two_step_supported_auth_types);
             this.userId = response.user_id;
@@ -114,6 +115,7 @@ public class AccountRestClient extends BaseWPComRestClient {
         public String twoStepNonceAuthenticator;
         public String twoStepNonceBackup;
         public String twoStepNonceSms;
+        public String twoStepNonceWebauthn;
         public String twoStepNotificationSent;
         public String userId;
         public String userName;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialRequest.java
@@ -62,6 +62,7 @@ public class AccountSocialRequest extends BaseRequest<AccountSocialResponse> {
             parsed.two_step_nonce_authenticator = data.optString("two_step_nonce_authenticator");
             parsed.two_step_nonce_backup = data.optString("two_step_nonce_backup");
             parsed.two_step_nonce_sms = data.optString("two_step_nonce_sms");
+            parsed.two_step_nonce_webauthn = data.optString("two_step_nonce_webauthn");
             parsed.two_step_notification_sent = data.optString("two_step_notification_sent");
             parsed.user_id = data.optString("user_id");
             parsed.username = data.optString("username");

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/account/AccountSocialResponse.java
@@ -11,6 +11,7 @@ public class AccountSocialResponse implements Response {
     public String two_step_nonce_authenticator;
     public String two_step_nonce_backup;
     public String two_step_nonce_sms;
+    public String two_step_nonce_webauthn;
     public String two_step_notification_sent;
     public String user_id;
     public String username;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -255,32 +255,24 @@ public class Authenticator {
         private static final String TWO_STEP_BACKUP_NONCE = "two_step_nonce_backup";
         private static final String TWO_STEP_AUTHENTICATOR_NONCE = "two_step_nonce_authenticator";
         private static final String TWO_STEP_PUSH_NONCE = "two_step_nonce_push";
-        private final String mUserId;
-        private final String mWebauthnNonce;
-        private final String mBackupNonce;
-        private final String authenticatorNonce;
-        private final String pushNonce;
+        public final String mUserId;
+        public final String mWebauthnNonce;
+        public final String mBackupNonce;
+        public final String mAuthenticatorNonce;
+        public final String mPushNonce;
 
         public WebauthnResponse(JSONObject data) throws JSONException {
             mUserId = data.getString(USER_ID);
             mWebauthnNonce = data.getString(TWO_STEP_WEBAUTHN_NONCE);
             mBackupNonce = data.getString(TWO_STEP_BACKUP_NONCE);
-            authenticatorNonce = data.getString(TWO_STEP_AUTHENTICATOR_NONCE);
-            pushNonce = data.getString(TWO_STEP_PUSH_NONCE);
-        }
-
-        public String getUserId() {
-            return mUserId;
-        }
-
-        public String getWebauthnNonce() {
-            return mWebauthnNonce;
+            mAuthenticatorNonce = data.getString(TWO_STEP_AUTHENTICATOR_NONCE);
+            mPushNonce = data.getString(TWO_STEP_PUSH_NONCE);
         }
 
         public boolean isSocialLogin() {
             return notNullOrEmpty(mBackupNonce)
-                   || notNullOrEmpty(authenticatorNonce)
-                   || notNullOrEmpty(pushNonce);
+                   || notNullOrEmpty(mAuthenticatorNonce)
+                   || notNullOrEmpty(mPushNonce);
         }
 
         private boolean notNullOrEmpty(String field) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -270,6 +270,16 @@ public class Authenticator {
         public String getWebauthnNonce() {
             return mWebauthnNonce;
         }
+
+        public boolean isSocialLogin() {
+            return notNullOrEmpty(mBackupNonce)
+                   || notNullOrEmpty(authenticatorNonce)
+                   || notNullOrEmpty(pushNonce);
+        }
+
+        private boolean notNullOrEmpty(String field) {
+            return field != null && !field.isEmpty();
+        }
     }
 
     public void sendAuthEmail(final AuthEmailPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -252,15 +252,21 @@ public class Authenticator {
     public static class WebauthnResponse implements OauthResponse {
         private static final String USER_ID = "user_id";
         private static final String TWO_STEP_WEBAUTHN_NONCE = "two_step_nonce_webauthn";
-        private String mUserId;
-        private String mWebauthnNonce;
-        private String mBackupNonce;
-        private String authenticatorNonce;
-        private String pushNonce;
+        private static final String TWO_STEP_BACKUP_NONCE = "two_step_nonce_backup";
+        private static final String TWO_STEP_AUTHENTICATOR_NONCE = "two_step_nonce_authenticator";
+        private static final String TWO_STEP_PUSH_NONCE = "two_step_nonce_push";
+        private final String mUserId;
+        private final String mWebauthnNonce;
+        private final String mBackupNonce;
+        private final String authenticatorNonce;
+        private final String pushNonce;
 
         public WebauthnResponse(JSONObject data) throws JSONException {
             mUserId = data.getString(USER_ID);
             mWebauthnNonce = data.getString(TWO_STEP_WEBAUTHN_NONCE);
+            mBackupNonce = data.getString(TWO_STEP_BACKUP_NONCE);
+            authenticatorNonce = data.getString(TWO_STEP_AUTHENTICATOR_NONCE);
+            pushNonce = data.getString(TWO_STEP_PUSH_NONCE);
         }
 
         public String getUserId() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -253,11 +253,14 @@ public class Authenticator {
         private static final String USER_ID = "user_id";
         private static final String TWO_STEP_WEBAUTHN_NONCE = "two_step_nonce_webauthn";
         private String mUserId;
-        private String mTwoStepWebauthnNonce;
+        private String mWebauthnNonce;
+        private String mBackupNonce;
+        private String authenticatorNonce;
+        private String pushNonce;
 
         public WebauthnResponse(JSONObject data) throws JSONException {
             mUserId = data.getString(USER_ID);
-            mTwoStepWebauthnNonce = data.getString(TWO_STEP_WEBAUTHN_NONCE);
+            mWebauthnNonce = data.getString(TWO_STEP_WEBAUTHN_NONCE);
         }
 
         public String getUserId() {
@@ -265,7 +268,7 @@ public class Authenticator {
         }
 
         public String getWebauthnNonce() {
-            return mTwoStepWebauthnNonce;
+            return mWebauthnNonce;
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -428,6 +428,7 @@ public class AccountStore extends Store {
         public String nonceAuthenticator;
         public String nonceBackup;
         public String nonceSms;
+        public String nonceWebauthn;
         public String notificationSent;
         public String phoneNumber;
         public String userId;
@@ -442,6 +443,7 @@ public class AccountStore extends Store {
             this.nonceAuthenticator = payload.twoStepNonceAuthenticator;
             this.nonceBackup = payload.twoStepNonceBackup;
             this.nonceSms = payload.twoStepNonceSms;
+            this.nonceWebauthn = payload.twoStepNonceWebauthn;
             this.notificationSent = payload.twoStepNotificationSent;
             this.phoneNumber = payload.phoneNumber;
             this.userId = payload.userId;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -454,12 +454,18 @@ public class AccountStore extends Store {
     }
 
     public static class OnSecurityKeyAuthStarted extends OnChanged<AuthenticationError> {
-        public String userId;
-        public String webauthnNonce;
+        public final String userId;
+        public final String webauthnNonce;
+        public final String mBackupNonce;
+        public final String authenticatorNonce;
+        public final String pushNonce;
 
-        public OnSecurityKeyAuthStarted(String userId, String webauthnNonce) {
-            this.userId = userId;
-            this.webauthnNonce = webauthnNonce;
+        public OnSecurityKeyAuthStarted(WebauthnResponse response) {
+            userId = response.mUserId;
+            webauthnNonce = response.mWebauthnNonce;
+            mBackupNonce = response.mBackupNonce;
+            authenticatorNonce = response.mAuthenticatorNonce;
+            pushNonce = response.mPushNonce;
         }
     }
 
@@ -1351,9 +1357,7 @@ public class AccountStore extends Store {
             }
             emitChange(new OnAuthenticationChanged());
         } else if (response instanceof WebauthnResponse) {
-            WebauthnResponse webauthnResponse = (WebauthnResponse) response;
-            OnSecurityKeyAuthStarted event = new OnSecurityKeyAuthStarted(webauthnResponse.getUserId(),
-                    webauthnResponse.getWebauthnNonce());
+            OnSecurityKeyAuthStarted event = new OnSecurityKeyAuthStarted((WebauthnResponse) response);
             if (payload.nextAction != null) {
                 mDispatcher.dispatch(payload.nextAction);
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -459,6 +459,7 @@ public class AccountStore extends Store {
         public final String mBackupNonce;
         public final String authenticatorNonce;
         public final String pushNonce;
+        public final boolean isSocialLogin;
 
         public OnSecurityKeyAuthStarted(WebauthnResponse response) {
             userId = response.mUserId;
@@ -466,6 +467,7 @@ public class AccountStore extends Store {
             mBackupNonce = response.mBackupNonce;
             authenticatorNonce = response.mAuthenticatorNonce;
             pushNonce = response.mPushNonce;
+            isSocialLogin = response.isSocialLogin();
         }
     }
 


### PR DESCRIPTION
Summary
==========
Following the previous changes introduced in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2874, this PR simply adds the `webauthn` nonce to the Social login payload to be used in the WPLogin library. The objective is to add Security Key authentication support for Social logins (a.k.a Login with Google)

How to Test
==========
1. This is best tested alongside the WPLogin PR in your client app.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.