### PR TITLE
Allow filtering orders by customer and product

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
@@ -11,7 +11,9 @@ class WCOrderListDescriptor(
     val searchQuery: String? = null,
     val excludeFutureOrders: Boolean = false,
     val beforeFilter: String? = null,
-    val afterFilter: String? = null
+    val afterFilter: String? = null,
+    val productId: Long? = null,
+    val customerId: Long? = null
 ) : ListDescriptor {
     override val config: ListConfig = ListConfig.default
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -148,7 +148,9 @@ class OrderRestClient @Inject constructor(
             ).putIfNotEmpty(
                 "search" to listDescriptor.searchQuery,
                 "before" to listDescriptor.beforeFilter,
-                "after" to listDescriptor.afterFilter
+                "after" to listDescriptor.afterFilter,
+                "customer" to listDescriptor.customerId?.toString(),
+                "product" to listDescriptor.productId?.toString()
             )
 
             val response = wooNetwork.executeGetGsonRequest(


### PR DESCRIPTION
This PR adds support for filtering Orders by a given customer and a product https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-orders