### PR TITLE
Woo: Removed fields that are no longer returned by the API from "deposits/overview-all"

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WooPaymentsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WooPaymentsTest.kt
@@ -36,7 +36,6 @@ class ReleaseStack_WooPaymentsTest : ReleaseStack_WCBase() {
         assertEquals(2, result.result?.account?.depositsSchedule?.delayDays)
         assertEquals("daily", result.result?.account?.depositsSchedule?.interval)
         assertEquals(0L, result.result?.balance?.available?.get(0)?.amount)
-        assertEquals(null, result.result?.balance?.available?.get(0)?.depositsCount)
         assertEquals("usd", result.result?.balance?.available?.get(0)?.currency)
         assertEquals(0, result.result?.balance?.available?.get(0)?.sourceTypes?.card)
         assertEquals(0, result.result?.balance?.instant?.size)
@@ -45,7 +44,6 @@ class ReleaseStack_WooPaymentsTest : ReleaseStack_WCBase() {
         assertEquals(null, result.result?.balance?.pending?.get(0)?.fee)
         assertEquals(null, result.result?.balance?.pending?.get(0)?.feePercentage)
         assertEquals(null, result.result?.balance?.pending?.get(0)?.net)
-        assertEquals(0, result.result?.balance?.pending?.get(0)?.depositsCount)
         assertEquals(0, result.result?.balance?.pending?.get(0)?.sourceTypes?.card)
         assertEquals(0, result.result?.deposit?.lastManualDeposits?.size)
         assertEquals(1, result.result?.deposit?.lastPaid?.size)
@@ -60,7 +58,6 @@ class ReleaseStack_WooPaymentsTest : ReleaseStack_WCBase() {
         assertEquals("po_1KQLho2HswaZkMX3M9Qhzf4W", result.result?.deposit?.lastPaid?.get(0)?.depositId)
         assertEquals("paid", result.result?.deposit?.lastPaid?.get(0)?.status)
         assertEquals("deposit", result.result?.deposit?.lastPaid?.get(0)?.type)
-        assertEquals(0, result.result?.deposit?.nextScheduled?.size)
     }
 
     @Test
@@ -80,7 +77,6 @@ class ReleaseStack_WooPaymentsTest : ReleaseStack_WCBase() {
         assertEquals(2, getResult?.account?.depositsSchedule?.delayDays)
         assertEquals("daily", getResult?.account?.depositsSchedule?.interval)
         assertEquals(0L, getResult?.balance?.available?.get(0)?.amount)
-        assertEquals(null, getResult?.balance?.available?.get(0)?.depositsCount)
         assertEquals("usd", getResult?.balance?.available?.get(0)?.currency)
         assertEquals(0, getResult?.balance?.available?.get(0)?.sourceTypes?.card)
         assertEquals(0, getResult?.balance?.instant?.size)
@@ -89,7 +85,6 @@ class ReleaseStack_WooPaymentsTest : ReleaseStack_WCBase() {
         assertEquals(null, getResult?.balance?.pending?.get(0)?.fee)
         assertEquals(null, getResult?.balance?.pending?.get(0)?.feePercentage)
         assertEquals(null, getResult?.balance?.pending?.get(0)?.net)
-        assertEquals(0, getResult?.balance?.pending?.get(0)?.depositsCount)
         assertEquals(0, getResult?.balance?.pending?.get(0)?.sourceTypes?.card)
         assertEquals(0, getResult?.deposit?.lastManualDeposits?.size)
         assertEquals(1, getResult?.deposit?.lastPaid?.size)
@@ -104,7 +99,6 @@ class ReleaseStack_WooPaymentsTest : ReleaseStack_WCBase() {
         assertEquals("po_1KQLho2HswaZkMX3M9Qhzf4W", getResult?.deposit?.lastPaid?.get(0)?.depositId)
         assertEquals("paid", getResult?.deposit?.lastPaid?.get(0)?.status)
         assertEquals("deposit", getResult?.deposit?.lastPaid?.get(0)?.type)
-        assertEquals(0, getResult?.deposit?.nextScheduled?.size)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/persistence/mappers/WooPaymentsDepositsOverviewMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/persistence/mappers/WooPaymentsDepositsOverviewMapperTest.kt
@@ -47,21 +47,6 @@ class WooPaymentsDepositsOverviewMapperTest {
                         created = 1L
                     )
                 ),
-                nextScheduled = listOf(
-                    WooPaymentsDeposit(
-                        id = "id",
-                        date = 1L,
-                        type = "type",
-                        amount = 1L,
-                        status = "status",
-                        bankAccount = "bankAccount",
-                        currency = "currency",
-                        automatic = true,
-                        fee = 1L,
-                        feePercentage = 1.0,
-                        created = 1L
-                    )
-                ),
                 lastManualDeposits = listOf(
                     WooPaymentsManualDeposit(
                         currency = "currency",
@@ -77,10 +62,8 @@ class WooPaymentsDepositsOverviewMapperTest {
                         sourceTypes = WooPaymentsSourceTypes(
                             card = 1
                         ),
-                        depositsCount = 1,
                         feePercentage = 1.0,
                         net = 1L,
-                        transactionIds = listOf("transactionIds1"),
                         fee = 1L
                     )
                 ),
@@ -91,10 +74,8 @@ class WooPaymentsDepositsOverviewMapperTest {
                         sourceTypes = WooPaymentsSourceTypes(
                             card = 1
                         ),
-                        depositsCount = 1,
                         feePercentage = 1.0,
                         net = 1L,
-                        transactionIds = listOf("transactionIds2"),
                         fee = 1L
                     )
                 ),
@@ -105,10 +86,8 @@ class WooPaymentsDepositsOverviewMapperTest {
                         sourceTypes = WooPaymentsSourceTypes(
                             card = 1
                         ),
-                        depositsCount = 1,
                         feePercentage = 1.0,
                         net = 1L,
-                        transactionIds = listOf("transactionIds3"),
                         fee = 1L
                     )
                 )
@@ -143,41 +122,24 @@ class WooPaymentsDepositsOverviewMapperTest {
         assertThat(result.deposit?.lastPaid?.get(0)?.feePercentage).isEqualTo(1.0)
         assertThat(result.deposit?.lastPaid?.get(0)?.status).isEqualTo("status")
         assertThat(result.deposit?.lastPaid?.get(0)?.type).isEqualTo("type")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.amount).isEqualTo(1L)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.automatic).isEqualTo(true)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.bankAccount).isEqualTo("bankAccount")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.created).isEqualTo(1L)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.currency).isEqualTo("currency")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.date).isEqualTo(1L)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.depositId).isEqualTo("id")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.fee).isEqualTo(1L)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.feePercentage).isEqualTo(1.0)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.status).isEqualTo("status")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.type).isEqualTo("type")
         assertThat(result.balance?.available?.get(0)?.amount).isEqualTo(1L)
         assertThat(result.balance?.available?.get(0)?.currency).isEqualTo("usd")
