### PR TITLE
Renames dynamic cards list property for consistency

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/dashboard/CardsStoreTest.kt
@@ -271,7 +271,7 @@ private val DYNAMIC_CARD_MODEL = DynamicCardModel(
 )
 
 private val DYNAMIC_CARDS_MODEL = DynamicCardsModel(
-    pages = listOf(DYNAMIC_CARD_MODEL)
+    dynamicCards = listOf(DYNAMIC_CARD_MODEL)
 )
 
 private val ACTIVITY_LOG_MODEL = ActivityLogModel(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/dashboard/CardModel.kt
@@ -62,7 +62,7 @@ sealed class CardModel(
     }
 
     data class DynamicCardsModel(
-        val pages: List<DynamicCardModel> = emptyList(),
+        val dynamicCards: List<DynamicCardModel> = emptyList(),
     ) : CardModel(Type.DYNAMIC) {
         data class DynamicCardModel(
             val id: String,


### PR DESCRIPTION
This PR is a follow up to https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2923 renaming the dynamic cards list property for consistency.

**Note:** Please merge after the WPAndroid PR is approved so that the two PRs are merged together and no breakages is introduced in `trunk`