### PR TITLE
Stats/custom range

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCStatsTest.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.module.ResponseMockingInterceptor
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsAvailabilityResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
@@ -61,13 +60,13 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
     fun testNewVisitorStatsSuccess() = runBlocking {
         interceptor.respondWith("wc-visitor-stats-response-success.json")
         val payload = orderStatsRestClient.fetchNewVisitorStats(
-                siteModel, OrderStatsApiUnit.MONTH, StatsGranularity.YEARS, "2019-08-06", 8, true
+                siteModel, StatsGranularity.MONTHS, "2019-08-06", 8, true
         )
 
         with(payload) {
             assertNull(error)
             assertEquals(siteModel, site)
-            assertEquals(StatsGranularity.YEARS, granularity)
+            assertEquals(StatsGranularity.MONTHS, granularity)
             assertNotNull(stats)
             assertNotNull(stats?.data)
             assertEquals(stats?.dataList?.size, 12)
@@ -84,13 +83,13 @@ class MockedStack_WCStatsTest : MockedStack_Base() {
         interceptor.respondWithError(errorJson)
 
         val payload = orderStatsRestClient.fetchNewVisitorStats(
-                siteModel, OrderStatsApiUnit.MONTH, StatsGranularity.YEARS, "2019-08-06", 8, true
+                siteModel, StatsGranularity.MONTHS, "2019-08-06", 8, true
         )
 
         with(payload) {
             assertNotNull(error)
             assertEquals(siteModel, site)
-            assertEquals(StatsGranularity.YEARS, granularity)
+            assertEquals(StatsGranularity.MONTHS, granularity)
             assertNull(stats)
             assertEquals(OrderStatsErrorType.INVALID_PARAM, error.type)
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.DateUtils
 import javax.inject.Inject
 
 class WooLeaderboardsFragment : StoreSelectingFragment() {
@@ -128,4 +129,24 @@ class WooLeaderboardsFragment : StoreSelectingFragment() {
                 action(it)
             }
         }
+
+    private fun StatsGranularity.startDateTime(site: SiteModel) = when (this) {
+        DAYS -> DateUtils.getStartDateForSite(site, DateUtils.getStartOfCurrentDay())
+        WEEKS -> DateUtils.getFirstDayOfCurrentWeekBySite(site)
+        MONTHS -> DateUtils.getFirstDayOfCurrentMonthBySite(site)
+        YEARS -> DateUtils.getFirstDayOfCurrentYearBySite(site)
+    }
+
+    private fun StatsGranularity.endDateTime(site: SiteModel) = when (this) {
+        DAYS -> DateUtils.getEndDateForSite(site)
+        WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
+        MONTHS -> DateUtils.getLastDayOfCurrentMonthForSite(site)
+        YEARS -> DateUtils.getLastDayOfCurrentYearForSite(site)
+    }
+
+    private fun StatsGranularity.datePeriod(site: SiteModel): String {
+        val startDate = startDateTime(site)
+        val endDate = endDateTime(site)
+        return DateUtils.getDatePeriod(startDate, endDate)
+    }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/leaderboards/WooLeaderboardsFragment.kt
@@ -135,6 +135,7 @@ class WooLeaderboardsFragment : StoreSelectingFragment() {
         WEEKS -> DateUtils.getFirstDayOfCurrentWeekBySite(site)
         MONTHS -> DateUtils.getFirstDayOfCurrentMonthBySite(site)
         YEARS -> DateUtils.getFirstDayOfCurrentYearBySite(site)
+        else -> error("The sample code does not support the $this granularity.")
     }
 
     private fun StatsGranularity.endDateTime(site: SiteModel) = when (this) {
@@ -142,11 +143,6 @@ class WooLeaderboardsFragment : StoreSelectingFragment() {
         WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
         MONTHS -> DateUtils.getLastDayOfCurrentMonthForSite(site)
         YEARS -> DateUtils.getLastDayOfCurrentYearForSite(site)
-    }
-
-    private fun StatsGranularity.datePeriod(site: SiteModel): String {
-        val startDate = startDateTime(site)
-        val endDate = endDateTime(site)
-        return DateUtils.getDatePeriod(startDate, endDate)
+        else -> error("The sample code does not support the $this granularity.")
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -211,28 +211,50 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
 
         fetch_current_day_visitor_stats.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchNewVisitorStatsPayload(site = it, granularity = StatsGranularity.DAYS)
+                val payload = FetchNewVisitorStatsPayload(
+                    site = it,
+                    granularity = StatsGranularity.DAYS,
+                    startDate = DateUtils.getStartDateForSite(it, DateUtils.getStartOfCurrentDay()),
+                    endDate = DateUtils.getEndDateForSite(it)
+                )
                 dispatcher.dispatch(WCStatsActionBuilder.newFetchNewVisitorStatsAction(payload))
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_week_visitor_stats_forced.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchNewVisitorStatsPayload(it, StatsGranularity.WEEKS, forced = true)
+                val payload = FetchNewVisitorStatsPayload(
+                    site = it,
+                    granularity = StatsGranularity.WEEKS,
+                    startDate = DateUtils.getFirstDayOfCurrentWeekBySite(it),
+                    endDate = DateUtils.getLastDayOfCurrentWeekForSite(it),
+                    forced = true
+                )
                 dispatcher.dispatch(WCStatsActionBuilder.newFetchNewVisitorStatsAction(payload))
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_month_visitor_stats.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchNewVisitorStatsPayload(site = it, granularity = StatsGranularity.MONTHS)
+                val payload = FetchNewVisitorStatsPayload(
+                    site = it,
+                    granularity = StatsGranularity.MONTHS,
+                    startDate = DateUtils.getFirstDayOfCurrentMonthBySite(it),
+                    endDate = DateUtils.getLastDayOfCurrentMonthForSite(it)
+                )
                 dispatcher.dispatch(WCStatsActionBuilder.newFetchNewVisitorStatsAction(payload))
             } ?: prependToLog("No site selected!")
         }
 
         fetch_current_year_visitor_stats_forced.setOnClickListener {
             selectedSite?.let {
-                val payload = FetchNewVisitorStatsPayload(it, StatsGranularity.YEARS, forced = true)
+                val payload = FetchNewVisitorStatsPayload(
+                    site = it,
+                    granularity = StatsGranularity.YEARS,
+                    startDate = DateUtils.getFirstDayOfCurrentYearBySite(it),
+                    endDate = DateUtils.getLastDayOfCurrentYearForSite(it),
+                    forced = true
+                )
                 dispatcher.dispatch(WCStatsActionBuilder.newFetchNewVisitorStatsAction(payload))
             } ?: prependToLog("No site selected!")
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.OnWCRevenueStatsChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.OnWCStatsChanged
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.DateUtils
 import javax.inject.Inject
 
 class WooRevenueStatsFragment : StoreSelectingFragment() {
@@ -34,7 +35,7 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-            inflater.inflate(R.layout.fragment_woo_revenue_stats, container, false)
+        inflater.inflate(R.layout.fragment_woo_revenue_stats, container, false)
 
     @Suppress("LongMethod", "ComplexMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -50,7 +51,12 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_day_revenue_stats.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS)
+                    val payload = FetchRevenueStatsPayload(
+                        site = it,
+                        granularity = StatsGranularity.DAYS,
+                        startDate = DateUtils.getStartDateForSite(it, DateUtils.getStartOfCurrentDay()),
+                        endDate = DateUtils.getEndDateForSite(it)
+                    )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
                         prependToLog("Revenue stats ${it.rowsAffected != 0}")
                         onFetchRevenueStatsLoaded(it)
@@ -62,10 +68,18 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_day_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, forced = true)
+                    val payload = FetchRevenueStatsPayload(
+                        site = it,
+                        granularity = StatsGranularity.DAYS,
+                        forced = true,
+                        startDate = DateUtils.getStartDateForSite(it, DateUtils.getStartOfCurrentDay()),
+                        endDate = DateUtils.getEndDateForSite(it)
+                    )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.DAYS} " +
-                                ": ${it.rowsAffected != 0}")
+                        prependToLog(
+                            "Revenue stats with granularity ${StatsGranularity.DAYS} " +
+                                ": ${it.rowsAffected != 0}"
+                        )
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -75,10 +89,17 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_week_revenue_stats.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.WEEKS)
+                    val payload = FetchRevenueStatsPayload(
+                        site = it,
+                        granularity = StatsGranularity.WEEKS,
+                        startDate = DateUtils.getFirstDayOfCurrentWeekBySite(it),
+                        endDate = DateUtils.getLastDayOfCurrentWeekForSite(it)
+                    )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.WEEKS} " +
-                                ": ${it.rowsAffected != 0}")
+                        prependToLog(
+                            "Revenue stats with granularity ${StatsGranularity.WEEKS} " +
+                                ": ${it.rowsAffected != 0}"
+                        )
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -88,13 +109,18 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_week_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(site = it,
-                            granularity = StatsGranularity.WEEKS,
-                            forced = true
+                    val payload = FetchRevenueStatsPayload(
+                        site = it,
+                        granularity = StatsGranularity.WEEKS,
+                        startDate = DateUtils.getFirstDayOfCurrentWeekBySite(it),
+                        endDate = DateUtils.getLastDayOfCurrentWeekForSite(it),
+                        forced = true
                     )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.WEEKS} " +
-                                ": ${it.rowsAffected != 0}")
+                        prependToLog(
+                            "Revenue stats forced with granularity ${StatsGranularity.WEEKS} " +
+                                ": ${it.rowsAffected != 0}"
+                        )
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -104,10 +130,17 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_month_revenue_stats.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.MONTHS)
+                    val payload = FetchRevenueStatsPayload(
+                        site = it,
+                        granularity = StatsGranularity.MONTHS,
+                        startDate = DateUtils.getFirstDayOfCurrentMonthBySite(it),
+                        endDate = DateUtils.getLastDayOfCurrentMonthForSite(it)
+                    )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.MONTHS} " +
-                                ": ${it.rowsAffected != 0}")
+                        prependToLog(
+                            "Revenue stats with granularity ${StatsGranularity.MONTHS} " +
+                                ": ${it.rowsAffected != 0}"
+                        )
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -117,13 +150,18 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_month_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(site = it,
-                            granularity = StatsGranularity.MONTHS,
-                            forced = true
+                    val payload = FetchRevenueStatsPayload(
+                        site = it,
+                        granularity = StatsGranularity.MONTHS,
+                        startDate = DateUtils.getFirstDayOfCurrentMonthBySite(it),
+                        endDate = DateUtils.getLastDayOfCurrentMonthForSite(it),
+                        forced = true
                     )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.MONTHS} " +
