### PR TITLE
Add plugins info

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -67,7 +67,9 @@ open class WooCommerceStore @Inject constructor(
         WOO_SHIPMENT_TRACKING("woocommerce-shipment-tracking/woocommerce-shipment-tracking"),
         WOO_SUBSCRIPTIONS("woocommerce-subscriptions/woocommerce-subscriptions"),
         WOO_GIFT_CARDS("woocommerce-gift-cards/woocommerce-gift-cards"),
-        WOO_MIN_MAX_QUANTITIES("woocommerce-min-max-quantities/woocommerce-min-max-quantities")
+        WOO_MIN_MAX_QUANTITIES("woocommerce-min-max-quantities/woocommerce-min-max-quantities"),
+        WOO_PRODUCT_BUNDLES("woocommerce-product-bundles/woocommerce-product-bundles"),
+        WOO_COMPOSITE_PRODUCTS("woocommerce-composite-products/woocommerce-composite-products")
     }
 
     companion object {


### PR DESCRIPTION
Part of:  https://github.com/woocommerce/woocommerce-android/issues/9550

### Why 
As part of the extensions support milestone 2, we wanted to promote the usage of the Woo extensions and make those extensions easy to find in the Woo ecosystem.

### Description
This small PR adds the missing product type extensions to the WooPlugin enum

### Testing
It's best to test this PR together with Woo PR.
https://github.com/woocommerce/woocommerce-android/pull/10270