### PR TITLE
Add Woo_Square plugin slug to WooCommerceStore

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -67,7 +67,8 @@ open class WooCommerceStore @Inject constructor(
         WOO_SHIPMENT_TRACKING("woocommerce-shipment-tracking/woocommerce-shipment-tracking"),
         WOO_SUBSCRIPTIONS("woocommerce-subscriptions/woocommerce-subscriptions"),
         WOO_GIFT_CARDS("woocommerce-gift-cards/woocommerce-gift-cards"),
-        WOO_MIN_MAX_QUANTITIES("woocommerce-min-max-quantities/woocommerce-min-max-quantities")
+        WOO_MIN_MAX_QUANTITIES("woocommerce-min-max-quantities/woocommerce-min-max-quantities"),
+        WOO_SQUARE("woocommerce-square/woocommerce-square"),
     }
 
     companion object {


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-android/pull/10279

This PR adds the Woo Square Plugin slug to the WooCommerce Store