### PR TITLE
Fix locale issue for v3 endpoints keeping previous fallback to locale

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -26,7 +26,8 @@ import org.wordpress.android.util.LanguageUtils;
 import okhttp3.HttpUrl;
 
 public abstract class BaseWPComRestClient {
-    private static final String WPCOM_V1_PREFIX = "/wpcom/v1";
+    private static final String WPCOM_V2_PREFIX = "/wpcom/v2";
+    private static final String WPCOM_V3_PREFIX = "/wpcom/v3";
     private static final String LOCALE_PARAM_NAME_FOR_V1 = "locale";
     private static final String LOCALE_PARAM_NAME_FOR_V2 = "_locale";
 
@@ -152,7 +153,8 @@ public abstract class BaseWPComRestClient {
 
 
     private @NonNull String getLocaleParamName(@NonNull String url) {
-        return url.contains(WPCOM_V1_PREFIX) ? LOCALE_PARAM_NAME_FOR_V1 : LOCALE_PARAM_NAME_FOR_V2;
+        return url.contains(WPCOM_V2_PREFIX) || url.contains(WPCOM_V3_PREFIX) ? LOCALE_PARAM_NAME_FOR_V2
+                : LOCALE_PARAM_NAME_FOR_V1;
     }
 
     protected @Nullable HttpUrl getHttpUrlWithLocale(@NonNull String url) {


### PR DESCRIPTION
The same as https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2937 but keeping the previous fallback to `locale` instead of `_locale`

Context p1704484851389609/1704423861.366279-slack-C0180B5PRJ4

Thanks @zwarm for thinking of this implementation