### PR TITLE
Issue/add timeout error to list store

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -442,6 +442,7 @@ class ListStore @Inject constructor(
     enum class ListErrorType {
         GENERIC_ERROR,
         PERMISSION_ERROR,
-        PARSE_ERROR
+        PARSE_ERROR,
+        TIMEOUT_ERROR
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.TIMEOUT_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.SearchOrdersResponsePayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -943,6 +944,7 @@ class OrderRestClient @Inject constructor(
             wpAPINetworkError.errorCode == "woocommerce_rest_shop_order_invalid_id" -> OrderErrorType.INVALID_ID
             wpAPINetworkError.errorCode == "rest_no_route" -> OrderErrorType.PLUGIN_NOT_ACTIVE
             wpAPINetworkError.type == BaseRequest.GenericErrorType.PARSE_ERROR -> OrderErrorType.PARSE_ERROR
+            wpAPINetworkError.type == BaseRequest.GenericErrorType.TIMEOUT -> TIMEOUT_ERROR
             else -> OrderErrorType.fromString(wpAPINetworkError.errorCode.orEmpty())
         }
         return OrderError(orderErrorType, wpAPINetworkError.combinedErrorMessage)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.store.ListStore.ListErrorType
 import org.wordpress.android.fluxc.store.ListStore.OnListDataFailure
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.PARSE_ERROR
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.TIMEOUT_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -299,6 +300,7 @@ class WCOrderStore @Inject constructor(
         INVALID_RESPONSE,
         GENERIC_ERROR,
         PARSE_ERROR,
+        TIMEOUT_ERROR,
         EMPTY_BILLING_EMAIL;
 
         companion object {
@@ -830,6 +832,7 @@ class WCOrderStore @Inject constructor(
                 ListError(
                     type = when (fetchError.type) {
                         PARSE_ERROR -> ListErrorType.PARSE_ERROR
+                        TIMEOUT_ERROR -> ListErrorType.TIMEOUT_ERROR
                         else -> ListErrorType.GENERIC_ERROR
                     },
                     message = fetchError.message


### PR DESCRIPTION
Summary
==========
Fix issue https://github.com/woocommerce/woocommerce-android/issues/10795 by adding to the Orders request error mapping the option to raise a Timeout error instead of resorting to a generic error.

How to Test
==========
1. Better tested through https://github.com/woocommerce/woocommerce-android/pull/10900

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.