### PR TITLE
Allow passing a "source type" when creating Woo Orders.

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/orders/WooOrdersFragment.kt
@@ -556,7 +556,8 @@ class WooOrdersFragment : StoreSelectingFragment(), WCAddOrderShipmentTrackingDi
                                     shippingAddress = shippingAddress,
                                     billingAddress = billingAddress,
                                     customerNote = customerNote
-                            )
+                            ),
+                            attributionSourceType = "fluxc-example-app"
                     )
                     if (result.isError) {
                         prependToLog("Order creation failed, error ${result.error.type} ${result.error.message}")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCMetaData.OrderAttributionInfoKeys
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
@@ -786,10 +787,22 @@ class OrderRestClient @Inject constructor(
 
     suspend fun createOrder(
         site: SiteModel,
-        request: UpdateOrderRequest
+        request: UpdateOrderRequest,
+        attributionSourceType: String?
     ): WooPayload<OrderEntity> {
         val url = WOOCOMMERCE.orders.pathV3
-        val body = request.toNetworkRequest()
+        val metaData = mapOf(
+            "meta_data" to listOfNotNull(
+                attributionSourceType?.let {
+                    mapOf(
+                        "key" to OrderAttributionInfoKeys.SOURCE_TYPE,
+                        "value" to attributionSourceType
+                    )
+                }
+            )
+        )
+
+        val body = request.toNetworkRequest() + metaData
 
         val response = wooNetwork.executePostGsonRequest(
             site = site,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -228,9 +228,13 @@ class OrderUpdateStore @Inject internal constructor(
         }
     }
 
-    suspend fun createOrder(site: SiteModel, createOrderRequest: UpdateOrderRequest): WooResult<OrderEntity> {
+    suspend fun createOrder(
+        site: SiteModel,
+        createOrderRequest: UpdateOrderRequest,
+        attributionSourceType: String? = null
+    ): WooResult<OrderEntity> {
         return coroutineEngine.withDefaultContext(T.API, this, "createOrder") {
-            val result = wcOrderRestClient.createOrder(site, createOrderRequest)
+            val result = wcOrderRestClient.createOrder(site, createOrderRequest, attributionSourceType)
 
             return@withDefaultContext if (result.isError) {
                 WooResult(result.error)

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -424,7 +424,7 @@ class OrderUpdateStoreTest {
         setUp {
             orderRestClient = mock {
                 onBlocking {
-                    createOrder(any(), any())
+                    createOrder(any(), any(), any())
                 }.doReturn(
                     WooPayload(newOrder)
                 )

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.TestCoroutineScope
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -424,7 +425,7 @@ class OrderUpdateStoreTest {
         setUp {
             orderRestClient = mock {
                 onBlocking {
-                    createOrder(any(), any(), any())
+                    createOrder(any(), any(), anyOrNull())
                 }.doReturn(
                     WooPayload(newOrder)
                 )


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-android/issues/10990

This PR updates the Woo Order store by allowing passing a custom "source type" to attribute the order to (check https://github.com/woocommerce/woocommerce-android/issues/10960 for more details).

Instead of hardcoding the value of the mobile app in FluxC, I opted for making a configurable value, where each client can use their own, even though for now WCAndroid is the only client.


##### Testing
1. Open the example app and sign in.
2. Click on Woo, then Orders.
3. Select a site.
4. Click on Create an order.
5. Enter a product ID.
6. Skip the other steps.
7. When the order is created, check it in wp-admin, and confirm it has a source type set to: "fluxc-example-app" (the Origin will be unknown, as this source type value is not mapped by Core)