### PR TITLE
[Fix] Update target sdk from 33 to 34.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ allprojects {
 ext {
     minSdkVersion = 24
     compileSdkVersion = 34
-    targetSdkVersion = 33
+    targetSdkVersion = 34
 }
 
 ext {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.15.0"
+def catalogVersion = "1.16.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {


### PR DESCRIPTION
Related: #2942

Update `targetSdk` version from 33 to 34.

- [ ] Checkout this branch
- [ ] Use this branch through WP (uncomment locaFluxCPath in local-builds.gradle)
- [ ] Log out if already logged in
- [ ] Try out login and various flows
- [ ] Ensure, no issues or crashes