### PR TITLE
Update or delete product category API changes

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCProductsTest.kt
@@ -847,7 +847,7 @@ class MockedStack_WCProductsTest : MockedStack_Base() {
     }
 
     @Test
-    fun testAddProductCategorySuccess() {
+    fun testAddProductCategorySuccess() = runBlocking {
         interceptor.respondWith("wc-add-product-category-response-success.json")
 
         val productCategoryModel = WCProductCategoryModel().apply { name = "test12" }

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_WCProductTest.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched
 import org.wordpress.android.fluxc.store.WCProductStore
-import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductPasswordPayload
@@ -317,7 +316,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
 
     @Throws(InterruptedException::class)
     @Test
-    fun testAddProductCategory() {
+    fun testAddProductCategory() = runBlocking {
         // Remove all product categories from the database
         ProductSqlUtils.deleteAllProductCategories()
         assertEquals(0, ProductSqlUtils.getProductCategoriesForSite(sSite).size)
@@ -329,12 +328,7 @@ class ReleaseStack_WCProductTest : ReleaseStack_WCBase() {
             // duplicate category names fail in the API level so added a random number next to the "Test"
             name = "Test" + Random.nextInt(0, 10000)
         }
-        mDispatcher.dispatch(
-            WCProductActionBuilder.newAddProductCategoryAction(
-                AddProductCategoryPayload(sSite, productCategoryModel)
-            )
-        )
-        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), MILLISECONDS))
+        productStore.addProductCategory(sSite, productCategoryModel)
 
         // Verify results
         val fetchAllCategories = productStore.getProductCategoriesForSite(sSite)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -4,7 +4,38 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.fragment_woo_products.*
+import kotlinx.android.synthetic.main.fragment_woo_products.add_new_product
+import kotlinx.android.synthetic.main.fragment_woo_products.add_product_category
+import kotlinx.android.synthetic.main.fragment_woo_products.add_product_tags
+import kotlinx.android.synthetic.main.fragment_woo_products.batch_generate_variations
+import kotlinx.android.synthetic.main.fragment_woo_products.batch_update_variations
+import kotlinx.android.synthetic.main.fragment_woo_products.delete_product
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_all_reviews
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_categories
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_shipping_class
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_shipping_classes
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_sku_availability
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_tags
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_variations
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_products
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_products_with_filters
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_review_by_id
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_reviews_for_product
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_single_product
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_single_variation
+import kotlinx.android.synthetic.main.fragment_woo_products.fetch_specific_products
+import kotlinx.android.synthetic.main.fragment_woo_products.load_more_product_categories
+import kotlinx.android.synthetic.main.fragment_woo_products.load_more_product_shipping_classes
+import kotlinx.android.synthetic.main.fragment_woo_products.load_more_product_tags
+import kotlinx.android.synthetic.main.fragment_woo_products.load_more_product_variations
+import kotlinx.android.synthetic.main.fragment_woo_products.observe_product_categories
+import kotlinx.android.synthetic.main.fragment_woo_products.search_products
+import kotlinx.android.synthetic.main.fragment_woo_products.search_products_sku
+import kotlinx.android.synthetic.main.fragment_woo_products.test_add_ons
+import kotlinx.android.synthetic.main.fragment_woo_products.update_product
+import kotlinx.android.synthetic.main.fragment_woo_products.update_product_images
+import kotlinx.android.synthetic.main.fragment_woo_products.update_review_status
+import kotlinx.android.synthetic.main.fragment_woo_products.update_variation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -31,7 +62,6 @@ import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.WCAddonsStore
 import org.wordpress.android.fluxc.store.WCProductStore
-import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.DeleteProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductCategoriesPayload
@@ -79,7 +109,7 @@ class WooProductsFragment : StoreSelectingFragment() {
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-            inflater.inflate(layout.fragment_woo_products, container, false)
+        inflater.inflate(layout.fragment_woo_products, container, false)
 
     @Suppress("LongMethod", "ComplexMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -92,10 +122,10 @@ class WooProductsFragment : StoreSelectingFragment() {
                         prependToLog("Submitting request to fetch product by remoteProductID $remoteProductId")
                         coroutineScope.launch {
                             val result = wcProductStore.fetchSingleProduct(
-                                    FetchSingleProductPayload(
-                                            site,
-                                            remoteProductId
-                                    )
+                                FetchSingleProductPayload(
+                                    site,
+                                    remoteProductId
+                                )
                             )
 
                             val product = wcProductStore.getProductByRemoteId(site, result.remoteProductId)
@@ -116,25 +146,25 @@ class WooProductsFragment : StoreSelectingFragment() {
         fetch_single_variation.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
-                        activity,
-                        "Enter the remoteProductId of variation to fetch:"
+                    activity,
+                    "Enter the remoteProductId of variation to fetch:"
                 ) { productIdText ->
                     val productRemoteId = productIdText.text.toString().toLongOrNull()
                     productRemoteId?.let { productId ->
                         showSingleLineDialog(
-                                activity,
-                                "Enter the remoteVariationId of variation to fetch:"
+                            activity,
+                            "Enter the remoteVariationId of variation to fetch:"
                         ) { variationIdText ->
                             variationIdText.text.toString().toLongOrNull()?.let { variationId ->
                                 coroutineScope.launch {
                                     prependToLog(
                                         "Submitting request to fetch product by " +
-                                            "remoteProductId $productRemoteId, " +
-                                            "remoteVariationProductID $variationId"
+                                                "remoteProductId $productRemoteId, " +
+                                                "remoteVariationProductID $variationId"
                                     )
                                     val result = wcProductStore.fetchSingleVariation(site, productId, variationId)
                                     prependToLog("Fetching single variation " +
-                                        "${result.error?.let { "failed" } ?: "was successful"}"
+                                            "${result.error?.let { "failed" } ?: "was successful"}"
                                     )
                                     val variation = wcProductStore.getVariationByRemoteId(
                                         site,
@@ -155,8 +185,8 @@ class WooProductsFragment : StoreSelectingFragment() {
         fetch_product_sku_availability.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
-                        activity,
-                        "Enter a product SKU:"
+                    activity,
+                    "Enter a product SKU:"
                 ) { editText ->
                     val payload = FetchProductSkuAvailabilityPayload(site, editText.text.toString())
                     dispatcher.dispatch(WCProductActionBuilder.newFetchProductSkuAvailabilityAction(payload))
@@ -241,8 +271,8 @@ class WooProductsFragment : StoreSelectingFragment() {
         fetch_product_variations.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
-                        activity,
-                        "Enter the remoteProductId of product to fetch variations:"
+                    activity,
+                    "Enter the remoteProductId of product to fetch variations:"
                 ) { editText ->
                     editText.text.toString().toLongOrNull()?.let { id ->
                         coroutineScope.launch {
@@ -296,19 +326,19 @@ class WooProductsFragment : StoreSelectingFragment() {
         fetch_reviews_for_product.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
-                        activity,
-                        "Enter the remoteProductId of product to fetch reviews:"
+                    activity,
+                    "Enter the remoteProductId of product to fetch reviews:"
                 ) { editText ->
                     val remoteProductId = editText.text.toString().toLongOrNull()
                     remoteProductId?.let { id ->
                         coroutineScope.launch {
                             prependToLog("Submitting request to fetch product reviews for remoteProductID $id")
                             val result = wcProductStore.fetchProductReviews(
-                                    FetchProductReviewsPayload(
-                                            site,
-                                            productIds = listOf(remoteProductId)
-                                    ),
-                                    deletePreviouslyCachedReviews = false
+                                FetchProductReviewsPayload(
+                                    site,
+                                    productIds = listOf(remoteProductId)
+                                ),
+                                deletePreviouslyCachedReviews = false
                             )
                             prependToLog("Fetched ${result.rowsAffected} product reviews")
                         }
@@ -334,8 +364,8 @@ class WooProductsFragment : StoreSelectingFragment() {
         fetch_review_by_id.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
-                        activity,
-                        "Enter the remoteReviewId of the review to fetch:"
+                    activity,
+                    "Enter the remoteReviewId of the review to fetch:"
                 ) { editText ->
                     val reviewId = editText.text.toString().toLongOrNull()
                     reviewId?.let { id ->
@@ -384,7 +414,7 @@ class WooProductsFragment : StoreSelectingFragment() {
                     } else {
                         prependToLog(
                             "Product Review status update failed, " +
-                                "${result.error.type} ${result.error.message}"
+                                    "${result.error.type} ${result.error.message}"
                         )
                     }
                 }
@@ -394,8 +424,8 @@ class WooProductsFragment : StoreSelectingFragment() {
         fetch_product_shipping_class.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
-                        activity,
-                        "Enter the remoteShippingClassId of the site to fetch:"
+                    activity,
+                    "Enter the remoteShippingClassId of the site to fetch:"
                 ) { editText ->
                     pendingFetchSingleProductShippingClassRemoteId = editText.text.toString().toLongOrNull()
                     pendingFetchSingleProductShippingClassRemoteId?.let { id ->
@@ -419,7 +449,7 @@ class WooProductsFragment : StoreSelectingFragment() {
             selectedSite?.let { site ->
                 prependToLog("Submitting offset request to fetch product shipping classes for site ${site.id}")
                 val payload = FetchProductShippingClassListPayload(
-                        site, offset = pendingFetchProductShippingClassListOffset
+                    site, offset = pendingFetchProductShippingClassListOffset
                 )
                 dispatcher.dispatch(WCProductActionBuilder.newFetchProductShippingClassListAction(payload))
             }
@@ -446,7 +476,7 @@ class WooProductsFragment : StoreSelectingFragment() {
             selectedSite?.let { site ->
                 prependToLog("Submitting offset request to fetch product categories for site ${site.id}")
                 val payload = FetchProductCategoriesPayload(
-                        site, offset = pendingFetchProductCategoriesOffset
+                    site, offset = pendingFetchProductCategoriesOffset
                 )
                 dispatcher.dispatch(WCProductActionBuilder.newFetchProductCategoriesAction(payload))
             }
@@ -455,17 +485,18 @@ class WooProductsFragment : StoreSelectingFragment() {
         add_product_category.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
-                        activity,
-                        "Enter a category name:"
+                    activity,
+                    "Enter a category name:"
                 ) { editText ->
                     enteredCategoryName = editText.text.toString()
-                    if (enteredCategoryName != null && enteredCategoryName?.isNotEmpty() == true) {
+                    if (!enteredCategoryName.isNullOrEmpty()) {
                         prependToLog("Submitting request to add product category")
-                        val wcProductCategoryModel = WCProductCategoryModel().apply {
-                            name = enteredCategoryName!!
+                        coroutineScope.launch {
+                            val wcProductCategoryModel = WCProductCategoryModel().apply {
+                                name = enteredCategoryName!!
+                            }
+                            wcProductStore.addProductCategory(site, wcProductCategoryModel)
                         }
-                        val payload = AddProductCategoryPayload(site, wcProductCategoryModel)
-                        dispatcher.dispatch(WCProductActionBuilder.newAddProductCategoryAction(payload))
                     } else {
                         prependToLog("No category name entered...doing nothing")
                     }
@@ -475,8 +506,8 @@ class WooProductsFragment : StoreSelectingFragment() {
 
         fetch_product_tags.setOnClickListener {
             showSingleLineDialog(
-                    activity,
-                    "Enter a search query, leave blank for none:"
+                activity,
+                "Enter a search query, leave blank for none:"
             ) { editText ->
                 val searchQuery = editText.text.toString()
                 selectedSite?.let { site ->
@@ -498,12 +529,12 @@ class WooProductsFragment : StoreSelectingFragment() {
         add_product_tags.setOnClickListener {
             selectedSite?.let { site ->
                 showSingleLineDialog(
-                        activity,
-                        "Enter tag name:"
+                    activity,
+                    "Enter tag name:"
                 ) { editTextTagName1 ->
                     showSingleLineDialog(
-                            activity,
-                            "Enter another tag name:"
+                        activity,
+                        "Enter another tag name:"
                     ) { editTextTagName2 ->
                         val tagName1 = editTextTagName1.text.toString()
                         val tagName2 = editTextTagName2.text.toString()
@@ -529,13 +560,13 @@ class WooProductsFragment : StoreSelectingFragment() {
 
         update_product_images.setOnClickListener {
             showSingleLineDialog(
-                    activity,
-                    "Enter the remoteProductId of the product to update images:"
+                activity,
+                "Enter the remoteProductId of the product to update images:"
             ) { editTextProduct ->
                 editTextProduct.text.toString().toLongOrNull()?.let { productId ->
                     showSingleLineDialog(
-                            activity,
-                            "Enter the mediaId of the image to assign to the product:"
+                        activity,
+                        "Enter the mediaId of the image to assign to the product:"
                     ) { editTextMedia ->
                         editTextMedia.text.toString().toLongOrNull()?.let { mediaId ->
                             updateProductImages(productId, mediaId)
@@ -559,8 +590,8 @@ class WooProductsFragment : StoreSelectingFragment() {
 
         delete_product.setOnClickListener {
             showSingleLineDialog(
-                    activity,
-                    "Enter the remoteProductId of the product to delete:"
+                activity,
+                "Enter the remoteProductId of the product to delete:"
             ) { editTextProduct ->
                 editTextProduct.text.toString().toLongOrNull()?.let { productId ->
                     selectedSite?.let { site ->
@@ -575,7 +606,7 @@ class WooProductsFragment : StoreSelectingFragment() {
             replaceFragment(WooBatchUpdateVariationsFragment.newInstance(selectedPos))
         }
 
-        batch_generate_variations.setOnClickListener{
+        batch_generate_variations.setOnClickListener {
             replaceFragment(WooBatchGenerateVariationsFragment.newInstance(selectedPos))
         }
     }
@@ -621,9 +652,11 @@ class WooProductsFragment : StoreSelectingFragment() {
                 FETCH_PRODUCTS -> {
                     prependToLog("Fetched ${event.rowsAffected} products")
                 }
+
                 DELETED_PRODUCT -> {
                     prependToLog("${event.rowsAffected} product deleted")
                 }
+
                 else -> prependToLog("Product store was updated from a " + event.causeOfChange)
             }
         }
@@ -670,8 +703,10 @@ class WooProductsFragment : StoreSelectingFragment() {
         selectedSite?.let { site ->
             when (event.causeOfChange) {
                 FETCH_PRODUCT_CATEGORIES -> {
-                    prependToLog("Fetched ${event.rowsAffected} product categories. " +
-                            "More categories available ${event.canLoadMore}")
+                    prependToLog(
+                        "Fetched ${event.rowsAffected} product categories. " +
+                                "More categories available ${event.canLoadMore}"
+                    )
 
                     if (event.canLoadMore) {
                         pendingFetchProductCategoriesOffset += event.rowsAffected
@@ -682,12 +717,15 @@ class WooProductsFragment : StoreSelectingFragment() {
                         load_more_product_categories.isEnabled = false
                     }
                 }
+
                 ADDED_PRODUCT_CATEGORY -> {
                     val category = enteredCategoryName?.let {
                         wcProductStore.getProductCategoryByNameAndParentId(site, it)
                     }
                     prependToLog("${event.rowsAffected} product category added with name: ${category?.name}")
-                } else -> { }
+                }
+
+                else -> {}
             }
         }
     }
@@ -721,7 +759,7 @@ class WooProductsFragment : StoreSelectingFragment() {
     private fun checkProductShippingClassesAndLoadMore(event: OnProductShippingClassesChanged) {
         prependToLog(
             "Fetched ${event.rowsAffected} product shipping classes. " +
-                "More shipping classes available ${event.canLoadMore}"
+                    "More shipping classes available ${event.canLoadMore}"
         )
 
         if (event.canLoadMore) {
@@ -764,7 +802,8 @@ class WooProductsFragment : StoreSelectingFragment() {
                         prependToLog("Error occurred when trying to add some product tags")
                     }
                 }
-                else -> { }
+
+                else -> {}
             }
         }
     }

--- a/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
+++ b/plugins/woocommerce/src/main/java/org/wordpress/android/fluxc/action/WCProductAction.java
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.action;
 import org.wordpress.android.fluxc.annotations.Action;
 import org.wordpress.android.fluxc.annotations.ActionEnum;
 import org.wordpress.android.fluxc.annotations.action.IAction;
-import org.wordpress.android.fluxc.store.WCProductStore.AddProductCategoryPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload;
 import org.wordpress.android.fluxc.store.WCProductStore.DeleteProductPayload;
@@ -57,8 +56,6 @@ public enum WCProductAction implements IAction {
     UPDATE_PRODUCT_PASSWORD,
     @Action(payloadType = FetchProductCategoriesPayload.class)
     FETCH_PRODUCT_CATEGORIES,
-    @Action(payloadType = AddProductCategoryPayload.class)
-    ADD_PRODUCT_CATEGORY,
     @Action(payloadType = FetchProductTagsPayload.class)
     FETCH_PRODUCT_TAGS,
     @Action(payloadType = AddProductTagsPayload.class)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -34,7 +34,8 @@ enum class WooErrorType {
     INVALID_PARAM,
     PLUGIN_NOT_ACTIVE,
     EMPTY_RESPONSE,
-    INVALID_COUPON
+    INVALID_COUPON,
+    RESOURCE_ALREADY_EXISTS
 }
 
 fun WPComGsonNetworkError.toWooError(): WooError {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1541,6 +1541,35 @@ class ProductRestClient @Inject constructor(
         }
     }
 
+    suspend fun deleteProductCategory(site: SiteModel, remoteId: Long): WooPayload<WCProductCategoryModel> {
+        val path = WOOCOMMERCE.products.categories.id(remoteId).pathV3
+
+        val params = mutableMapOf(
+            "force" to "true",
+        )
+        val response = wooNetwork.executeDeleteGsonRequest(
+            site = site,
+            path = path,
+            params = params,
+            clazz = ProductCategoryApiResponse::class.java
+        )
+
+        return when {
+            response is WPAPIResponse.Success -> {
+                val updatedCategory = response.data?.let {
+                    it.asProductCategoryModel().apply {
+                        localSiteId = site.id
+                    }
+                }
+                WooPayload(updatedCategory)
+            }
+
+            else -> return WooPayload(
+                error = (response as WPAPIResponse.Error).error.toWooError()
+            )
+        }
+    }
+
     /**
      * Makes a GET request to `/wp-json/wc/v3/products/reviews` retrieving a list of product reviews
      * for a given WooCommerce [SiteModel].

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -47,13 +47,13 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductCategorySorting.N
 import org.wordpress.android.fluxc.store.WCProductStore.ProductError
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType
 import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.WCProductStore.ProductErrorType.TERM_EXISTS
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
-import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductCategoryResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductTagsResponsePayload
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteDeleteProductPayload
@@ -1387,57 +1387,6 @@ class ProductRestClient @Inject constructor(
         }
     }
 
-    /**
-     * Posts a new Add Category record to the API for a category.
-     *
-     * Makes a POST request to `/wp-json/wc/v3/products/categories/id` to save a Category record.
-     * Returns a [WCProductCategoryModel] on successful response.
-     *
-     * Dispatches [WCProductAction.ADDED_PRODUCT_CATEGORY] action with the results.
-     */
-    fun addProductCategory(
-        site: SiteModel,
-        category: WCProductCategoryModel
-    ) {
-        coroutineEngine.launch(AppLog.T.API, this, "addProductCategory") {
-            val url = WOOCOMMERCE.products.categories.pathV3
-
-            val body = mutableMapOf(
-                "name" to category.name,
-                "parent" to category.parent
-            )
-
-            val response = wooNetwork.executePostGsonRequest(
-                site = site,
-                path = url,
-                body = body,
-                clazz = ProductCategoryApiResponse::class.java
-            )
-
-            when (response) {
-                is WPAPIResponse.Success -> {
-                    val categoryResponse = response.data?.let {
-                        it.asProductCategoryModel().apply {
-                            localSiteId = site.id
-                        }
-                    }
-                    val payload = RemoteAddProductCategoryResponsePayload(site, categoryResponse)
-                    dispatcher.dispatch(WCProductActionBuilder.newAddedProductCategoryAction(payload))
-                }
-
-                is WPAPIResponse.Error -> {
-                    val productCategorySaveError = wpAPINetworkErrorToProductError(response.error)
-                    val payload = RemoteAddProductCategoryResponsePayload(
-                        productCategorySaveError,
-                        site,
-                        category
-                    )
-                    dispatcher.dispatch(WCProductActionBuilder.newAddedProductCategoryAction(payload))
-                }
-            }
-        }
-    }
-
     suspend fun addProductCategories(
         site: SiteModel,
         categories: List<WCProductCategoryModel>
@@ -1487,6 +1436,77 @@ class ProductRestClient @Inject constructor(
         }
     }
 
+    /**
+     * Posts a new Add Category record to the API for a category.
+     *
+     * Makes a POST request to `/wp-json/wc/v3/products/categories/id` to save a Category record.
+     * Returns a [WCProductCategoryModel] on successful response.
+     */
+    suspend fun addProductCategory(
+        site: SiteModel,
+        category: WCProductCategoryModel
+    ): WooPayload<WCProductCategoryModel> {
+        val url = WOOCOMMERCE.products.categories.pathV3
+
+        val body = mutableMapOf(
+            "name" to category.name,
+            "parent" to category.parent
+        )
+
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            body = body,
+            clazz = ProductCategoryApiResponse::class.java
+        )
+
+        return when (response) {
+            is WPAPIResponse.Success -> {
+                val updatedCategory = response.data?.let {
+                    it.asProductCategoryModel().apply {
+                        localSiteId = site.id
+                    }
+                }
+                WooPayload(updatedCategory)
+            }
+
+            is WPAPIResponse.Error -> {
+                val productCategorySaveError = wpAPINetworkErrorToProductError(response.error)
+                when (productCategorySaveError.type) {
+                    TERM_EXISTS -> {
+                        WooPayload(
+                            error = WooError(
+                                type = WooErrorType.RESOURCE_ALREADY_EXISTS,
+                                original = GenericErrorType.UNKNOWN,
+                                message = "Product category already exists."
+                            )
+                        )
+                    }
+
+                    else -> {
+                        WooPayload(
+                            error = WooError(
+                                type = WooErrorType.GENERIC_ERROR,
+                                original = GenericErrorType.UNKNOWN,
+                                message = "Unknown server error while adding a new product category."
+                            )
+                        )
+                    }
+                }
+            }
+
+            else -> {
+                WooPayload(
+                    error = WooError(
+                        type = WooErrorType.EMPTY_RESPONSE,
+                        original = GenericErrorType.UNKNOWN,
+                        message = "Invalid response for adding a new product category."
+                    )
+                )
+            }
+        }
+    }
+
     suspend fun updateProductCategory(
         site: SiteModel,
         category: WCProductCategoryModel
@@ -1506,14 +1526,6 @@ class ProductRestClient @Inject constructor(
         )
 
         return when {
-            response is WPAPIResponse.Success && response.data == null -> WooPayload(
-                WooError(
-                    type = WooErrorType.EMPTY_RESPONSE,
-                    original = GenericErrorType.UNKNOWN,
-                    message = "Success response with empty data"
-                )
-            )
-
             response is WPAPIResponse.Success -> {
                 val updatedCategory = response.data?.let {
                     it.asProductCategoryModel().apply {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -754,6 +754,12 @@ object ProductSqlUtils {
         }
     }
 
+    fun deleteProductCategory(productCategory: WCProductCategoryModel) =
+            WellSql.delete(WCProductCategoryModel::class.java)
+                .where()
+                .equals(WCProductCategoryModelTable.REMOTE_CATEGORY_ID, productCategory.remoteCategoryId)
+                .endWhere().execute()
+
     fun deleteAllProductCategoriesForSite(site: SiteModel): Int {
         return WellSql.delete(WCProductCategoryModel::class.java)
                 .where()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -918,9 +918,6 @@ class WCProductStore @Inject constructor(
             WCProductAction.FETCH_PRODUCT_CATEGORIES ->
                 fetchProductCategories(action.payload as FetchProductCategoriesPayload)
 
-            WCProductAction.ADD_PRODUCT_CATEGORY ->
-                addProductCategory(action.payload as AddProductCategoryPayload)
-
             WCProductAction.FETCH_PRODUCT_TAGS ->
                 fetchProductTags(action.payload as FetchProductTagsPayload)
 
@@ -1301,10 +1298,6 @@ class WCProductStore @Inject constructor(
         }
     }
 
-    private fun addProductCategory(payload: AddProductCategoryPayload) {
-        with(payload) { wcProductRestClient.addProductCategory(site, category) }
-    }
-
     suspend fun addProductCategories(
         site: SiteModel,
         categories: List<WCProductCategoryModel>
@@ -1329,6 +1322,21 @@ class WCProductStore @Inject constructor(
             }
         }
 
+        return@withDefaultContext result.asWooResult()
+    }
+
+    suspend fun addProductCategory(
+        site: SiteModel,
+        category: WCProductCategoryModel
+    ): WooResult<WCProductCategoryModel> = coroutineEngine.withDefaultContext(API, this, "addProductCategory") {
+        val result = wcProductRestClient.addProductCategory(
+            site = site,
+            category = category
+        )
+        if (!result.isError) {
+            val updatedCategory = result.result!!
+            ProductSqlUtils.insertOrUpdateProductCategory(updatedCategory)
+        }
         return@withDefaultContext result.asWooResult()
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1355,6 +1355,19 @@ class WCProductStore @Inject constructor(
         return@withDefaultContext result.asWooResult()
     }
 
+    suspend fun deleteProductCategory(site: SiteModel, remoteId: Long): WooResult<WCProductCategoryModel> =
+        coroutineEngine.withDefaultContext(API, this, "deleteProductCategory") {
+            val result = wcProductRestClient.deleteProductCategory(
+                site = site,
+                remoteId = remoteId
+            )
+            if (!result.isError) {
+                val updatedCategory = result.result!!
+                ProductSqlUtils.insertOrUpdateProductCategory(updatedCategory)
+            }
+            return@withDefaultContext result.asWooResult()
+        }
+
     private fun fetchProductTags(payload: FetchProductTagsPayload) {
         with(payload) { wcProductRestClient.fetchProductTags(site, pageSize, offset, searchQuery) }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1320,7 +1320,8 @@ class WCProductStore @Inject constructor(
                 AppLog.w(
                     API,
                     "addProductCategories: not all categories were added. " +
-                        "Expected: ${categories.size}, added: ${addedCategories.size}")
+                            "Expected: ${categories.size}, added: ${addedCategories.size}"
+                )
             }
 
             addedCategories.forEach { category ->
@@ -1328,6 +1329,21 @@ class WCProductStore @Inject constructor(
             }
         }
 
+        return@withDefaultContext result.asWooResult()
+    }
+
+    suspend fun updateProductCategory(
+        site: SiteModel,
+        category: WCProductCategoryModel
+    ): WooResult<WCProductCategoryModel> = coroutineEngine.withDefaultContext(API, this, "updateProductCategory") {
+        val result = wcProductRestClient.updateProductCategory(
+            site = site,
+            category = category
+        )
+        if (!result.isError) {
+            val updatedCategory = result.result!!
+            ProductSqlUtils.insertOrUpdateProductCategory(updatedCategory)
+        }
         return@withDefaultContext result.asWooResult()
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1362,8 +1362,8 @@ class WCProductStore @Inject constructor(
                 remoteId = remoteId
             )
             if (!result.isError) {
-                val updatedCategory = result.result!!
-                ProductSqlUtils.insertOrUpdateProductCategory(updatedCategory)
+                val deletedCategory = result.result!!
+                ProductSqlUtils.deleteProductCategory(deletedCategory)
             }
             return@withDefaultContext result.asWooResult()
         }


### PR DESCRIPTION
⚠️ Do not merge. I'll handle the merging of all 3 PRs as this PR has breaking changes.

### Editing Product Categories

This PR adds 3 changes: 
- Refactors the logic for adding a product category into the suspending function
- Adds new functions to enable updating existing product categories
- Adds function to delete existing product categories

### Test
- To test editing an existing product category, check the instructions from this PR: https://github.com/woocommerce/woocommerce-android/pull/11077
- To test deleting a product category, check instructions here: https://github.com/woocommerce/woocommerce-android/pull/11085
 

