### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to `Theme` Model Classes (`breaking`)

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -188,8 +188,10 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         // Get the theme from store to make sure the "active" state is correct, so we can deactivate it before deletion
         ThemeModel themeToDelete = mThemeStore.getInstalledThemeByThemeId(jetpackSite, EDIN_THEME_ID);
-        // if Edin is active update site's active theme to something else and delete Edin
-        deactivateAndDeleteTheme(jetpackSite, themeToDelete);
+        if (themeToDelete != null) {
+            // if Edin is active update site's active theme to something else and delete Edin
+            deactivateAndDeleteTheme(jetpackSite, themeToDelete);
+        }
 
         signOutWPCom();
     }
@@ -426,7 +428,9 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
             activateTheme(jetpackSite, otherThemeToActivate);
 
             // Make sure another theme is activated
-            assertNotEquals(theme.getThemeId(), mThemeStore.getActiveThemeForSite(jetpackSite).getThemeId());
+            ThemeModel activeTheme = mThemeStore.getActiveThemeForSite(jetpackSite);
+            assertNotNull(activeTheme);
+            assertNotEquals(theme.getThemeId(), activeTheme.getThemeId());
         }
         // delete existing theme from site
         deleteTheme(jetpackSite, theme);

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -156,7 +156,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
         }
 
         // install the theme
-        ThemeModel themeToInstall = new ThemeModel();
+        @SuppressWarnings("deprecation") ThemeModel themeToInstall = new ThemeModel();
         themeToInstall.setThemeId(themeId);
         installTheme(jetpackSite, themeToInstall);
         assertTrue(isThemeInstalled(jetpackSite, themeId));
