### PR TITLE
Improvements to the WPCom themes fetching endpoint

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestJetpack.java
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.fluxc.store.ThemeStore;
+import org.wordpress.android.fluxc.store.ThemeStore.FetchWPComThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched;
 import org.wordpress.android.fluxc.store.ThemeStore.OnSiteThemesChanged;
 import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated;
@@ -385,7 +386,7 @@ public class ReleaseStack_ThemeTestJetpack extends ReleaseStack_Base {
     private void fetchWpComThemes() throws InterruptedException {
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_WPCOM_THEMES;
-        mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
+        mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction(new FetchWPComThemesPayload()));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_ThemeTestWPCom.java
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.ThemeStore;
+import org.wordpress.android.fluxc.store.ThemeStore.FetchWPComThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched;
 import org.wordpress.android.fluxc.store.ThemeStore.OnSiteThemesChanged;
 import org.wordpress.android.fluxc.store.ThemeStore.OnStarterDesignsFetched;
@@ -225,7 +226,7 @@ public class ReleaseStack_ThemeTestWPCom extends ReleaseStack_WPComBase {
         // no need to sign into account, this is a test for an endpoint that does not require authentication
         mCountDownLatch = new CountDownLatch(1);
         mNextEvent = TestEvents.FETCHED_WPCOM_THEMES;
-        mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
+        mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction(new FetchWPComThemesPayload()));
         assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -8,17 +8,21 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_themes.*
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.example.ui.common.showSiteSelectorDialog
+import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.ThemeModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.ThemeStore
+import org.wordpress.android.fluxc.store.ThemeStore.FetchWPComThemesPayload
 import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched
 import org.wordpress.android.fluxc.store.ThemeStore.OnSiteThemesChanged
 import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated
@@ -50,8 +54,12 @@ class ThemeFragment : Fragment() {
         dispatcher.unregister(this)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-            inflater.inflate(R.layout.fragment_themes, container, false)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
+        inflater.inflate(R.layout.fragment_themes, container, false)
 
     @Suppress("LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -144,14 +152,29 @@ class ThemeFragment : Fragment() {
         }
 
         fetch_wpcom_themes.setOnClickListener {
-            dispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction())
+            lifecycleScope.launch {
+                val filter = showSingleLineDialog(
+                    activity = requireActivity(),
+                    message = "Enter filter (Optional)",
+                    isNumeric = false
+                )
+                dispatcher.dispatch(
+                    ThemeActionBuilder.newFetchWpComThemesAction(
+                        FetchWPComThemesPayload(filter)
+                    )
+                )
+            }
         }
 
         fetch_installed_themes.setOnClickListener {
             if (getJetpackConnectedSite() == null) {
                 prependToLog("No Jetpack connected site found, unable to test.")
             } else {
-                dispatcher.dispatch(ThemeActionBuilder.newFetchInstalledThemesAction(getJetpackConnectedSite()))
+                dispatcher.dispatch(
+                    ThemeActionBuilder.newFetchInstalledThemesAction(
+                        getJetpackConnectedSite()
+                    )
+                )
             }
         }
 
@@ -159,7 +182,11 @@ class ThemeFragment : Fragment() {
             if (getJetpackConnectedSite() == null) {
                 prependToLog("No Jetpack connected site found, unable to test.")
             } else {
-                dispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(getJetpackConnectedSite()))
+                dispatcher.dispatch(
+                    ThemeActionBuilder.newFetchCurrentThemeAction(
+                        getJetpackConnectedSite()
+                    )
+                )
             }
         }
 
