### PR TITLE
Set a default value of false for is_single_user_site

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -259,7 +259,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column
     private Boolean mWasEcommerceTrial;
     @Column
-    private Boolean mIsSingleUserSite;
+    private boolean mIsSingleUserSite;
 
     @Override
     public int getId() {
@@ -1114,11 +1114,11 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         this.mPlanActiveFeatures = planActiveFeatures;
     }
 
-    public Boolean isSingleUserSite() {
+    public boolean isSingleUserSite() {
         return mIsSingleUserSite;
     }
 
-    public void setIsSingleUserSite(Boolean isSingleUserSite) {
+    public void setIsSingleUserSite(boolean isSingleUserSite) {
         mIsSingleUserSite = isSingleUserSite;
     }
 }


### PR DESCRIPTION
This PR is an attempt to figure out why accessing `site.isSingleUserSite` returns a null. This may not be the reason why, but the only thing I can think of is that old data in the DB is left as null or the `Boolean` wrapper in SiteModel can have three values: true, false, or null.

Also gson will set boolean as false if the field is not in the response or if the field in the response is null. 🤷 


wdyt?