@@ -178,7 +178,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
 
         // Install edin if necessary before attempting to delete
         if (!isThemeInstalled(jetpackSite, themeId)) {
-            ThemeModel themeToInstall = new ThemeModel();
+            @SuppressWarnings("deprecation") ThemeModel themeToInstall = new ThemeModel();
             themeToInstall.setThemeId(themeId);
             installTheme(jetpackSite, themeToInstall);
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -80,7 +80,7 @@ class ThemeFragment : Fragment() {
                 if (site == null) {
                     prependToLog("No WP.com site found, unable to test.")
                 } else {
-                    val theme = ThemeModel()
+                    @Suppress("DEPRECATION") val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
                     val payload = ThemeStore.SiteThemePayload(site, theme)
@@ -98,7 +98,7 @@ class ThemeFragment : Fragment() {
                 if (site == null) {
                     prependToLog("No Jetpack connected site found, unable to test.")
                 } else {
-                    val theme = ThemeModel()
+                    @Suppress("DEPRECATION") val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
                     val payload = ThemeStore.SiteThemePayload(site, theme)
@@ -116,7 +116,7 @@ class ThemeFragment : Fragment() {
                 if (site == null) {
                     prependToLog("No Jetpack connected site found, unable to test.")
                 } else {
-                    val theme = ThemeModel()
+                    @Suppress("DEPRECATION") val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
                     val payload = ThemeStore.SiteThemePayload(site, theme)
@@ -134,7 +134,7 @@ class ThemeFragment : Fragment() {
                 if (site == null) {
                     prependToLog("No Jetpack connected site found, unable to test.")
                 } else {
-                    val theme = ThemeModel()
+                    @Suppress("DEPRECATION") val theme = ThemeModel()
                     theme.localSiteId = site.id
                     theme.themeId = id
                     val payload = ThemeStore.SiteThemePayload(site, theme)

--- a/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/theme/ThemeStoreUnitTest.java
@@ -169,7 +169,7 @@ public class ThemeStoreUnitTest {
     }
 
     private ThemeModel generateTestTheme(int siteId, String themeId, String themeName) {
-        ThemeModel theme = new ThemeModel();
+        @SuppressWarnings("deprecation") ThemeModel theme = new ThemeModel();
         theme.setLocalSiteId(siteId);
         theme.setThemeId(themeId);
         theme.setName(themeName);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.model;
 
+import androidx.annotation.Nullable;
+
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.annotation.Column;
 import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
@@ -49,7 +51,7 @@ public class ThemeModel implements Identifiable, Serializable {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public boolean equals(@Nullable Object other) {
         if (other == null || !(other instanceof ThemeModel)) {
             return false;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.model;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.yarolegovich.wellsql.core.Identifiable;
@@ -12,27 +13,28 @@ import org.wordpress.android.util.StringUtils;
 import java.io.Serializable;
 
 @Table
+@SuppressWarnings("NotNullFieldNotInitialized")
 public class ThemeModel implements Identifiable, Serializable {
     private static final long serialVersionUID = 5966516212440517166L;
 
     @PrimaryKey @Column private int mId;
 
     @Column private int mLocalSiteId;
-    @Column private String mThemeId;
-    @Column private String mName;
-    @Column private String mDescription;
-    @Column private String mSlug;
-    @Column private String mVersion;
-    @Column private String mAuthorName;
-    @Column private String mAuthorUrl;
-    @Column private String mThemeUrl;
-    @Column private String mScreenshotUrl;
-    @Column private String mDemoUrl;
-    @Column private String mDownloadUrl;
-    @Column private String mStylesheet;
-    @Column private String mPriceText;
+    @NonNull @Column private String mThemeId;
+    @NonNull @Column private String mName;
+    @NonNull @Column private String mDescription;
+    @Nullable @Column private String mSlug;
+    @Nullable @Column private String mVersion;
+    @Nullable @Column private String mAuthorName;
+    @Nullable @Column private String mAuthorUrl;
+    @Nullable @Column private String mThemeUrl;
+    @NonNull @Column private String mScreenshotUrl;
+    @Nullable @Column private String mDemoUrl;
+    @Nullable @Column private String mDownloadUrl;
+    @Nullable @Column private String mStylesheet;
+    @Nullable @Column private String mPriceText;
     @Column private boolean mFree = true;
-    @Column private String mMobileFriendlyCategorySlug;
+    @Nullable @Column private String mMobileFriendlyCategorySlug;
     @Column private boolean mActive;
     @Column private boolean mAutoUpdate;
     @Column private boolean mAutoUpdateTranslation;
@@ -88,107 +90,120 @@ public class ThemeModel implements Identifiable, Serializable {
         this.mLocalSiteId = localSiteId;
     }
 
+    @NonNull
     public String getThemeId() {
         return mThemeId;
     }
 
-    public void setThemeId(String themeId) {
+    public void setThemeId(@NonNull String themeId) {
         mThemeId = themeId;
     }
 
+    @NonNull
     public String getName() {
         return mName;
     }
 
-    public void setName(String name) {
+    public void setName(@NonNull String name) {
         mName = name;
     }
 
+    @NonNull
     public String getDescription() {
         return mDescription;
     }
 
-    public void setDescription(String description) {
+    public void setDescription(@NonNull String description) {
         mDescription = description;
     }
 
+    @Nullable
     public String getSlug() {
         return mSlug;
     }
 
-    public void setSlug(String slug) {
+    public void setSlug(@Nullable String slug) {
         mSlug = slug;
     }
 
+    @Nullable
     public String getVersion() {
         return mVersion;
     }
 
-    public void setVersion(String version) {
+    public void setVersion(@Nullable String version) {
         mVersion = version;
     }
 
+    @Nullable
     public String getAuthorName() {
         return mAuthorName;
     }
 
-    public void setAuthorName(String authorName) {
+    public void setAuthorName(@Nullable String authorName) {
         mAuthorName = authorName;
     }
 
+    @Nullable
     public String getAuthorUrl() {
         return mAuthorUrl;
     }
 
-    public void setAuthorUrl(String authorUrl) {
+    public void setAuthorUrl(@Nullable String authorUrl) {
         mAuthorUrl = authorUrl;
     }
 
+    @Nullable
     public String getThemeUrl() {
         return mThemeUrl;
     }
 
-    public void setThemeUrl(String themeUrl) {
+    public void setThemeUrl(@Nullable String themeUrl) {
         mThemeUrl = themeUrl;
     }
 
+    @NonNull
     public String getScreenshotUrl() {
         return mScreenshotUrl;
     }
 
-    public void setScreenshotUrl(String screenshotUrl) {
+    public void setScreenshotUrl(@NonNull String screenshotUrl) {
         mScreenshotUrl = screenshotUrl;
     }
 
+    @Nullable
     public String getDemoUrl() {
         return mDemoUrl;
     }
 
-    public void setDemoUrl(String demoUrl) {
+    public void setDemoUrl(@Nullable String demoUrl) {
         mDemoUrl = demoUrl;
     }
 
+    @Nullable
     public String getDownloadUrl() {
         return mDownloadUrl;
     }
 
-    public void setDownloadUrl(String downloadUrl) {
+    public void setDownloadUrl(@Nullable String downloadUrl) {
         mDownloadUrl = downloadUrl;
     }
 
+    @Nullable
     public String getStylesheet() {
         return mStylesheet;
     }
 
-    public void setStylesheet(String stylesheet) {
+    public void setStylesheet(@Nullable String stylesheet) {
         mStylesheet = stylesheet;
     }
 
+    @Nullable
     public String getPriceText() {
         return mPriceText;
     }
 
-    public void setPriceText(String priceText) {
+    public void setPriceText(@Nullable String priceText) {
         mPriceText = priceText;
     }
 
@@ -196,11 +211,12 @@ public class ThemeModel implements Identifiable, Serializable {
         return mFree;
     }
 
+    @Nullable
     public String getMobileFriendlyCategorySlug() {
         return mMobileFriendlyCategorySlug;
     }
 
-    public void setMobileFriendlyCategorySlug(String mobileFriendlyCategorySlug) {
+    public void setMobileFriendlyCategorySlug(@Nullable String mobileFriendlyCategorySlug) {
         mMobileFriendlyCategorySlug = mobileFriendlyCategorySlug;
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -13,7 +13,6 @@ import org.wordpress.android.util.StringUtils;
 import java.io.Serializable;
 
 @Table
-@SuppressWarnings("NotNullFieldNotInitialized")
 public class ThemeModel implements Identifiable, Serializable {
     private static final long serialVersionUID = 5966516212440517166L;
 
@@ -33,7 +32,7 @@ public class ThemeModel implements Identifiable, Serializable {
     @Nullable @Column private String mDownloadUrl;
     @Nullable @Column private String mStylesheet;
     @Nullable @Column private String mPriceText;
-    @Column private boolean mFree = true;
+    @Column private boolean mFree;
     @Nullable @Column private String mMobileFriendlyCategorySlug;
     @Column private boolean mActive;
     @Column private boolean mAutoUpdate;
@@ -41,6 +40,96 @@ public class ThemeModel implements Identifiable, Serializable {
 
     // local use only
     @Column private boolean mIsWpComTheme;
+
+    @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    public ThemeModel() {
+        this.mId = 0;
+        this.mLocalSiteId = 0;
+        this.mThemeId = "";
+        this.mName = "";
+        this.mDescription = "";
+        this.mSlug = null;
+        this.mVersion = null;
+        this.mAuthorName = null;
+        this.mAuthorUrl = null;
+        this.mThemeUrl = null;
+        this.mScreenshotUrl = "";
+        this.mDemoUrl = null;
+        this.mDownloadUrl = null;
+        this.mStylesheet = null;
+        this.mPriceText = null;
+        this.mFree = true;
+        this.mMobileFriendlyCategorySlug = null;
+        this.mActive = false;
+        this.mAutoUpdate = false;
+        this.mAutoUpdateTranslation = false;
+        this.mIsWpComTheme = false;
+    }
+
+    /**
+     * Use when creating a WP.com theme.
+     */
+    public ThemeModel(
+            @NonNull String themeId,
+            @NonNull String name,
+            @NonNull String description,
+            @Nullable String slug,
+            @Nullable String version,
+            @Nullable String authorName,
+            @Nullable String authorUrl,
+            @Nullable String themeUrl,
+            @NonNull String screenshotUrl,
+            @Nullable String demoUrl,
+            @Nullable String downloadUrl,
+            @Nullable String stylesheet,
+            @Nullable String priceText,
+            boolean free,
+            @Nullable String mobileFriendlyCategorySlug) {
+        this.mThemeId = themeId;
+        this.mName = name;
+        this.mDescription = description;
+        this.mSlug = slug;
+        this.mVersion = version;
+        this.mAuthorName = authorName;
+        this.mAuthorUrl = authorUrl;
+        this.mThemeUrl = themeUrl;
+        this.mScreenshotUrl = screenshotUrl;
+        this.mDemoUrl = demoUrl;
+        this.mDownloadUrl = downloadUrl;
+        this.mStylesheet = stylesheet;
+        this.mPriceText = priceText;
+        this.mFree = free;
+        this.mMobileFriendlyCategorySlug = mobileFriendlyCategorySlug;
+    }
+
+    /**
+     * Use when creating a Jetpack theme.
+     */
+    public ThemeModel(
+            @NonNull String themeId,
+            @NonNull String name,
+            @NonNull String description,
+            @Nullable String version,
+            @Nullable String authorName,
+            @Nullable String authorUrl,
+            @Nullable String themeUrl,
+            @NonNull String screenshotUrl,
+            boolean active,
+            boolean autoUpdate,
+            boolean autoUpdateTranslation) {
+        this.mThemeId = themeId;
+        this.mName = name;
+        this.mDescription = description;
+        this.mVersion = version;
+        this.mAuthorName = authorName;
+        this.mAuthorUrl = authorUrl;
+        this.mThemeUrl = themeUrl;
+        this.mScreenshotUrl = screenshotUrl;
+        this.mActive = active;
+        this.mAutoUpdate = autoUpdate;
+        this.mAutoUpdateTranslation = autoUpdateTranslation;
+    }
 
     @Override
     public int getId() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -51,6 +51,7 @@ public class ThemeModel implements Identifiable, Serializable {
     }
 
     @Override
+    @SuppressWarnings("ConditionCoveredByFurtherCondition")
     public boolean equals(@Nullable Object other) {
         if (other == null || !(other instanceof ThemeModel)) {
             return false;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java
@@ -56,6 +56,7 @@ public class ThemeModel implements Identifiable, Serializable {
         this.mAuthorName = null;
         this.mAuthorUrl = null;
         this.mThemeUrl = null;
+        this.mThemeType = null;
         this.mScreenshotUrl = "";
         this.mDemoUrl = null;
         this.mDownloadUrl = null;
@@ -66,6 +67,7 @@ public class ThemeModel implements Identifiable, Serializable {
         this.mActive = false;
         this.mAutoUpdate = false;
         this.mAutoUpdateTranslation = false;
+        this.mIsExternalTheme = false;
         this.mIsWpComTheme = false;
     }
 
@@ -81,11 +83,13 @@ public class ThemeModel implements Identifiable, Serializable {
             @Nullable String authorName,
             @Nullable String authorUrl,
             @Nullable String themeUrl,
+            @Nullable String themeType,
             @NonNull String screenshotUrl,
             @Nullable String demoUrl,
             @Nullable String downloadUrl,
             @Nullable String stylesheet,
             @Nullable String priceText,
+            boolean isExternalTheme,
             boolean free,
             @Nullable String mobileFriendlyCategorySlug) {
         this.mThemeId = themeId;
@@ -96,11 +100,13 @@ public class ThemeModel implements Identifiable, Serializable {
         this.mAuthorName = authorName;
         this.mAuthorUrl = authorUrl;
         this.mThemeUrl = themeUrl;
+        this.mThemeType = themeType;
         this.mScreenshotUrl = screenshotUrl;
         this.mDemoUrl = demoUrl;
         this.mDownloadUrl = downloadUrl;
         this.mStylesheet = stylesheet;
         this.mPriceText = priceText;
+        this.mIsExternalTheme = isExternalTheme;
         this.mFree = free;
         this.mMobileFriendlyCategorySlug = mobileFriendlyCategorySlug;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -187,7 +187,7 @@ private fun BaseNetworkError.toWPAPINetworkError(): WPAPINetworkError {
         is WPAPINetworkError -> this
         is WPComGsonNetworkError -> WPAPINetworkError(
             baseError = this,
-            errorCode = this.apiError.orEmpty()
+            errorCode = this.apiError
         )
         else -> WPAPINetworkError(this)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -46,8 +46,8 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
     public static final String REST_AUTHORIZATION_FORMAT = "Bearer %s";
 
     public static class WPComGsonNetworkError extends BaseNetworkError {
-        public String apiError;
-        public WPComGsonNetworkError(BaseNetworkError error) {
+        @NonNull public String apiError;
+        public WPComGsonNetworkError(@NonNull BaseNetworkError error) {
             super(error);
             this.apiError = "";
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -318,9 +318,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
      */
     @NonNull
     private String getThemeIdWithWpComSuffix(@NonNull ThemeModel theme) {
-        if (theme.getThemeId() == null) {
-            return "";
-        } else if (theme.getThemeId().endsWith("-wpcom")) {
+        if (theme.getThemeId().endsWith("-wpcom")) {
             return theme.getThemeId();
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -137,8 +137,7 @@ public class ThemeRestClient extends BaseWPComRestClient {
                     mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
                 }, error -> {
                     AppLog.e(AppLog.T.API, "Received error response to WP.com themes fetch request.");
-                    ThemesError themeError = new ThemesError(
-                            error.apiError, error.message);
+                    ThemesError themeError = new ThemesError(error.apiError, error.message);
                     FetchedWpComThemesPayload payload = new FetchedWpComThemesPayload(themeError);
                     mDispatcher.dispatch(ThemeActionBuilder.newFetchedWpComThemesAction(payload));
                 }));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -234,7 +234,11 @@ public class ThemeRestClient extends BaseWPComRestClient {
         if (!free) {
             priceText = response.price;
         }
-        ThemeModel theme = new ThemeModel(
+        boolean isExternalTheme = false;
+        if (response.theme_type != null) {
+            isExternalTheme = response.theme_type.equals(THEME_TYPE_EXTERNAL);
+        }
+        return new ThemeModel(
                 response.id,
                 response.name,
                 response.description,
@@ -243,19 +247,16 @@ public class ThemeRestClient extends BaseWPComRestClient {
                 response.author,
                 response.author_uri,
                 response.theme_uri,
+                response.theme_type,
                 response.screenshot,
                 response.demo_uri,
                 response.download_uri,
                 response.stylesheet,
                 priceText,
+                isExternalTheme,
                 free,
                 getMobileFriendlyCategorySlug(response.taxonomies)
         );
-        theme.setThemeType(response.theme_type);
-        if (response.theme_type != null) {
-            theme.setIsExternalTheme(response.theme_type.equals(THEME_TYPE_EXTERNAL));
-        }
-        return theme;
     }
 
     @Nullable

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.persistence;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.wellsql.generated.ThemeModelTable;
 import com.yarolegovich.wellsql.WellSql;
@@ -78,6 +79,7 @@ public class ThemeSqlUtils {
         insertOrUpdateSiteTheme(site, theme);
     }
 
+    @NonNull
     public static List<ThemeModel> getActiveThemeForSite(@NonNull SiteModel site) {
         return WellSql.select(ThemeModel.class)
                 .where().beginGroup()
@@ -108,7 +110,8 @@ public class ThemeSqlUtils {
                 .endWhere().getAsModel();
     }
 
-    public static ThemeModel getWpComThemeByThemeId(String themeId) {
+    @Nullable
+    public static ThemeModel getWpComThemeByThemeId(@NonNull String themeId) {
         if (TextUtils.isEmpty(themeId)) {
             return null;
         }
@@ -126,8 +129,9 @@ public class ThemeSqlUtils {
         return matches.get(0);
     }
 
-    public static ThemeModel getSiteThemeByThemeId(SiteModel siteModel, String themeId) {
-        if (siteModel == null || TextUtils.isEmpty(themeId)) {
+    @Nullable
+    public static ThemeModel getSiteThemeByThemeId(@NonNull SiteModel siteModel, @NonNull String themeId) {
+        if (TextUtils.isEmpty(themeId)) {
             return null;
         }
         List<ThemeModel> matches = WellSql.select(ThemeModel.class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -96,7 +96,8 @@ public class ThemeSqlUtils {
                 .endWhere().getAsModel();
     }
 
-    public static List<ThemeModel> getWpComMobileFriendlyThemes(String categorySlug) {
+    @NonNull
+    public static List<ThemeModel> getWpComMobileFriendlyThemes(@NonNull String categorySlug) {
         return WellSql.select(ThemeModel.class)
                 .where()
                 .equals(ThemeModelTable.MOBILE_FRIENDLY_CATEGORY_SLUG, categorySlug)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -105,6 +105,7 @@ public class ThemeSqlUtils {
                 .endWhere().getAsModel();
     }
 
+    @NonNull
     public static List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {
         return WellSql.select(ThemeModel.class)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -88,6 +88,7 @@ public class ThemeSqlUtils {
                 .endGroup().endWhere().getAsModel();
     }
 
+    @NonNull
     public static List<ThemeModel> getWpComThemes() {
         return WellSql.select(ThemeModel.class)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -132,12 +132,11 @@ public class ThemeStore extends Store {
         UNKNOWN_THEME,
         MISSING_THEME;
 
-        public static ThemeErrorType fromString(String type) {
-            if (type != null) {
-                for (ThemeErrorType v : ThemeErrorType.values()) {
-                    if (type.equalsIgnoreCase(v.name())) {
-                        return v;
-                    }
+        @NonNull
+        public static ThemeErrorType fromString(@NonNull String type) {
+            for (ThemeErrorType v : ThemeErrorType.values()) {
+                if (type.equalsIgnoreCase(v.name())) {
+                    return v;
                 }
             }
             return GENERIC_ERROR;
@@ -146,15 +145,15 @@ public class ThemeStore extends Store {
 
     @SuppressWarnings("WeakerAccess")
     public static class ThemesError implements OnChangedError {
-        public ThemeErrorType type;
-        public String message;
+        @NonNull public ThemeErrorType type;
+        @Nullable public String message;
 
-        public ThemesError(String type, String message) {
+        public ThemesError(@NonNull String type, @Nullable String message) {
             this.type = ThemeErrorType.fromString(type);
             this.message = message;
         }
 
-        public ThemesError(ThemeErrorType type) {
+        public ThemesError(@NonNull ThemeErrorType type) {
             this.type = type;
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -321,6 +321,7 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getWpComMobileFriendlyThemes(categorySlug);
     }
 
+    @NonNull
     public List<ThemeModel> getThemesForSite(@NonNull SiteModel site) {
         return ThemeSqlUtils.getThemesForSite(site);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -324,21 +324,24 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getThemesForSite(site);
     }
 
-    public ThemeModel getInstalledThemeByThemeId(SiteModel siteModel, String themeId) {
-        if (themeId == null || themeId.isEmpty()) {
+    @Nullable
+    public ThemeModel getInstalledThemeByThemeId(@NonNull SiteModel siteModel, @NonNull String themeId) {
+        if (TextUtils.isEmpty(themeId)) {
             return null;
         }
         return ThemeSqlUtils.getSiteThemeByThemeId(siteModel, themeId);
     }
 
+    @Nullable
     @SuppressWarnings("WeakerAccess")
-    public ThemeModel getWpComThemeByThemeId(String themeId) {
+    public ThemeModel getWpComThemeByThemeId(@NonNull String themeId) {
         if (TextUtils.isEmpty(themeId)) {
             return null;
         }
         return ThemeSqlUtils.getWpComThemeByThemeId(themeId);
     }
 
+    @Nullable
     public ThemeModel getActiveThemeForSite(@NonNull SiteModel site) {
         List<ThemeModel> activeTheme = ThemeSqlUtils.getActiveThemeForSite(site);
         return activeTheme.isEmpty() ? null : activeTheme.get(0);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -186,10 +186,10 @@ public class ThemeStore extends Store {
 
     @SuppressWarnings("WeakerAccess")
     public static class OnThemeActivated extends OnChanged<ThemesError> {
-        public SiteModel site;
-        public ThemeModel theme;
+        @NonNull public SiteModel site;
+        @NonNull public ThemeModel theme;
 
-        public OnThemeActivated(SiteModel site, ThemeModel theme) {
+        public OnThemeActivated(@NonNull SiteModel site, @NonNull ThemeModel theme) {
             this.site = site;
             this.theme = theme;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -316,7 +316,8 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getWpComThemes();
     }
 
-    public List<ThemeModel> getWpComMobileFriendlyThemes(String categorySlug) {
+    @NonNull
+    public List<ThemeModel> getWpComMobileFriendlyThemes(@NonNull String categorySlug) {
         return ThemeSqlUtils.getWpComMobileFriendlyThemes(categorySlug);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -219,10 +219,10 @@ public class ThemeStore extends Store {
 
     @SuppressWarnings("WeakerAccess")
     public static class OnThemeInstalled extends OnChanged<ThemesError> {
-        public SiteModel site;
-        public ThemeModel theme;
+        @NonNull public SiteModel site;
+        @NonNull public ThemeModel theme;
 
-        public OnThemeInstalled(SiteModel site, ThemeModel theme) {
+        public OnThemeInstalled(@NonNull SiteModel site, @NonNull ThemeModel theme) {
             this.site = site;
             this.theme = theme;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -208,10 +208,10 @@ public class ThemeStore extends Store {
 
     @SuppressWarnings("WeakerAccess")
     public static class OnThemeDeleted extends OnChanged<ThemesError> {
-        public SiteModel site;
-        public ThemeModel theme;
+        @NonNull public SiteModel site;
+        @NonNull public ThemeModel theme;
 
-        public OnThemeDeleted(SiteModel site, ThemeModel theme) {
+        public OnThemeDeleted(@NonNull SiteModel site, @NonNull ThemeModel theme) {
             this.site = site;
             this.theme = theme;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -311,6 +311,7 @@ public class ThemeStore extends Store {
         AppLog.d(AppLog.T.API, "ThemeStore onRegister");
     }
 
+    @NonNull
     public List<ThemeModel> getWpComThemes() {
         return ThemeSqlUtils.getWpComThemes();
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -197,8 +197,8 @@ public class ThemeStore extends Store {
 
     @SuppressWarnings("WeakerAccess")
     public static class OnThemeRemoved extends OnChanged<ThemesError> {
-        public SiteModel site;
-        public ThemeModel theme;
+        @NonNull public SiteModel site;
+        @NonNull public ThemeModel theme;
 
         public OnThemeRemoved(@NonNull SiteModel site, @NonNull ThemeModel theme) {
             this.site = site;


### PR DESCRIPTION
Parent #2799
Closes #2840

This PR adds any missing nullability annotation to [ThemeModel.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7ea7465680431fa4df5f0433d4c8b8395055b997/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java#L4) model and all related store & sql-util classes.

FYI: This change is `breaking`, meaning that any client that depended on the [ThemeModel.java](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7ea7465680431fa4df5f0433d4c8b8395055b997/fluxc/src/main/java/org/wordpress/android/fluxc/model/ThemeModel.java#L4) model should update to the new APIs (`non-default constructors`) as the existing API (`default constructor`) are now deprecated. As such, this change is inherently `risky`, meaning that there are compile-time changes associated with this change and thus needs testing to verify correctness, both on the library's and client's side.

PS: Any other changes on any other class are just some propagating missing nullability annotation changes, which stem from the main set of classes being updated, this PR's focus, plus, some other extra minor analysis, refactor and test related changes.

-----

PS: @antonis I added you as the main reviewer, not so randomly (it being a continuation of #2893), since I just wanted someone from the Jetpack/WordPress mobile team to be aware of and sign-off on that change. Feel free to merge this PR directly yourself if you deem so.

-----

Nullability Annotations List (`Model`):

1. [Add missing nl-a to equals parameter on theme model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/2f9c0e66e04f544cd56daa4303139acc457edd93)
2. [Add missing n-a to theme model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/f4f622d0254de8542e5b794699b16b8c8cd1eccb)
3. [Add default and non-default constructors for theme model](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/a02a96917b92385499cf3b4bf26fcfc2e1c4eb7b)

Nullability Annotations List (`Store`):

1. [Add missing n-a to themes error on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/27d46f8b4d301cd4f8e2b54355efc4df20660945)
2. [Add missing n-a to on theme activated on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/67bf8c37f571f26ea09414b980a28d6917fc7f68)
3. [Add missing n-a to on theme removed on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/0c52f8ab71cff6512a5f50297a6275784fa18c44)
4. [Add missing n-a to on theme deleted on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/d329bd1b431229e37dbae1d9a8e013863b98779e)
5. [Add missing n-a to on theme installed on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/a51329c03da5953a608f43d1c053f49e63ad9ec6)
6. [Add missing n-a to get wp com themes on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/7334e98c3198277c5604366c0e35c3b4eceaed58)
7. [Add missing n-a to get wp com mobile fr. themes on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/9001e951fc71627a1607d2b26fcc04e8d30f25c9)
8. [Add missing n-a to get themes for site on theme store](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/1dfeb902f2ce54b7fa376829919fae29e53ef4d4)

Warnings Suppression List:

1. [Suppress condition covered by further condition warning](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897/commits/9dadc580157c249ab2121e6ce59693d7b4828986)

-----

## Associated Clients

It is highly recommending that this change is being tested on the below associated clients:

- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android)

-----

## To Test (`REST`):

- Smoke test the `FluxC Example` app via the `THEME` screen. Verify everything is working as expected.
- In addition to the above, using [local-builds.gradle](https://github.com/wordpress-mobile/WordPress-Android/blob/44a6d0611175f132ff6920b4d6a3e16d565259b6/local-builds.gradle-example#L18) on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android), smoke test any theme related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected. For a couple of examples, you can expand and follow the inner and more explicit test steps within:

## To Test (`XMLRPC`):

N/A

<details>
    <summary>1. [JP/WP] Themes Screen [ThemeBrowserActivity.java + ThemeBrowserFragment.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` apps.

- Go to `Themes` screen, verify it is shown and functioning as expected.
- For example try scrolling up-and-down and searching for a theme.
- Check your current theme and tap on the `Customize`, `Details` and `Support` buttons. Verify that everything works as expected.
- From the themes list, find your current theme on top, click on its menu items and again tap on the `Customize`, `Details` and `Support` buttons. Verify that everything works as expected.
- From the themes list, find another theme, other than your current one, click on its menu items and again tap on the `Details` and `Support` buttons. Verify that everything works as expected.
- Then, tap on the `View` and `Try & Customize` buttons. Verify that everything works as expected.
- Finally, tap on `Activate` button. Verify that the selected theme is activated and that everything works as expected.

</details>

<details>
    <summary>2. [JP] Site Creation Screens [SiteCreationActivity.kt + HomePagePickerFragment.kt + DesignPreviewFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app only.

- From `Choose Site`, tap on the `+` button on top and via the `Create WordPress.com site`, go to `Site Creation` screen, verify it is shown and functioning as expected.
- For example, while on the `What's your website about?` screen, select a topic from the list of topics (ie. `Food`).
- Then, while on the `Choose a theme` screen, select a theme from the list of themes (per category, ie `About`).
- Finally, verify that the `Preview` screen is shown and functioning as expected.

</details>

-----

## Merge instructions:

1. [x] Wait for the accompanying [JP/WPAndroid#19583](https://github.com/wordpress-mobile/WordPress-Android/pull/19583) to be reviewed and approved.
2. [x] Remove the `[PR] Not Ready for Merge` label.
3. [x] Merge this PR.
4. [x] Follow-up with the merge instructions on the accompanying [JP/WPAndroid#19583](https://github.com/wordpress-mobile/WordPress-Android/pull/19583) client PR.