### PR TITLE
Add DB timestamp in PostModel

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/CauseOfOnPostChanged.kt
@@ -10,7 +10,7 @@ sealed class CauseOfOnPostChanged {
     object FetchPosts : CauseOfOnPostChanged()
     object RemoveAllPosts : CauseOfOnPostChanged()
     class RemovePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
-    class UpdatePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
+    class UpdatePost(val localPostId: Int, val remotePostId: Long, val isLocalUpdate: Boolean) : CauseOfOnPostChanged()
     class RemoteAutoSavePost(val localPostId: Int, val remotePostId: Long) : CauseOfOnPostChanged()
     object FetchPostLikes : CauseOfOnPostChanged()
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostImmutableModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostImmutableModel.kt
@@ -52,6 +52,7 @@ interface PostImmutableModel {
     val autoShareId: Long
     val publicizeSkipConnectionsJson: String
     val publicizeSkipConnectionsList: List<PublicizeSkipConnection>
+    val dbTimestamp: Long
 
     fun hasFeaturedImage(): Boolean
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -551,7 +551,7 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     public void setDbTimestamp(long timestamp) {
         mDbTimestamp = timestamp;
     }
-
+    @Override
     public long getDbTimestamp() {
         return mDbTimestamp;
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -548,8 +548,8 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
         mAutoShareMessage = autoShareMessage;
     }
 
-    public void setDbTimestamp() {
-        mDbTimestamp = System.currentTimeMillis();
+    public void setDbTimestamp(long timestamp) {
+        mDbTimestamp = timestamp;
     }
 
     public long getDbTimestamp() {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java
@@ -109,6 +109,9 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
     // JSON - an array of PublicizeSkipConnection objects representing publicize skip connections
     @Column private String mPublicizeSkipConnectionsJson;
 
+    // keeps a timestamp that represents when this post was added in the db
+    @Column private long mDbTimestamp;
+
     public PostModel() {}
 
     @Override
@@ -543,6 +546,14 @@ public class PostModel extends Payload<BaseNetworkError> implements Cloneable, I
 
     public void setAutoShareMessage(String autoShareMessage) {
         mAutoShareMessage = autoShareMessage;
+    }
+
+    public void setDbTimestamp() {
+        mDbTimestamp = System.currentTimeMillis();
+    }
+
+    public long getDbTimestamp() {
+        return mDbTimestamp;
     }
 
     @Override

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -68,7 +68,7 @@ public class PostSqlUtils {
         }
         int numberOfDeletedRows = 0;
         if (postResult.isEmpty()) {
-            // insert
+            // insert post
             post.setDbTimestamp(System.currentTimeMillis());
             WellSql.insert(post).asSingleTransaction(true).execute();
             return 1;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -49,7 +49,6 @@ public class PostSqlUtils {
         if (post == null) {
             return 0;
         }
-
         List<PostModel> postResult;
         if (post.isLocalDraft()) {
             postResult = WellSql.select(PostModel.class)
@@ -70,6 +69,7 @@ public class PostSqlUtils {
         int numberOfDeletedRows = 0;
         if (postResult.isEmpty()) {
             // insert
+            post.setDbTimestamp();
             WellSql.insert(post).asSingleTransaction(true).execute();
             return 1;
         } else {
@@ -93,6 +93,7 @@ public class PostSqlUtils {
             // Update only if local changes for this post don't exist
             if (overwriteLocalChanges || !postResult.get(0).isLocallyChanged()) {
                 int oldId = postResult.get(0).getId();
+                post.setDbTimestamp();
                 return WellSql.update(PostModel.class).whereId(oldId)
                               .put(post, new UpdateAllExceptId<>(PostModel.class)).execute()
                        + numberOfDeletedRows;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PostSqlUtils.java
@@ -69,7 +69,7 @@ public class PostSqlUtils {
         int numberOfDeletedRows = 0;
         if (postResult.isEmpty()) {
             // insert
-            post.setDbTimestamp();
+            post.setDbTimestamp(System.currentTimeMillis());
             WellSql.insert(post).asSingleTransaction(true).execute();
             return 1;
         } else {
@@ -93,7 +93,7 @@ public class PostSqlUtils {
             // Update only if local changes for this post don't exist
             if (overwriteLocalChanges || !postResult.get(0).isLocallyChanged()) {
                 int oldId = postResult.get(0).getId();
-                post.setDbTimestamp();
+                post.setDbTimestamp(System.currentTimeMillis());
                 return WellSql.update(PostModel.class).whereId(oldId)
                               .put(post, new UpdateAllExceptId<>(PostModel.class)).execute()
                        + numberOfDeletedRows;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -2001,7 +2001,7 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("DROP TABLE IF EXISTS WCOrderStatsModel")
                     db.execSQL("DROP TABLE IF EXISTS WCVisitorStatsModel")
                 }
-                200 -> migrate(version) {
+                199 -> migrate(version) {
                     db.execSQL("ALTER TABLE PostModel ADD DB_TIMESTAMP INTEGER")
                 }
             }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -41,7 +41,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 199
+        return 200
     }
 
     override fun getDbName(): String {
@@ -2000,6 +2000,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 198 -> migrate(version) {
                     db.execSQL("DROP TABLE IF EXISTS WCOrderStatsModel")
                     db.execSQL("DROP TABLE IF EXISTS WCVisitorStatsModel")
+                }
+                200 -> migrate(version) {
+                    db.execSQL("ALTER TABLE PostModel ADD DB_TIMESTAMP INTEGER")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1055,7 +1055,12 @@ public class PostStore extends Store {
 
         if (payload.isError()) {
             OnPostChanged event = new OnPostChanged(
-                    new CauseOfOnPostChanged.UpdatePost(payload.post.getId(), payload.post.getRemotePostId(), false), 0);
+                    new CauseOfOnPostChanged.UpdatePost(
+                            payload.post.getId(),
+                            payload.post.getRemotePostId(),
+                            false),
+                    0
+            );
             event.error = payload.error;
             emitChange(event);
         } else {
@@ -1127,7 +1132,11 @@ public class PostStore extends Store {
             post.setDateLocallyChanged((DateTimeUtils.iso8601UTCFromDate(new Date())));
         }
         int rowsAffected = mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(post);
-        CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.UpdatePost(post.getId(), post.getRemotePostId(), isLocalUpdate);
+        CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.UpdatePost(
+                post.getId(),
+                post.getRemotePostId(),
+                isLocalUpdate
+        );
         OnPostChanged onPostChanged = new OnPostChanged(causeOfChange, rowsAffected);
         emitChange(onPostChanged);
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1055,7 +1055,7 @@ public class PostStore extends Store {
 
         if (payload.isError()) {
             OnPostChanged event = new OnPostChanged(
-                    new CauseOfOnPostChanged.UpdatePost(payload.post.getId(), payload.post.getRemotePostId()), 0);
+                    new CauseOfOnPostChanged.UpdatePost(payload.post.getId(), payload.post.getRemotePostId(), false), 0);
             event.error = payload.error;
             emitChange(event);
         } else {
@@ -1122,12 +1122,12 @@ public class PostStore extends Store {
         }
     }
 
-    private void updatePost(PostModel post, boolean changeLocalDate) {
-        if (changeLocalDate) {
+    private void updatePost(PostModel post, boolean isLocalUpdate) {
+        if (isLocalUpdate) {
             post.setDateLocallyChanged((DateTimeUtils.iso8601UTCFromDate(new Date())));
         }
         int rowsAffected = mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(post);
-        CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.UpdatePost(post.getId(), post.getRemotePostId());
+        CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.UpdatePost(post.getId(), post.getRemotePostId(), isLocalUpdate);
         OnPostChanged onPostChanged = new OnPostChanged(causeOfChange, rowsAffected);
         emitChange(onPostChanged);
 


### PR DESCRIPTION
This PR adds a new field to the PostModel table in the database that represents the timestamp of the moment that this post was inserted or updated in our local database. 

This field will be exposed by the PostImmutableModel.dbTimestamp property. 

We need this so we can determine if a post object in our database needs to be refetched so we can avoid conflicts on post editing. 