### PR TITLE
Avoid NPE when source_url is missing from `/wp/v2/media` response

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaWPRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaWPRestResponse.kt
@@ -28,7 +28,7 @@ data class MediaWPRESTResponse(
     @SerializedName("media_type") val mediaType: String,
     @SerializedName("mime_type") val mimeType: String,
     @SerializedName("media_details") val mediaDetails: MediaDetails,
-    @SerializedName("source_url") val sourceURL: String
+    @SerializedName("source_url") val sourceURL: String?
 ) {
     data class Attribute(
         val rendered: String
@@ -68,7 +68,7 @@ fun MediaWPRESTResponse.toMediaModel(localSiteId: Int) = MediaModel(
     DateTimeUtils.iso8601FromDate(
         SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT).parse(dateGmt)
     ),
-    sourceURL,
+    sourceURL.orEmpty(),
     mediaDetails.sizes?.thumbnail?.sourceURL,
     mediaDetails.file,
     mediaDetails.file?.substringAfterLast('.', ""),


### PR DESCRIPTION
The changes introduced in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2886 are causing a crash in WCAndroid (https://github.com/woocommerce/woocommerce-android/issues/10264): we changed the `url` property of `MediaModel` to be non-null, but it seems that the API still returns null values (or the property is missing from the response).

This PR aligns the behavior in this case with what we [do](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/63d05c6137b822ad5767bfe34ecfb8108a9a2b83/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java#L545) for XMLPRC, we default to an empty String when it's null, and it's up to the clients to handle the error in this case.