### PR TITLE
Fix updates on filtered order list

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDaoDecorator.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDaoDecorator.kt
@@ -15,6 +15,16 @@ class OrdersDaoDecorator @Inject constructor(
     private val dispatcher: Dispatcher,
     private val ordersDao: OrdersDao,
 ) {
+    enum class ListUpdateStrategy {
+        DEFAULT,
+        // Re-fetch the order list
+        REFRESH,
+        // Re-load the order list from the DB
+        INVALIDATE,
+        // Do not update the list
+        SUPPRESS
+    }
+
     suspend fun updateLocalOrder(
         orderId: Long,
         localSiteId: LocalOrRemoteId.LocalId,
@@ -28,26 +38,37 @@ class OrdersDaoDecorator @Inject constructor(
     @Suppress("unused")
     suspend fun getAllOrders(): List<OrderEntity> = ordersDao.getAllOrders()
 
-    /**
-     * @param suppressListRefresh Suppresses emit of ListRequiresRefresh event. Can be used
-     * when this method is invoked in a loop and the app needs to emit the event at the end.
-     */
-    suspend fun insertOrUpdateOrder(order: OrderEntity, suppressListRefresh: Boolean = false) {
+    suspend fun insertOrUpdateOrder(
+        order: OrderEntity,
+        listUpdateStrategy: ListUpdateStrategy = ListUpdateStrategy.DEFAULT
+    ) {
         val orderBeforeUpdate = ordersDao.getOrder(order.orderId, order.localSiteId)
         ordersDao.insertOrUpdateOrder(order)
 
-        if(!suppressListRefresh) {
-            // Draft orders are not returned from the API. We need to re-fetch order list from the API
-            // when the order is new or its status changed from draft to another status.
-            val orderIsNewOrMovingFromDraft = orderBeforeUpdate == null
-                    || (order.status != "auto-draft" && orderBeforeUpdate.status == "auto-draft")
-            if (orderIsNewOrMovingFromDraft) {
-                // Re-fetch order list
+        when (listUpdateStrategy) {
+            ListUpdateStrategy.REFRESH -> {
                 emitRefreshListEvent(order.localSiteId)
-            } else {
-                // Re-load order list from local db
+            }
+
+            ListUpdateStrategy.INVALIDATE -> {
                 emitInvalidateListEvent(order.localSiteId)
             }
+
+            ListUpdateStrategy.DEFAULT -> {
+                // Draft orders are not returned from the API. We need to re-fetch order list from the API
+                // when the order is new or its status changed from draft to another status.
+                val orderIsNewOrMovingFromDraft = orderBeforeUpdate == null
+                        || (order.status != "auto-draft" && orderBeforeUpdate.status == "auto-draft")
+                if (orderIsNewOrMovingFromDraft) {
+                    // Re-fetch order list
+                    emitRefreshListEvent(order.localSiteId)
+                } else {
+                    // Re-load order list from local db
+                    emitInvalidateListEvent(order.localSiteId)
+                }
+            }
+
+            ListUpdateStrategy.SUPPRESS -> {} // Don't update the list
         }
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDaoDecorator.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDaoDecorator.kt
@@ -62,7 +62,9 @@ class OrdersDaoDecorator @Inject constructor(
         }
         return when {
             orderBeforeUpdate == null -> UpdateOrderResult.INSERTED
-            order != orderBeforeUpdate -> UpdateOrderResult.UPDATED
+            // Ignore changes to the modifiedDate - it's updated even when there are no other changes
+            // and results in an infinite loop.
+            order.copy(dateModified = "") != orderBeforeUpdate.copy(dateModified = "") -> UpdateOrderResult.UPDATED
             else -> UpdateOrderResult.UNCHANGED
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/InsertOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/InsertOrder.kt
@@ -23,7 +23,7 @@ class InsertOrder @Inject internal constructor(
     ) {
         transactionExecutor.executeInTransaction {
             ordersPack.forEach { (order, metaData) ->
-                ordersDaoDecorator.insertOrUpdateOrder(order, suppressListRefresh = true)
+                ordersDaoDecorator.insertOrUpdateOrder(order, OrdersDaoDecorator.ListUpdateStrategy.SUPPRESS)
                 ordersMetaDataDao.updateOrderMetaData(
                     order.orderId,
                     order.localSiteId,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/InsertOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/InsertOrder.kt
@@ -24,7 +24,10 @@ class InsertOrder @Inject internal constructor(
         var orderChanged = false
         transactionExecutor.executeInTransaction {
             ordersPack.forEach { (order, metaData) ->
-                val result = ordersDaoDecorator.insertOrUpdateOrder(order, OrdersDaoDecorator.ListUpdateStrategy.SUPPRESS)
+                val result = ordersDaoDecorator.insertOrUpdateOrder(
+                    order,
+                    OrdersDaoDecorator.ListUpdateStrategy.SUPPRESS
+                )
                 if (result != OrdersDaoDecorator.UpdateOrderResult.UNCHANGED) {
                     orderChanged = true
                 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -665,7 +665,7 @@ class WCOrderStore @Inject constructor(
         orderId: Long,
         localSiteId: LocalId,
         newStatus: String,
-        listUpdateStrategy: OrdersDaoDecorator.ListUpdateStrategy
+        listUpdateStrategy: OrdersDaoDecorator.ListUpdateStrategy = OrdersDaoDecorator.ListUpdateStrategy.DEFAULT
     ) {
         val updatedOrder = ordersDaoDecorator.getOrder(orderId, localSiteId)!!
             .copy(status = newStatus)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.store
 
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -618,17 +620,21 @@ class WCOrderStore @Inject constructor(
 
                 emit(OptimisticUpdateResult(optimisticUpdateResult))
 
-                val remotePayload = wcOrderRestClient.updateOrderStatus(orderModel, site, newStatus.statusKey)
-                val remoteUpdateResult: OnOrderChanged = if (remotePayload.isError) {
-                    revertOrderStatus(remotePayload)
-                } else {
-                    ordersDaoDecorator.insertOrUpdateOrder(
-                        remotePayload.order,
-                        // Re-fetch the list to ensure the order is correctly placed even when a filter is applied
-                        OrdersDaoDecorator.ListUpdateStrategy.REFRESH
-                    )
-                    OnOrderChanged()
-                }.copy(causeOfChange = WCOrderAction.UPDATE_ORDER_STATUS)
+                // Ensure the code gets executed even when the VM dies - eg. when the client app marks an order as
+                // completed and navigates to a different screen.
+                val remoteUpdateResult: OnOrderChanged = withContext(NonCancellable) {
+                    val remotePayload = wcOrderRestClient.updateOrderStatus(orderModel, site, newStatus.statusKey)
+                    if (remotePayload.isError) {
+                        revertOrderStatus(remotePayload)
+                    } else {
+                        ordersDaoDecorator.insertOrUpdateOrder(
+                            remotePayload.order,
+                            // Re-fetch the list to ensure the order is correctly placed even when a filter is applied
+                            OrdersDaoDecorator.ListUpdateStrategy.REFRESH
+                        )
+                        OnOrderChanged()
+                    }.copy(causeOfChange = WCOrderAction.UPDATE_ORDER_STATUS)
+                }
 
                 emit(RemoteUpdateResult(remoteUpdateResult))
                 // Needs to remain here until all event bus observables are removed from the client code


### PR DESCRIPTION
This PR fixes two bugs in the WooCommerce Android app.

**Issue 1**
 When a filter is applied on the order list (eg. status: Pending Payment) and the user changes status of one the orders (eg. to Completed), the order remains in the list even though its status is not Pending Payment anymore.

**Solution for Issue 1**
This is fixed in the first three commits. The point of the fix is to re-fetch the list  from the remote after the order status is updated in the remote. When the app optimistically updates the order in the local database, we just invalidate the list (reload it from database) instead of refetching it. 

**Issue 2**
This issue was there before this PR but wasn't as apparent as it is now. When the user collects a payment, the app marks the order as completed locally (optimistic update) and send a request to the server to update it in the remote. However, when the app navigates away from the Payment Selection screen, all the coroutines are cancelled and the result of the request is never processed => the outcome of this is the app isn't notified about it, it doesn't update the database and doesn't refresh the order list. The order remains in the list as in issue 1.

**Solution for Issue 2**
Fixed in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2973/commits/d63a9246a8ada928abb6760125cd8db79ef73e7b. I wrapped the request to the server and handling of the response into a NonCancellable coroutine context to ensure the result is handled.

**Issue 3**
When the user collects money using IPP, the order is re-fetched. However, the current implementation only invalidates the list (reloads it from database) instead of re-fetching it from the remote. This is essentially still Issue 1 in a different scenario.

**Solution for Issue 3**
Fixed in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2973/commits/a66593959265cb4b734a2c40caf033dfeb91fd54. I updated the logic that takes care of inserting/updating the order - it checks whether the order has changed after it was refetched. If it has changed, the app refreshes the list instead of just invalidating it. It could refresh it no matter if the order has changed, but that would result in a lot of refreshes - moreover, the UI displays a loading indicator when the list is being refreshed so we don't want to refresh it more often than we need to.

To test
Test these changes in the WooCommerce Android app. More details on the corresponding PR.