### PR TITLE
Adds XMLRPCRequest missing accept header

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/XMLRPCRequest.java
@@ -51,6 +51,7 @@ public class XMLRPCRequest extends BaseRequest<Object> {
     public XMLRPCRequest(@NonNull String url, XMLRPC method, List<Object> params, Listener<? super Object[]> listener,
                          BaseErrorListener errorListener) {
         super(Method.POST, url, errorListener);
+        addHeader("Accept", "*/*");
         mListener = listener;
         mMethod = method;
         // First params are always username/password

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java
@@ -191,7 +191,8 @@ public class MediaXMLRPCClient extends BaseXMLRPCClient implements ProgressListe
         Builder builder = new Request.Builder()
                 .url(url)
                 .post(requestBody)
-                .addHeader("User-Agent", mUserAgent.toString());
+                .addHeader("User-Agent", mUserAgent.toString())
+                .addHeader("Accept", "*/*");
 
         if (authString != null) {
             // Add the authorization header


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/7846

## Description
This PR adds the `Accept: */*` header to:
* aAll XMLRPC Requests https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2911/commits/2b4718bd544d7b5c40f9ec95137a0820c0bb3c30
* the media upload request https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2911/commits/115f8b738d8aa5c3cca37a5feae24aa7f0e399ff

This aligns with the behaviour of the iOS app https://github.com/wordpress-mobile/WordPress-Android/issues/7846#issuecomment-811776264

## To test
1. Use the WPAndroid app from https://github.com/wordpress-mobile/WordPress-Android/pull/19683
2. Setup a proxy to observe the network traffic
3. Login to a self-hosted site. You can use JN to create an ephemeral self hosted site an use the `Add self-hosted site` option from the site chooser > add(+) menu.
5. Create a Post, write a comment etc
6. Add an image from the device
7. **Verify** that all the network requests have the `Accept: */*` header.