### PR TITLE
Preparations to support order deletion from the app

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
@@ -5,11 +5,13 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import org.wordpress.android.fluxc.module.DatabaseModule
+import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.persistence.TransactionExecutor
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.AddonsDao
 import org.wordpress.android.fluxc.persistence.dao.CouponsDao
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Module(
@@ -49,6 +51,11 @@ interface WCDatabaseModule {
 
         @Provides fun provideWooPaymentsDepositsOverviewDao(database: WCAndroidDatabase) =
             database.wooPaymentsDepositsOverviewDao
+
+        /**
+         * OrderSqlUtils is a Kotlin object, we can't use [Inject] to inject it.
+         */
+        @Provides fun provideOrderSqlUtils() = OrderSqlUtils
     }
     @Binds fun bindTransactionExecutor(database: WCAndroidDatabase): TransactionExecutor
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.model.list.ListDescriptor
 import org.wordpress.android.fluxc.model.list.ListDescriptorTypeIdentifier
 import org.wordpress.android.fluxc.model.list.ListDescriptorUniqueIdentifier
 
-class WCOrderListDescriptor(
+data class WCOrderListDescriptor(
     val site: SiteModel,
     val statusFilter: String? = null,
     val searchQuery: String? = null,
@@ -13,7 +13,8 @@ class WCOrderListDescriptor(
     val beforeFilter: String? = null,
     val afterFilter: String? = null,
     val productId: Long? = null,
-    val customerId: Long? = null
+    val customerId: Long? = null,
+    val excludedIds: List<Long>? = null
 ) : ListDescriptor {
     override val config: ListConfig = ListConfig.default
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -152,7 +152,8 @@ class OrderRestClient @Inject constructor(
                 "before" to listDescriptor.beforeFilter,
                 "after" to listDescriptor.afterFilter,
                 "customer" to listDescriptor.customerId?.toString(),
-                "product" to listDescriptor.productId?.toString()
+                "product" to listDescriptor.productId?.toString(),
+                "exclude" to listDescriptor.excludedIds?.joinToString()
             )
 
             val response = wooNetwork.executeGetGsonRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/OrderSqlUtils.kt
@@ -52,6 +52,15 @@ object OrderSqlUtils {
                 .execute()
     }
 
+    fun deleteOrderSummaryById(site: SiteModel, orderId: Long) {
+        WellSql.delete(WCOrderSummaryModel::class.java)
+                .where()
+                .equals(WCOrderSummaryModelTable.LOCAL_SITE_ID, site.id)
+                .equals(WCOrderSummaryModelTable.REMOTE_ORDER_ID, orderId)
+                .endWhere()
+                .execute()
+    }
+
     fun insertOrUpdateOrderStatusOption(orderStatus: WCOrderStatusModel): Int {
         val result = WellSql.select(WCOrderStatusModel::class.java)
                 .where().beginGroup()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -38,7 +38,8 @@ class OrderUpdateStore @Inject internal constructor(
     private val coroutineEngine: CoroutineEngine,
     private val wcOrderRestClient: OrderRestClient,
     private val ordersDaoDecorator: OrdersDaoDecorator,
-    private val siteSqlUtils: SiteSqlUtils
+    private val siteSqlUtils: SiteSqlUtils,
+    private val orderSqlUtils: OrderSqlUtils
 ) {
     suspend fun updateCustomerOrderNote(
         orderId: Long,
@@ -277,7 +278,7 @@ class OrderUpdateStore @Inject internal constructor(
                 WooResult(result.error)
             } else {
                 ordersDaoDecorator.deleteOrder(site.localId(), orderId)
-                OrderSqlUtils.deleteOrderSummaryById(site, orderId)
+                orderSqlUtils.deleteOrderSummaryById(site, orderId)
                 WooResult(Unit)
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/OrderUpdateStore.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDtoMapper.Companion.toDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.dao.OrdersDaoDecorator
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
@@ -276,6 +277,7 @@ class OrderUpdateStore @Inject internal constructor(
                 WooResult(result.error)
             } else {
                 ordersDaoDecorator.deleteOrder(site.localId(), orderId)
+                OrderSqlUtils.deleteOrderSummaryById(site, orderId)
                 WooResult(Unit)
             }
         }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Shipping
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
+import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.persistence.dao.OrdersDaoDecorator
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
@@ -45,6 +46,7 @@ class OrderUpdateStoreTest {
     private val siteSqlUtils: SiteSqlUtils = mock {
         on { getSiteWithLocalId(any()) } doReturn site
     }
+    private val orderSqlUtils: OrderSqlUtils = mock()
     private val ordersDaoDecorator: OrdersDaoDecorator = mock {
         onBlocking { getOrder(TEST_REMOTE_ORDER_ID, TEST_LOCAL_SITE_ID) } doReturn initialOrder
     }
@@ -56,9 +58,10 @@ class OrderUpdateStoreTest {
                         TestCoroutineScope().coroutineContext,
                         mock()
                 ),
-                orderRestClient,
-                ordersDaoDecorator,
-                siteSqlUtils
+                wcOrderRestClient = orderRestClient,
+                ordersDaoDecorator = ordersDaoDecorator,
+                siteSqlUtils = siteSqlUtils,
+                orderSqlUtils = orderSqlUtils
         )
     }
 
@@ -518,6 +521,7 @@ class OrderUpdateStoreTest {
         )
 
         verify(ordersDaoDecorator).deleteOrder(site.localId(), TEST_REMOTE_ORDER_ID)
+        verify(orderSqlUtils).deleteOrderSummaryById(site, TEST_REMOTE_ORDER_ID)
     }
 
     private companion object {


### PR DESCRIPTION
To support deleting orders from the app, we need to handle deletion in a cancellable way (a way that supports undoing by the user), this PR adds two changes to support this:

1. Update the order list descriptor to support excluding specific orders.
2. Delete the Order summary DB entity when an order is deleted.

##### Testing
Please check https://github.com/woocommerce/woocommerce-android/pull/11068