### PR TITLE
Add date type parameter

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -1249,7 +1249,7 @@ class WCStatsStoreTest {
     @Test
     fun testFetchCurrentDayRevenueStatsDate() = runBlocking {
         val plus12SiteDate = SiteModel().apply { timezone = "12" }.let {
-            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any())
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
@@ -1260,7 +1260,7 @@ class WCStatsStoreTest {
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
             verify(mockOrderStatsRestClient).fetchRevenueStats(any(), any(),
-                    dateArgument.capture(), any(), any(), any(), any())
+                    dateArgument.capture(), any(), any(), any(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate
@@ -1269,7 +1269,7 @@ class WCStatsStoreTest {
         reset(mockOrderStatsRestClient)
 
         val minus12SiteDate = SiteModel().apply { timezone = "-12" }.let {
-            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any())
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
@@ -1280,7 +1280,7 @@ class WCStatsStoreTest {
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
             verify(mockOrderStatsRestClient).fetchRevenueStats(any(), any(), dateArgument.capture(), any(),
-                    any(), any(), any())
+                    any(), any(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate
@@ -1296,7 +1296,7 @@ class WCStatsStoreTest {
     @Test
     fun testFetchCurrentDayRevenueStatsDateSpecificEndDate() = runBlocking {
         val plus12SiteDate = SiteModel().apply { timezone = "12" }.let {
-            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any())
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val endDate = DateUtils.formatDate("yyyy-MM-dd", Date())
@@ -1309,7 +1309,7 @@ class WCStatsStoreTest {
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
             verify(mockOrderStatsRestClient).fetchRevenueStats(any(), any(),
-                    dateArgument.capture(), any(), any(), any(), any())
+                    dateArgument.capture(), any(), any(), any(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate
@@ -1318,7 +1318,7 @@ class WCStatsStoreTest {
         reset(mockOrderStatsRestClient)
 
         val minus12SiteDate = SiteModel().apply { timezone = "-12" }.let {
-            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any())
+            whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
@@ -1329,7 +1329,7 @@ class WCStatsStoreTest {
             // The date value passed to the network client should match the current date on the site
             val dateArgument = argumentCaptor<String>()
             verify(mockOrderStatsRestClient).fetchRevenueStats(any(), any(), dateArgument.capture(), any(),
-                    any(), any(), any())
+                    any(), any(), any(), any())
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
             return@let siteDate
@@ -1349,7 +1349,7 @@ class WCStatsStoreTest {
         val currentDayStatsModel = WCStatsTestUtils.generateSampleRevenueStatsModel()
         val site = SiteModel().apply { id = currentDayStatsModel.localSiteId }
         val currentDayGranularity = StatsGranularity.valueOf(currentDayStatsModel.interval.toUpperCase())
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(
                         FetchRevenueStatsResponsePayload(
                                 site,
@@ -1388,7 +1388,7 @@ class WCStatsStoreTest {
         val currentWeekPayload = FetchRevenueStatsResponsePayload(
                 site, curretnWeekGranularity, currentWeekStatsModel
         )
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(currentWeekPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(
@@ -1421,7 +1421,7 @@ class WCStatsStoreTest {
         val currentMonthPayload = FetchRevenueStatsResponsePayload(
                 site, currentMonthGranularity, currentMonthStatsModel
         )
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(currentMonthPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(
@@ -1454,7 +1454,7 @@ class WCStatsStoreTest {
         val allSiteCurrentDayPayload = FetchRevenueStatsResponsePayload(
                 site, allSiteCurrentDayGranularity, altSiteOrderStatsModel
         )
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(allSiteCurrentDayPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(
@@ -1484,7 +1484,7 @@ class WCStatsStoreTest {
         val nonExistentPayload = FetchRevenueStatsResponsePayload(
                 nonExistentSite, nonExistentSiteGranularity, altSiteOrderStatsModel
         )
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(nonExistentPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(
@@ -1509,7 +1509,7 @@ class WCStatsStoreTest {
         assertTrue(nonExistentOrderStats.isEmpty())
 
         // missing data
-        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any()))
+        whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(nonExistentPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -161,6 +161,14 @@ class OrderStatsRestClient @Inject constructor(
      * @param[granularity] one of 'hour', 'day', 'week', 'month', or 'year'
      * @param[startDate] the start date to include in ISO format (YYYY-MM-dd'T'HH:mm:ss)
      * @param[endDate] the end date to include in ISO format (YYYY-MM-dd'T'HH:mm:ss)
+     * @param[perPage] the number of items to return in a paginated response
+     * @param[forceRefresh] a boolean value indicating whether we should avoid cached data
+     * @param[revenueRangeId] a unique id for this request. We will use this id to save the response in the local db.
+     * @param[dateType] override the "woocommerce_date_type" option that is used for revenue reports.
+     * Product stats are based on the order creation date, while the order/revenue
+     * stats are based on a store option in the analytics settings with the order paid date as the default.
+     * In WC version 8.6+, a new parameter `date_type` is available to override the date type so that we can
+     * show the order/revenue and product stats based on the same date column, order creation date.
      *
      * Possible non-generic errors:
      * [OrderStatsErrorType.INVALID_PARAM] if [granularity], [startDate], or [endDate] are invalid or incompatible
@@ -172,7 +180,8 @@ class OrderStatsRestClient @Inject constructor(
         endDate: String,
         perPage: Int,
         forceRefresh: Boolean = false,
-        revenueRangeId: String = ""
+        revenueRangeId: String = "",
+        dateType: String = "date_created",
     ): FetchRevenueStatsResponsePayload {
         val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
         val params = mapOf(
@@ -181,7 +190,8 @@ class OrderStatsRestClient @Inject constructor(
             "before" to endDate,
             "per_page" to perPage.toString(),
             "order" to "asc",
-            "force_cache_refresh" to forceRefresh.toString()
+            "force_cache_refresh" to forceRefresh.toString(),
+            "date_type" to dateType
         )
 
         val response = wooNetwork.executeGetGsonRequest(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes https://github.com/woocommerce/woocommerce-android/issues/10455
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As described in pe5pgL-49w-p2, because the app displays the revenue and product stats on the same analytics screen, when the revenue stats are fetched with the WC date type option from the analytics settings (`date_paid` by default) that's different from the date column (`date_created`) used in product stats, the data could look inconsistent for orders completed on a different date from the creation date. As a relatively simpler solution, a new parameter `date_type` was added to the revenue stats endpoint in core https://github.com/woocommerce/woocommerce/pull/42938 that we can set to `date_created` so that the revenue stats can always be based on the same date column as product stats.

## How

In `OrderStatsRestClient.fetchRevenueStats`, a new parameter `dateType="date_created"` was added. This new parameter is backward compatible, so stores without the parameter support just won't have the date type column overridden on the API. The core PR isn't merged yet but the main spec is pretty settled.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand-testing is optional, as the parameter doesn't have any effect in existing stores right now.
You can test the changes here using this Woo PR https://github.com/woocommerce/woocommerce-android/pull/10494