-        assertThat(result.balance?.available?.get(0)?.depositsCount).isEqualTo(1)
         assertThat(result.balance?.available?.get(0)?.fee).isEqualTo(1L)
         assertThat(result.balance?.available?.get(0)?.feePercentage).isEqualTo(1.0)
         assertThat(result.balance?.available?.get(0)?.net).isEqualTo(1L)
         assertThat(result.balance?.available?.get(0)?.sourceTypes?.card).isEqualTo(1)
-        assertThat(result.balance?.available?.get(0)?.transactionIds?.get(0)).isEqualTo("transactionIds2")
         assertThat(result.balance?.instant?.get(0)?.amount).isEqualTo(1L)
         assertThat(result.balance?.instant?.get(0)?.currency).isEqualTo("eur")
-        assertThat(result.balance?.instant?.get(0)?.depositsCount).isEqualTo(1)
         assertThat(result.balance?.instant?.get(0)?.fee).isEqualTo(1L)
         assertThat(result.balance?.instant?.get(0)?.feePercentage).isEqualTo(1.0)
         assertThat(result.balance?.instant?.get(0)?.net).isEqualTo(1L)
         assertThat(result.balance?.instant?.get(0)?.sourceTypes?.card).isEqualTo(1)
-        assertThat(result.balance?.instant?.get(0)?.transactionIds?.get(0)).isEqualTo("transactionIds3")
         assertThat(result.balance?.pending?.get(0)?.amount).isEqualTo(1L)
         assertThat(result.balance?.pending?.get(0)?.currency).isEqualTo("rub")
-        assertThat(result.balance?.pending?.get(0)?.depositsCount).isEqualTo(1)
         assertThat(result.balance?.pending?.get(0)?.fee).isEqualTo(1L)
         assertThat(result.balance?.pending?.get(0)?.feePercentage).isEqualTo(1.0)
         assertThat(result.balance?.pending?.get(0)?.net).isEqualTo(1L)
         assertThat(result.balance?.pending?.get(0)?.sourceTypes?.card).isEqualTo(1)
-        assertThat(result.balance?.pending?.get(0)?.transactionIds?.get(0)).isEqualTo("transactionIds1")
         assertThat(result.account?.defaultCurrency).isEqualTo("defaultCurrency")
         assertThat(result.account?.depositsBlocked).isEqualTo(true)
         assertThat(result.account?.depositsEnabled).isEqualTo(true)
@@ -223,23 +185,6 @@ class WooPaymentsDepositsOverviewMapperTest {
                     depositType = DepositType.LAST_PAID
                 )
             ),
-            nextScheduledDeposits = listOf(
-                WooPaymentsDepositEntity(
-                    localSiteId = LocalId(1),
-                    depositId = "id",
-                    date = 1L,
-                    type = "type",
-                    amount = 1L,
-                    status = "status2",
-                    bankAccount = "bankAccount2",
-                    currency = "rub",
-                    automatic = true,
-                    fee = 1L,
-                    feePercentage = 1.0,
-                    created = 1L,
-                    depositType = DepositType.NEXT_SCHEDULED
-                )
-            ),
             lastManualDeposits = listOf(
                 WooPaymentsManualDepositEntity(
                     localSiteId = LocalId(1),
@@ -255,10 +200,8 @@ class WooPaymentsDepositsOverviewMapperTest {
                     sourceTypes = WooPaymentsSourceTypesEntity(
                         card = 1
                     ),
-                    depositsCount = 1,
                     feePercentage = 1.0,
                     net = 1L,
-                    transactionIds = listOf("transactionIds1"),
                     fee = 1L,
                     balanceType = BalanceType.AVAILABLE,
                 )
@@ -271,10 +214,8 @@ class WooPaymentsDepositsOverviewMapperTest {
                     sourceTypes = WooPaymentsSourceTypesEntity(
                         card = 1
                     ),
-                    depositsCount = 1,
                     feePercentage = 1.0,
                     net = 1L,
-                    transactionIds = listOf("transactionIds2"),
                     fee = 1L,
                     balanceType = BalanceType.AVAILABLE,
                 )
@@ -287,10 +228,8 @@ class WooPaymentsDepositsOverviewMapperTest {
                     sourceTypes = WooPaymentsSourceTypesEntity(
                         card = 1
                     ),
-                    depositsCount = 1,
                     feePercentage = 1.0,
                     net = 1L,
-                    transactionIds = listOf("transactionIds3"),
                     fee = 1L,
                     balanceType = BalanceType.AVAILABLE,
                 )
@@ -314,41 +253,24 @@ class WooPaymentsDepositsOverviewMapperTest {
         assertThat(result.deposit?.lastPaid?.get(0)?.feePercentage).isEqualTo(1.0)
         assertThat(result.deposit?.lastPaid?.get(0)?.status).isEqualTo("status1")
         assertThat(result.deposit?.lastPaid?.get(0)?.type).isEqualTo("type")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.amount).isEqualTo(1L)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.automatic).isEqualTo(true)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.bankAccount).isEqualTo("bankAccount2")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.created).isEqualTo(1L)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.currency).isEqualTo("rub")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.date).isEqualTo(1L)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.depositId).isEqualTo("id")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.fee).isEqualTo(1L)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.feePercentage).isEqualTo(1.0)
