### PR TITLE
Update Product rest client to sync metada values on product updates

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1909,6 +1909,15 @@ class ProductRestClient @Inject constructor(
                 }
             }
         }
+        if (storedWCProductModel.metadata != updatedProductModel.metadata) {
+            JsonParser().apply {
+                body["meta_data"] = try {
+                    parse(updatedProductModel.metadata).asJsonArray
+                } catch (ex: Exception) {
+                    JsonArray()
+                }
+            }
+        }
 
         return body
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1914,6 +1914,7 @@ class ProductRestClient @Inject constructor(
                 body["meta_data"] = try {
                     parse(updatedProductModel.metadata).asJsonArray
                 } catch (ex: Exception) {
+                    AppLog.e(AppLog.T.API, "Error parsing product metadata", ex)
                     JsonArray()
                 }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 import com.google.gson.JsonArray
 import com.google.gson.JsonParser
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.util.AppLog
 
 object ProductVariationMapper {
     /**
@@ -14,7 +15,13 @@ object ProductVariationMapper {
      * fields of [variationModel]. This is to ensure that we do not update product fields that do not contain any
      * changes.
      */
-    @Suppress("ForbiddenComment", "LongMethod", "ComplexMethod", "SwallowedException", "TooGenericExceptionCaught")
+    @Suppress(
+        "ForbiddenComment",
+        "LongMethod",
+        "ComplexMethod",
+        "SwallowedException",
+        "TooGenericExceptionCaught"
+    )
     fun variantModelToProductJsonBody(
         variationModel: WCProductVariationModel?,
         updatedVariationModel: WCProductVariationModel
@@ -112,6 +119,7 @@ object ProductVariationMapper {
                 body["meta_data"] = try {
                     parse(updatedVariationModel.metadata).asJsonArray
                 } catch (ex: Exception) {
+                    AppLog.e(AppLog.T.API, "Error parsing product variation metadata", ex)
                     JsonArray()
                 }
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
@@ -107,6 +107,16 @@ object ProductVariationMapper {
                 }
             }
         }
+        if (storedVariationModel.metadata != updatedVariationModel.metadata) {
+            JsonParser().apply {
+                body["meta_data"] = try {
+                    parse(updatedVariationModel.metadata).asJsonArray
+                } catch (ex: Exception) {
+                    JsonArray()
+                }
+            }
+        }
+
         return body
     }
 }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-android/issues/10124. Update `ProductRestClient` to send any `metada` fields as a json array whenever any of these values change. 
Changes can be tested following the instructions from this PR https://github.com/woocommerce/woocommerce-android/pull/10171