### PR TITLE
Fix locale issue for v3 endpoints.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -26,7 +26,7 @@ import org.wordpress.android.util.LanguageUtils;
 import okhttp3.HttpUrl;
 
 public abstract class BaseWPComRestClient {
-    private static final String WPCOM_V2_PREFIX = "/wpcom/v2";
+    private static final String WPCOM_V1_PREFIX = "/wpcom/v1";
     private static final String LOCALE_PARAM_NAME_FOR_V1 = "locale";
     private static final String LOCALE_PARAM_NAME_FOR_V2 = "_locale";
 
@@ -152,7 +152,7 @@ public abstract class BaseWPComRestClient {
 
 
     private @NonNull String getLocaleParamName(@NonNull String url) {
-        return url.contains(WPCOM_V2_PREFIX) ? LOCALE_PARAM_NAME_FOR_V2 : LOCALE_PARAM_NAME_FOR_V1;
+        return url.contains(WPCOM_V1_PREFIX) ? LOCALE_PARAM_NAME_FOR_V1 : LOCALE_PARAM_NAME_FOR_V2;
     }
 
     protected @Nullable HttpUrl getHttpUrlWithLocale(@NonNull String url) {


### PR DESCRIPTION
locale query param should be "locale" for v1 endpoints, and "_locale" for other endpoints.

To test,
- Change the device language to a language other than English,
- Run this PR on WordPress-Android and ensure the blogging prompt is in the selected language.

Internal context: p1704423861366279-slack-C0180B5PRJ4