### PR TITLE
[Passkey] Support Webauthn login steps

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/AuthenticationAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/AuthenticationAction.java
@@ -6,8 +6,10 @@ import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder.DiscoveryResultPayload;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.AuthEmailResponsePayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayload;
+import org.wordpress.android.fluxc.store.AccountStore.StartWebauthnChallengePayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticateErrorPayload;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
+import org.wordpress.android.fluxc.store.AccountStore.FinishWebauthnChallengePayload;
 
 @ActionEnum
 public enum AuthenticationAction implements IAction {
@@ -25,5 +27,10 @@ public enum AuthenticationAction implements IAction {
     @Action(payloadType = DiscoveryResultPayload.class)
     DISCOVERY_RESULT,
     @Action(payloadType = AuthEmailResponsePayload.class)
-    SENT_AUTH_EMAIL
+    SENT_AUTH_EMAIL,
+    @Action(payloadType = StartWebauthnChallengePayload.class)
+    START_SECURITY_KEY_CHALLENGE,
+
+    @Action(payloadType = FinishWebauthnChallengePayload.class)
+    FINISH_SECURITY_KEY_CHALLENGE
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/BaseWebauthnRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/BaseWebauthnRequest.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn
+
+import com.android.volley.NetworkResponse
+import com.android.volley.ParseError
+import com.android.volley.Request
+import com.android.volley.Response
+import com.android.volley.Response.ErrorListener
+import com.android.volley.toolbox.HttpHeaderParser
+import com.google.gson.Gson
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.UnsupportedEncodingException
+
+abstract class BaseWebauthnRequest<T>(
+    url: String,
+    errorListener: ErrorListener,
+    private val listener: Response.Listener<T>
+) : Request<T>(Method.POST, url, errorListener) {
+    abstract val parameters: Map<String, String>
+    abstract fun serializeResponse(response: String): T
+
+    internal val gson by lazy { Gson() }
+
+    private fun NetworkResponse?.extractResult(): Response<T> {
+        if (this == null) {
+            val error = WebauthnChallengeRequestException("Webauthn challenge response is null")
+            return Response.error(ParseError(error))
+        }
+
+        return try {
+            val headers = HttpHeaderParser.parseCacheHeaders(this)
+            val charsetName = HttpHeaderParser.parseCharset(this.headers)
+            String(this.data, charset(charsetName))
+                .let { JSONObject(it).getJSONObject(WEBAUTHN_DATA) }
+                .let { serializeResponse(it.toString()) }
+                .let { Response.success(it, headers) }
+        }
+        catch (exception: UnsupportedEncodingException) { Response.error(ParseError(exception)) }
+        catch (exception: JSONException) { Response.error(ParseError(exception)) }
+    }
+
+    override fun getParams() = parameters
+    override fun deliverResponse(response: T) = listener.onResponse(response)
+    override fun parseNetworkResponse(response: NetworkResponse?) = response.extractResult()
+
+    internal enum class WebauthnRequestParameters(val value: String) {
+        USER_ID("user_id"),
+        AUTH_TYPE("auth_type"),
+        TWO_STEP_NONCE("two_step_nonce"),
+        CLIENT_ID("client_id"),
+        CLIENT_SECRET("client_secret"),
+        CLIENT_DATA("client_data"),
+        GET_BEARER_TOKEN("get_bearer_token"),
+        CREATE_2FA_COOKIES_ONLY("create_2fa_cookies_only")
+    }
+
+    class WebauthnChallengeRequestException(message: String): Exception(message)
+
+    companion object {
+        private const val baseWPLoginUrl = "https://wordpress.com/wp-login.php?action"
+        private const val challengeEndpoint = "webauthn-challenge-endpoint"
+        private const val authEndpoint = "webauthn-authentication-endpoint"
+        private const val WEBAUTHN_DATA = "data"
+
+        internal const val webauthnChallengeEndpointUrl = "$baseWPLoginUrl=$challengeEndpoint"
+        internal const val webauthnAuthEndpointUrl = "$baseWPLoginUrl=$authEndpoint"
+        internal const val WEBAUTHN_AUTH_TYPE = "webauthn"
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/VolleyWebauthnRequests.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/VolleyWebauthnRequests.kt
@@ -1,0 +1,57 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn
+
+import com.android.volley.Response
+import com.android.volley.Response.ErrorListener
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.AUTH_TYPE
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.CLIENT_DATA
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.CLIENT_ID
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.CLIENT_SECRET
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.CREATE_2FA_COOKIES_ONLY
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.GET_BEARER_TOKEN
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.TWO_STEP_NONCE
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.USER_ID
+
+class WebauthnChallengeRequest(
+    userId: String,
+    twoStepNonce: String,
+    clientId: String,
+    clientSecret: String,
+    listener: Response.Listener<WebauthnChallengeInfo>,
+    errorListener: ErrorListener
+): BaseWebauthnRequest<WebauthnChallengeInfo>(webauthnChallengeEndpointUrl, errorListener, listener) {
+    override val parameters: Map<String, String> = mapOf(
+        CLIENT_ID.value to clientId,
+        CLIENT_SECRET.value to clientSecret,
+        USER_ID.value to userId,
+        AUTH_TYPE.value to WEBAUTHN_AUTH_TYPE,
+        TWO_STEP_NONCE.value to twoStepNonce
+    )
+
+    override fun serializeResponse(response: String): WebauthnChallengeInfo =
+        gson.fromJson(response, WebauthnChallengeInfo::class.java)
+}
+
+@SuppressWarnings("LongParameterList")
+class WebauthnTokenRequest(
+    userId: String,
+    twoStepNonce: String,
+    clientId: String,
+    clientSecret: String,
+    clientData: String,
+    listener: Response.Listener<WebauthnToken>,
+    errorListener: ErrorListener
+) : BaseWebauthnRequest<WebauthnToken>(webauthnAuthEndpointUrl, errorListener, listener) {
+    override val parameters = mapOf(
+        CLIENT_ID.value to clientId,
+        CLIENT_SECRET.value to clientSecret,
+        USER_ID.value to userId,
+        AUTH_TYPE.value to WEBAUTHN_AUTH_TYPE,
+        TWO_STEP_NONCE.value to twoStepNonce,
+        CLIENT_DATA.value to clientData,
+        GET_BEARER_TOKEN.value to "true",
+        CREATE_2FA_COOKIES_ONLY.value to "true"
+    )
+
+    override fun serializeResponse(response: String): WebauthnToken =
+        gson.fromJson(response, WebauthnToken::class.java)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/WebauthnModels.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/WebauthnModels.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn
+
+import com.google.gson.annotations.SerializedName
+
+class WebauthnChallengeInfo(
+    val challenge: String,
+    val rpId: String,
+    val allowCredentials: List<WebauthnCredentialResponse>,
+    val timeout: Int,
+    @SerializedName("two_step_nonce")
+    val twoStepNonce: String
+)
+
+class WebauthnCredentialResponse(
+    val type: String,
+    val id: String,
+    val transports: List<String>
+)
+
+class WebauthnToken(
+    @SerializedName("bearer_token")
+    val bearerToken: String
+)


### PR DESCRIPTION
This PR is an exact copy of the changes made by @ThomazFB  PR #2874.

In order to support passkey in WP/JP release/23.6, FluxC branch `release/2.53.1` was created off of tag `2.53.0`, as this was the tag supported in release/23.6.