-                                ": ${it.rowsAffected != 0}")
+                        prependToLog(
+                            "Revenue stats forced with granularity ${StatsGranularity.MONTHS} " +
+                                ": ${it.rowsAffected != 0}"
+                        )
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -133,10 +171,17 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_year_revenue_stats.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(it, StatsGranularity.YEARS)
+                    val payload = FetchRevenueStatsPayload(
+                        site = it,
+                        granularity = StatsGranularity.YEARS,
+                        startDate = DateUtils.getFirstDayOfCurrentYearBySite(it),
+                        endDate = DateUtils.getLastDayOfCurrentYearForSite(it)
+                    )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats with granularity ${StatsGranularity.YEARS} " +
-                                ": ${it.rowsAffected != 0}")
+                        prependToLog(
+                            "Revenue stats with granularity ${StatsGranularity.YEARS} " +
+                                ": ${it.rowsAffected != 0}"
+                        )
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -146,13 +191,18 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         fetch_current_year_revenue_stats_forced.setOnClickListener {
             selectedSite?.let {
                 coroutineScope.launch {
-                    val payload = FetchRevenueStatsPayload(site = it,
-                            granularity = StatsGranularity.YEARS,
-                            forced = true
+                    val payload = FetchRevenueStatsPayload(
+                        site = it,
+                        granularity = StatsGranularity.YEARS,
+                        startDate = DateUtils.getFirstDayOfCurrentYearBySite(it),
+                        endDate = DateUtils.getLastDayOfCurrentYearForSite(it),
+                        forced = true
                     )
                     wcStatsStore.fetchRevenueStats(payload).takeUnless { it.isError }?.let {
-                        prependToLog("Revenue stats forced with granularity ${StatsGranularity.YEARS} " +
-                                ": ${it.rowsAffected != 0}")
+                        prependToLog(
+                            "Revenue stats forced with granularity ${StatsGranularity.YEARS} " +
+                                ": ${it.rowsAffected != 0}"
+                        )
                         onFetchRevenueStatsLoaded(it)
                     } ?: prependToLog("Fetching revenueStats failed.")
                 }
@@ -206,15 +256,18 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
             }
 
             val wcRevenueStatsModel = wcStatsStore.getRawRevenueStats(
-                    site,
-                    event.granularity,
-                    event.startDate!!,
-                    event.endDate!!)
+                site,
+                event.granularity,
+                event.startDate!!,
+                event.endDate!!
+            )
             wcRevenueStatsModel?.let {
                 val revenueSum = it.parseTotal()?.totalSales
-                prependToLog("Fetched stats with total " + revenueSum + " for granularity " +
+                prependToLog(
+                    "Fetched stats with total " + revenueSum + " for granularity " +
                         event.granularity.toString().toLowerCase() + " from " + site.name +
-                        " between " + event.startDate + " and " + event.endDate)
+                        " between " + event.startDate + " and " + event.endDate
+                )
             } ?: prependToLog("No stats were stored for site " + site.name + " =(")
         } ?: prependToLog("No stats were stored for site " + selectedSite?.name + " =(")
     }
