### PR TITLE
Add exception catch block to Gson BundledProduct parsing operation

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -128,12 +128,11 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     val isConfigurable: Boolean
         get() = when (type) {
             CoreProductType.BUNDLE.value -> {
-                try {
-                    Gson().fromJson(bundledItems, Array<WCBundledProduct>::class.java)
-                        .any { it.isConfigurable() }
-                } catch (error: Throwable) {
-                    false
-                }
+                runCatching { Gson().fromJson(bundledItems, Array<WCBundledProduct>::class.java) }
+                    .takeIf { it.isSuccess }?.getOrNull()
+                    ?.let { products ->
+                        products.any { it.isConfigurable() }
+                    } ?: false
             }
             else -> false
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -128,13 +128,12 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     val isConfigurable: Boolean
         get() = when (type) {
             CoreProductType.BUNDLE.value -> {
-                runCatching { Gson().fromJson(bundledItems, Array<WCBundledProduct>::class.java) }
-                    .fold(
-                        onSuccess = { products ->
-                            products.any { it.isConfigurable() }
-                        },
-                        onFailure = { false }
-                    )
+                try {
+                    Gson().fromJson(bundledItems, Array<WCBundledProduct>::class.java)
+                        .any { it.isConfigurable() }
+                } catch (error: Throwable) {
+                    false
+                }
             }
             else -> false
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -128,8 +128,13 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     val isConfigurable: Boolean
         get() = when (type) {
             CoreProductType.BUNDLE.value -> {
-                Gson().fromJson(bundledItems, Array<WCBundledProduct>::class.java)
-                    ?.any { it.isConfigurable() } ?: false
+                runCatching { Gson().fromJson(bundledItems, Array<WCBundledProduct>::class.java) }
+                    .fold(
+                        onSuccess = { products ->
+                            products.any { it.isConfigurable() }
+                        },
+                        onFailure = { false }
+                    )
             }
             else -> false
         }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/model/WCProductModelTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/model/WCProductModelTest.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductType
 
 class WCProductModelTest {
     @Test
@@ -44,7 +45,8 @@ class WCProductModelTest {
     @Test
     fun `isConfigurable should return false when bundledItems is malformed JSON`() {
         val sut = WCProductModel().apply {
-            this.bundledItems = "#ˆ%*(!@*#ˆ%(*!#ˆ(%*!"
+            type = CoreProductType.BUNDLE.value
+            this.bundledItems = "malformed: [#ˆ%*(!@*#ˆ%(*!#ˆ(%*!]"
         }
 
         val result = sut.isConfigurable

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/model/WCProductModelTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/model/WCProductModelTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.model
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class WCProductModelTest {
@@ -38,5 +39,16 @@ class WCProductModelTest {
         val result = sut.getAttributeList()
 
         Assertions.assertThat(result).isNotEmpty
+    }
+
+    @Test
+    fun `isConfigurable should return false when bundledItems is malformed JSON`() {
+        val sut = WCProductModel().apply {
+            this.bundledItems = "#ˆ%*(!@*#ˆ%(*!#ˆ(%*!"
+        }
+
+        val result = sut.isConfigurable
+
+        assertThat(result).isFalse
     }
 }


### PR DESCRIPTION
Summary
==========
Fix issue https://github.com/woocommerce/woocommerce-android/issues/10449 by adding an exception recovery, where if it's not possible to acquire the Bundled Products info, the `isConfigurable` is set to `false` immediately. 

How to Test
==========
1. Add this FluxC version to the Woo app and verify that all Bundled Product features in the Order Creation flow still work as expected.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