-        assertThat(result.deposit?.nextScheduled?.get(0)?.status).isEqualTo("status2")
-        assertThat(result.deposit?.nextScheduled?.get(0)?.type).isEqualTo("type")
         assertThat(result.balance?.available?.get(0)?.amount).isEqualTo(1L)
         assertThat(result.balance?.available?.get(0)?.currency).isEqualTo("usd")
-        assertThat(result.balance?.available?.get(0)?.depositsCount).isEqualTo(1)
         assertThat(result.balance?.available?.get(0)?.fee).isEqualTo(1L)
         assertThat(result.balance?.available?.get(0)?.feePercentage).isEqualTo(1.0)
         assertThat(result.balance?.available?.get(0)?.net).isEqualTo(1L)
         assertThat(result.balance?.available?.get(0)?.sourceTypes?.card).isEqualTo(1)
-        assertThat(result.balance?.available?.get(0)?.transactionIds?.get(0)).isEqualTo("transactionIds2")
         assertThat(result.balance?.instant?.get(0)?.amount).isEqualTo(1L)
         assertThat(result.balance?.instant?.get(0)?.currency).isEqualTo("eur")
-        assertThat(result.balance?.instant?.get(0)?.depositsCount).isEqualTo(1)
         assertThat(result.balance?.instant?.get(0)?.fee).isEqualTo(1L)
         assertThat(result.balance?.instant?.get(0)?.feePercentage).isEqualTo(1.0)
         assertThat(result.balance?.instant?.get(0)?.net).isEqualTo(1L)
         assertThat(result.balance?.instant?.get(0)?.sourceTypes?.card).isEqualTo(1)
-        assertThat(result.balance?.instant?.get(0)?.transactionIds?.get(0)).isEqualTo("transactionIds3")
         assertThat(result.balance?.pending?.get(0)?.amount).isEqualTo(1L)
         assertThat(result.balance?.pending?.get(0)?.currency).isEqualTo("rub")
-        assertThat(result.balance?.pending?.get(0)?.depositsCount).isEqualTo(1)
         assertThat(result.balance?.pending?.get(0)?.fee).isEqualTo(1L)
         assertThat(result.balance?.pending?.get(0)?.feePercentage).isEqualTo(1.0)
         assertThat(result.balance?.pending?.get(0)?.net).isEqualTo(1L)
         assertThat(result.balance?.pending?.get(0)?.sourceTypes?.card).isEqualTo(1)
-        assertThat(result.balance?.pending?.get(0)?.transactionIds?.get(0)).isEqualTo("transactionIds1")
         assertThat(result.account?.defaultCurrency).isEqualTo("defaultCurrency")
         assertThat(result.account?.depositsBlocked).isEqualTo(true)
         assertThat(result.account?.depositsEnabled).isEqualTo(true)

