### PR TITLE
Merge Release 2.70.1 into trunk

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/ThemeRestClient.java
@@ -229,7 +229,8 @@ public class ThemeRestClient extends BaseWPComRestClient {
 
     @NonNull
     private static ThemeModel createThemeFromWPComResponse(@NonNull WPComThemeResponse response) {
-        boolean free = TextUtils.isEmpty(response.price);
+        boolean free = response.theme_tier == null || response.theme_tier.slug == null
+                       || response.theme_tier.slug.equalsIgnoreCase("free");
         String priceText = null;
         if (!free) {
             priceText = response.price;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/theme/WPComThemeResponse.java
@@ -23,6 +23,12 @@ public class WPComThemeResponse {
         @Nullable public WPComThemeMobileFriendlyTaxonomy[] theme_mobile_friendly;
     }
 
+    public static class WPComThemeTier {
+        @Nullable public String slug;
+        @Nullable public String feature;
+        @Nullable public String platform;
+    }
+
     @NonNull public String id;
     @Nullable public String slug;
     @Nullable public String stylesheet;
@@ -38,4 +44,5 @@ public class WPComThemeResponse {
     @Nullable public String download_uri;
     @Nullable public String price;
     @Nullable public WPComThemeTaxonomies taxonomies;
+    @Nullable public WPComThemeTier theme_tier;
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -36,11 +36,12 @@ class VisitsAndViewsStore
         site: SiteModel,
         granularity: StatsGranularity,
         limitMode: Top,
-        forced: Boolean = false,
-        useSiteTimezone: Boolean = true
+        forced: Boolean = false
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
-        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
-        val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
+        val dateWithTimeZone = statsUtils.getFormattedDate(
+            currentTimeProvider.currentDate(),
+            SiteUtils.getNormalizedTimezone(site.timezone)
+        )
         logProgress(granularity, "Site timezone: ${site.timezone}")
         try {
             logProgress(granularity, "Current date: ${currentTimeProvider.currentDate()}")
@@ -134,11 +135,12 @@ class VisitsAndViewsStore
     fun getVisits(
         site: SiteModel,
         granularity: StatsGranularity,
-        limitMode: LimitMode,
-        useSiteTimezone: Boolean = true
+        limitMode: LimitMode
     ): VisitsAndViewsModel? {
-        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
-        val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
+        val dateWithTimeZone = statsUtils.getFormattedDate(
+            currentTimeProvider.currentDate(),
+            SiteUtils.getNormalizedTimezone(site.timezone)
+        )
         return getVisits(site, granularity, limitMode, dateWithTimeZone)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -37,7 +37,7 @@ class VisitsAndViewsStore
         granularity: StatsGranularity,
         limitMode: Top,
         forced: Boolean = false,
-        useSiteTimezone: Boolean = false
+        useSiteTimezone: Boolean = true
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
         val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
@@ -85,7 +85,7 @@ class VisitsAndViewsStore
         limitMode: Top,
         date: Date,
         forced: Boolean = false,
-        useSiteTimezone: Boolean = false
+        useSiteTimezone: Boolean = true
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
         val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
@@ -135,7 +135,7 @@ class VisitsAndViewsStore
         site: SiteModel,
         granularity: StatsGranularity,
         limitMode: LimitMode,
-        useSiteTimezone: Boolean = false
+        useSiteTimezone: Boolean = true
     ): VisitsAndViewsModel? {
         val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
@@ -147,7 +147,7 @@ class VisitsAndViewsStore
         granularity: StatsGranularity,
         limitMode: Top,
         date: Date,
-        useSiteTimezone: Boolean = false
+        useSiteTimezone: Boolean = true
     ): VisitsAndViewsModel? {
         val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -86,9 +86,9 @@ class VisitsAndViewsStore
         limitMode: Top,
         date: Date,
         forced: Boolean = false,
-        useSiteTimezone: Boolean = true
+        applySiteTimezone: Boolean = true
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
-        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val timezone = if (applySiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
         logProgress(granularity, "Site timezone: ${site.timezone}")
         try {
@@ -149,9 +149,9 @@ class VisitsAndViewsStore
         granularity: StatsGranularity,
         limitMode: Top,
         date: Date,
-        useSiteTimezone: Boolean = true
+        applySiteTimezone: Boolean = true
     ): VisitsAndViewsModel? {
-        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val timezone = if (applySiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
         return getVisits(site, granularity, limitMode, dateWithTimeZone)
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -36,12 +36,11 @@ class VisitsAndViewsStore
         site: SiteModel,
         granularity: StatsGranularity,
         limitMode: Top,
-        forced: Boolean = false
+        forced: Boolean = false,
+        useSiteTimezone: Boolean = false
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
-        val dateWithTimeZone = statsUtils.getFormattedDate(
-                currentTimeProvider.currentDate(),
-                SiteUtils.getNormalizedTimezone(site.timezone)
-        )
+        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
         logProgress(granularity, "Site timezone: ${site.timezone}")
         try {
             logProgress(granularity, "Current date: ${currentTimeProvider.currentDate()}")
@@ -135,12 +134,11 @@ class VisitsAndViewsStore
     fun getVisits(
         site: SiteModel,
         granularity: StatsGranularity,
-        limitMode: LimitMode
+        limitMode: LimitMode,
+        useSiteTimezone: Boolean = false
     ): VisitsAndViewsModel? {
-        val dateWithTimeZone = statsUtils.getFormattedDate(
-                currentTimeProvider.currentDate(),
-                SiteUtils.getNormalizedTimezone(site.timezone)
-        )
+        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val dateWithTimeZone = statsUtils.getFormattedDate(currentTimeProvider.currentDate(), timezone)
         return getVisits(site, granularity, limitMode, dateWithTimeZone)
     }
 
@@ -148,9 +146,11 @@ class VisitsAndViewsStore
         site: SiteModel,
         granularity: StatsGranularity,
         limitMode: Top,
-        date: Date
+        date: Date,
+        useSiteTimezone: Boolean = false
     ): VisitsAndViewsModel? {
-        val dateWithTimeZone = statsUtils.getFormattedDate(date, SiteUtils.getNormalizedTimezone(site.timezone))
+        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
         return getVisits(site, granularity, limitMode, dateWithTimeZone)
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/time/VisitsAndViewsStore.kt
@@ -85,9 +85,9 @@ class VisitsAndViewsStore
         limitMode: Top,
         date: Date,
         forced: Boolean = false,
-        normalizeTimezone: Boolean = false
+        useSiteTimezone: Boolean = false
     ) = coroutineEngine.withDefaultContext(STATS, this, "fetchVisits") {
-        val timezone = if (normalizeTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
+        val timezone = if (useSiteTimezone) SiteUtils.getNormalizedTimezone(site.timezone) else null
         val dateWithTimeZone = statsUtils.getFormattedDate(date, timezone)
         logProgress(granularity, "Site timezone: ${site.timezone}")
         try {


### PR DESCRIPTION
Includes:
* Make timezone optional in VisitsAndViewsStore by @irfano in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2967
* Checks the theme_tier for defining if a theme is free by @antonis in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2969


**Full Changelog**: https://github.com/wordpress-mobile/WordPress-FluxC-Android/compare/2.70.0...2.70.1