### PR TITLE
Checks the theme_tier for defining if a theme is free

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -229,7 +229,8 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     @NonNull
     private static ThemeModel createThemeFromWPComResponse(@NonNull WPComThemeResponse response) {
-        boolean free = TextUtils.isEmpty(response.price);
+        boolean free = response.theme_tier == null || response.theme_tier.slug == null
+                       || response.theme_tier.slug.equalsIgnoreCase("free");
         String priceText = null;
         if (!free) {
             priceText = response.price;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
@@ -23,6 +23,12 @@ public class WPComThemeResponse {
         @Nullable public WPComThemeMobileFriendlyTaxonomy[] theme_mobile_friendly;
     }
 
+    public static class WPComThemeTier {
+        @Nullable public String slug;
+        @Nullable public String feature;
+        @Nullable public String platform;
+    }
+
     @NonNull public String id;
     @Nullable public String slug;
     @Nullable public String stylesheet;
@@ -38,4 +44,5 @@ public class WPComThemeResponse {
     @Nullable public String download_uri;
     @Nullable public String price;
     @Nullable public WPComThemeTaxonomies taxonomies;
+    @Nullable public WPComThemeTier theme_tier;
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/20419

**`WordPress-Android` PR:** https://github.com/wordpress-mobile/WordPress-Android/pull/20425

## Description
Checks the theme_tier for defining if a theme is free

## To test:
With the app from https://github.com/wordpress-mobile/WordPress-Android/pull/20425 check steps at https://github.com/wordpress-mobile/WordPress-Android/issues/20419 and verify that the non-free themes are not listed

⚠️ Since this PR is targeting a beta the merge process is tracked in p1709801508524249/1709801487.743599-slack-CC7L49W13