### PR TITLE
Fix: site.username NullPointerException

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpapi
 sealed interface Nonce {
     val value: String?
         get() = null
-    val username: String
+    val username: String?
 
     data class Available(override val value: String, override val username: String) : Nonce
     data class FailedRequest(
@@ -14,7 +14,7 @@ sealed interface Nonce {
         val errorMessage: String? = null,
     ) : Nonce
 
-    data class Unknown(override val username: String) : Nonce
+    data class Unknown(override val username: String?) : Nonce
 
     enum class CookieNonceErrorType {
         NOT_AUTHENTICATED,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -37,6 +37,7 @@ class NonceRestClient @Inject constructor(
      *  that became available in WordPress 5.3.
      */
     suspend fun requestNonce(site: SiteModel): Nonce {
+        if (site.username == null || site.password == null) return Unknown(site.username)
         return requestNonce(site.url, site.username, site.password)
     }
 


### PR DESCRIPTION
This PR prevents a crash in `NonceRestClient` when `site.username` is null. 

- The`Nonce` interface was updated to allow for nulls in username
- In `NonceRestClient`, a null check gate was added to `requestNonce` and when found, will return an `Unknown` Nonce instance.

Testing instructions can be found in the WP companion PR (Coming soon)

**Merge Instructions**
- On success testing of WP PR
- Remove the Not Ready For Merge label
- Merge as normal