### PR TITLE
Enhanced Error Handling in Order List Fetching: Precise Categorization of Errors

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -827,8 +827,13 @@ class WCOrderStore @Inject constructor(
             loadedMore = payload.loadedMore,
             canLoadMore = payload.canLoadMore,
             error = payload.error?.let { fetchError ->
-                // TODO: Use the actual error type
-                ListError(type = ListErrorType.GENERIC_ERROR, message = fetchError.message)
+                ListError(
+                    type = when (fetchError.type) {
+                        PARSE_ERROR -> ListErrorType.PARSE_ERROR
+                        else -> ListErrorType.GENERIC_ERROR
+                    },
+                    message = fetchError.message
+                )
             }
         )))
     }


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/2950
## Description
This PR updates the handleFetchOrderListCompleted function in the WCOrderStore to improve error handling by differentiating between generic and parsing-related errors. Previously, all errors were broadly classified as generic, limiting the specificity for troubleshooting. The enhancement uses a when expression to accurately assign ListErrorType based on the error encountered, either as PARSE_ERROR for parsing issues or GENERIC_ERROR for other types. 

The best way to test this PR is to follow the instructions on https://github.com/woocommerce/woocommerce-android/pull/10717

