### PR TITLE
[Credential Manager] Add raw challenge JSON data

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -24,7 +24,6 @@ import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComErrorListener;
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError;
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.WebauthnChallengeInfo;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.WebauthnChallengeRequest;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.WebauthnToken;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.WebauthnTokenRequest;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -128,7 +128,7 @@ public class Authenticator {
     }
 
     public void makeRequest(String userId, String webauthnNonce,
-                            Response.Listener<String> listener,
+                            Response.Listener<JSONObject> listener,
                             ErrorListener errorListener) {
         WebauthnChallengeRequest request = new WebauthnChallengeRequest(
                 userId,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -129,7 +129,7 @@ public class Authenticator {
     }
 
     public void makeRequest(String userId, String webauthnNonce,
-                            Response.Listener<WebauthnChallengeInfo> listener,
+                            Response.Listener<String> listener,
                             ErrorListener errorListener) {
         WebauthnChallengeRequest request = new WebauthnChallengeRequest(
                 userId,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/VolleyWebauthnRequests.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/VolleyWebauthnRequests.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn
 import com.android.volley.Response
 import com.android.volley.Response.ErrorListener
 import com.google.gson.annotations.SerializedName
+import org.json.JSONObject
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.AUTH_TYPE
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.CLIENT_DATA
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.CLIENT_ID
@@ -17,9 +18,9 @@ class WebauthnChallengeRequest(
     twoStepNonce: String,
     clientId: String,
     clientSecret: String,
-    listener: Response.Listener<String>,
+    listener: Response.Listener<JSONObject>,
     errorListener: ErrorListener
-): BaseWebauthnRequest<String>(webauthnChallengeEndpointUrl, errorListener, listener) {
+): BaseWebauthnRequest<JSONObject>(webauthnChallengeEndpointUrl, errorListener, listener) {
     override val parameters: Map<String, String> = mapOf(
         CLIENT_ID.value to clientId,
         CLIENT_SECRET.value to clientSecret,
@@ -28,7 +29,7 @@ class WebauthnChallengeRequest(
         TWO_STEP_NONCE.value to twoStepNonce
     )
 
-    override fun serializeResponse(response: String) = response
+    override fun serializeResponse(response: String) = JSONObject(response)
 }
 
 @SuppressWarnings("LongParameterList")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/VolleyWebauthnRequests.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/VolleyWebauthnRequests.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn
 
 import com.android.volley.Response
 import com.android.volley.Response.ErrorListener
+import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.AUTH_TYPE
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.CLIENT_DATA
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.BaseWebauthnRequest.WebauthnRequestParameters.CLIENT_ID
@@ -54,3 +55,8 @@ class WebauthnTokenRequest(
     override fun serializeResponse(response: String): WebauthnToken =
         gson.fromJson(response, WebauthnToken::class.java)
 }
+
+class WebauthnToken(
+    @SerializedName("bearer_token")
+    val bearerToken: String
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/VolleyWebauthnRequests.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/VolleyWebauthnRequests.kt
@@ -16,9 +16,9 @@ class WebauthnChallengeRequest(
     twoStepNonce: String,
     clientId: String,
     clientSecret: String,
-    listener: Response.Listener<WebauthnChallengeInfo>,
+    listener: Response.Listener<String>,
     errorListener: ErrorListener
-): BaseWebauthnRequest<WebauthnChallengeInfo>(webauthnChallengeEndpointUrl, errorListener, listener) {
+): BaseWebauthnRequest<String>(webauthnChallengeEndpointUrl, errorListener, listener) {
     override val parameters: Map<String, String> = mapOf(
         CLIENT_ID.value to clientId,
         CLIENT_SECRET.value to clientSecret,
@@ -27,8 +27,7 @@ class WebauthnChallengeRequest(
         TWO_STEP_NONCE.value to twoStepNonce
     )
 
-    override fun serializeResponse(response: String): WebauthnChallengeInfo =
-        gson.fromJson(response, WebauthnChallengeInfo::class.java)
+    override fun serializeResponse(response: String) = response
 }
 
 @SuppressWarnings("LongParameterList")

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/WebauthnModels.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/WebauthnModels.kt
@@ -2,21 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn
 
 import com.google.gson.annotations.SerializedName
 
-class WebauthnChallengeInfo(
-    val challenge: String,
-    val rpId: String,
-    val allowCredentials: List<WebauthnCredentialResponse>,
-    val timeout: Int,
-    @SerializedName("two_step_nonce")
-    val twoStepNonce: String
-)
-
-class WebauthnCredentialResponse(
-    val type: String,
-    val id: String,
-    val transports: List<String>
-)
-
 class WebauthnToken(
     @SerializedName("bearer_token")
     val bearerToken: String

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/WebauthnModels.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/webauthn/WebauthnModels.kt
@@ -1,8 +1,0 @@
-package org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn
-
-import com.google.gson.annotations.SerializedName
-
-class WebauthnToken(
-    @SerializedName("bearer_token")
-    val bearerToken: String
-)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -11,6 +11,7 @@ import com.yarolegovich.wellsql.WellSql;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.json.JSONObject;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.AccountAction;
@@ -356,7 +357,7 @@ public class AccountStore extends Store {
     }
 
     public static class WebauthnChallengeReceived extends OnChanged<AuthenticationError> {
-        public String response;
+        public JSONObject mJsonResponse;
         public String mUserId;
     }
 
@@ -1411,10 +1412,10 @@ public class AccountStore extends Store {
 
     private void requestWebauthnChallenge(final StartWebauthnChallengePayload payload) {
         mAuthenticator.makeRequest(payload.mUserId, payload.mWebauthnNonce,
-                (Response.Listener<String>) response -> {
+                (Response.Listener<JSONObject>) response -> {
                     WebauthnChallengeReceived event = new WebauthnChallengeReceived();
                     event.mUserId = payload.mUserId;
-                    event.response = response;
+                    event.mJsonResponse = response;
                     emitChange(event);
                 },
                 error -> {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -357,6 +357,7 @@ public class AccountStore extends Store {
 
     public static class WebauthnChallengeReceived extends OnChanged<AuthenticationError> {
         public String response;
+        public String mUserId;
     }
 
     public static class FinishWebauthnChallengePayload {
@@ -1412,6 +1413,7 @@ public class AccountStore extends Store {
         mAuthenticator.makeRequest(payload.mUserId, payload.mWebauthnNonce,
                 (Response.Listener<String>) response -> {
                     WebauthnChallengeReceived event = new WebauthnChallengeReceived();
+                    event.mUserId = payload.mUserId;
                     event.response = response;
                     emitChange(event);
                 },

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -7,7 +7,6 @@ import androidx.annotation.Nullable;
 
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
-import com.google.gson.Gson;
 import com.yarolegovich.wellsql.WellSql;
 
 import org.greenrobot.eventbus.Subscribe;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -43,7 +43,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.AuthEma
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.OauthResponse;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.Token;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.Authenticator.TwoFactorResponse;
-import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.WebauthnChallengeInfo;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.webauthn.WebauthnToken;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType;
 import org.wordpress.android.fluxc.persistence.AccountSqlUtils;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
+import com.google.gson.Gson;
 import com.yarolegovich.wellsql.WellSql;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -359,6 +360,7 @@ public class AccountStore extends Store {
     public static class WebauthnChallengeReceived extends OnChanged<AuthenticationError> {
         public WebauthnChallengeInfo mChallengeInfo;
         public String mUserId;
+        public String mRawChallengeInfoJson;
     }
 
     public static class FinishWebauthnChallengePayload {
@@ -1414,6 +1416,7 @@ public class AccountStore extends Store {
         mAuthenticator.makeRequest(payload.mUserId, payload.mWebauthnNonce,
                 (Response.Listener<WebauthnChallengeInfo>) info -> {
                     WebauthnChallengeReceived event = new WebauthnChallengeReceived();
+                    event.mRawChallengeInfoJson = new Gson().toJson(info);
                     event.mChallengeInfo = info;
                     event.mUserId = payload.mUserId;
                     emitChange(event);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -357,8 +357,14 @@ public class AccountStore extends Store {
     }
 
     public static class WebauthnChallengeReceived extends OnChanged<AuthenticationError> {
+        private static final String TWO_STEP_NONCE_KEY = "two_step_nonce";
+
         public JSONObject mJsonResponse;
         public String mUserId;
+
+        public String getWebauthnNonce() {
+            return mJsonResponse.optString(TWO_STEP_NONCE_KEY);
+        }
     }
 
     public static class FinishWebauthnChallengePayload {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/AccountStore.java
@@ -358,9 +358,7 @@ public class AccountStore extends Store {
     }
 
     public static class WebauthnChallengeReceived extends OnChanged<AuthenticationError> {
-        public WebauthnChallengeInfo mChallengeInfo;
-        public String mUserId;
-        public String mRawChallengeInfoJson;
+        public String response;
     }
 
     public static class FinishWebauthnChallengePayload {
@@ -1414,11 +1412,9 @@ public class AccountStore extends Store {
 
     private void requestWebauthnChallenge(final StartWebauthnChallengePayload payload) {
         mAuthenticator.makeRequest(payload.mUserId, payload.mWebauthnNonce,
-                (Response.Listener<WebauthnChallengeInfo>) info -> {
+                (Response.Listener<String>) response -> {
                     WebauthnChallengeReceived event = new WebauthnChallengeReceived();
-                    event.mRawChallengeInfoJson = new Gson().toJson(info);
-                    event.mChallengeInfo = info;
-                    event.mUserId = payload.mUserId;
+                    event.response = response;
                     emitChange(event);
                 },
                 error -> {


### PR DESCRIPTION
⚠️⚠️⚠️ Merge only when https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/135 is approved.

# Summary
Small adjustment to allow the Webauthn payload to contain the entire JSON data instead of the parsed values. The Credential Manager API requires the raw JSON, while the FIDO2 API requires only some fields, so this PR adjusts the payload to contain only the JSON file, as we're moving away from FIDO2 to support only the Credential Manager.