### PR TITLE
Persist and map Order Attribution Info

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.fluxc.example.ui.orders.AddressEditDialogFragment.A
 import org.wordpress.android.fluxc.example.utils.showSingleLineDialog
 import org.wordpress.android.fluxc.example.utils.showTwoButtonsDialog
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
+import org.wordpress.android.fluxc.model.OrderAttributionInfo
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
@@ -596,6 +597,25 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                         else -> {
                             prependToLog("Order $orderId has been deleted succesfully")
                         }
+                    }
+                }
+            }
+        }
+
+        fetch_order_attribution.setOnClickListener {
+            selectedSite?.let { site ->
+                showSingleLineDialog(activity, "Enter the remoteOrderId of order to fetch:") { editText ->
+                    val enteredRemoteId = editText.text.toString().toLongOrNull()
+                    coroutineScope.launch {
+                        enteredRemoteId?.let { id ->
+                            prependToLog("Submitting request to fetch order by remoteOrderID: $enteredRemoteId")
+                            wcOrderStore.fetchSingleOrder(site, id).takeUnless { it.isError }?.let {
+                                val attributionInfo = OrderAttributionInfo(
+                                    metadata = wcOrderStore.getOrderMetadata(enteredRemoteId, site)
+                                )
+                                prependToLog("Order Attribution Information:\n$attributionInfo}")
+                            } ?: prependToLog("Fetching Order Failed")
+                        } ?: prependToLog("No valid remoteOrderId defined...doing nothing")
                     }
                 }
             }

--- a/example/src/main/res/layout/fragment_woo_orders.xml
+++ b/example/src/main/res/layout/fragment_woo_orders.xml
@@ -166,5 +166,12 @@
             android:layout_height="wrap_content"
             android:enabled="false"
             android:text="Delete an order" />
+
+        <Button
+            android:id="@+id/fetch_order_attribution"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch Order Attribution" />
     </LinearLayout>
 </ScrollView>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderAttributionInfo.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/OrderAttributionInfo.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.model
+
+import org.wordpress.android.fluxc.persistence.entity.OrderMetaDataEntity
+
+data class OrderAttributionInfo(
+    val sourceType: String? = null,
+    val campaign: String? = null,
+    val source: String? = null,
+    val medium: String? = null,
+    val deviceType: String? = null,
+    val sessionPageViews: String? = null
+) {
+    constructor(metadata: List<OrderMetaDataEntity>) : this(
+        sourceType = metadata.find { it.key == WCMetaData.OrderAttributionInfoKeys.SOURCE_TYPE }?.value,
+        campaign = metadata.find { it.key == WCMetaData.OrderAttributionInfoKeys.CAMPAIGN }?.value,
+        source = metadata.find { it.key == WCMetaData.OrderAttributionInfoKeys.SOURCE }?.value,
+        medium = metadata.find { it.key == WCMetaData.OrderAttributionInfoKeys.MEDIUM }?.value,
+        deviceType = metadata.find { it.key == WCMetaData.OrderAttributionInfoKeys.DEVICE_TYPE }?.value,
+        sessionPageViews = metadata.find {
+            it.key == WCMetaData.OrderAttributionInfoKeys.SESSION_PAGE_VIEWS
+        }?.value
+    )
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCMetaData.kt
@@ -20,6 +20,7 @@ data class WCMetaData(
         val SUPPORTED_KEYS: Set<String> = buildSet {
             add(SubscriptionMetadataKeys.SUBSCRIPTION_RENEWAL)
             add(BundleMetadataKeys.BUNDLED_ITEM_ID)
+            addAll(OrderAttributionInfoKeys.ALL_KEYS)
         }
 
         fun addAsMetadata(metadata: JsonArray, key: String, value: String) {
@@ -34,9 +35,29 @@ data class WCMetaData(
     object SubscriptionMetadataKeys {
         const val SUBSCRIPTION_RENEWAL = "_subscription_renewal"
     }
+
     object BundleMetadataKeys {
         const val BUNDLED_ITEM_ID = "_bundled_item_id"
         const val BUNDLE_MIN_SIZE = "_bundle_min_size"
         const val BUNDLE_MAX_SIZE = "_bundle_max_size"
+    }
+
+    object OrderAttributionInfoKeys {
+        const val SOURCE_TYPE = "_wc_order_attribution_source_type"
+        const val CAMPAIGN = "_wc_order_attribution_utm_campaign"
+        const val SOURCE = "_wc_order_attribution_utm_source"
+        const val MEDIUM = "_wc_order_attribution_utm_medium"
+        const val DEVICE_TYPE = "_wc_order_attribution_device_type"
+        const val SESSION_PAGE_VIEWS = "_wc_order_attribution_session_pages"
+
+        val ALL_KEYS
+            get() = setOf(
+                SOURCE_TYPE,
+                CAMPAIGN,
+                SOURCE,
+                MEDIUM,
+                DEVICE_TYPE,
+                SESSION_PAGE_VIEWS
+            )
     }
 }


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/10961

This PR adds the following:
- Adds the Order Attribution info metadata keys to the list of persisted keys.
- Adds a model for representing the Order Attribution.


#### Testing
1. Ensure your website uses WooCommerce 8.5 or newer, and create a new order (to make sure it has the attribution info).
2. Open the example app.
3. Click on Woo then Orders.
4. Select a site.
5. Click on "Fetch Order Attribution"
6. Enter the order ID of the order created in Step 1.
7. Confirm the attribution info is shown.