### PR TITLE
Blaze/mock target endpoints

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
@@ -2,29 +2,36 @@ package org.wordpress.android.fluxc.store.blaze
 
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignsModel
+import org.wordpress.android.fluxc.model.blaze.BlazeTargetingLocation
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeCampaignsError
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeCampaignsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeCampaignsFetchedPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeCampaignsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeCampaignsRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeCampaignsUtils
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.BlazeTargetingPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.Campaign
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.CampaignStats
 import org.wordpress.android.fluxc.network.rest.wpcom.blaze.ContentConfig
+import org.wordpress.android.fluxc.network.rest.wpcom.blaze.FakeBlazeTargetingRestClient
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao.BlazeCampaignEntity
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingDao
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingDeviceEntity
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingLanguageEntity
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingTopicEntity
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 
@@ -44,7 +51,6 @@ const val CLICKS = 0L
 const val PAGE = 1
 const val TOTAL_ITEMS = 1
 const val TOTAL_PAGES = 1
-
 
 private val CONTENT_CONFIG_RESPONSE = ContentConfig(
     title = TITLE,
@@ -101,11 +107,13 @@ private val NO_RESULTS_BLAZE_CAMPAIGNS_MODEL = BlazeCampaignsModel(
     totalPages = 0
 )
 
-@RunWith(MockitoJUnitRunner::class)
 class BlazeCampaignsStoreTest {
-    @Mock private lateinit var restClient: BlazeCampaignsRestClient
-    @Mock private lateinit var dao: BlazeCampaignsDao
-    @Mock private lateinit var siteModel: SiteModel
+    private val restClient: BlazeCampaignsRestClient = mock()
+    private val targetingRestClient: FakeBlazeTargetingRestClient = mock()
+    private val blazeCampaignsDao: BlazeCampaignsDao = mock()
+    private val blazeTargetingDao: BlazeTargetingDao = mock()
+    private val siteModel = SiteModel().apply { siteId = SITE_ID }
+
     private lateinit var store: BlazeCampaignsStore
 
     private val successResponse = BLAZE_CAMPAIGNS_RESPONSE
@@ -113,8 +121,13 @@ class BlazeCampaignsStoreTest {
 
     @Before
     fun setUp() {
-        store = BlazeCampaignsStore(restClient, dao, initCoroutineEngine())
-        whenever(siteModel.siteId).thenReturn(SITE_ID)
+        store = BlazeCampaignsStore(
+            restClient = restClient,
+            fakeTargetingRestClient = targetingRestClient,
+            campaignsDao = blazeCampaignsDao,
+            targetingDao = blazeTargetingDao,
+            coroutineEngine = initCoroutineEngine()
+        )
     }
 
     @Test
@@ -125,7 +138,10 @@ class BlazeCampaignsStoreTest {
 
             store.fetchBlazeCampaigns(siteModel, PAGE)
 
-            verify(dao).insertCampaignsAndPageInfoForSite(SITE_ID, BLAZE_CAMPAIGNS_MODEL)
+            verify(blazeCampaignsDao).insertCampaignsAndPageInfoForSite(
+                SITE_ID,
+                BLAZE_CAMPAIGNS_MODEL
+            )
         }
 
     @Test
@@ -136,7 +152,7 @@ class BlazeCampaignsStoreTest {
             )
             val result = store.fetchBlazeCampaigns(siteModel)
 
-            verifyNoInteractions(dao)
+            verifyNoInteractions(blazeCampaignsDao)
             assertThat(result.model).isNull()
             assertEquals(GENERIC_ERROR, result.error.type)
             assertNull(result.error.message)
@@ -144,7 +160,7 @@ class BlazeCampaignsStoreTest {
 
     @Test
     fun `given unmatched site, when get is triggered, then empty campaigns list returned`() = test {
-        whenever(dao.getCampaignsAndPaginationForSite(SITE_ID)).thenReturn(
+        whenever(blazeCampaignsDao.getCampaignsAndPaginationForSite(SITE_ID)).thenReturn(
             NO_RESULTS_BLAZE_CAMPAIGNS_MODEL
         )
 
@@ -159,7 +175,9 @@ class BlazeCampaignsStoreTest {
 
     @Test
     fun `given matched site, when get recent is triggered, then campaign is returned`() = test {
-        whenever(dao.getMostRecentCampaignForSite(SITE_ID)).thenReturn(BLAZE_CAMPAIGN_MODEL)
+        whenever(blazeCampaignsDao.getMostRecentCampaignForSite(SITE_ID)).thenReturn(
+            BLAZE_CAMPAIGN_MODEL
+        )
 
         val result = store.getMostRecentBlazeCampaign(siteModel)
 
@@ -180,5 +198,138 @@ class BlazeCampaignsStoreTest {
         val result = store.getMostRecentBlazeCampaign(siteModel)
 
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun `when fetching targeting locations, then locations are returned`() = test {
+        whenever(targetingRestClient.fetchBlazeLocations(any())).thenReturn(
+            BlazeTargetingPayload(
+                List(10) {
+                    BlazeTargetingLocation(
+                        id = it.toLong(),
+                        name = "location",
+                        type = "city",
+                        parent = null
+                    )
+                }
+            )
+        )
+
+        val locations = store.fetchBlazeTargetingLocations("query")
+
+        assertThat(locations.isError).isFalse()
+        assertThat(locations.model).isNotNull
+        assertThat(locations.model?.size).isEqualTo(10)
+    }
+
+    @Test
+    fun `when fetching targeting topics, then persist data in DB`() = test {
+        whenever(targetingRestClient.fetchBlazeTopics()).thenReturn(
+            BlazeTargetingPayload(
+                List(10) {
+                    BlazeTargetingTopicEntity(
+                        id = it.toString(),
+                        description = "Topic $it"
+                    )
+                }
+            )
+        )
+
+        store.fetchBlazeTargetingTopics()
+
+        verify(blazeTargetingDao).replaceTopics(any())
+    }
+
+    @Test
+    fun `when observing targeting topics, then return data from DB`() = test {
+        whenever(blazeTargetingDao.observeTopics()).thenReturn(
+            flowOf(
+                List(10) {
+                    BlazeTargetingTopicEntity(
+                        id = it.toString(),
+                        description = "Topic $it"
+                    )
+                }
+            )
+        )
+
+        val topics = store.observeBlazeTargetingTopics().first()
+
+        assertThat(topics).isNotNull
+        assertThat(topics.size).isEqualTo(10)
+    }
+
+    @Test
+    fun `when fetching targeting languages, then persist data in DB`() = test {
+        whenever(targetingRestClient.fetchBlazeLanguages()).thenReturn(
+            BlazeTargetingPayload(
+                List(10) {
+                    BlazeTargetingLanguageEntity(
+                        id = it.toString(),
+                        name = "Language $it"
+                    )
+                }
+            )
+        )
+
+        store.fetchBlazeTargetingLanguages()
+
+        verify(blazeTargetingDao).replaceLanguages(any())
+    }
+
+    @Test
+    fun `when observing targeting languages, then return data from DB`() = test {
+        whenever(blazeTargetingDao.observeLanguages()).thenReturn(
+            flowOf(
+                List(10) {
+                    BlazeTargetingLanguageEntity(
+                        id = it.toString(),
+                        name = "Language $it"
+                    )
+                }
+            )
+        )
+
+        val languages = store.observeBlazeTargetingLanguages().first()
+
+        assertThat(languages).isNotNull
+        assertThat(languages.size).isEqualTo(10)
+    }
+
+    @Test
+    fun `when fetching targeting devices, then persist data in DB`() = test {
+        whenever(targetingRestClient.fetchBlazeDevices()).thenReturn(
+            BlazeTargetingPayload(
+                List(10) {
+                    BlazeTargetingDeviceEntity(
+                        id = it.toString(),
+                        name = "Device $it"
+                    )
+                }
+            )
+        )
+
+        store.fetchBlazeTargetingDevices()
+
+        verify(blazeTargetingDao).replaceDevices(any())
+    }
+
+    @Test
+    fun `when observing targeting devices, then return data from DB`() = test {
+        whenever(blazeTargetingDao.observeDevices()).thenReturn(
+            flowOf(
+                List(10) {
+                    BlazeTargetingDeviceEntity(
+                        id = it.toString(),
+                        name = "Device $it"
+                    )
+                }
+            )
+        )
+
+        val devices = store.observeBlazeTargetingDevices().first()
+
+        assertThat(devices).isNotNull
+        assertThat(devices.size).isEqualTo(10)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
@@ -202,7 +202,7 @@ class BlazeCampaignsStoreTest {
 
     @Test
     fun `when fetching targeting locations, then locations are returned`() = test {
-        whenever(targetingRestClient.fetchBlazeLocations(any())).thenReturn(
+        whenever(targetingRestClient.fetchBlazeLocations(any(), any())).thenReturn(
             BlazeTargetingPayload(
                 List(10) {
                     BlazeTargetingLocation(
@@ -224,12 +224,13 @@ class BlazeCampaignsStoreTest {
 
     @Test
     fun `when fetching targeting topics, then persist data in DB`() = test {
-        whenever(targetingRestClient.fetchBlazeTopics()).thenReturn(
+        whenever(targetingRestClient.fetchBlazeTopics(any())).thenReturn(
             BlazeTargetingPayload(
                 List(10) {
                     BlazeTargetingTopicEntity(
                         id = it.toString(),
-                        description = "Topic $it"
+                        description = "Topic $it",
+                        locale = "en"
                     )
                 }
             )
@@ -242,12 +243,13 @@ class BlazeCampaignsStoreTest {
 
     @Test
     fun `when observing targeting topics, then return data from DB`() = test {
-        whenever(blazeTargetingDao.observeTopics()).thenReturn(
+        whenever(blazeTargetingDao.observeTopics(any())).thenReturn(
             flowOf(
                 List(10) {
                     BlazeTargetingTopicEntity(
                         id = it.toString(),
-                        description = "Topic $it"
+                        description = "Topic $it",
+                        locale = "en"
                     )
                 }
             )
@@ -261,12 +263,13 @@ class BlazeCampaignsStoreTest {
 
     @Test
     fun `when fetching targeting languages, then persist data in DB`() = test {
-        whenever(targetingRestClient.fetchBlazeLanguages()).thenReturn(
+        whenever(targetingRestClient.fetchBlazeLanguages(any())).thenReturn(
             BlazeTargetingPayload(
                 List(10) {
                     BlazeTargetingLanguageEntity(
                         id = it.toString(),
-                        name = "Language $it"
+                        name = "Language $it",
+                        locale = "en"
                     )
                 }
             )
@@ -279,12 +282,13 @@ class BlazeCampaignsStoreTest {
 
     @Test
     fun `when observing targeting languages, then return data from DB`() = test {
-        whenever(blazeTargetingDao.observeLanguages()).thenReturn(
+        whenever(blazeTargetingDao.observeLanguages(any())).thenReturn(
             flowOf(
                 List(10) {
                     BlazeTargetingLanguageEntity(
                         id = it.toString(),
-                        name = "Language $it"
+                        name = "Language $it",
+                        locale = "en"
                     )
                 }
             )
@@ -298,12 +302,13 @@ class BlazeCampaignsStoreTest {
 
     @Test
     fun `when fetching targeting devices, then persist data in DB`() = test {
-        whenever(targetingRestClient.fetchBlazeDevices()).thenReturn(
+        whenever(targetingRestClient.fetchBlazeDevices(any())).thenReturn(
             BlazeTargetingPayload(
                 List(10) {
                     BlazeTargetingDeviceEntity(
                         id = it.toString(),
-                        name = "Device $it"
+                        name = "Device $it",
+                        locale = "en"
                     )
                 }
             )
@@ -316,12 +321,13 @@ class BlazeCampaignsStoreTest {
 
     @Test
     fun `when observing targeting devices, then return data from DB`() = test {
-        whenever(blazeTargetingDao.observeDevices()).thenReturn(
+        whenever(blazeTargetingDao.observeDevices(any())).thenReturn(
             flowOf(
                 List(10) {
                     BlazeTargetingDeviceEntity(
                         id = it.toString(),
-                        name = "Device $it"
+                        name = "Device $it",
+                        locale = "en"
                     )
                 }
             )

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/24.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/24.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 24,
-    "identityHash": "67882ec476531ffc716822588639d385",
+    "identityHash": "da8cb68764ed29eed6f2bd4c7914b96a",
     "entities": [
       {
         "tableName": "BloggingReminders",
@@ -873,7 +873,7 @@
       },
       {
         "tableName": "BlazeTargetingLanguages",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `locale` TEXT NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -884,6 +884,12 @@
           {
             "fieldPath": "name",
             "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
             "affinity": "TEXT",
             "notNull": true
           }
@@ -899,7 +905,7 @@
       },
       {
         "tableName": "BlazeTargetingDevices",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `locale` TEXT NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -910,6 +916,12 @@
           {
             "fieldPath": "name",
             "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
             "affinity": "TEXT",
             "notNull": true
           }
@@ -925,7 +937,7 @@
       },
       {
         "tableName": "BlazeTargetingTopics",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `description` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `description` TEXT NOT NULL, `locale` TEXT NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -936,6 +948,12 @@
           {
             "fieldPath": "description",
             "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
             "affinity": "TEXT",
             "notNull": true
           }
@@ -953,7 +971,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '67882ec476531ffc716822588639d385')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'da8cb68764ed29eed6f2bd4c7914b96a')"
     ]
   }
 }

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/24.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/24.json
@@ -1,0 +1,959 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "67882ec476531ffc716822588639d385",
+    "entities": [
+      {
+        "tableName": "BloggingReminders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `monday` INTEGER NOT NULL, `tuesday` INTEGER NOT NULL, `wednesday` INTEGER NOT NULL, `thursday` INTEGER NOT NULL, `friday` INTEGER NOT NULL, `saturday` INTEGER NOT NULL, `sunday` INTEGER NOT NULL, `hour` INTEGER NOT NULL, `minute` INTEGER NOT NULL, `isPromptRemindersOptedIn` INTEGER NOT NULL, `isPromptsCardOptedIn` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monday",
+            "columnName": "monday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tuesday",
+            "columnName": "tuesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wednesday",
+            "columnName": "wednesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thursday",
+            "columnName": "thursday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friday",
+            "columnName": "friday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saturday",
+            "columnName": "saturday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sunday",
+            "columnName": "sunday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hour",
+            "columnName": "hour",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minute",
+            "columnName": "minute",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPromptRemindersOptedIn",
+            "columnName": "isPromptRemindersOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPromptsCardOptedIn",
+            "columnName": "isPromptsCardOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOffers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `name` TEXT, `shortName` TEXT, `tagline` TEXT, `description` TEXT, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "shortName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_PlanOffers_internalPlanId",
+            "unique": true,
+            "columnNames": [
+              "internalPlanId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_PlanOffers_internalPlanId` ON `${TABLE_NAME}` (`internalPlanId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PlanOfferIds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `productId` INTEGER NOT NULL, `internalPlanId` INTEGER NOT NULL, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PlanOfferFeatures",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalPlanId` INTEGER NOT NULL, `stringId` TEXT, `name` TEXT, `description` TEXT, FOREIGN KEY(`internalPlanId`) REFERENCES `PlanOffers`(`internalPlanId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalPlanId",
+            "columnName": "internalPlanId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringId",
+            "columnName": "stringId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "PlanOffers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "internalPlanId"
+            ],
+            "referencedColumns": [
+              "internalPlanId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Comments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remoteCommentId` INTEGER NOT NULL, `remotePostId` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `remoteSiteId` INTEGER NOT NULL, `authorUrl` TEXT, `authorName` TEXT, `authorEmail` TEXT, `authorProfileImageUrl` TEXT, `authorId` INTEGER NOT NULL, `postTitle` TEXT, `status` TEXT, `datePublished` TEXT, `publishedTimestamp` INTEGER NOT NULL, `content` TEXT, `url` TEXT, `hasParent` INTEGER NOT NULL, `parentId` INTEGER NOT NULL, `iLike` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteCommentId",
+            "columnName": "remoteCommentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remotePostId",
+            "columnName": "remotePostId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteSiteId",
+            "columnName": "remoteSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorUrl",
+            "columnName": "authorUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorName",
+            "columnName": "authorName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorEmail",
+            "columnName": "authorEmail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorProfileImageUrl",
+            "columnName": "authorProfileImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "authorId",
+            "columnName": "authorId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postTitle",
+            "columnName": "postTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "datePublished",
+            "columnName": "datePublished",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publishedTimestamp",
+            "columnName": "publishedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasParent",
+            "columnName": "hasParent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iLike",
+            "columnName": "iLike",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DashboardCards",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteLocalId` INTEGER NOT NULL, `type` TEXT NOT NULL, `date` TEXT NOT NULL, `json` TEXT NOT NULL, PRIMARY KEY(`siteLocalId`, `type`))",
+        "fields": [
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "siteLocalId",
+            "type"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BloggingPrompts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `siteLocalId` INTEGER NOT NULL, `text` TEXT NOT NULL, `date` TEXT NOT NULL, `isAnswered` INTEGER NOT NULL, `respondentsCount` INTEGER NOT NULL, `attribution` TEXT NOT NULL, `respondentsAvatars` TEXT NOT NULL, `answeredLink` TEXT NOT NULL, `bloganuaryId` TEXT, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAnswered",
+            "columnName": "isAnswered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "respondentsCount",
+            "columnName": "respondentsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attribution",
+            "columnName": "attribution",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "respondentsAvatars",
+            "columnName": "respondentsAvatars",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "answeredLink",
+            "columnName": "answeredLink",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bloganuaryId",
+            "columnName": "bloganuaryId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "date"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "FeatureFlagConfigurations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "RemoteConfigurations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `source` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "JetpackCPConnectedSites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`remoteSiteId` INTEGER, `localSiteId` INTEGER NOT NULL, `url` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `activeJetpackConnectionPlugins` TEXT NOT NULL, PRIMARY KEY(`remoteSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "remoteSiteId",
+            "columnName": "remoteSiteId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeJetpackConnectionPlugins",
+            "columnName": "activeJetpackConnectionPlugins",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "remoteSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Domains",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteLocalId` INTEGER NOT NULL, `domain` TEXT NOT NULL, `primaryDomain` INTEGER NOT NULL, `wpcomDomain` INTEGER NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryDomain",
+            "columnName": "primaryDomain",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wpcomDomain",
+            "columnName": "wpcomDomain",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BlazeCampaigns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `campaignId` INTEGER NOT NULL, `title` TEXT NOT NULL, `imageUrl` TEXT, `createdAt` TEXT NOT NULL, `endDate` TEXT, `uiStatus` TEXT NOT NULL, `budgetCents` INTEGER NOT NULL, `impressions` INTEGER NOT NULL, `clicks` INTEGER NOT NULL, `targetUrn` TEXT, PRIMARY KEY(`siteId`, `campaignId`))",
+        "fields": [
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "campaignId",
+            "columnName": "campaignId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uiStatus",
+            "columnName": "uiStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetCents",
+            "columnName": "budgetCents",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "impressions",
+            "columnName": "impressions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clicks",
+            "columnName": "clicks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetUrn",
+            "columnName": "targetUrn",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "siteId",
+            "campaignId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_BlazeCampaigns_siteId",
+            "unique": false,
+            "columnNames": [
+              "siteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_BlazeCampaigns_siteId` ON `${TABLE_NAME}` (`siteId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BlazeCampaignsPagination",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteId` INTEGER NOT NULL, `page` INTEGER NOT NULL, `totalItems` INTEGER NOT NULL, `totalPages` INTEGER NOT NULL, PRIMARY KEY(`siteId`))",
+        "fields": [
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "page",
+            "columnName": "page",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalItems",
+            "columnName": "totalItems",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPages",
+            "columnName": "totalPages",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "siteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "JetpackSocial",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`siteLocalId` INTEGER NOT NULL, `isShareLimitEnabled` INTEGER NOT NULL, `toBePublicizedCount` INTEGER NOT NULL, `shareLimit` INTEGER NOT NULL, `publicizedCount` INTEGER NOT NULL, `sharedPostsCount` INTEGER NOT NULL, `sharesRemaining` INTEGER NOT NULL, `isEnhancedPublishingEnabled` INTEGER NOT NULL, `isSocialImageGeneratorEnabled` INTEGER NOT NULL, PRIMARY KEY(`siteLocalId`))",
+        "fields": [
+          {
+            "fieldPath": "siteLocalId",
+            "columnName": "siteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShareLimitEnabled",
+            "columnName": "isShareLimitEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toBePublicizedCount",
+            "columnName": "toBePublicizedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shareLimit",
+            "columnName": "shareLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicizedCount",
+            "columnName": "publicizedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharedPostsCount",
+            "columnName": "sharedPostsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sharesRemaining",
+            "columnName": "sharesRemaining",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnhancedPublishingEnabled",
+            "columnName": "isEnhancedPublishingEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSocialImageGeneratorEnabled",
+            "columnName": "isSocialImageGeneratorEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "siteLocalId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BlazeTargetingLanguages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BlazeTargetingDevices",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BlazeTargetingTopics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `description` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '67882ec476531ffc716822588639d385')"
+    ]
+  }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingDevice.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingDevice.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.fluxc.model.blaze
+
+class BlazeTargetingDevice(
+    val id: String,
+    val name: String
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingLanguage.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingLanguage.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.fluxc.model.blaze
+
+data class BlazeTargetingLanguage(
+    val id: String,
+    val name: String
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingLocation.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingLocation.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.fluxc.model.blaze
+
+data class BlazeTargetingLocation(
+    val id: Long,
+    val name: String,
+    val type: String,
+    val parent: BlazeTargetingLocation?
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingTopic.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingTopic.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.fluxc.model.blaze
+
+class BlazeTargetingTopic(
+    val id: String,
+    val description: String
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.persistence.RemoteConfigDao
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.buildDb
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingDao
 import org.wordpress.android.fluxc.persistence.bloggingprompts.BloggingPromptsDao
 import org.wordpress.android.fluxc.persistence.comments.CommentsDao
 import org.wordpress.android.fluxc.persistence.dashboard.CardsDao
@@ -86,6 +87,12 @@ class DatabaseModule {
     @Provides
     fun provideBlazeCampaignsDao(wpAndroidDatabase: WPAndroidDatabase): BlazeCampaignsDao {
         return wpAndroidDatabase.blazeCampaignsDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideBlazeTargetingDao(wpAndroidDatabase: WPAndroidDatabase): BlazeTargetingDao {
+        return wpAndroidDatabase.blazeTargetingDao()
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/FakeBlazeTargetingRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/FakeBlazeTargetingRestClient.kt
@@ -12,6 +12,7 @@ import javax.inject.Inject
 private const val FAKE_DELAY = 500L
 
 class FakeBlazeTargetingRestClient @Inject constructor() {
+    @Suppress("MagicNumber")
     suspend fun fetchBlazeLocations(
         query: String
     ): BlazeTargetingPayload<List<BlazeTargetingLocation>> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/FakeBlazeTargetingRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/FakeBlazeTargetingRestClient.kt
@@ -12,9 +12,10 @@ import javax.inject.Inject
 private const val FAKE_DELAY = 500L
 
 class FakeBlazeTargetingRestClient @Inject constructor() {
-    @Suppress("MagicNumber")
+    @Suppress("MagicNumber", "UNUSED_PARAMETER")
     suspend fun fetchBlazeLocations(
-        query: String
+        query: String,
+        locale: String
     ): BlazeTargetingPayload<List<BlazeTargetingLocation>> {
         if (query.length < 3) {
             return BlazeTargetingPayload(emptyList())
@@ -28,22 +29,22 @@ class FakeBlazeTargetingRestClient @Inject constructor() {
         )
     }
 
-    suspend fun fetchBlazeTopics(): BlazeTargetingPayload<List<BlazeTargetingTopicEntity>> {
+    suspend fun fetchBlazeTopics(locale: String): BlazeTargetingPayload<List<BlazeTargetingTopicEntity>> {
         delay(FAKE_DELAY)
 
-        return BlazeTargetingPayload(fakeTopics)
+        return BlazeTargetingPayload(generateFakeTopics(locale))
     }
 
-    suspend fun fetchBlazeLanguages(): BlazeTargetingPayload<List<BlazeTargetingLanguageEntity>> {
+    suspend fun fetchBlazeLanguages(locale: String): BlazeTargetingPayload<List<BlazeTargetingLanguageEntity>> {
         delay(FAKE_DELAY)
 
-        return BlazeTargetingPayload(fakeLanguages)
+        return BlazeTargetingPayload(generateFakeLanguages(locale))
     }
 
-    suspend fun fetchBlazeDevices(): BlazeTargetingPayload<List<BlazeTargetingDeviceEntity>> {
+    suspend fun fetchBlazeDevices(locale: String): BlazeTargetingPayload<List<BlazeTargetingDeviceEntity>> {
         delay(FAKE_DELAY)
 
-        return BlazeTargetingPayload(fakeDevices)
+        return BlazeTargetingPayload(generateFakeDevices(locale))
     }
 }
 
@@ -190,90 +191,106 @@ private val fakeLocations
         )
     )
 
-private val fakeTopics
-    get() = listOf(
-        BlazeTargetingTopicEntity(
-            id = "IAB1",
-            description = "Arts & Entertainment"
-        ),
-        BlazeTargetingTopicEntity(
-            id = "IAB2",
-            description = "Automotive"
-        ),
-        BlazeTargetingTopicEntity(
-            id = "IAB3",
-            description = "Business"
-        ),
-        BlazeTargetingTopicEntity(
-            id = "IAB4",
-            description = "Careers"
-        ),
-        BlazeTargetingTopicEntity(
-            id = "IAB5",
-            description = "Education"
-        ),
-        BlazeTargetingTopicEntity(
-            id = "IAB6",
-            description = "Family & Parenting"
-        ),
-        BlazeTargetingTopicEntity(
-            id = "IAB7",
-            description = "Health & Fitness"
-        )
+private fun generateFakeTopics(locale: String) = listOf(
+    BlazeTargetingTopicEntity(
+        id = "IAB1",
+        description = "Arts & Entertainment",
+        locale = locale
+    ),
+    BlazeTargetingTopicEntity(
+        id = "IAB2",
+        description = "Automotive",
+        locale = locale
+    ),
+    BlazeTargetingTopicEntity(
+        id = "IAB3",
+        description = "Business",
+        locale = locale
+    ),
+    BlazeTargetingTopicEntity(
+        id = "IAB4",
+        description = "Careers",
+        locale = locale
+    ),
+    BlazeTargetingTopicEntity(
+        id = "IAB5",
+        description = "Education",
+        locale = locale
+    ),
+    BlazeTargetingTopicEntity(
+        id = "IAB6",
+        description = "Family & Parenting",
+        locale = locale
+    ),
+    BlazeTargetingTopicEntity(
+        id = "IAB7",
+        description = "Health & Fitness",
+        locale = locale
     )
+)
 
-private val fakeLanguages
-    get() = listOf(
-        BlazeTargetingLanguageEntity(
-            id = "en",
-            name = "English"
-        ),
-        BlazeTargetingLanguageEntity(
-            id = "es",
-            name = "Spanish"
-        ),
-        BlazeTargetingLanguageEntity(
-            id = "fr",
-            name = "French"
-        ),
-        BlazeTargetingLanguageEntity(
-            id = "de",
-            name = "German"
-        ),
-        BlazeTargetingLanguageEntity(
-            id = "it",
-            name = "Italian"
-        ),
-        BlazeTargetingLanguageEntity(
-            id = "ja",
-            name = "Japanese"
-        ),
-        BlazeTargetingLanguageEntity(
-            id = "ko",
-            name = "Korean"
-        ),
-        BlazeTargetingLanguageEntity(
-            id = "pt",
-            name = "Portuguese"
-        ),
-        BlazeTargetingLanguageEntity(
-            id = "ru",
-            name = "Russian"
-        ),
-        BlazeTargetingLanguageEntity(
-            id = "zh",
-            name = "Chinese"
-        )
+private fun generateFakeLanguages(locale: String) = listOf(
+    BlazeTargetingLanguageEntity(
+        id = "en",
+        name = "English",
+        locale = locale
+    ),
+    BlazeTargetingLanguageEntity(
+        id = "es",
+        name = "Spanish",
+        locale = locale
+    ),
+    BlazeTargetingLanguageEntity(
+        id = "fr",
+        name = "French",
+        locale = locale
+    ),
+    BlazeTargetingLanguageEntity(
+        id = "de",
+        name = "German",
+        locale = locale
+    ),
+    BlazeTargetingLanguageEntity(
+        id = "it",
+        name = "Italian",
+        locale = locale
+    ),
+    BlazeTargetingLanguageEntity(
+        id = "ja",
+        name = "Japanese",
+        locale = locale
+    ),
+    BlazeTargetingLanguageEntity(
+        id = "ko",
+        name = "Korean",
+        locale = locale
+    ),
+    BlazeTargetingLanguageEntity(
+        id = "pt",
+        name = "Portuguese",
+        locale = locale
+    ),
+    BlazeTargetingLanguageEntity(
+        id = "ru",
+        name = "Russian",
+        locale = locale
+    ),
+    BlazeTargetingLanguageEntity(
+        id = "zh",
+        name = "Chinese",
+        locale = locale
     )
+)
 
-private val fakeDevices
-    get() = listOf(
-        BlazeTargetingDeviceEntity(
-            id = "mobile",
-            name = "Mobile"
-        ),
-        BlazeTargetingDeviceEntity(
-            id = "desktop",
-            name = "Desktop"
-        )
+private fun generateFakeDevices(locale: String) = listOf(
+    BlazeTargetingDeviceEntity(
+        id = "mobile",
+        name = "Mobile",
+        locale = locale
+    ),
+    BlazeTargetingDeviceEntity(
+        id = "desktop",
+        name = "Desktop",
+        locale = locale
     )
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/FakeBlazeTargetingRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/FakeBlazeTargetingRestClient.kt
@@ -1,0 +1,278 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.blaze
+
+import kotlinx.coroutines.delay
+import org.wordpress.android.fluxc.Payload
+import org.wordpress.android.fluxc.model.blaze.BlazeTargetingLocation
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingDeviceEntity
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingLanguageEntity
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingTopicEntity
+import javax.inject.Inject
+
+private const val FAKE_DELAY = 500L
+
+class FakeBlazeTargetingRestClient @Inject constructor() {
+    suspend fun fetchBlazeLocations(
+        query: String
+    ): BlazeTargetingPayload<List<BlazeTargetingLocation>> {
+        if (query.length < 3) {
+            return BlazeTargetingPayload(emptyList())
+        }
+
+        delay(FAKE_DELAY)
+
+        return BlazeTargetingPayload(
+            fakeLocations
+                .filter { it.name.contains(query, ignoreCase = true) }
+        )
+    }
+
+    suspend fun fetchBlazeTopics(): BlazeTargetingPayload<List<BlazeTargetingTopicEntity>> {
+        delay(FAKE_DELAY)
+
+        return BlazeTargetingPayload(fakeTopics)
+    }
+
+    suspend fun fetchBlazeLanguages(): BlazeTargetingPayload<List<BlazeTargetingLanguageEntity>> {
+        delay(FAKE_DELAY)
+
+        return BlazeTargetingPayload(fakeLanguages)
+    }
+
+    suspend fun fetchBlazeDevices(): BlazeTargetingPayload<List<BlazeTargetingDeviceEntity>> {
+        delay(FAKE_DELAY)
+
+        return BlazeTargetingPayload(fakeDevices)
+    }
+}
+
+data class BlazeTargetingPayload<T>(
+    val data: T
+) : Payload<WPComGsonNetworkError>()
+
+private val fakeLocations
+    get() = listOf(
+        BlazeTargetingLocation(
+            id = 1,
+            name = "United States",
+            type = "country",
+            parent = null
+        ),
+        BlazeTargetingLocation(
+            id = 2,
+            name = "California",
+            type = "state",
+            parent = BlazeTargetingLocation(
+                id = 1,
+                name = "United States",
+                type = "country",
+                parent = null
+            )
+        ),
+        BlazeTargetingLocation(
+            id = 3,
+            name = "San Francisco",
+            type = "city",
+            parent = BlazeTargetingLocation(
+                id = 2,
+                name = "California",
+                type = "state",
+                parent = BlazeTargetingLocation(
+                    id = 1,
+                    name = "United States",
+                    type = "country",
+                    parent = null
+                )
+            )
+        ),
+        BlazeTargetingLocation(
+            id = 4,
+            name = "Los Angeles",
+            type = "city",
+            parent = BlazeTargetingLocation(
+                id = 2,
+                name = "California",
+                type = "state",
+                parent = BlazeTargetingLocation(
+                    id = 1,
+                    name = "United States",
+                    type = "country",
+                    parent = null
+                )
+            )
+        ),
+        BlazeTargetingLocation(
+            id = 5,
+            name = "New York",
+            type = "state",
+            parent = BlazeTargetingLocation(
+                id = 1,
+                name = "United States",
+                type = "country",
+                parent = null
+            )
+        ),
+        BlazeTargetingLocation(
+            id = 6,
+            name = "New York City",
+            type = "city",
+            parent = BlazeTargetingLocation(
+                id = 5,
+                name = "New York",
+                type = "state",
+                parent = BlazeTargetingLocation(
+                    id = 1,
+                    name = "United States",
+                    type = "country",
+                    parent = null
+                )
+            )
+        ),
+        BlazeTargetingLocation(
+            id = 7,
+            name = "Chicago",
+            type = "city",
+            parent = BlazeTargetingLocation(
+                id = 5,
+                name = "New York",
+                type = "state",
+                parent = BlazeTargetingLocation(
+                    id = 1,
+                    name = "United States",
+                    type = "country",
+                    parent = null
+                )
+            )
+        ),
+        BlazeTargetingLocation(
+            id = 8,
+            name = "Texas",
+            type = "state",
+            parent = BlazeTargetingLocation(
+                id = 1,
+                name = "United States",
+                type = "country",
+                parent = null
+            )
+        ),
+        BlazeTargetingLocation(
+            id = 9,
+            name = "Houston",
+            type = "city",
+            parent = BlazeTargetingLocation(
+                id = 8,
+                name = "Texas",
+                type = "state",
+                parent = BlazeTargetingLocation(
+                    id = 1,
+                    name = "United States",
+                    type = "country",
+                    parent = null
+                )
+            )
+        ),
+        BlazeTargetingLocation(
+            id = 10,
+            name = "Dallas",
+            type = "city",
+            parent = BlazeTargetingLocation(
+                id = 8,
+                name = "Texas",
+                type = "state",
+                parent = BlazeTargetingLocation(
+                    id = 1,
+                    name = "United States",
+                    type = "country",
+                    parent = null
+                )
+            )
+        )
+    )
+
+private val fakeTopics
+    get() = listOf(
+        BlazeTargetingTopicEntity(
+            id = "IAB1",
+            description = "Arts & Entertainment"
+        ),
+        BlazeTargetingTopicEntity(
+            id = "IAB2",
+            description = "Automotive"
+        ),
+        BlazeTargetingTopicEntity(
+            id = "IAB3",
+            description = "Business"
+        ),
+        BlazeTargetingTopicEntity(
+            id = "IAB4",
+            description = "Careers"
+        ),
+        BlazeTargetingTopicEntity(
+            id = "IAB5",
+            description = "Education"
+        ),
+        BlazeTargetingTopicEntity(
+            id = "IAB6",
+            description = "Family & Parenting"
+        ),
+        BlazeTargetingTopicEntity(
+            id = "IAB7",
+            description = "Health & Fitness"
+        )
+    )
+
+private val fakeLanguages
+    get() = listOf(
+        BlazeTargetingLanguageEntity(
+            id = "en",
+            name = "English"
+        ),
+        BlazeTargetingLanguageEntity(
+            id = "es",
+            name = "Spanish"
+        ),
+        BlazeTargetingLanguageEntity(
+            id = "fr",
+            name = "French"
+        ),
+        BlazeTargetingLanguageEntity(
+            id = "de",
+            name = "German"
+        ),
+        BlazeTargetingLanguageEntity(
+            id = "it",
+            name = "Italian"
+        ),
+        BlazeTargetingLanguageEntity(
+            id = "ja",
+            name = "Japanese"
+        ),
+        BlazeTargetingLanguageEntity(
+            id = "ko",
+            name = "Korean"
+        ),
+        BlazeTargetingLanguageEntity(
+            id = "pt",
+            name = "Portuguese"
+        ),
+        BlazeTargetingLanguageEntity(
+            id = "ru",
+            name = "Russian"
+        ),
+        BlazeTargetingLanguageEntity(
+            id = "zh",
+            name = "Chinese"
+        )
+    )
+
+private val fakeDevices
+    get() = listOf(
+        BlazeTargetingDeviceEntity(
+            id = "mobile",
+            name = "Mobile"
+        ),
+        BlazeTargetingDeviceEntity(
+            id = "desktop",
+            name = "Desktop"
+        )
+    )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
@@ -18,6 +18,10 @@ import org.wordpress.android.fluxc.persistence.RemoteConfigDao.RemoteConfig
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao.BlazeCampaignEntity
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao.BlazeCampaignsPaginationEntity
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingDao
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingDeviceEntity
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingLanguageEntity
+import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingTopicEntity
 import org.wordpress.android.fluxc.persistence.bloggingprompts.BloggingPromptsDao
 import org.wordpress.android.fluxc.persistence.bloggingprompts.BloggingPromptsDao.BloggingPromptEntity
 import org.wordpress.android.fluxc.persistence.comments.CommentsDao
@@ -31,7 +35,7 @@ import org.wordpress.android.fluxc.persistence.jetpacksocial.JetpackSocialDao
 import org.wordpress.android.fluxc.persistence.jetpacksocial.JetpackSocialDao.JetpackSocialEntity
 
 @Database(
-        version = 23,
+        version = 24,
         entities = [
             BloggingReminders::class,
             PlanOffer::class,
@@ -47,6 +51,9 @@ import org.wordpress.android.fluxc.persistence.jetpacksocial.JetpackSocialDao.Je
             BlazeCampaignEntity::class,
             BlazeCampaignsPaginationEntity::class,
             JetpackSocialEntity::class,
+            BlazeTargetingLanguageEntity::class,
+            BlazeTargetingDeviceEntity::class,
+            BlazeTargetingTopicEntity::class,
         ],
         autoMigrations = [
             AutoMigration(from = 11, to = 12),
@@ -55,6 +62,7 @@ import org.wordpress.android.fluxc.persistence.jetpacksocial.JetpackSocialDao.Je
             AutoMigration(from = 16, to = 17),
             AutoMigration(from = 17, to = 18),
             AutoMigration(from = 22, to = 23),
+            AutoMigration(from = 23, to = 24),
         ]
 )
 @TypeConverters(
@@ -82,6 +90,8 @@ abstract class WPAndroidDatabase : RoomDatabase() {
     abstract fun jetpackCPConnectedSitesDao(): JetpackCPConnectedSitesDao
 
     abstract fun blazeCampaignsDao(): BlazeCampaignsDao
+
+    abstract fun blazeTargetingDao(): BlazeTargetingDao
 
     abstract fun jetpackSocialDao(): JetpackSocialDao
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/blaze/BlazeTargetingDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/blaze/BlazeTargetingDao.kt
@@ -1,0 +1,76 @@
+package org.wordpress.android.fluxc.persistence.blaze
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BlazeTargetingDao {
+    @Query("SELECT * FROM BlazeTargetingDevices")
+    fun observeDevices(): Flow<List<BlazeTargetingDeviceEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertDevices(devices: List<BlazeTargetingDeviceEntity>)
+
+    @Query("DELETE FROM BlazeTargetingDevices")
+    suspend fun deleteDevices()
+
+    @Transaction
+    suspend fun replaceDevices(devices: List<BlazeTargetingDeviceEntity>) {
+        deleteDevices()
+        insertDevices(devices)
+    }
+
+    @Query("SELECT * FROM BlazeTargetingTopics")
+    fun observeTopics(): Flow<List<BlazeTargetingTopicEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTopics(topics: List<BlazeTargetingTopicEntity>)
+
+    @Query("DELETE FROM BlazeTargetingTopics")
+    suspend fun deleteTopics()
+
+    @Transaction
+    suspend fun replaceTopics(topics: List<BlazeTargetingTopicEntity>) {
+        deleteTopics()
+        insertTopics(topics)
+    }
+
+    @Query("SELECT * FROM BlazeTargetingLanguages")
+    fun observeLanguages(): Flow<List<BlazeTargetingLanguageEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertLanguages(languages: List<BlazeTargetingLanguageEntity>)
+
+    @Query("DELETE FROM BlazeTargetingLanguages")
+    suspend fun deleteLanguages()
+
+    @Transaction
+    suspend fun replaceLanguages(languages: List<BlazeTargetingLanguageEntity>) {
+        deleteLanguages()
+        insertLanguages(languages)
+    }
+}
+
+@Entity(tableName = "BlazeTargetingDevices")
+data class BlazeTargetingDeviceEntity(
+    @PrimaryKey val id: String,
+    val name: String
+)
+
+@Entity(tableName = "BlazeTargetingTopics")
+data class BlazeTargetingTopicEntity(
+    @PrimaryKey val id: String,
+    val description: String
+)
+
+@Entity(tableName = "BlazeTargetingLanguages")
+data class BlazeTargetingLanguageEntity(
+    @PrimaryKey val id: String,
+    val name: String
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/blaze/BlazeTargetingDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/blaze/BlazeTargetingDao.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface BlazeTargetingDao {
-    @Query("SELECT * FROM BlazeTargetingDevices")
-    fun observeDevices(): Flow<List<BlazeTargetingDeviceEntity>>
+    @Query("SELECT * FROM BlazeTargetingDevices WHERE locale = :locale")
+    fun observeDevices(locale: String): Flow<List<BlazeTargetingDeviceEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertDevices(devices: List<BlazeTargetingDeviceEntity>)
@@ -26,8 +26,8 @@ interface BlazeTargetingDao {
         insertDevices(devices)
     }
 
-    @Query("SELECT * FROM BlazeTargetingTopics")
-    fun observeTopics(): Flow<List<BlazeTargetingTopicEntity>>
+    @Query("SELECT * FROM BlazeTargetingTopics WHERE locale = :locale")
+    fun observeTopics(locale: String): Flow<List<BlazeTargetingTopicEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertTopics(topics: List<BlazeTargetingTopicEntity>)
@@ -41,8 +41,8 @@ interface BlazeTargetingDao {
         insertTopics(topics)
     }
 
-    @Query("SELECT * FROM BlazeTargetingLanguages")
-    fun observeLanguages(): Flow<List<BlazeTargetingLanguageEntity>>
+    @Query("SELECT * FROM BlazeTargetingLanguages WHERE locale = :locale")
+    fun observeLanguages(locale: String): Flow<List<BlazeTargetingLanguageEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertLanguages(languages: List<BlazeTargetingLanguageEntity>)
@@ -60,17 +60,23 @@ interface BlazeTargetingDao {
 @Entity(tableName = "BlazeTargetingDevices")
 data class BlazeTargetingDeviceEntity(
     @PrimaryKey val id: String,
-    val name: String
+    val name: String,
+    val locale: String
 )
 
 @Entity(tableName = "BlazeTargetingTopics")
 data class BlazeTargetingTopicEntity(
     @PrimaryKey val id: String,
-    val description: String
+    val description: String,
+    val locale: String
 )
 
 @Entity(tableName = "BlazeTargetingLanguages")
 data class BlazeTargetingLanguageEntity(
     @PrimaryKey val id: String,
-    val name: String
+    val name: String,
+    /**
+     * The locale used to localize the name of the language.
+     */
+    val locale: String
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStore.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.store.Store
 import org.wordpress.android.fluxc.store.Store.OnChangedError
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -96,12 +97,15 @@ class BlazeCampaignsStore @Inject constructor(
         campaignsDao.observeMostRecentCampaignForSite(site.siteId)
             .map { it?.toDomainModel() }
 
-    suspend fun fetchBlazeTargetingLocations(query: String) = coroutineEngine.withDefaultContext(
+    suspend fun fetchBlazeTargetingLocations(
+        query: String,
+        locale: String = Locale.getDefault().language
+    ) = coroutineEngine.withDefaultContext(
         AppLog.T.API,
         this,
         "fetch blaze locations"
     ) {
-        fakeTargetingRestClient.fetchBlazeLocations(query).let { payload ->
+        fakeTargetingRestClient.fetchBlazeLocations(query, locale).let { payload ->
             when {
                 payload.isError -> BlazeTargetingResult(BlazeTargetingError(payload.error))
                 else -> BlazeTargetingResult(payload.data)
@@ -109,12 +113,14 @@ class BlazeCampaignsStore @Inject constructor(
         }
     }
 
-    suspend fun fetchBlazeTargetingTopics() = coroutineEngine.withDefaultContext(
+    suspend fun fetchBlazeTargetingTopics(
+        locale: String = Locale.getDefault().language
+    ) = coroutineEngine.withDefaultContext(
         AppLog.T.API,
         this,
         "fetch blaze topics"
     ) {
-        fakeTargetingRestClient.fetchBlazeTopics().let { payload ->
+        fakeTargetingRestClient.fetchBlazeTopics(locale).let { payload ->
             when {
                 payload.isError -> BlazeTargetingResult(BlazeTargetingError(payload.error))
                 else -> {
@@ -125,14 +131,18 @@ class BlazeCampaignsStore @Inject constructor(
         }
     }
 
-    fun observeBlazeTargetingTopics() = targetingDao.observeTopics()
+    fun observeBlazeTargetingTopics(
+        locale: String = Locale.getDefault().language
+    ) = targetingDao.observeTopics(locale)
 
-    suspend fun fetchBlazeTargetingLanguages() = coroutineEngine.withDefaultContext(
+    suspend fun fetchBlazeTargetingLanguages(
+        locale: String = Locale.getDefault().language
+    ) = coroutineEngine.withDefaultContext(
         AppLog.T.API,
         this,
         "fetch blaze languages"
     ) {
-        fakeTargetingRestClient.fetchBlazeLanguages().let { payload ->
+        fakeTargetingRestClient.fetchBlazeLanguages(locale).let { payload ->
             when {
                 payload.isError -> BlazeTargetingResult(BlazeTargetingError(payload.error))
                 else -> {
@@ -143,14 +153,18 @@ class BlazeCampaignsStore @Inject constructor(
         }
     }
 
-    fun observeBlazeTargetingLanguages() = targetingDao.observeLanguages()
+    fun observeBlazeTargetingLanguages(
+        locale: String = Locale.getDefault().language
+    ) = targetingDao.observeLanguages(locale)
 
-    suspend fun fetchBlazeTargetingDevices() = coroutineEngine.withDefaultContext(
+    suspend fun fetchBlazeTargetingDevices(
+        locale: String = Locale.getDefault().language
+    ) = coroutineEngine.withDefaultContext(
         AppLog.T.API,
         this,
         "fetch blaze devices"
     ) {
-        fakeTargetingRestClient.fetchBlazeDevices().let { payload ->
+        fakeTargetingRestClient.fetchBlazeDevices(locale).let { payload ->
             when {
                 payload.isError -> BlazeTargetingResult(BlazeTargetingError(payload.error))
                 else -> {
@@ -161,7 +175,9 @@ class BlazeCampaignsStore @Inject constructor(
         }
     }
 
-    fun observeBlazeTargetingDevices() = targetingDao.observeDevices()
+    fun observeBlazeTargetingDevices(
+        locale: String = Locale.getDefault().language
+    ) = targetingDao.observeDevices(locale)
 
     data class BlazeCampaignsResult<T>(
         val model: T? = null,


### PR DESCRIPTION
This PR adds the following changes:

1. Domain models for the Blaze targeting endpoints.
2. Caching logic for the supported types.
3. Mocked rest client to return some fake data for the tests.
4. Support for localization of the endpoints according to this peeHDf-2fw-p2#comment-1621


There is nothing to test for now, just code review and having green CI is enough.