--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/33.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/33.json
@@ -1,0 +1,1615 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 33,
+    "identityHash": "43fd0900518251fbd271b5ffe7a0d89f",
+    "entities": [
+      {
+        "tableName": "AddonEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`addonLocalId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `globalGroupLocalId` INTEGER, `productRemoteId` INTEGER, `localSiteId` INTEGER, `type` TEXT NOT NULL, `display` TEXT, `name` TEXT NOT NULL, `titleFormat` TEXT NOT NULL, `description` TEXT, `required` INTEGER NOT NULL, `position` INTEGER NOT NULL, `restrictions` TEXT, `priceType` TEXT, `price` TEXT, `min` INTEGER, `max` INTEGER, FOREIGN KEY(`globalGroupLocalId`) REFERENCES `GlobalAddonGroupEntity`(`globalGroupLocalId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "addonLocalId",
+            "columnName": "addonLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "globalGroupLocalId",
+            "columnName": "globalGroupLocalId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "productRemoteId",
+            "columnName": "productRemoteId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "display",
+            "columnName": "display",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleFormat",
+            "columnName": "titleFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "required",
+            "columnName": "required",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restrictions",
+            "columnName": "restrictions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priceType",
+            "columnName": "priceType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "min",
+            "columnName": "min",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "max",
+            "columnName": "max",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "addonLocalId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_AddonEntity_globalGroupLocalId",
+            "unique": false,
+            "columnNames": [
+              "globalGroupLocalId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AddonEntity_globalGroupLocalId` ON `${TABLE_NAME}` (`globalGroupLocalId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "GlobalAddonGroupEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "globalGroupLocalId"
+            ],
+            "referencedColumns": [
+              "globalGroupLocalId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "AddonOptionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`addonOptionLocalId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `addonLocalId` INTEGER NOT NULL, `priceType` TEXT NOT NULL, `label` TEXT, `price` TEXT, `image` TEXT, FOREIGN KEY(`addonLocalId`) REFERENCES `AddonEntity`(`addonLocalId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "addonOptionLocalId",
+            "columnName": "addonOptionLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addonLocalId",
+            "columnName": "addonLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priceType",
+            "columnName": "priceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "addonOptionLocalId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_AddonOptionEntity_addonLocalId",
+            "unique": false,
+            "columnNames": [
+              "addonLocalId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AddonOptionEntity_addonLocalId` ON `${TABLE_NAME}` (`addonLocalId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AddonEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "addonLocalId"
+            ],
+            "referencedColumns": [
+              "addonLocalId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Coupons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `code` TEXT, `amount` TEXT, `dateCreated` TEXT, `dateCreatedGmt` TEXT, `dateModified` TEXT, `dateModifiedGmt` TEXT, `discountType` TEXT, `description` TEXT, `dateExpires` TEXT, `dateExpiresGmt` TEXT, `usageCount` INTEGER, `isForIndividualUse` INTEGER, `usageLimit` INTEGER, `usageLimitPerUser` INTEGER, `limitUsageToXItems` INTEGER, `isShippingFree` INTEGER, `areSaleItemsExcluded` INTEGER, `minimumAmount` TEXT, `maximumAmount` TEXT, `includedProductIds` TEXT, `excludedProductIds` TEXT, `includedCategoryIds` TEXT, `excludedCategoryIds` TEXT, PRIMARY KEY(`id`, `localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dateCreated",
+            "columnName": "dateCreated",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dateCreatedGmt",
+            "columnName": "dateCreatedGmt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dateModifiedGmt",
+            "columnName": "dateModifiedGmt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "discountType",
+            "columnName": "discountType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dateExpires",
+            "columnName": "dateExpires",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dateExpiresGmt",
+            "columnName": "dateExpiresGmt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "usageCount",
+            "columnName": "usageCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isForIndividualUse",
+            "columnName": "isForIndividualUse",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "usageLimit",
+            "columnName": "usageLimit",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "usageLimitPerUser",
+            "columnName": "usageLimitPerUser",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "limitUsageToXItems",
+            "columnName": "limitUsageToXItems",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isShippingFree",
+            "columnName": "isShippingFree",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "areSaleItemsExcluded",
+            "columnName": "areSaleItemsExcluded",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "minimumAmount",
+            "columnName": "minimumAmount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maximumAmount",
+            "columnName": "maximumAmount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "includedProductIds",
+            "columnName": "includedProductIds",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "excludedProductIds",
+            "columnName": "excludedProductIds",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "includedCategoryIds",
+            "columnName": "includedCategoryIds",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "excludedCategoryIds",
+            "columnName": "excludedCategoryIds",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id",
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "CouponEmails",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`couponId` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `email` TEXT NOT NULL, PRIMARY KEY(`couponId`, `localSiteId`, `email`), FOREIGN KEY(`couponId`, `localSiteId`) REFERENCES `Coupons`(`id`, `localSiteId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "couponId",
+            "columnName": "couponId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "couponId",
+            "localSiteId",
+            "email"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Coupons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "couponId",
+              "localSiteId"
+            ],
+            "referencedColumns": [
+              "id",
+              "localSiteId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAddonGroupEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`globalGroupLocalId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `restrictedCategoriesIds` TEXT NOT NULL, `localSiteId` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "globalGroupLocalId",
+            "columnName": "globalGroupLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restrictedCategoriesIds",
+            "columnName": "restrictedCategoriesIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "globalGroupLocalId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "OrderNotes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `noteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `dateCreated` TEXT, `note` TEXT, `author` TEXT, `isSystemNote` INTEGER NOT NULL, `isCustomerNote` INTEGER NOT NULL, PRIMARY KEY(`localSiteId`, `noteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderId",
+            "columnName": "orderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCreated",
+            "columnName": "dateCreated",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isSystemNote",
+            "columnName": "isSystemNote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustomerNote",
+            "columnName": "isCustomerNote",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId",
+            "noteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "OrderEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `number` TEXT NOT NULL, `status` TEXT NOT NULL, `currency` TEXT NOT NULL, `orderKey` TEXT NOT NULL, `dateCreated` TEXT NOT NULL, `dateModified` TEXT NOT NULL, `total` TEXT NOT NULL, `totalTax` TEXT NOT NULL, `shippingTotal` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `paymentMethodTitle` TEXT NOT NULL, `datePaid` TEXT NOT NULL, `pricesIncludeTax` INTEGER NOT NULL, `customerNote` TEXT NOT NULL, `discountTotal` TEXT NOT NULL, `discountCodes` TEXT NOT NULL, `refundTotal` TEXT NOT NULL, `customerId` INTEGER NOT NULL DEFAULT 0, `billingFirstName` TEXT NOT NULL, `billingLastName` TEXT NOT NULL, `billingCompany` TEXT NOT NULL, `billingAddress1` TEXT NOT NULL, `billingAddress2` TEXT NOT NULL, `billingCity` TEXT NOT NULL, `billingState` TEXT NOT NULL, `billingPostcode` TEXT NOT NULL, `billingCountry` TEXT NOT NULL, `billingEmail` TEXT NOT NULL, `billingPhone` TEXT NOT NULL, `shippingFirstName` TEXT NOT NULL, `shippingLastName` TEXT NOT NULL, `shippingCompany` TEXT NOT NULL, `shippingAddress1` TEXT NOT NULL, `shippingAddress2` TEXT NOT NULL, `shippingCity` TEXT NOT NULL, `shippingState` TEXT NOT NULL, `shippingPostcode` TEXT NOT NULL, `shippingCountry` TEXT NOT NULL, `shippingPhone` TEXT NOT NULL, `lineItems` TEXT NOT NULL, `shippingLines` TEXT NOT NULL, `feeLines` TEXT NOT NULL, `taxLines` TEXT NOT NULL, `couponLines` TEXT NOT NULL DEFAULT '', `metaData` TEXT NOT NULL, `paymentUrl` TEXT NOT NULL DEFAULT '', `isEditable` INTEGER NOT NULL DEFAULT 1, `needsPayment` INTEGER, `needsProcessing` INTEGER, `giftCardCode` TEXT NOT NULL DEFAULT '', `giftCardAmount` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`localSiteId`, `orderId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderId",
+            "columnName": "orderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderKey",
+            "columnName": "orderKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCreated",
+            "columnName": "dateCreated",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalTax",
+            "columnName": "totalTax",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingTotal",
+            "columnName": "shippingTotal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentMethod",
+            "columnName": "paymentMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentMethodTitle",
+            "columnName": "paymentMethodTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datePaid",
+            "columnName": "datePaid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pricesIncludeTax",
+            "columnName": "pricesIncludeTax",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customerNote",
+            "columnName": "customerNote",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discountTotal",
+            "columnName": "discountTotal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discountCodes",
+            "columnName": "discountCodes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refundTotal",
+            "columnName": "refundTotal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customerId",
+            "columnName": "customerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "billingFirstName",
+            "columnName": "billingFirstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingLastName",
+            "columnName": "billingLastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingCompany",
+            "columnName": "billingCompany",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingAddress1",
+            "columnName": "billingAddress1",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingAddress2",
+            "columnName": "billingAddress2",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingCity",
+            "columnName": "billingCity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingState",
+            "columnName": "billingState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingPostcode",
+            "columnName": "billingPostcode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingCountry",
+            "columnName": "billingCountry",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingEmail",
+            "columnName": "billingEmail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "billingPhone",
+            "columnName": "billingPhone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingFirstName",
+            "columnName": "shippingFirstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingLastName",
+            "columnName": "shippingLastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingCompany",
+            "columnName": "shippingCompany",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingAddress1",
+            "columnName": "shippingAddress1",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingAddress2",
+            "columnName": "shippingAddress2",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingCity",
+            "columnName": "shippingCity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingState",
+            "columnName": "shippingState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingPostcode",
+            "columnName": "shippingPostcode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingCountry",
+            "columnName": "shippingCountry",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingPhone",
+            "columnName": "shippingPhone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lineItems",
+            "columnName": "lineItems",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shippingLines",
+            "columnName": "shippingLines",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feeLines",
+            "columnName": "feeLines",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taxLines",
+            "columnName": "taxLines",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "couponLines",
+            "columnName": "couponLines",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "metaData",
+            "columnName": "metaData",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentUrl",
+            "columnName": "paymentUrl",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "needsPayment",
+            "columnName": "needsPayment",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "needsProcessing",
+            "columnName": "needsProcessing",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "giftCardCode",
+            "columnName": "giftCardCode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "giftCardAmount",
+            "columnName": "giftCardAmount",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId",
+            "orderId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_OrderEntity_localSiteId_orderId",
+            "unique": false,
+            "columnNames": [
+              "localSiteId",
+              "orderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_OrderEntity_localSiteId_orderId` ON `${TABLE_NAME}` (`localSiteId`, `orderId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "OrderMetaData",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `id` INTEGER NOT NULL, `orderId` INTEGER NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `isDisplayable` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`localSiteId`, `orderId`, `id`), FOREIGN KEY(`localSiteId`, `orderId`) REFERENCES `OrderEntity`(`localSiteId`, `orderId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderId",
+            "columnName": "orderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDisplayable",
+            "columnName": "isDisplayable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId",
+            "orderId",
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_OrderMetaData_localSiteId_orderId",
+            "unique": false,
+            "columnNames": [
+              "localSiteId",
+              "orderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_OrderMetaData_localSiteId_orderId` ON `${TABLE_NAME}` (`localSiteId`, `orderId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "OrderEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "localSiteId",
+              "orderId"
+            ],
+            "referencedColumns": [
+              "localSiteId",
+              "orderId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "InboxNotes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `remoteId` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `name` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `dateCreated` TEXT NOT NULL, `status` TEXT NOT NULL, `source` TEXT, `type` TEXT, `dateReminder` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCreated",
+            "columnName": "dateCreated",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dateReminder",
+            "columnName": "dateReminder",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_InboxNotes_remoteId_localSiteId",
+            "unique": true,
+            "columnNames": [
+              "remoteId",
+              "localSiteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_InboxNotes_remoteId_localSiteId` ON `${TABLE_NAME}` (`remoteId`, `localSiteId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "InboxNoteActions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`remoteId` INTEGER NOT NULL, `inboxNoteLocalId` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `name` TEXT NOT NULL, `label` TEXT NOT NULL, `url` TEXT NOT NULL, `query` TEXT, `status` TEXT, `primary` INTEGER NOT NULL, `actionedText` TEXT, PRIMARY KEY(`remoteId`, `inboxNoteLocalId`), FOREIGN KEY(`inboxNoteLocalId`) REFERENCES `InboxNotes`(`localId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inboxNoteLocalId",
+            "columnName": "inboxNoteLocalId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "primary",
+            "columnName": "primary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionedText",
+            "columnName": "actionedText",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "remoteId",
+            "inboxNoteLocalId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_InboxNoteActions_inboxNoteLocalId",
+            "unique": false,
+            "columnNames": [
+              "inboxNoteLocalId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_InboxNoteActions_inboxNoteLocalId` ON `${TABLE_NAME}` (`inboxNoteLocalId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "InboxNotes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "inboxNoteLocalId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TopPerformerProducts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `datePeriod` TEXT NOT NULL, `productId` INTEGER NOT NULL, `name` TEXT NOT NULL, `imageUrl` TEXT, `quantity` INTEGER NOT NULL, `currency` TEXT NOT NULL, `total` REAL NOT NULL, `millisSinceLastUpdated` INTEGER NOT NULL, PRIMARY KEY(`datePeriod`, `productId`, `localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "datePeriod",
+            "columnName": "datePeriod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "millisSinceLastUpdated",
+            "columnName": "millisSinceLastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "datePeriod",
+            "productId",
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "TaxBasedOnSetting",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `selectedOption` TEXT NOT NULL, PRIMARY KEY(`localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedOption",
+            "columnName": "selectedOption",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "TaxRate",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `localSiteId` INTEGER NOT NULL, `country` TEXT, `state` TEXT, `postcode` TEXT, `city` TEXT, `rate` TEXT, `name` TEXT, `taxClass` TEXT, PRIMARY KEY(`id`, `localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "postcode",
+            "columnName": "postcode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "taxClass",
+            "columnName": "taxClass",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id",
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "WooPaymentsDepositsOverview",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localSiteId` INTEGER NOT NULL, `depositsEnabled` INTEGER, `depositsBlocked` INTEGER, `defaultCurrency` TEXT, `delayDays` INTEGER, `weeklyAnchor` TEXT, `monthlyAnchor` INTEGER, `interval` TEXT, PRIMARY KEY(`localSiteId`))",
+        "fields": [
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "account.depositsEnabled",
+            "columnName": "depositsEnabled",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "account.depositsBlocked",
+            "columnName": "depositsBlocked",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "account.defaultCurrency",
+            "columnName": "defaultCurrency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "account.depositsSchedule.delayDays",
+            "columnName": "delayDays",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "account.depositsSchedule.weeklyAnchor",
+            "columnName": "weeklyAnchor",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "account.depositsSchedule.monthlyAnchor",
+            "columnName": "monthlyAnchor",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "account.depositsSchedule.interval",
+            "columnName": "interval",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localSiteId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "WooPaymentsDeposits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `localSiteId` INTEGER NOT NULL, `depositId` TEXT, `date` INTEGER, `type` TEXT, `amount` INTEGER, `status` TEXT, `bankAccount` TEXT, `currency` TEXT, `automatic` INTEGER, `fee` INTEGER, `feePercentage` REAL, `created` INTEGER, `depositType` TEXT NOT NULL, FOREIGN KEY(`localSiteId`) REFERENCES `WooPaymentsDepositsOverview`(`localSiteId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "depositId",
+            "columnName": "depositId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bankAccount",
+            "columnName": "bankAccount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "automatic",
+            "columnName": "automatic",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fee",
+            "columnName": "fee",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "feePercentage",
+            "columnName": "feePercentage",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "depositType",
+            "columnName": "depositType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "WooPaymentsDepositsOverview",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "localSiteId"
+            ],
+            "referencedColumns": [
+              "localSiteId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "WooPaymentsManualDeposits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `localSiteId` INTEGER NOT NULL, `currency` TEXT, `date` INTEGER, FOREIGN KEY(`localSiteId`) REFERENCES `WooPaymentsDepositsOverview`(`localSiteId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "WooPaymentsDepositsOverview",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "localSiteId"
+            ],
+            "referencedColumns": [
+              "localSiteId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "WooPaymentsBalance",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `localSiteId` INTEGER NOT NULL, `amount` INTEGER, `currency` TEXT, `fee` INTEGER, `feePercentage` REAL, `net` INTEGER, `balanceType` TEXT NOT NULL, `card` INTEGER, FOREIGN KEY(`localSiteId`) REFERENCES `WooPaymentsDepositsOverview`(`localSiteId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localSiteId",
+            "columnName": "localSiteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fee",
+            "columnName": "fee",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "feePercentage",
+            "columnName": "feePercentage",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "net",
+            "columnName": "net",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "balanceType",
+            "columnName": "balanceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceTypes.card",
+            "columnName": "card",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "WooPaymentsDepositsOverview",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "localSiteId"
+            ],
+            "referencedColumns": [
+              "localSiteId"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '43fd0900518251fbd271b5ffe7a0d89f')"
+    ]
+  }
+}

--- a/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
+++ b/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
@@ -11,6 +11,13 @@ import org.junit.runner.RunWith
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_10_11
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_11_12
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_15_16
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_20_21
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_21_22
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_22_23
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_24_25
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_27_28
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_30_31
+import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_31_32
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_3_4
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_4_5
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_5_6
@@ -18,10 +25,6 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_6_7
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_7_8
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_8_9
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
-import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_20_21
-import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_21_22
-import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_22_23
-import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_27_28
 
 @RunWith(AndroidJUnit4::class)
 class MigrationTests {
@@ -216,7 +219,7 @@ class MigrationTests {
     fun testMigrate24to25() {
         helper.apply {
             createDatabase(TEST_DB, 24).close()
-            runMigrationsAndValidate(TEST_DB, 25, false)
+            runMigrationsAndValidate(TEST_DB, 25, true, MIGRATION_24_25)
         }
     }
 
@@ -257,6 +260,30 @@ class MigrationTests {
         helper.apply {
             createDatabase(TEST_DB, 29).close()
             runMigrationsAndValidate(TEST_DB, 30, false)
+        }
+    }
+
+    @Test
+    fun testMigration30to31() {
+        helper.apply {
+            createDatabase(TEST_DB, 30).close()
+            runMigrationsAndValidate(TEST_DB, 31, false, MIGRATION_30_31)
+        }
+    }
+
+    @Test
+    fun testMigration31to32() {
+        helper.apply {
+            createDatabase(TEST_DB, 31).close()
+            runMigrationsAndValidate(TEST_DB, 32, false, MIGRATION_31_32)
+        }
+    }
+
+    @Test
+    fun testMigration32to33() {
+        helper.apply {
+            createDatabase(TEST_DB, 32).close()
+            runMigrationsAndValidate(TEST_DB, 33, false)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/woo/WooPaymentsDepositsOverview.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/woo/WooPaymentsDepositsOverview.kt
@@ -30,9 +30,7 @@ data class WooPaymentsDepositsOverview(
             val fee: Long?,
             val feePercentage: Double?,
             val net: Long?,
-            val transactionIds: List<String>?,
             val sourceTypes: SourceTypes?,
-            val depositsCount: Int?,
         )
 
         data class SourceTypes(
@@ -43,7 +41,6 @@ data class WooPaymentsDepositsOverview(
     data class Deposit(
         val lastManualDeposits: List<ManualDeposit>?,
         val lastPaid: List<Info>?,
-        val nextScheduled: List<Info>?
     ) {
         data class Info(
             val amount: Long?,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/woo/WooPaymentsDepositsOverviewComposedEntities.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/woo/WooPaymentsDepositsOverviewComposedEntities.kt
@@ -9,7 +9,6 @@ data class WooPaymentsDepositsOverviewComposedEntities(
     val overview: WooPaymentsDepositsOverviewEntity,
 
     val lastPaidDeposits: List<WooPaymentsDepositEntity>?,
-    val nextScheduledDeposits: List<WooPaymentsDepositEntity>?,
     val lastManualDeposits: List<WooPaymentsManualDepositEntity>?,
 
     val pendingBalances: List<WooPaymentsBalanceEntity>?,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/woo/WooPaymentsDepositsOverviewApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/woo/WooPaymentsDepositsOverviewApiResponse.kt
@@ -10,7 +10,6 @@ data class WooPaymentsDepositsOverviewApiResponse(
 
 data class WooPaymentsCurrencyDeposits(
     @SerializedName("last_paid") val lastPaid: List<WooPaymentsDeposit>?,
-    @SerializedName("next_scheduled") val nextScheduled: List<WooPaymentsDeposit>?,
     @SerializedName("last_manual_deposits") val lastManualDeposits: List<WooPaymentsManualDeposit>?
 )
 
@@ -43,10 +42,8 @@ data class WooPaymentsBalance(
     val amount: Long?,
     val currency: String?,
     @SerializedName("source_types") val sourceTypes: WooPaymentsSourceTypes?,
-    @SerializedName("deposits_count") val depositsCount: Int?,
     @SerializedName("fee_percentage") val feePercentage: Double?,
     @SerializedName("net") val net: Long?,
-    @SerializedName("transaction_ids") val transactionIds: List<String>?,
     val fee: Long?,
 )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.fluxc.persistence.migrations.AutoMigration17to18
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration18to19
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration19to20
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration23to24
+import org.wordpress.android.fluxc.persistence.migrations.AutoMigration32to33
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_10_11
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_11_12
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_15_16
@@ -65,7 +66,7 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_8_9
 import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
 
 @Database(
-    version = 32,
+    version = 33,
     entities = [
         AddonEntity::class,
         AddonOptionEntity::class,
@@ -98,6 +99,8 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
         AutoMigration(from = 26, to = 27),
         AutoMigration(from = 28, to = 29),
         AutoMigration(from = 29, to = 30),
+        AutoMigration(from = 31, to = 32),
+        AutoMigration(from = 32, to = 33, spec = AutoMigration32to33::class),
     ]
 )
 @TypeConverters(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/WooPaymentsDepositsOverviewDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/WooPaymentsDepositsOverviewDao.kt
@@ -10,7 +10,6 @@ import org.wordpress.android.fluxc.model.payments.woo.WooPaymentsDepositsOvervie
 import org.wordpress.android.fluxc.persistence.entity.BalanceType
 import org.wordpress.android.fluxc.persistence.entity.DepositType
 import org.wordpress.android.fluxc.persistence.entity.DepositType.LAST_PAID
-import org.wordpress.android.fluxc.persistence.entity.DepositType.NEXT_SCHEDULED
 import org.wordpress.android.fluxc.persistence.entity.WooPaymentsBalanceEntity
 import org.wordpress.android.fluxc.persistence.entity.WooPaymentsDepositEntity
 import org.wordpress.android.fluxc.persistence.entity.WooPaymentsDepositsOverviewEntity
@@ -25,7 +24,6 @@ interface WooPaymentsDepositsOverviewDao {
             overview = overview,
 
             lastPaidDeposits = getDeposits(localSiteId, LAST_PAID),
-            nextScheduledDeposits = getDeposits(localSiteId, NEXT_SCHEDULED),
             lastManualDeposits = getManualDeposits(localSiteId),
 
             pendingBalances = getBalances(localSiteId, BalanceType.PENDING),
@@ -85,7 +83,6 @@ interface WooPaymentsDepositsOverviewDao {
         localSiteId: LocalId,
         overviewEntity: WooPaymentsDepositsOverviewEntity,
         lastPaidDepositsEntities: List<WooPaymentsDepositEntity>,
-        nextScheduledDepositsEntities: List<WooPaymentsDepositEntity>,
         manualDepositEntities: List<WooPaymentsManualDepositEntity>,
         pendingBalancesEntities: List<WooPaymentsBalanceEntity>,
         availableBalancesEntities: List<WooPaymentsBalanceEntity>,
@@ -94,7 +91,6 @@ interface WooPaymentsDepositsOverviewDao {
         insertOverview(overviewEntity)
 
         lastPaidDepositsEntities.forEach { insertDeposit(it) }
-        nextScheduledDepositsEntities.forEach { insertDeposit(it) }
         manualDepositEntities.forEach { insertManualDeposit(it) }
 
         pendingBalancesEntities.forEach { insertBalance(it) }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/WooPaymentsDepositsOverviewEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/WooPaymentsDepositsOverviewEntity.kt
@@ -63,7 +63,6 @@ data class WooPaymentsDepositEntity(
 
 enum class DepositType {
     LAST_PAID,
-    NEXT_SCHEDULED
 }
 
 @Entity(
@@ -105,8 +104,6 @@ data class WooPaymentsBalanceEntity(
     val fee: Long?,
     val feePercentage: Double?,
     val net: Long?,
-    val transactionIds: List<String>?,
-    val depositsCount: Int?,
 
     @Embedded
     val sourceTypes: SourceTypes?,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/mappers/WooPaymentsDepositsOverviewMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/mappers/WooPaymentsDepositsOverviewMapper.kt
@@ -59,9 +59,6 @@ class WooPaymentsDepositsOverviewMapper @Inject constructor() {
                     lastPaid = it.lastPaid?.map {
                         info -> mapApiDepositToModel(info)
                     },
-                    nextScheduled = it.nextScheduled?.map {
-                        info -> mapApiDepositToModel(info)
-                    }
                 )
             }
         )
@@ -97,21 +94,6 @@ class WooPaymentsDepositsOverviewMapper @Inject constructor() {
                             depositId = it.depositId
                         )
                     },
-                    nextScheduled = entity.nextScheduledDeposits?.map {
-                        Info(
-                            amount = it.amount,
-                            automatic = it.automatic,
-                            bankAccount = it.bankAccount,
-                            created = it.created,
-                            currency = it.currency,
-                            date = it.date,
-                            fee = it.fee,
-                            feePercentage = it.feePercentage,
-                            status = it.status,
-                            type = it.type,
-                            depositId = it.depositId
-                        )
-                    }
                 )
             )
         }
@@ -128,8 +110,6 @@ class WooPaymentsDepositsOverviewMapper @Inject constructor() {
             fee = it.fee,
             feePercentage = it.feePercentage,
             net = it.net,
-            transactionIds = it.transactionIds,
-            depositsCount = it.depositsCount
         )
 
     fun mapModelDepositToEntity(
@@ -180,9 +160,7 @@ class WooPaymentsDepositsOverviewMapper @Inject constructor() {
             fee = balance.fee,
             feePercentage = balance.feePercentage,
             net = balance.net,
-            transactionIds = balance.transactionIds,
             balanceType = balanceType,
-            depositsCount = balance.depositsCount
         )
 
     fun mapModelToEntity(
@@ -205,8 +183,6 @@ class WooPaymentsDepositsOverviewMapper @Inject constructor() {
             fee = available.fee,
             feePercentage = available.feePercentage,
             net = available.net,
-            transactionIds = available.transactionIds,
-            depositsCount = available.depositsCount
         )
 
     private fun mapEntityAccountToModel(account: WooPaymentsAccountDepositSummaryEntity?) =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/migrations/Migrations.kt
@@ -1056,3 +1056,9 @@ internal val MIGRATION_31_32 = object : Migration(31, 32) {
         }
     }
 }
+
+@DeleteColumn.Entries(
+    DeleteColumn(tableName = "WooPaymentsBalance", columnName = "transactionIds"),
+    DeleteColumn(tableName = "WooPaymentsBalance", columnName = "depositsCount"),
+)
+internal class AutoMigration32to33 : AutoMigrationSpec

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCWooPaymentsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCWooPaymentsStore.kt
@@ -48,9 +48,6 @@ class WCWooPaymentsStore @Inject constructor(
             lastPaidDepositsEntities = depositsOverview.deposit?.lastPaid?.map {
                 mapper.mapModelDepositToEntity(it, site, DepositType.LAST_PAID)
             }.orEmpty(),
-            nextScheduledDepositsEntities = depositsOverview.deposit?.nextScheduled?.map {
-                mapper.mapModelDepositToEntity(it, site, DepositType.NEXT_SCHEDULED)
-            }.orEmpty(),
             manualDepositEntities = depositsOverview.deposit?.lastManualDeposits?.map {
                 mapper.mapModelManualDepositToEntity(it, site)
             }.orEmpty(),


### PR DESCRIPTION
To address changes in the API the PR reviews the fields that are no longer returned.

```
GET deposits/overview-all
Response deposit.next_scheduled should no longer be returned.
Response balance.instant[].transaction_ids should no longer be returned.
Response balance.pending[].deposits_count should no longer be returned.
```

https://github.com/Automattic/woocommerce-payments-server/issues/4296