### PR TITLE
Add logic to persist the subscription's payment sync date metadata

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
@@ -23,7 +23,7 @@ class StripProductVariationMetaData @Inject internal constructor(private val gso
 
     companion object {
         val SUPPORTED_KEYS: Set<String> = buildSet {
-            addAll(WCProductVariationModel.SubscriptionMetadataKeys.ALL_KEYS)
+            addAll(WCProductModel.SubscriptionMetadataKeys.ALL_KEYS)
             addAll(WCProductVariationModel.QuantityRulesMetadataKeys.ALL_KEYS)
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -584,6 +584,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         const val SUBSCRIPTION_TRIAL_PERIOD = "_subscription_trial_period"
         const val SUBSCRIPTION_TRIAL_LENGTH = "_subscription_trial_length"
         const val SUBSCRIPTION_ONE_TIME_SHIPPING = "_subscription_one_time_shipping"
+        const val SUBSCRIPTION_PAYMENT_SYNC_DATE = "_subscription_payment_sync_date"
         val ALL_KEYS = setOf(
             SUBSCRIPTION_PRICE,
             SUBSCRIPTION_TRIAL_LENGTH,
@@ -592,7 +593,8 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             SUBSCRIPTION_PERIOD_INTERVAL,
             SUBSCRIPTION_LENGTH,
             SUBSCRIPTION_TRIAL_PERIOD,
-            SUBSCRIPTION_ONE_TIME_SHIPPING
+            SUBSCRIPTION_ONE_TIME_SHIPPING,
+            SUBSCRIPTION_PAYMENT_SYNC_DATE
         )
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -150,27 +150,6 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
         return gson.fromJson(attributes, responseType) as? List<ProductVariantOption> ?: emptyList()
     }
 
-    object SubscriptionMetadataKeys {
-        const val SUBSCRIPTION_PRICE = "_subscription_price"
-        const val SUBSCRIPTION_PERIOD = "_subscription_period"
-        const val SUBSCRIPTION_PERIOD_INTERVAL = "_subscription_period_interval"
-        const val SUBSCRIPTION_LENGTH = "_subscription_length"
-        const val SUBSCRIPTION_SIGN_UP_FEE = "_subscription_sign_up_fee"
-        const val SUBSCRIPTION_TRIAL_PERIOD = "_subscription_trial_period"
-        const val SUBSCRIPTION_TRIAL_LENGTH = "_subscription_trial_length"
-        const val SUBSCRIPTION_ONE_TIME_SHIPPING = "_subscription_one_time_shipping"
-        val ALL_KEYS = setOf(
-            SUBSCRIPTION_PRICE,
-            SUBSCRIPTION_TRIAL_LENGTH,
-            SUBSCRIPTION_SIGN_UP_FEE,
-            SUBSCRIPTION_PERIOD,
-            SUBSCRIPTION_PERIOD_INTERVAL,
-            SUBSCRIPTION_LENGTH,
-            SUBSCRIPTION_TRIAL_PERIOD,
-            SUBSCRIPTION_ONE_TIME_SHIPPING
-        )
-    }
-
     object QuantityRulesMetadataKeys {
         const val MINIMUM_ALLOWED_QUANTITY = "variation_minimum_allowed_quantity"
         const val MAXIMUM_ALLOWED_QUANTITY = "variation_maximum_allowed_quantity"


### PR DESCRIPTION
This PR adds the key `_subscription_payment_sync_date` to the list of keys we persist and expose when parsing product and variation details.

This is needed for https://github.com/woocommerce/woocommerce-android/pull/10208