### PR TITLE
Make timezone optional in VisitsAndViewsStore

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -36,11 +36,12 @@ class VisitsAndViewsStore
         site: SiteModel,
         granularity: StatsGranularity,
         limitMode: Top,
-        forced: Boolean = false,
-        useSiteTimezone: Boolean = true
+        forced: Boolean = false
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
-        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
-        val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
+        val dateWithTimeZone = statsUtils.getFormattedDate(
+            currentTimeProvider.currentDate(),
+            SiteUtils.getNormalizedTimezone(site.timezone)
+        )
         logProgress(granularity, "Site timezone: ${site.timezone}")
         try {
             logProgress(granularity, "Current date: ${currentTimeProvider.currentDate()}")
@@ -134,11 +135,12 @@ class VisitsAndViewsStore
     fun getVisits(
         site: SiteModel,
         granularity: StatsGranularity,
-        limitMode: LimitMode,
-        useSiteTimezone: Boolean = true
+        limitMode: LimitMode
     ): VisitsAndViewsModel? {
-        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
-        val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
+        val dateWithTimeZone = statsUtils.getFormattedDate(
+            currentTimeProvider.currentDate(),
+            SiteUtils.getNormalizedTimezone(site.timezone)
+        )
         return getVisits(site, granularity, limitMode, dateWithTimeZone)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -37,7 +37,7 @@ class VisitsAndViewsStore
         granularity: StatsGranularity,
         limitMode: Top,
         forced: Boolean = false,
-        useSiteTimezone: Boolean = false
+        useSiteTimezone: Boolean = true
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
         val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
@@ -85,7 +85,7 @@ class VisitsAndViewsStore
         limitMode: Top,
         date: Date,
         forced: Boolean = false,
-        useSiteTimezone: Boolean = false
+        useSiteTimezone: Boolean = true
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
         val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
@@ -135,7 +135,7 @@ class VisitsAndViewsStore
         site: SiteModel,
         granularity: StatsGranularity,
         limitMode: LimitMode,
-        useSiteTimezone: Boolean = false
+        useSiteTimezone: Boolean = true
     ): VisitsAndViewsModel? {
         val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
@@ -147,7 +147,7 @@ class VisitsAndViewsStore
         granularity: StatsGranularity,
         limitMode: Top,
         date: Date,
-        useSiteTimezone: Boolean = false
+        useSiteTimezone: Boolean = true
     ): VisitsAndViewsModel? {
         val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -86,9 +86,9 @@ class VisitsAndViewsStore
         limitMode: Top,
         date: Date,
         forced: Boolean = false,
-        useSiteTimezone: Boolean = true
+        applySiteTimezone: Boolean = true
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
-        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val timezone = if (applySiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
         logProgress(granularity, "Site timezone: ${site.timezone}")
         try {
@@ -149,9 +149,9 @@ class VisitsAndViewsStore
         granularity: StatsGranularity,
         limitMode: Top,
         date: Date,
-        useSiteTimezone: Boolean = true
+        applySiteTimezone: Boolean = true
     ): VisitsAndViewsModel? {
-        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val timezone = if (applySiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
         return getVisits(site, granularity, limitMode, dateWithTimeZone)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -36,12 +36,11 @@ class VisitsAndViewsStore
         site: SiteModel,
         granularity: StatsGranularity,
         limitMode: Top,
-        forced: Boolean = false
+        forced: Boolean = false,
+        useSiteTimezone: Boolean = false
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
-        val dateWithTimeZone = statsUtils.getFormattedDate(
-                currentTimeProvider.currentDate(),
-                SiteUtils.getNormalizedTimezone(site.timezone)
-        )
+        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
         logProgress(granularity, "Site timezone: ${site.timezone}")
         try {
             logProgress(granularity, "Current date: ${currentTimeProvider.currentDate()}")
@@ -135,12 +134,11 @@ class VisitsAndViewsStore
     fun getVisits(
         site: SiteModel,
         granularity: StatsGranularity,
-        limitMode: LimitMode
+        limitMode: LimitMode,
+        useSiteTimezone: Boolean = false
     ): VisitsAndViewsModel? {
-        val dateWithTimeZone = statsUtils.getFormattedDate(
-                currentTimeProvider.currentDate(),
-                SiteUtils.getNormalizedTimezone(site.timezone)
-        )
+        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
         return getVisits(site, granularity, limitMode, dateWithTimeZone)
     }
 
@@ -148,9 +146,11 @@ class VisitsAndViewsStore
         site: SiteModel,
         granularity: StatsGranularity,
         limitMode: Top,
-        date: Date
+        date: Date,
+        useSiteTimezone: Boolean = false
     ): VisitsAndViewsModel? {
-        val dateWithTimeZone = statsUtils.getFormattedDate(date, SiteUtils.getNormalizedTimezone(site.timezone))
+        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
         return getVisits(site, granularity, limitMode, dateWithTimeZone)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -85,9 +85,9 @@ class VisitsAndViewsStore
         limitMode: Top,
         date: Date,
         forced: Boolean = false,
-        normalizeTimezone: Boolean = false
+        useSiteTimezone: Boolean = false
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
-        val timezone = if (normalizeTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
         logProgress(granularity, "Site timezone: ${site.timezone}")
         try {


### PR DESCRIPTION
This is following PR of https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2965 to fix https://github.com/wordpress-mobile/WordPress-Android/issues/20412. #2965 alone did not resolve the issue. 

This PR,
- Renames `normalizeTimezone` param to `applySiteTimezone` as the function applying the site timezone to the date param.
- Adds `applySiteTimezone` param to `getVisits` function.

> [!NOTE]  
> @notandyvee, @aditi-bhatia, a single review from either of you is sufficient.

Can be tested through https://github.com/wordpress-mobile/WordPress-Android/pull/20416