@@ -240,8 +267,11 @@ class ThemeFragment : Fragment() {
         } else {
             prependToLog("success: WP.com themes fetched count = " + themeStore.wpComThemes.size)
 
-            listOf(ThemeStore.MOBILE_FRIENDLY_CATEGORY_BLOG, ThemeStore.MOBILE_FRIENDLY_CATEGORY_WEBSITE,
-                    ThemeStore.MOBILE_FRIENDLY_CATEGORY_PORTFOLIO).forEach { category ->
+            listOf(
+                ThemeStore.MOBILE_FRIENDLY_CATEGORY_BLOG,
+                ThemeStore.MOBILE_FRIENDLY_CATEGORY_WEBSITE,
+                ThemeStore.MOBILE_FRIENDLY_CATEGORY_PORTFOLIO
+            ).forEach { category ->
                 val mobileFriendlyThemes = themeStore.getWpComMobileFriendlyThemes(category)
                 prependToLog(category + " theme count = " + mobileFriendlyThemes.size)
                 mobileFriendlyThemes.forEach { theme ->

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ThemeFragment.kt
@@ -158,9 +158,16 @@ class ThemeFragment : Fragment() {
                     message = "Enter filter (Optional)",
                     isNumeric = false
                 )
+                val limit = showSingleLineDialog(
+                    activity = requireActivity(),
+                    message = "Limit results? (Optional, defaults to 500)",
+                    isNumeric = true
+                )
                 dispatcher.dispatch(
                     ThemeActionBuilder.newFetchWpComThemesAction(
-                        FetchWPComThemesPayload(filter)
+                        limit?.let {
+                            FetchWPComThemesPayload(filter, it.toInt())
+                        } ?: FetchWPComThemesPayload(filter)
                     )
                 )
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/action/ThemeAction.java
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchStarterDesignsPayload;
+import org.wordpress.android.fluxc.store.ThemeStore.FetchWPComThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedStarterDesignsPayload;
@@ -14,7 +15,7 @@ import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 @ActionEnum
 public enum ThemeAction implements IAction {
     // Remote actions
-    @Action
+    @Action(payloadType = FetchWPComThemesPayload.class)
     FETCH_WP_COM_THEMES,
     @Action(payloadType = FetchStarterDesignsPayload.class)
     FETCH_STARTER_DESIGNS,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.JetpackThemeResponse.JetpackThemeListResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeListResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeMobileFriendlyTaxonomy;
-import org.wordpress.android.fluxc.store.ThemeStore.FetchWPComThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedStarterDesignsPayload;
@@ -43,10 +42,6 @@ import javax.inject.Singleton;
 
 @Singleton
 public class ThemeRestClient extends BaseWPComRestClient {
-    /**
-     * Used by {@link #fetchWpComThemes()} request all themes in a single fetch.
-     */
-    private static final String WP_THEME_FETCH_NUMBER_PARAM = "number=500";
     private static final String WPCOM_MOBILE_FRIENDLY_TAXONOMY_SLUG = "mobile-friendly";
     private static final String THEME_TYPE_EXTERNAL = "managed-external";
 
@@ -128,9 +123,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
      *
      * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/themes/">Previous version</a>
      */
-    public void fetchWpComThemes(@Nullable String filter) {
-        String url = WPCOMREST.themes.getUrlV1_2() + "?" + WP_THEME_FETCH_NUMBER_PARAM;
+    public void fetchWpComThemes(@Nullable String filter, int resultsLimit) {
+        String url = WPCOMREST.themes.getUrlV1_2();
         Map<String, String> params = new HashMap<>();
+        params.put("number", String.valueOf(resultsLimit));
         if (filter != null) {
             params.put("filter", filter);
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -78,7 +78,10 @@ public class ThemeRestClient extends BaseWPComRestClient {
      * [Undocumented!] Endpoint: v1.1/sites/$siteId/themes/$themeId/install
      */
     public void installTheme(@NonNull final SiteModel site, @NonNull final ThemeModel theme) {
-        String themeId = getThemeIdWithWpComSuffix(theme);
+        String themeId = theme.getThemeId();
+        if (!site.isWPComAtomic()) {
+            themeId = getThemeIdWithWpComSuffix(theme);
+        }
         String url = WPCOMREST.sites.site(site.getSiteId()).themes.theme(themeId).install.getUrlV1_1();
         add(WPComGsonRequest.buildPostRequest(url, null, JetpackThemeResponse.class,
                 response -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.JetpackThemeResponse.JetpackThemeListResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeListResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.WPComThemeResponse.WPComThemeMobileFriendlyTaxonomy;
+import org.wordpress.android.fluxc.store.ThemeStore.FetchWPComThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedCurrentThemePayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedSiteThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.FetchedStarterDesignsPayload;
@@ -127,9 +128,13 @@ public class ThemeRestClient extends BaseWPComRestClient {
      *
      * @see <a href="https://developer.wordpress.com/docs/api/1.1/get/themes/">Previous version</a>
      */
-    public void fetchWpComThemes() {
+    public void fetchWpComThemes(@Nullable String filter) {
         String url = WPCOMREST.themes.getUrlV1_2() + "?" + WP_THEME_FETCH_NUMBER_PARAM;
-        add(WPComGsonRequest.buildGetRequest(url, null, WPComThemeListResponse.class,
+        Map<String, String> params = new HashMap<>();
+        if (filter != null) {
+            params.put("filter", filter);
+        }
+        add(WPComGsonRequest.buildGetRequest(url, params, WPComThemeListResponse.class,
                 response -> {
                     AppLog.d(AppLog.T.API, "Received response to WP.com themes fetch request.");
                     List<ThemeModel> themes = createThemeListFromArrayResponse(response);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ThemeSqlUtils.java
@@ -93,6 +93,14 @@ public class ThemeSqlUtils {
                 .endWhere().getAsModel();
     }
 
+    public static List<ThemeModel> getWpComThemes(@NonNull List<String> themeIds) {
+        return WellSql.select(ThemeModel.class)
+                .where()
+                .equals(ThemeModelTable.IS_WP_COM_THEME, true)
+                .isIn(ThemeModelTable.THEME_ID, themeIds)
+                .endWhere().getAsModel();
+    }
+
     public static List<ThemeModel> getWpComMobileFriendlyThemes(String categorySlug) {
         return WellSql.select(ThemeModel.class)
                 .where()

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -333,6 +333,10 @@ public class ThemeStore extends Store {
         return ThemeSqlUtils.getWpComThemes();
     }
 
+    public List<ThemeModel> getWpComThemes(@NonNull List<String> themeIds) {
+        return ThemeSqlUtils.getWpComThemes(themeIds);
+    }
+
     public List<ThemeModel> getWpComMobileFriendlyThemes(String categorySlug) {
         return ThemeSqlUtils.getWpComMobileFriendlyThemes(categorySlug);
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -33,12 +33,21 @@ public class ThemeStore extends Store {
     public static final String MOBILE_FRIENDLY_CATEGORY_WEBSITE = "starting-website";
     public static final String MOBILE_FRIENDLY_CATEGORY_PORTFOLIO = "starting-portfolio";
 
+    // A high number to ensure we get all themes in one request
+    private static final int DEFAULT_LIMIT_OF_THEME_RESULTS = 500;
+
     // Payloads
     public static class FetchWPComThemesPayload extends Payload<BaseNetworkError> {
         @Nullable public String filter;
+        public int resultsLimit = DEFAULT_LIMIT_OF_THEME_RESULTS;
 
         public FetchWPComThemesPayload(@Nullable String filter) {
             this.filter = filter;
+        }
+
+        public FetchWPComThemesPayload(@Nullable String filter, int resultsLimit) {
+            this.filter = filter;
+            this.resultsLimit = resultsLimit;
         }
     }
 
@@ -357,7 +366,7 @@ public class ThemeStore extends Store {
     }
 
     private void fetchWpComThemes(@NonNull FetchWPComThemesPayload payload) {
-        mThemeRestClient.fetchWpComThemes(payload.filter);
+        mThemeRestClient.fetchWpComThemes(payload.filter, payload.resultsLimit);
     }
 
     private void fetchStarterDesigns(@NonNull FetchStarterDesignsPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -34,6 +34,14 @@ public class ThemeStore extends Store {
     public static final String MOBILE_FRIENDLY_CATEGORY_PORTFOLIO = "starting-portfolio";
 
     // Payloads
+    public static class FetchWPComThemesPayload extends Payload<BaseNetworkError> {
+        @Nullable public String filter;
+
+        public FetchWPComThemesPayload(@Nullable String filter) {
+            this.filter = filter;
+        }
+    }
+
     public static class FetchedCurrentThemePayload extends Payload<ThemesError> {
         @NonNull public SiteModel site;
         @Nullable public ThemeModel theme;
@@ -260,7 +268,7 @@ public class ThemeStore extends Store {
         }
         switch ((ThemeAction) actionType) {
             case FETCH_WP_COM_THEMES:
-                fetchWpComThemes();
+                fetchWpComThemes((FetchWPComThemesPayload) action.getPayload());
                 break;
             case FETCHED_WP_COM_THEMES:
                 handleWpComThemesFetched((FetchedWpComThemesPayload) action.getPayload());
@@ -348,8 +356,8 @@ public class ThemeStore extends Store {
         ThemeSqlUtils.insertOrReplaceActiveThemeForSite(site, theme);
     }
 
-    private void fetchWpComThemes() {
-        mThemeRestClient.fetchWpComThemes();
+    private void fetchWpComThemes(@NonNull FetchWPComThemesPayload payload) {
+        mThemeRestClient.fetchWpComThemes(payload.filter);
     }
 
     private void fetchStarterDesigns(@NonNull FetchStarterDesignsPayload payload) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ThemeStore.java
@@ -41,6 +41,8 @@ public class ThemeStore extends Store {
         @Nullable public String filter;
         public int resultsLimit = DEFAULT_LIMIT_OF_THEME_RESULTS;
 
+        public FetchWPComThemesPayload() {}
+
         public FetchWPComThemesPayload(@Nullable String filter) {
             this.filter = filter;
         }


### PR DESCRIPTION
⚠️ this has a breaking change for WPAndroid, please don't merge, I'll synchronize merging when this and the accompanying WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/19668 is approved.

------ 
This PR adds some improvements that WCAndroid needs to implement theme selection support for WooExpress sites (https://github.com/woocommerce/woocommerce-android/issues/10224):

1. Allows passing a `filter` query to the fetching endpoint.
2. Allows customizing the results limit of the fetching endpoint.
3. Adds a function that allows querying themes from the DB using a list of IDs (will be useful for us given the hardcoded list of themes we will support)
4. Fix theme installation on atomic sites: it seems theme installation was broken in the Jetpack app for quite a while, because we try to add a suffix `-wpcom` to the theme's ID, while we should do it only for self-hosted Jetpack sites, Calypso does a similar thing [here](https://github.com/Automattic/wp-calypso/blob/5d2ed9937b86f0b840f9392fe1577d3d026ebcc6/client/state/themes/actions/suffix-theme-id-for-install.js#L17-L19), the commit 89d2c38 fixes this.

#### Testing
1. Open the example app, and sign in.
2. Click on Themes.
3. Click on Fetch WP.Com themes.
7. Test different scenarios, and confirm they work as expected.
8. Pick an atomic site.
9. Type the ID of a theme.
10. Click on Install WP.COM theme on Jetpack Site
11. Confirm it works.