@@ -242,25 +295,25 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
         when (event.causeOfChange) {
             WCStatsAction.FETCH_NEW_VISITOR_STATS -> {
                 val visitorStatsMap = wcStatsStore.getNewVisitorStats(
-                        site!!,
-                        event.granularity,
-                        event.quantity,
-                        event.date,
-                        event.isCustomField
+                    site!!,
+                    event.granularity,
+                    event.quantity,
+                    event.date,
+                    event.isCustomField
                 )
                 if (visitorStatsMap.isEmpty()) {
                     prependToLog("No visitor stats were stored for site " + site.name + " =(")
                 } else {
                     if (event.isCustomField) {
                         prependToLog(
-                                "Fetched visitor stats for " + visitorStatsMap.size + " " +
-                                        event.granularity.toString().toLowerCase() + " from " + site.name +
-                                        " with quantity " + event.quantity + " and date " + event.date
+                            "Fetched visitor stats for " + visitorStatsMap.size + " " +
+                                event.granularity.toString().toLowerCase() + " from " + site.name +
+                                " with quantity " + event.quantity + " and date " + event.date
                         )
                     } else {
                         prependToLog(
-                                "Fetched visitor stats for " + visitorStatsMap.size + " " +
-                                        event.granularity.toString().toLowerCase() + " from " + site.name
+                            "Fetched visitor stats for " + visitorStatsMap.size + " " +
+                                event.granularity.toString().toLowerCase() + " from " + site.name
                         )
                     }
                 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCProductLeaderboardsMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/leaderboards/WCProductLeaderboardsMapperTest.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.model.leaderboards.WCProductLeaderboardsMappe
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.PRODUCTS
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCProductStore
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.test
 import org.wordpress.android.fluxc.wc.leaderboards.WCLeaderboardsTestFixtures.generateSampleLeaderboardsApiResponse
 import org.wordpress.android.fluxc.wc.leaderboards.WCLeaderboardsTestFixtures.generateSampleProductList
@@ -27,6 +26,10 @@ import org.wordpress.android.fluxc.wc.leaderboards.WCLeaderboardsTestFixtures.st
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner::class)
 class WCProductLeaderboardsMapperTest {
+    companion object {
+        const val DATE_PERIOD = "2024-01-01-2024-01-31"
+    }
+
     private lateinit var mapperUnderTest: WCProductLeaderboardsMapper
     private lateinit var productStore: WCProductStore
 
@@ -56,7 +59,7 @@ class WCProductLeaderboardsMapperTest {
                 productApiResponse!!,
                 stubSite,
                 productStore,
-                DAYS.datePeriod(stubSite)
+                DATE_PERIOD
         )
         assertThat(result).isNotNull
         assertThat(result.size).isEqualTo(3)
@@ -70,7 +73,7 @@ class WCProductLeaderboardsMapperTest {
                 productApiResponse!!,
                 stubSite,
                 productStore,
-                DAYS.datePeriod(stubSite)
+                DATE_PERIOD
         )
         assertThat(result).isNotNull
         assertThat(result.size).isEqualTo(2)
@@ -83,7 +86,7 @@ class WCProductLeaderboardsMapperTest {
                 productApiResponse!!,
                 stubSite,
                 productStore,
-                DAYS.datePeriod(stubSite)
+                DATE_PERIOD
         )
         assertThat(result).isNotNull
         assertThat(result).isEmpty()

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -24,15 +24,12 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCNewVisitorStatsModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats.OrderStatsRestClient.OrderStatsApiUnit
 import org.wordpress.android.fluxc.persistence.WCVisitorStatsSqlUtils
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.store.WCStatsStore
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsResponsePayload
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.DAYS
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.utils.DateUtils
 import org.wordpress.android.fluxc.utils.SiteUtils.getCurrentDateTimeForSite
@@ -66,233 +63,291 @@ class WCStatsStoreTest {
 
     @Test
     fun testGetQuantityForDays() {
-        val quantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-25", "2018-01-28",
-                OrderStatsApiUnit.DAY, 30)
+        val quantity1 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.DAYS, "2018-01-25",
+            "2018-01-28"
+        )
         assertEquals(4, quantity1)
 
-        val quantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-01",
-                OrderStatsApiUnit.DAY, 30)
+        val quantity2 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.DAYS, "2018-01-01",
+            "2018-01-01"
+        )
         assertEquals(1, quantity2)
 
-        val quantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-31",
-                OrderStatsApiUnit.DAY, 30)
+        val quantity3 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.DAYS, "2018-01-01",
+            "2018-01-31"
+        )
         assertEquals(31, quantity3)
 
-        val quantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-28", "2018-01-25",
-                OrderStatsApiUnit.DAY, 30)
+        val quantity4 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.DAYS, "2018-01-28",
+            "2018-01-25"
+        )
         assertEquals(4, quantity4)
 
-        val quantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-01",
-                OrderStatsApiUnit.DAY, 30)
+        val quantity5 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.DAYS, "2018-01-01",
+            "2018-01-01"
+        )
         assertEquals(1, quantity5)
 
-        val quantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-31", "2018-01-01",
-                OrderStatsApiUnit.DAY, 30)
+        val quantity6 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.DAYS, "2018-01-31",
+            "2018-01-01"
+        )
         assertEquals(31, quantity6)
-
-        val defaultQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("", "",
-                OrderStatsApiUnit.DAY, 30)
-        assertEquals(30, defaultQuantity1)
-
-        val defaultQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit(null, null,
-                OrderStatsApiUnit.DAY, 30)
-        assertEquals(30, defaultQuantity2)
     }
 
     @Test
     fun testGetQuantityForWeeks() {
-        val quantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-10-22", "2018-10-23",
-                OrderStatsApiUnit.WEEK, 17)
+        val quantity1 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-10-22",
+            "2018-10-23"
+        )
         assertEquals(1, quantity1)
 
