### PR TITLE
Blaze: Add stubbed implementation of the payments endpoint

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
@@ -402,7 +402,6 @@ class BlazeCampaignsStoreTest {
             savedPaymentMethods = listOf(
                 BlazePaymentMethod(
                     id = "payment-method-id",
-                    type = BlazePaymentMethod.PaymentMethodType.CREDIT_CARD,
                     name = "Visa **** 4689",
                     info = BlazePaymentMethod.PaymentMethodInfo.CreditCardInfo(
                         lastDigits = "4689",
@@ -415,7 +414,6 @@ class BlazeCampaignsStoreTest {
                 ),
                 BlazePaymentMethod(
                     id = "payment-method-id-2",
-                    type = BlazePaymentMethod.PaymentMethodType.CREDIT_CARD,
                     name = "MasterCard **** 1234",
                     info = BlazePaymentMethod.PaymentMethodInfo.CreditCardInfo(
                         lastDigits = "1234",

--- a/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
@@ -17,6 +17,9 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.blaze.BlazeAdForecast
 import org.wordpress.android.fluxc.model.blaze.BlazeAdSuggestion
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignsModel
+import org.wordpress.android.fluxc.model.blaze.BlazePaymentMethod
+import org.wordpress.android.fluxc.model.blaze.BlazePaymentMethodUrls
+import org.wordpress.android.fluxc.model.blaze.BlazePaymentMethods
 import org.wordpress.android.fluxc.model.blaze.BlazeTargetingDevice
 import org.wordpress.android.fluxc.model.blaze.BlazeTargetingLanguage
 import org.wordpress.android.fluxc.model.blaze.BlazeTargetingLocation
@@ -391,5 +394,53 @@ class BlazeCampaignsStoreTest {
 
         assertThat(forecastResult.isError).isFalse()
         assertThat(forecastResult.model).isEqualTo(forecast)
+    }
+
+    @Test
+    fun `when fetching payment methods, then return data successfully`() = test {
+        val paymentMethods = BlazePaymentMethods(
+            savedPaymentMethods = listOf(
+                BlazePaymentMethod(
+                    id = "payment-method-id",
+                    type = BlazePaymentMethod.PaymentMethodType.CREDIT_CARD,
+                    name = "Visa **** 4689",
+                    info = BlazePaymentMethod.PaymentMethodInfo.CreditCardInfo(
+                        lastDigits = "4689",
+                        expMonth = 12,
+                        expYear = 2025,
+                        type = "Visa",
+                        nickname = "",
+                        cardHolderName = "John Doe"
+                    )
+                ),
+                BlazePaymentMethod(
+                    id = "payment-method-id-2",
+                    type = BlazePaymentMethod.PaymentMethodType.CREDIT_CARD,
+                    name = "MasterCard **** 1234",
+                    info = BlazePaymentMethod.PaymentMethodInfo.CreditCardInfo(
+                        lastDigits = "1234",
+                        expMonth = 12,
+                        expYear = 2025,
+                        type = "MasterCard",
+                        nickname = "",
+                        cardHolderName = "John Doe"
+                    )
+                )
+            ),
+            addPaymentMethodUrls = BlazePaymentMethodUrls(
+                formUrl = "https://example.com/blaze-pm-add",
+                successUrl = "https://example.com/blaze-pm-success",
+                idUrlParameter = "pmid"
+            )
+        )
+
+        whenever(creationRestClient.fetchPaymentMethods(any())).thenReturn(
+            BlazeCreationRestClient.BlazePayload(paymentMethods)
+        )
+
+        val paymentMethodsResult = store.fetchBlazePaymentMethods(siteModel)
+
+        assertThat(paymentMethodsResult.isError).isFalse()
+        assertThat(paymentMethodsResult.model).isEqualTo(paymentMethods)
     }
 }

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -42,6 +42,7 @@
 /sites/$site/wordads/dsp/api/v1.1/targeting/page-topics
 /sites/$site/wordads/dsp/api/v1.1/suggestions
 /sites/$site/wordads/dsp/api/v1.1/forecast
+/sites/$site/wordads/dsp/api/v1.1/payment-methods
 
 /sites/$site/launch
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazePaymentMethods.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazePaymentMethods.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.fluxc.model.blaze
+
+data class BlazePaymentMethods(
+    val savedPaymentMethods: List<BlazePaymentMethod>,
+    val addPaymentMethodUrls: BlazePaymentMethodUrls
+)
+
+data class BlazePaymentMethod(
+    val id: String,
+    val type: PaymentMethodType,
+    val name: String,
+    val info: PaymentMethodInfo
+) {
+    enum class PaymentMethodType {
+        CREDIT_CARD,
+        UNKNOWN
+    }
+
+    sealed interface PaymentMethodInfo {
+        data class CreditCardInfo(
+            val lastDigits: String,
+            val expMonth: Int,
+            val expYear: Int,
+            val type: String,
+            val nickname: String,
+            val cardHolderName: String
+        ) : PaymentMethodInfo
+
+        object Unknown : PaymentMethodInfo
+    }
+}
+
+data class BlazePaymentMethodUrls(
+    val formUrl: String,
+    val successUrl: String,
+    val idUrlParameter: String
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazePaymentMethods.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazePaymentMethods.kt
@@ -7,15 +7,9 @@ data class BlazePaymentMethods(
 
 data class BlazePaymentMethod(
     val id: String,
-    val type: PaymentMethodType,
     val name: String,
     val info: PaymentMethodInfo
 ) {
-    enum class PaymentMethodType {
-        CREDIT_CARD,
-        UNKNOWN
-    }
-
     sealed interface PaymentMethodInfo {
         data class CreditCardInfo(
             val lastDigits: String,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
@@ -362,10 +362,6 @@ private class BlazePaymentMethodsResponse(
         fun toDomainModel(): BlazePaymentMethod {
             return BlazePaymentMethod(
                 id = id,
-                type = when (type) {
-                    "credit_card" -> BlazePaymentMethod.PaymentMethodType.CREDIT_CARD
-                    else -> BlazePaymentMethod.PaymentMethodType.UNKNOWN
-                },
                 name = name,
                 info = when (type) {
                     "credit_card" -> BlazePaymentMethod.PaymentMethodInfo.CreditCardInfo(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStore.kt
@@ -251,6 +251,19 @@ class BlazeCampaignsStore @Inject constructor(
         }
     }
 
+    suspend fun fetchBlazePaymentMethods(
+        site: SiteModel
+    ) = coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetch blaze payment methods") {
+        creationRestClient.fetchPaymentMethods(site).let { payload ->
+            when {
+                payload.isError -> BlazeResult(BlazeError(payload.error))
+                else -> {
+                    BlazeResult(payload.data)
+                }
+            }
+        }
+    }
+
     data class BlazeCampaignsResult<T>(
         val model: T? = null,
         val cached: Boolean = false


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-android/issues/10722

This PR adds implementation of the payments endpoint for Blaze, as the API is not ready yet, the rest client returns a stubbed response for now.

There is nothing to test yet, just CI is enough.