### PR TITLE
Update dependency catalog version 

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.15.0"
+def catalogVersion = "29-bffed02761bd189cf126650c391b38c5dbfb989c"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {


### PR DESCRIPTION
This PR updates the dependency catalog version to support an update in the utils library

- [x] Set to dependency catalog test hash
- [x] Test using WP Companion PR [https://github.com/wordpress-mobile/WordPress-Android/pull/19846](url)
- [ ] Update with release version of dependency catalog
- [ ] Update WP Companion PR with trunk hash