-        val quantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-01",
-                OrderStatsApiUnit.WEEK, 17)
+        val quantity2 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2017-01-01",
+            "2018-01-01"
+        )
         assertEquals(53, quantity2)
 
-        val quantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-20", "2019-01-13",
-                OrderStatsApiUnit.WEEK, 17)
+        val quantity3 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2019-01-20",
+            "2019-01-13"
+        )
         assertEquals(2, quantity3)
 
-        val quantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-03-01",
-                OrderStatsApiUnit.WEEK, 17)
+        val quantity4 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2017-01-01",
+            "2018-03-01"
+        )
         assertEquals(61, quantity4)
 
-        val quantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-31",
-                OrderStatsApiUnit.WEEK, 17)
+        val quantity5 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-01-01",
+            "2018-01-31"
+        )
         assertEquals(5, quantity5)
 
-        val quantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-12-01", "2018-12-31",
-                OrderStatsApiUnit.WEEK, 17)
+        val quantity6 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-12-01",
+            "2018-12-31"
+        )
         assertEquals(6, quantity6)
 
-        val quantity7 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-11-01", "2018-11-30",
-                OrderStatsApiUnit.WEEK, 17)
+        val quantity7 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-11-01",
+            "2018-11-30"
+        )
         assertEquals(5, quantity7)
 
-        val inverseQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-10-23", "2018-10-22",
-                OrderStatsApiUnit.WEEK, 17)
+        val inverseQuantity1 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-10-23",
+            "2018-10-22"
+        )
         assertEquals(1, inverseQuantity1)
 
-        val inverseQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2017-01-01",
-                OrderStatsApiUnit.WEEK, 17)
+        val inverseQuantity2 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-01-01",
+            "2017-01-01"
+        )
         assertEquals(53, inverseQuantity2)
 
-        val inverseQuantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-13", "2019-01-20",
-                OrderStatsApiUnit.WEEK, 17)
+        val inverseQuantity3 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2019-01-13",
+            "2019-01-20"
+        )
         assertEquals(2, inverseQuantity3)
 
-        val inverseQuantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-03-01", "2017-01-01",
-                OrderStatsApiUnit.WEEK, 17)
+        val inverseQuantity4 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-03-01",
+            "2017-01-01"
+        )
         assertEquals(61, inverseQuantity4)
 
-        val inverseQuantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-31", "2018-01-01",
-                OrderStatsApiUnit.WEEK, 17)
+        val inverseQuantity5 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-01-31",
+            "2018-01-01"
+        )
         assertEquals(5, inverseQuantity5)
 
-        val inverseQuantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-12-31", "2018-12-01",
-                OrderStatsApiUnit.WEEK, 17)
+        val inverseQuantity6 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-12-31",
+            "2018-12-01"
+        )
         assertEquals(6, inverseQuantity6)
 
-        val inverseQuantity7 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-11-30", "2018-11-01",
-                OrderStatsApiUnit.WEEK, 17)
+        val inverseQuantity7 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.WEEKS, "2018-11-30",
+            "2018-11-01"
+        )
         assertEquals(5, inverseQuantity7)
-
-        val defaultQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("", "",
-                OrderStatsApiUnit.WEEK, 17)
-        assertEquals(17, defaultQuantity1)
-
-        val defaultQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit(null, null,
-                OrderStatsApiUnit.WEEK, 17)
-        assertEquals(17, defaultQuantity2)
     }
 
     @Test
     fun testGetQuantityForMonths() {
-        val quantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-10-22", "2018-10-23",
-                OrderStatsApiUnit.MONTH, 12)
+        val quantity1 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2018-10-22",
+            "2018-10-23"
+        )
         assertEquals(1, quantity1)
 
-        val quantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-01",
-                OrderStatsApiUnit.MONTH, 12)
+        val quantity2 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2017-01-01",
+            "2018-01-01"
+        )
         assertEquals(13, quantity2)
 
-        val quantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-01",
-                OrderStatsApiUnit.MONTH, 12)
+        val quantity3 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2018-01-01",
+            "2018-01-01"
+        )
         assertEquals(1, quantity3)
 
-        val quantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-03-01",
-                OrderStatsApiUnit.MONTH, 12)
+        val quantity4 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2017-01-01",
+            "2018-03-01"
+        )
         assertEquals(15, quantity4)
 
-        val quantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-31",
-                OrderStatsApiUnit.MONTH, 12)
+        val quantity5 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2017-01-01",
+            "2018-01-31"
+        )
         assertEquals(13, quantity5)
 
-        val quantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-12-31", "2019-01-01",
-                OrderStatsApiUnit.MONTH, 1)
+        val quantity6 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2018-12-31",
+            "2019-01-01"
+        )
         assertEquals(2, quantity6)
 
-        val inverseQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-10-23", "2018-10-22",
-                OrderStatsApiUnit.MONTH, 12)
+        val inverseQuantity1 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2018-10-23",
+            "2018-10-22"
+        )
         assertEquals(1, inverseQuantity1)
 
-        val inverseQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2017-01-01",
-                OrderStatsApiUnit.MONTH, 12)
+        val inverseQuantity2 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2018-01-01",
+            "2017-01-01"
+        )
         assertEquals(13, inverseQuantity2)
 
-        val inverseQuantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2018-01-01",
-                OrderStatsApiUnit.MONTH, 12)
+        val inverseQuantity3 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2018-01-01",
+            "2018-01-01"
+        )
         assertEquals(1, inverseQuantity3)
 
-        val inverseQuantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-03-01", "2017-01-01",
-                OrderStatsApiUnit.MONTH, 12)
+        val inverseQuantity4 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2018-03-01",
+            "2017-01-01"
+        )
         assertEquals(15, inverseQuantity4)
 
-        val inverseQuantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-31", "2017-01-01",
-                OrderStatsApiUnit.MONTH, 12)
+        val inverseQuantity5 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2018-01-31",
+            "2017-01-01"
+        )
         assertEquals(13, inverseQuantity5)
 
-        val inverseQuantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-01", "2018-12-31",
-                OrderStatsApiUnit.MONTH, 1)
+        val inverseQuantity6 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.MONTHS, "2019-01-01",
+            "2018-12-31"
+        )
         assertEquals(2, inverseQuantity6)
