### PR TITLE
Release/2.55.1

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -39,7 +39,7 @@ data class EditorTheme(
                     blockEditorSettings.gradients,
                     null,
                     blockEditorSettings.styles?.toString(),
-                    blockEditorSettings.features?.toString(),
+                    blockEditorSettings.featuresFiltered?.toString(),
                     blockEditorSettings.isBlockBasedTheme,
                     blockEditorSettings.galleryWithImageBlocks,
                     blockEditorSettings.quoteBlockV2,
@@ -83,7 +83,26 @@ data class BlockEditorSettings(
     @SerializedName("__experimentalFeatures") val features: JsonElement?,
     @JsonAdapter(EditorThemeElementListSerializer::class) val colors: List<EditorThemeElement>?,
     @JsonAdapter(EditorThemeElementListSerializer::class) val gradients: List<EditorThemeElement>?
-)
+) {
+    val featuresFiltered: JsonElement?
+        get() = features?.removeFontFamilies()
+
+    private fun JsonElement.removeFontFamilies(): JsonElement {
+        if (!isJsonObject) return this
+
+        val featuresObject = asJsonObject
+        if (!featuresObject.has("typography")) return this
+
+        val typography = featuresObject.get("typography")
+        if (!typography.isJsonObject) return this
+
+        val typographyObject = typography.asJsonObject
+        if (!typographyObject.has("fontFamilies")) return this
+
+        typographyObject.remove("fontFamilies")
+        return featuresObject
+    }
+}
 
 data class EditorThemeSupport(
     @JsonAdapter(EditorThemeElementListSerializer::class)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/EditorTheme.kt
@@ -88,19 +88,18 @@ data class BlockEditorSettings(
         get() = features?.removeFontFamilies()
 
     private fun JsonElement.removeFontFamilies(): JsonElement {
-        if (!isJsonObject) return this
-
-        val featuresObject = asJsonObject
-        if (!featuresObject.has("typography")) return this
-
-        val typography = featuresObject.get("typography")
-        if (!typography.isJsonObject) return this
-
-        val typographyObject = typography.asJsonObject
-        if (!typographyObject.has("fontFamilies")) return this
-
-        typographyObject.remove("fontFamilies")
-        return featuresObject
+        if (isJsonObject && asJsonObject.has("typography")) {
+            val featuresObject = asJsonObject
+            val typography = featuresObject.get("typography")
+            if (typography.isJsonObject) {
+                val typographyObject = typography.asJsonObject
+                if (typographyObject.has("fontFamilies")) {
+                    typographyObject.remove("fontFamilies")
+                    return featuresObject
+                }
+            }
+        }
+        return this
     }
 }
 


### PR DESCRIPTION
This PR merged `release/2.55.1` into `trunk`

## What's Changed
* Removes font families from the stored block editor settings response by @antonis in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2904