### PR TITLE
Blaze: campaign creation endpoint

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.blaze.BlazeAdForecast
 import org.wordpress.android.fluxc.model.blaze.BlazeAdSuggestion
+import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignsModel
 import org.wordpress.android.fluxc.model.blaze.BlazePaymentMethod
 import org.wordpress.android.fluxc.model.blaze.BlazePaymentMethodUrls
@@ -440,5 +441,30 @@ class BlazeCampaignsStoreTest {
 
         assertThat(paymentMethodsResult.isError).isFalse()
         assertThat(paymentMethodsResult.model).isEqualTo(paymentMethods)
+    }
+
+    @Test
+    fun `when creating a campaign, then persist it to the DB and return result`() = test {
+        val campaign = BlazeCampaignModel(
+            campaignId = CAMPAIGN_ID,
+            title = TITLE,
+            imageUrl = IMAGE_URL,
+            createdAt = BlazeCampaignsUtils.stringToDate(CREATED_AT),
+            endDate = BlazeCampaignsUtils.stringToDate(END_DATE),
+            uiStatus = UI_STATUS,
+            budgetCents = BUDGET_CENTS,
+            impressions = IMPRESSIONS,
+            clicks = CLICKS,
+            targetUrn = "urn:wpcom:post:199247490:9"
+        )
+
+        whenever(creationRestClient.createCampaign(any(), any())).thenReturn(
+            BlazeCreationRestClient.BlazePayload(campaign)
+        )
+
+        val result = store.createCampaign(siteModel, mock())
+
+        assertThat(result.isError).isFalse()
+        assertThat(result.model).isEqualTo(campaign)
     }
 }

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -43,6 +43,7 @@
 /sites/$site/wordads/dsp/api/v1.1/suggestions
 /sites/$site/wordads/dsp/api/v1.1/forecast
 /sites/$site/wordads/dsp/api/v1.1/payment-methods
+/sites/$site/wordads/dsp/api/v1.1/campaigns
 
 /sites/$site/launch
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.model.blaze
+
+import org.wordpress.android.fluxc.model.MediaModel
+import java.util.Date
+import java.util.TimeZone
+
+data class BlazeCampaignCreationRequest(
+    val origin: String,
+    val originVersion: String,
+    val targetResourceId: Long,
+    val type: BlazeCampaignType,
+    val paymentMethodId: String,
+    val tagLine: String,
+    val description: String,
+    val startDate: Date,
+    val endDate: Date,
+    val budget: Double,
+    val targetUrl: String,
+    val urlParams: Map<String, String>,
+    val mainImage: MediaModel,
+    val targetingParameters: BlazeTargetingParameters?,
+    val timeZoneId: String = TimeZone.getDefault().id
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignType.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignType.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.fluxc.model.blaze
+
+enum class BlazeCampaignType(val value: String) {
+    POST("post"),
+    PAGE("page"),
+    PRODUCT("product"),
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingParameters.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingParameters.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.model.blaze
 
 data class BlazeTargetingParameters(
-    val locations: List<BlazeTargetingLocation>? = null,
-    val languages: List<BlazeTargetingLanguage>? = null,
-    val devices: List<BlazeTargetingDevice>? = null,
-    val topics: List<BlazeTargetingTopic>? = null
+    val locations: List<String>? = null,
+    val languages: List<String>? = null,
+    val devices: List<String>? = null,
+    val topics: List<String>? = null
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingParameters.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeTargetingParameters.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.model.blaze
 
 data class BlazeTargetingParameters(
-    val locations: List<String>? = null,
+    val locations: List<Long>? = null,
     val languages: List<String>? = null,
     val devices: List<String>? = null,
     val topics: List<String>? = null

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
@@ -236,7 +236,7 @@ class BlazeCreationRestClient @Inject constructor(
         }
     }
 
-    @Suppress("UNREACHABLE_CODE")
+    @Suppress("UNREACHABLE_CODE", "MagicNumber")
     @SuppressLint("SimpleDateFormat")
     suspend fun createCampaign(
         site: SiteModel,
@@ -490,6 +490,7 @@ private data class BlazeCampaignCreationNetworkResponse(
         val url: String
     )
 
+    @Suppress("MagicNumber")
     fun toDomainModel(): BlazeCampaignModel = BlazeCampaignModel(
         targetUrn = targetUrn,
         createdAt = Date(), // Set to current date, as the API does not return the actual creation date


### PR DESCRIPTION
This PR adds a stubbed implementation of the Blaze campaign creation endpoint, please check the comments below for some remarks.

For testing, please check the WCAndroid PR: https://github.com/woocommerce/woocommerce-android/pull/10790