-
-        val defaultQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("", "",
-                OrderStatsApiUnit.MONTH, 12)
-        assertEquals(12, defaultQuantity1)
-
-        val defaultQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit(null, null,
-                OrderStatsApiUnit.MONTH, 12)
-        assertEquals(12, defaultQuantity2)
     }
 
     @Test
     fun testGetQuantityForYears() {
-        val quantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-01",
-                OrderStatsApiUnit.YEAR, 1)
+        val quantity1 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2017-01-01",
+            "2018-01-01"
+        )
         assertEquals(2, quantity1)
 
-        val quantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-03-01",
-                OrderStatsApiUnit.YEAR, 1)
+        val quantity2 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2017-01-01",
+            "2018-03-01"
+        )
         assertEquals(2, quantity2)
 
-        val quantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2018-01-05",
-                OrderStatsApiUnit.YEAR, 1)
+        val quantity3 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2017-01-01",
+            "2018-01-05"
+        )
         assertEquals(2, quantity3)
 
-        val quantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2019-03-01",
-                OrderStatsApiUnit.YEAR, 1)
+        val quantity4 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2017-01-01",
+            "2019-03-01"
+        )
         assertEquals(3, quantity4)
 
-        val quantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2015-03-05", "2017-01-01",
-                OrderStatsApiUnit.YEAR, 1)
+        val quantity5 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2015-03-05",
+            "2017-01-01"
+        )
         assertEquals(3, quantity5)
 
-        val quantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-12-31", "2019-01-01",
-                OrderStatsApiUnit.YEAR, 1)
+        val quantity6 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2018-12-31",
+            "2019-01-01"
+        )
         assertEquals(2, quantity6)
 
-        val quantity7 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-25", "2019-01-25",
-                OrderStatsApiUnit.YEAR, 1)
+        val quantity7 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2019-01-25",
+            "2019-01-25"
+        )
         assertEquals(1, quantity7)
 
-        val inverseQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-01", "2017-01-01",
-                OrderStatsApiUnit.YEAR, 1)
+        val inverseQuantity1 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2018-01-01",
+            "2017-01-01"
+        )
         assertEquals(2, inverseQuantity1)
 
-        val inverseQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-03-01", "2017-01-01",
-                OrderStatsApiUnit.YEAR, 1)
+        val inverseQuantity2 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2018-03-01",
+            "2017-01-01"
+        )
         assertEquals(2, inverseQuantity2)
 
-        val inverseQuantity3 = wcStatsStore.getQuantityByOrderStatsApiUnit("2018-01-05", "2017-01-01",
-                OrderStatsApiUnit.YEAR, 1)
+        val inverseQuantity3 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2018-01-05",
+            "2017-01-01"
+        )
         assertEquals(2, inverseQuantity3)
 
-        val inverseQuantity4 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-03-01", "2017-01-01",
-                OrderStatsApiUnit.YEAR, 1)
+        val inverseQuantity4 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2019-03-01",
+            "2017-01-01"
+        )
         assertEquals(3, inverseQuantity4)
 
-        val inverseQuantity5 = wcStatsStore.getQuantityByOrderStatsApiUnit("2017-01-01", "2015-03-05",
-                OrderStatsApiUnit.YEAR, 1)
+        val inverseQuantity5 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2017-01-01",
+            "2015-03-05"
+        )
         assertEquals(3, inverseQuantity5)
 
-        val inverseQuantity6 = wcStatsStore.getQuantityByOrderStatsApiUnit("2019-01-01", "2018-12-31",
-                OrderStatsApiUnit.YEAR, 1)
+        val inverseQuantity6 = wcStatsStore.getVisitorStatsQuantity(
+            StatsGranularity.YEARS, "2019-01-01",
+            "2018-12-31"
+        )
         assertEquals(2, inverseQuantity6)
