### PR TITLE
Implement unit tests for BaseWPComRestClient locale query parameter decision

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClient.java
@@ -28,8 +28,8 @@ import okhttp3.HttpUrl;
 public abstract class BaseWPComRestClient {
     private static final String WPCOM_V2_PREFIX = "/wpcom/v2";
     private static final String WPCOM_V3_PREFIX = "/wpcom/v3";
-    private static final String LOCALE_PARAM_NAME_FOR_V1 = "locale";
-    private static final String LOCALE_PARAM_NAME_FOR_V2 = "_locale";
+    private static final String LOCALE_PARAM = "locale";
+    private static final String UNDERSCORE_LOCALE_PARAM = "_locale";
 
     private AccessToken mAccessToken;
     private final RequestQueue mRequestQueue;
@@ -153,8 +153,8 @@ public abstract class BaseWPComRestClient {
 
 
     private @NonNull String getLocaleParamName(@NonNull String url) {
-        return url.contains(WPCOM_V2_PREFIX) || url.contains(WPCOM_V3_PREFIX) ? LOCALE_PARAM_NAME_FOR_V2
-                : LOCALE_PARAM_NAME_FOR_V1;
+        return url.contains(WPCOM_V2_PREFIX) || url.contains(WPCOM_V3_PREFIX) ? UNDERSCORE_LOCALE_PARAM
+                : LOCALE_PARAM;
     }
 
     protected @Nullable HttpUrl getHttpUrlWithLocale(@NonNull String url) {

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClientTest.java
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/BaseWPComRestClientTest.java
@@ -1,0 +1,64 @@
+package org.wordpress.android.fluxc.network.rest.wpcom;
+
+import android.content.Context;
+
+import com.android.volley.RequestQueue;
+import com.android.volley.toolbox.BasicNetwork;
+import com.android.volley.toolbox.DiskBasedCache;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.network.OkHttpStack;
+import org.wordpress.android.fluxc.network.UserAgent;
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken;
+import org.wordpress.android.fluxc.network.rest.wpcom.reader.ReaderRestClient;
+
+import java.io.File;
+
+import okhttp3.OkHttpClient;
+
+@RunWith(RobolectricTestRunner.class)
+public class BaseWPComRestClientTest {
+    final Context mAppContext = RuntimeEnvironment.application.getApplicationContext();
+    final BaseWPComRestClient mClassToTest = new ReaderRestClient(
+            mAppContext,
+            new Dispatcher(),
+            new RequestQueue(
+                    new DiskBasedCache(new File("")),
+                    new BasicNetwork(new OkHttpStack(new OkHttpClient()))
+            ),
+            new AccessToken(mAppContext),
+            new UserAgent(mAppContext, "app")
+    );
+
+    @Test
+    public void shouldUseUnderscoreLocaleParameterForWPComV2Requests() {
+        final String queryParameter =
+                mClassToTest.getHttpUrlWithLocale("https://public-api.wordpress.com/wpcom/v2/something")
+                            .queryParameter("_locale");
+        assertThat(queryParameter, not(nullValue()));
+    }
+
+    @Test
+    public void shouldUseUnderscoreLocaleParameterForWPComV3Requests() {
+        final String queryParameter =
+                mClassToTest.getHttpUrlWithLocale("https://public-api.wordpress.com/wpcom/v3/something")
+                            .queryParameter("_locale");
+        assertThat(queryParameter, not(nullValue()));
+    }
+
+    @Test
+    public void shouldUseLocaleParameterForV1Requests() {
+        final String queryParameter =
+                mClassToTest.getHttpUrlWithLocale("https://public-api.wordpress.com/rest/v1/")
+                            .queryParameter("locale");
+        assertThat(queryParameter, not(nullValue()));
+    }
+}


### PR DESCRIPTION
Add unit tests to the logic in `BaseWPComRestClient` that decides whether to use `locale` or `_locale` query parameter based on the request URL.