### PR TITLE
[Prompts] Crash Fix: Use Destructive Fallback Prompts migration

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
@@ -338,7 +338,9 @@ abstract class WPAndroidDatabase : RoomDatabase() {
                             "respondentsCount, attribution, respondentsAvatars, answeredLink) " +
                             "SELECT id, siteLocalId, text, date, isAnswered, " +
                             "respondentsCount, attribution, respondentsAvatars, " +
-                            "'$tagPrefix' || id FROM BloggingPrompts"
+                            "'$tagPrefix' || id FROM BloggingPrompts " +
+                            "WHERE true " +
+                            "ON CONFLICT DO NOTHING"
                     )
 
                     execSQL("DROP TABLE `BloggingPrompts`")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
@@ -105,7 +105,6 @@ abstract class WPAndroidDatabase : RoomDatabase() {
                 .addMigrations(MIGRATION_18_19)
                 .addMigrations(MIGRATION_19_20)
                 .addMigrations(MIGRATION_20_21)
-                .addMigrations(MIGRATION_21_22)
                 .build()
 
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -308,43 +307,6 @@ abstract class WPAndroidDatabase : RoomDatabase() {
                     execSQL(
                         "ALTER TABLE `BlazeCampaigns` ADD COLUMN `targetUrn` TEXT"
                     )
-                }
-            }
-        }
-
-        val MIGRATION_21_22 = object : Migration(21, 22) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                // migrate old data to new table schema
-                database.apply {
-                    execSQL(
-                        "CREATE TABLE IF NOT EXISTS `BloggingPrompts_new` (" +
-                            "`id` INTEGER NOT NULL," +
-                            "`siteLocalId` INTEGER NOT NULL," +
-                            "`text` TEXT NOT NULL," +
-                            "`date` TEXT NOT NULL," +
-                            "`isAnswered` INTEGER NOT NULL," +
-                            "`respondentsCount` INTEGER NOT NULL," +
-                            "`attribution` TEXT NOT NULL," +
-                            "`respondentsAvatars` TEXT NOT NULL," +
-                            "`answeredLink` TEXT NOT NULL," +
-                            "PRIMARY KEY(`date`)" +
-                            ")"
-                    )
-
-                    val tagPrefix = "https://wordpress.com/tag/dailyprompt-"
-                    execSQL(
-                        "INSERT INTO BloggingPrompts_new (" +
-                            "id, siteLocalId, text, date, isAnswered, " +
-                            "respondentsCount, attribution, respondentsAvatars, answeredLink) " +
-                            "SELECT id, siteLocalId, text, date, isAnswered, " +
-                            "respondentsCount, attribution, respondentsAvatars, " +
-                            "'$tagPrefix' || id FROM BloggingPrompts " +
-                            "WHERE true " +
-                            "ON CONFLICT DO NOTHING"
-                    )
-
-                    execSQL("DROP TABLE `BloggingPrompts`")
-                    execSQL("ALTER TABLE `BloggingPrompts_new` RENAME TO `BloggingPrompts`")
                 }
             }
         }


### PR DESCRIPTION
Fixes: #2913
WP-Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/19694

This avoids crashes when, for some reason, the Prompts table has multiple entries for the same day.

Since UPSERT is not supported by all Android API versions and the actual data inside the Prompts table changed along with the schema, it will be best to avoid the effort of maintaining stale data and just relying on Room's fallback to destructive migration, which will drop the table (and data) and create a new one with the correct schema.

This shouldn't have many downsides as we fetch new data as soon as the app opens and the user reaches the Dashboard. The only possible caveat is for users that have reminders setup with Prompts enabled, who might see a notification without Blogging Prompts if they don't open the app after updating it.

This can only be tested using the WordPress-Android PR (https://github.com/wordpress-mobile/WordPress-Android/pull/19694).

This is targeting a hotfix version `2.55.2` since it will need to be picked for a specific WP-Android release based on that FluxC version.