-
-        val defaultQuantity1 = wcStatsStore.getQuantityByOrderStatsApiUnit("", "",
-                OrderStatsApiUnit.YEAR, 1)
-        assertEquals(1, defaultQuantity1)
-
-        val defaultQuantity2 = wcStatsStore.getQuantityByOrderStatsApiUnit(null, null,
-                OrderStatsApiUnit.YEAR, 1)
-        assertEquals(1, defaultQuantity2)
     }
 
     @Test
     fun testFetchCurrentDayRevenueStatsDate() = runBlocking {
         val plus12SiteDate = SiteModel().apply { timezone = "12" }.let {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
-            ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
+            ).thenReturn(FetchRevenueStatsResponsePayload(it, StatsGranularity.DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val endDate = DateUtils.getEndDateForSite(it)
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate, endDate)
@@ -313,7 +368,7 @@ class WCStatsStoreTest {
 
         val minus12SiteDate = SiteModel().apply { timezone = "-12" }.let {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
-            ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
+            ).thenReturn(FetchRevenueStatsResponsePayload(it, StatsGranularity.DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val endDate = DateUtils.getEndDateForSite(it)
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate, endDate)
@@ -341,7 +396,7 @@ class WCStatsStoreTest {
     fun testFetchCurrentDayRevenueStatsDateSpecificEndDate() = runBlocking {
         val plus12SiteDate = SiteModel().apply { timezone = "12" }.let {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
-            ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
+            ).thenReturn(FetchRevenueStatsResponsePayload(it, StatsGranularity.DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val endDate = DateUtils.formatDate("yyyy-MM-dd", Date())
 
@@ -363,7 +418,7 @@ class WCStatsStoreTest {
 
         val minus12SiteDate = SiteModel().apply { timezone = "-12" }.let {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
-            ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
+            ).thenReturn(FetchRevenueStatsResponsePayload(it, StatsGranularity.DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
             val endDate = DateUtils.getEndDateForSite(it)
             val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate, endDate)
@@ -793,13 +848,13 @@ class WCStatsStoreTest {
         // that getNewVisitorStats is resilient and can recover from unexpected data
         //
         val defaultWeekVisitorStatsModel = WCStatsTestUtils.generateSampleNewVisitorStatsModel(
-            granularity = WEEKS.toString(),
+            granularity = StatsGranularity.WEEKS.toString(),
             data = UnitTestUtils.getStringFromResourceFile(this.javaClass, "wc/wrong-visitor-stats-data.json")
         )
         val site = SiteModel().apply { id = defaultWeekVisitorStatsModel.localSiteId }
         WCVisitorStatsSqlUtils.insertOrUpdateNewVisitorStats(defaultWeekVisitorStatsModel)
 
-        val defaultWeekVisitorStats = wcStatsStore.getNewVisitorStats(site, WEEKS)
+        val defaultWeekVisitorStats = wcStatsStore.getNewVisitorStats(site, StatsGranularity.WEEKS)
         assertTrue(defaultWeekVisitorStats.isNotEmpty())
         assertEquals(defaultWeekVisitorStats["2019-06-23"],10)
         assertEquals(defaultWeekVisitorStats["2019-06-22"],20)

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -294,7 +294,8 @@ class WCStatsStoreTest {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
-            val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
+            val endDate = DateUtils.getEndDateForSite(it)
+            val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate, endDate)
             wcStatsStore.fetchRevenueStats(payload)
 
             val timeOnSite = getCurrentDateTimeForSite(it, "yyyy-MM-dd'T'00:00:00")
@@ -314,7 +315,8 @@ class WCStatsStoreTest {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
-            val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
+            val endDate = DateUtils.getEndDateForSite(it)
+            val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate, endDate)
             wcStatsStore.fetchRevenueStats(payload)
 
             val timeOnSite = getCurrentDateTimeForSite(it, "yyyy-MM-dd'T'00:00:00")
@@ -363,7 +365,8 @@ class WCStatsStoreTest {
             whenever(mockOrderStatsRestClient.fetchRevenueStats(any(), any(), any(), any(), any(), any(), any(), any())
             ).thenReturn(FetchRevenueStatsResponsePayload(it, DAYS, WCRevenueStatsModel()))
             val startDate = DateUtils.getStartDateForSite(it, DateUtils.formatDate("yyyy-MM-dd'T'00:00:00", Date()))
-            val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate)
+            val endDate = DateUtils.getEndDateForSite(it)
+            val payload = FetchRevenueStatsPayload(it, StatsGranularity.DAYS, startDate, endDate)
             wcStatsStore.fetchRevenueStats(payload)
 
             val timeOnSite = getCurrentDateTimeForSite(it, "yyyy-MM-dd'T'00:00:00")
@@ -555,8 +558,10 @@ class WCStatsStoreTest {
                 .thenReturn(nonExistentPayload)
         wcStatsStore.fetchRevenueStats(
                 FetchRevenueStatsPayload(
-                        site,
-                        StatsGranularity.YEARS
+                    site = site,
+                    granularity = StatsGranularity.YEARS,
+                    startDate = "2019-01-01",
+                    endDate = "2019-01-07"
                 )
         )
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/stats/WCStatsStoreTest.kt
@@ -100,6 +100,7 @@ class WCStatsStoreTest {
         assertEquals(31, quantity6)
     }
 
+    @Suppress("LongMethod")
     @Test
     fun testGetQuantityForWeeks() {
         val quantity1 = wcStatsStore.getVisitorStatsQuantity(
@@ -187,6 +188,7 @@ class WCStatsStoreTest {
         assertEquals(5, inverseQuantity7)
     }
 
+    @Suppress("LongMethod")
     @Test
     fun testGetQuantityForMonths() {
         val quantity1 = wcStatsStore.getVisitorStatsQuantity(
@@ -262,6 +264,7 @@ class WCStatsStoreTest {
         assertEquals(2, inverseQuantity6)
     }
 
+    @Suppress("LongMethod")
     @Test
     fun testGetQuantityForYears() {
         val quantity1 = wcStatsStore.getVisitorStatsQuantity(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -35,42 +35,11 @@ class OrderStatsRestClient @Inject constructor(
         companion object {
             fun fromStatsGranularity(granularity: StatsGranularity): OrderStatsApiUnit {
                 return when (granularity) {
+                    StatsGranularity.HOURS -> HOUR
                     StatsGranularity.DAYS -> DAY
                     StatsGranularity.WEEKS -> WEEK
                     StatsGranularity.MONTHS -> MONTH
                     StatsGranularity.YEARS -> YEAR
-                }
-            }
-
-            /**
-             * Based on the design changes, when:
-             *  `Today` tab is selected: [OrderStatsApiUnit] field passed to the API should be [HOUR]
-             *  `This week` tab is selected: [OrderStatsApiUnit] field passed to the API should be [DAY]
-             *  `This month` tab is selected: [OrderStatsApiUnit] field passed to the API should be [DAY]
-             *  `This year` tab is selected: [OrderStatsApiUnit] field passed to the API should be [MONTH]
-             */
-            fun convertToRevenueStatsInterval(granularity: StatsGranularity): OrderStatsApiUnit {
-                return when (granularity) {
-                    StatsGranularity.DAYS -> HOUR
-                    StatsGranularity.WEEKS -> DAY
-                    StatsGranularity.MONTHS -> DAY
-                    StatsGranularity.YEARS -> MONTH
-                }
-            }
-
-            /**
-             * Based on the design changes, when:
-             *  `Today` tab is selected: [OrderStatsApiUnit] field passed to the visitor stats API should be [DAY]
-             *  `This week` tab is selected: [OrderStatsApiUnit] field passed to the visitor stats API should be [DAY]
-             *  `This month` tab is selected: [OrderStatsApiUnit] field passed to the visitor stats API should be [DAY]
-             *  `This year` tab is selected: [OrderStatsApiUnit] field passed to the visitor stats API should be [MONTH]
-             */
-            fun convertToVisitorsStatsApiUnit(granularity: StatsGranularity): OrderStatsApiUnit {
-                return when (granularity) {
-                    StatsGranularity.DAYS -> DAY
-                    StatsGranularity.WEEKS -> DAY
-                    StatsGranularity.MONTHS -> DAY
-                    StatsGranularity.YEARS -> MONTH
                 }
             }
         }
@@ -110,7 +79,7 @@ class OrderStatsRestClient @Inject constructor(
     ): FetchRevenueStatsResponsePayload {
         val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
         val params = mapOf(
-            "interval" to OrderStatsApiUnit.convertToRevenueStatsInterval(granularity).toString(),
+            "interval" to OrderStatsApiUnit.fromStatsGranularity(granularity).toString(),
             "after" to startDate,
             "before" to endDate,
             "per_page" to perPage.toString(),
@@ -203,7 +172,6 @@ class OrderStatsRestClient @Inject constructor(
 
     suspend fun fetchNewVisitorStats(
         site: SiteModel,
-        unit: OrderStatsApiUnit,
         granularity: StatsGranularity,
         date: String,
         quantity: Int,
@@ -213,7 +181,7 @@ class OrderStatsRestClient @Inject constructor(
     ): FetchNewVisitorStatsResponsePayload {
         val url = WPCOMREST.sites.site(site.siteId).stats.visits.urlV1_1
         val params = mapOf(
-            "unit" to unit.toString(),
+            "unit" to OrderStatsApiUnit.fromStatsGranularity(granularity).toString(),
             "date" to date,
             "quantity" to quantity.toString(),
             "stat_fields" to "visitors"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -32,16 +32,7 @@ class WCStatsStore @Inject constructor(
     private val coroutineEngine: CoroutineEngine
 ) : Store(dispatcher) {
     companion object {
-        const val WOO_COMMERCE_INITIAL_RELEASE = 2011
-
-        const val STATS_QUANTITY_DAYS = 30
-        const val STATS_QUANTITY_WEEKS = 17
-        const val STATS_QUANTITY_MONTHS = 12
-
         private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
-        private const val DATE_FORMAT_WEEK = "yyyy-'W'ww"
-        private const val DATE_FORMAT_MONTH = "yyyy-MM"
-        private const val DATE_FORMAT_YEAR = "yyyy"
 
         // Use WordPress's maximum per page quantity
         private const val ORDER_REVENUE_QUANTITY = 100
@@ -238,7 +229,7 @@ class WCStatsStore @Inject constructor(
             val result = wcOrderStatsClient.fetchNewVisitorStats(
                     site = payload.site,
                     granularity = payload.granularity,
-                    date = getFormattedDateByOrderStatsApiUnit(payload.site, payload.granularity, endDate),
+                    date = DateUtils.getDateTimeForSite(payload.site, DATE_FORMAT_DAY, endDate),
                     quantity = quantity,
                     force = payload.forced,
                     startDate = startDate,
@@ -286,23 +277,6 @@ class WCStatsStore @Inject constructor(
             StatsGranularity.YEARS -> DateUtils.getQuantityInYears(startDateCalendar, endDateCalendar)
             else -> error("Visitor stats do not support hours granularity")
         }.toInt()
-    }
-
-    /**
-     * Given a {@param endDate} end date, formats the end date based on the site's timezone
-     * If the start date or end date is empty, formats the current date
-     */
-    private fun getFormattedDateByOrderStatsApiUnit(
-        site: SiteModel,
-        granularity: StatsGranularity,
-        endDate: String?
-    ): String {
-        return when (granularity) {
-            StatsGranularity.WEEKS -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_WEEK, endDate)
-            StatsGranularity.MONTHS -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_MONTH, endDate)
-            StatsGranularity.YEARS -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_YEAR, endDate)
-            else -> DateUtils.getDateTimeForSite(site, DATE_FORMAT_DAY, endDate)
-        }
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -67,26 +67,6 @@ class WCStatsStore @Inject constructor(
                 return fromOrderStatsApiUnit(OrderStatsApiUnit.valueOf(value.toUpperCase()))
             }
         }
-
-        fun startDateTime(site: SiteModel) = when (this) {
-            DAYS -> DateUtils.getStartDateForSite(site, DateUtils.getStartOfCurrentDay())
-            WEEKS -> DateUtils.getFirstDayOfCurrentWeekBySite(site)
-            MONTHS -> DateUtils.getFirstDayOfCurrentMonthBySite(site)
-            YEARS -> DateUtils.getFirstDayOfCurrentYearBySite(site)
-        }
-
-        fun endDateTime(site: SiteModel) = when (this) {
-            DAYS -> DateUtils.getEndDateForSite(site)
-            WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
-            MONTHS -> DateUtils.getLastDayOfCurrentMonthForSite(site)
-            YEARS -> DateUtils.getLastDayOfCurrentYearForSite(site)
-        }
-
-        fun datePeriod(site: SiteModel): String {
-            val startDate = startDateTime(site)
-            val endDate = endDateTime(site)
-            return DateUtils.getDatePeriod(startDate, endDate)
-        }
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -123,9 +123,9 @@ class WCStatsStore @Inject constructor(
     class FetchNewVisitorStatsPayload(
         val site: SiteModel,
         val granularity: StatsGranularity,
-        val forced: Boolean = false,
-        val startDate: String? = null,
-        val endDate: String? = null
+        val startDate: String,
+        val endDate: String,
+        val forced: Boolean = false
     ) : Payload<BaseNetworkError>()
 
     class FetchNewVisitorStatsResponsePayload(
@@ -280,8 +280,8 @@ class WCStatsStore @Inject constructor(
 
     suspend fun fetchNewVisitorStats(payload: FetchNewVisitorStatsPayload): OnWCStatsChanged {
         val apiUnit = OrderStatsApiUnit.convertToVisitorsStatsApiUnit(payload.granularity)
-        val startDate = payload.startDate?.takeIf { it.isNotEmpty() } ?: getStartDate(payload.granularity)
-        val endDate = payload.endDate?.takeIf { it.isNotEmpty() } ?: getEndDate(payload.granularity, payload.site)
+        val startDate = payload.startDate
+        val endDate = payload.endDate
         val quantity = getQuantityForOrderStatsApiUnit(payload.site, apiUnit, startDate, endDate)
         return coroutineEngine.withDefaultContext(T.API, this, "fetchNewVisitorStats") {
             val result = wcOrderStatsClient.fetchNewVisitorStats(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -40,13 +40,13 @@ class WCStatsStore @Inject constructor(
         const val STATS_QUANTITY_WEEKS = 17
         const val STATS_QUANTITY_MONTHS = 12
 
-        const val STATS_GRANULARITY_DAYS = 1
-        const val STATS_GRANULARITY_YEARS = 12
-
         private const val DATE_FORMAT_DAY = "yyyy-MM-dd"
         private const val DATE_FORMAT_WEEK = "yyyy-'W'ww"
         private const val DATE_FORMAT_MONTH = "yyyy-MM"
         private const val DATE_FORMAT_YEAR = "yyyy"
+
+        // Use WordPress's maximum per page quantity
+        private const val ORDER_REVENUE_QUANTITY = 100
     }
 
     enum class StatsGranularity {
@@ -354,7 +354,7 @@ class WCStatsStore @Inject constructor(
                 granularity = payload.granularity,
                 startDate = startDate,
                 endDate = endDate,
-                perPage = getPerPageQuantityForRevenueStatsGranularity(payload.granularity),
+                perPage = ORDER_REVENUE_QUANTITY,
                 forceRefresh = payload.forced,
                 revenueRangeId = payload.revenueRangeId
             )
@@ -374,19 +374,6 @@ class WCStatsStore @Inject constructor(
                 }
             }
         }
-    }
-
-    /**
-     * Returns the page size in days depending on the provided [granularity],
-     * to use for fetching revenue stats.
-     */
-    private fun getPerPageQuantityForRevenueStatsGranularity(
-        granularity: StatsGranularity
-    ) = when (granularity) {
-        StatsGranularity.DAYS -> STATS_GRANULARITY_DAYS
-        StatsGranularity.WEEKS -> Calendar.getInstance().getActualMaximum(Calendar.DAY_OF_WEEK)
-        StatsGranularity.MONTHS -> Calendar.getInstance().getActualMaximum(Calendar.DAY_OF_MONTH)
-        StatsGranularity.YEARS -> STATS_GRANULARITY_YEARS
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -314,22 +314,6 @@ class WCStatsStore @Inject constructor(
         }
     }
 
-    private fun getStartDate(granularity: StatsGranularity) =
-        when (granularity) {
-            StatsGranularity.DAYS -> DateUtils.getStartOfCurrentDay()
-            StatsGranularity.WEEKS -> DateUtils.getFirstDayOfCurrentWeek(Calendar.getInstance(Locale.getDefault()))
-            StatsGranularity.MONTHS -> DateUtils.getFirstDayOfCurrentMonth()
-            StatsGranularity.YEARS -> DateUtils.getFirstDayOfCurrentYear()
-        }
-
-    private fun getEndDate(granularity: StatsGranularity, site: SiteModel) =
-        when (granularity) {
-            StatsGranularity.DAYS -> DateUtils.getStartOfCurrentDay()
-            StatsGranularity.WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
-            StatsGranularity.MONTHS -> DateUtils.getLastDayOfCurrentMonthForSite(site)
-            StatsGranularity.YEARS -> DateUtils.getLastDayOfCurrentYearForSite(site)
-        }
-
     /**
      * Given a {@param endDate} end date, formats the end date based on the site's timezone
      * If the start date or end date is empty, formats the current date
@@ -389,48 +373,6 @@ class WCStatsStore @Inject constructor(
                     )
                 }
             }
-        }
-    }
-
-    /**
-     * Given a [startDate], formats the date based on the site's timezone in format yyyy-MM-dd'T'hh:mm:ss
-     * If the start date is empty, fetches the date based on the [granularity]
-     */
-    private fun getStartDateForRevenueStatsGranularity(
-        site: SiteModel,
-        granularity: StatsGranularity,
-        startDate: String?
-    ): String {
-        return if (startDate.isNullOrEmpty()) {
-            when (granularity) {
-                StatsGranularity.DAYS -> DateUtils.getStartDateForSite(site, DateUtils.getStartOfCurrentDay())
-                StatsGranularity.WEEKS -> DateUtils.getFirstDayOfCurrentWeekBySite(site)
-                StatsGranularity.MONTHS -> DateUtils.getFirstDayOfCurrentMonthBySite(site)
-                StatsGranularity.YEARS -> DateUtils.getFirstDayOfCurrentYearBySite(site)
-            }
-        } else {
-            DateUtils.getStartDateForSite(site, startDate)
-        }
-    }
-
-    /**
-     * Given a [endDate], formats the date based on the site's timezone in format yyyy-MM-dd'T'hh:mm:ss
-     * If the end date is empty, fetches the date based on the [granularity]
-     */
-    private fun getEndDateForRevenueStatsGranularity(
-        site: SiteModel,
-        granularity: StatsGranularity,
-        endDate: String?
-    ): String {
-        return if (endDate.isNullOrEmpty()) {
-            when (granularity) {
-                StatsGranularity.DAYS -> DateUtils.getEndDateForSite(site)
-                StatsGranularity.WEEKS -> DateUtils.getLastDayOfCurrentWeekForSite(site)
-                StatsGranularity.MONTHS -> DateUtils.getLastDayOfCurrentMonthForSite(site)
-                StatsGranularity.YEARS -> DateUtils.getLastDayOfCurrentYearForSite(site)
-            }
-        } else {
-            DateUtils.getEndDateForSite(site, endDate)
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -81,8 +81,8 @@ class WCStatsStore @Inject constructor(
     class FetchRevenueStatsPayload(
         val site: SiteModel,
         val granularity: StatsGranularity,
-        val startDate: String? = null,
-        val endDate: String? = null,
+        val startDate: String,
+        val endDate: String,
         val forced: Boolean = false,
         val revenueRangeId: String = ""
     ) : Payload<BaseNetworkError>()
@@ -361,10 +361,8 @@ class WCStatsStore @Inject constructor(
     }
 
     suspend fun fetchRevenueStats(payload: FetchRevenueStatsPayload): OnWCRevenueStatsChanged {
-        val startDate = payload.startDate?.takeIf { it.isNotEmpty() }
-            ?: getStartDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.startDate)
-        val endDate = payload.endDate?.takeIf { it.isNotEmpty() }
-            ?: getEndDateForRevenueStatsGranularity(payload.site, payload.granularity, payload.endDate)
+        val startDate = payload.startDate
+        val endDate = payload.endDate
 
         return coroutineEngine.withDefaultContext(API, this, "fetchRevenueStats") {
             val result = wcOrderStatsClient.fetchRevenueStats(


### PR DESCRIPTION
This PRs main goal is to decouple granularities from ranges:

### Before
Currently the `StatsGranularity` enum was used both as a unit and also as a range, so when we used `StatsGranularity.YEARS`, we had logic that assumed that we mean the current year, and we used this to calculate the stats range.
This was fine when we used only predefined ranges, but with custom ranges, this will be problematic.

### After
With this PR, we are moving from the above assumption, and now all of the stats functions expect a range and a granularity.

### How
The changes are actually simple, it mainly involved making the `startDate` and `endDate` of the requests non-optional, and removed the code that calculated them from the granularities.

### Other changes
The PR includes some other improvements:
- Simplify the date formatting for the `/visits` endpoint, instead of having different formats depending on the granularity, the API works correctly with the day format, and it's what the iOS app uses.
- Use a fixed quantity of `100` for the revenue stats endpoint (pe5sF9-2ri-p2#comment-3427)
- Removed usage of the `OrderStatsApiUnit` from upper layers, as it's a network unit.
- The `StatsGranularity` we pass is mapped to the matching `OrderStatsApiUnit`, the logic of calculating the correct granularity will be moved to the upper layers (we removed this [logic](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/28e35ae36fe90c3b7bafb4610e71b9cd3f4e2dc4/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt#L46-L76))

### Testing
Check the WCAndroid PR https://github.com/woocommerce/woocommerce-android/pull/11033