### PR TITLE
New field for Post Conflict detection and resolution 

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
@@ -13,7 +13,8 @@ public enum PostStatus {
     PRIVATE,
     PENDING,
     TRASHED,
-    SCHEDULED; // NOTE: Only recognized for .com REST posts - XML-RPC returns scheduled posts with status 'publish'
+    SCHEDULED, // NOTE: Only recognized for .com REST posts - XML-RPC returns scheduled posts with status 'publish'
+    OLD_REVISION;
 
     public String toString() {
         switch (this) {
@@ -29,6 +30,8 @@ public enum PostStatus {
                 return "trash";
             case SCHEDULED:
                 return "future";
+            case OLD_REVISION:
+                return "old-revision";
             default:
                 return "";
         }
@@ -55,6 +58,8 @@ public enum PostStatus {
             return TRASHED;
         } else if (value.equals("future")) {
             return SCHEDULED;
+        } else if (value.equals("old-revision")) {
+            return OLD_REVISION;
         } else {
             return UNKNOWN;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/post/PostStatus.java
@@ -13,8 +13,7 @@ public enum PostStatus {
     PRIVATE,
     PENDING,
     TRASHED,
-    SCHEDULED, // NOTE: Only recognized for .com REST posts - XML-RPC returns scheduled posts with status 'publish'
-    OLD_REVISION;
+    SCHEDULED; // NOTE: Only recognized for .com REST posts - XML-RPC returns scheduled posts with status 'publish'
 
     public String toString() {
         switch (this) {
@@ -30,8 +29,6 @@ public enum PostStatus {
                 return "trash";
             case SCHEDULED:
                 return "future";
-            case OLD_REVISION:
-                return "old-revision";
             default:
                 return "";
         }
@@ -58,8 +55,6 @@ public enum PostStatus {
             return TRASHED;
         } else if (value.equals("future")) {
             return SCHEDULED;
-        } else if (value.equals("old-revision")) {
-            return OLD_REVISION;
         } else {
             return UNKNOWN;
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -616,6 +616,8 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("content", StringUtils.notNullStr(post.getContent()));
         params.put("excerpt", StringUtils.notNullStr(post.getExcerpt()));
         params.put("slug", StringUtils.notNullStr(post.getSlug()));
+        params.put("if_not_modified_since", post.getLastModified());
+
         if (post.getAuthorId() > 0) {
             params.put("author", String.valueOf(post.getAuthorId()));
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -306,7 +306,12 @@ public class PostRestClient extends BaseWPComRestClient {
         add(request);
     }
 
-    public void pushPost(final PostModel post, final SiteModel site, final boolean isFirstTimePublish) {
+    public void pushPost(
+            final PostModel post,
+            final SiteModel site,
+            final boolean isFirstTimePublish,
+            final boolean isConflictResolution
+    ) {
         String url;
 
         if (post.isLocalDraft()) {
@@ -315,7 +320,7 @@ public class PostRestClient extends BaseWPComRestClient {
             url = WPCOMREST.sites.site(site.getSiteId()).posts.post(post.getRemotePostId()).getUrlV1_2();
         }
 
-        Map<String, Object> body = postModelToParams(post);
+        Map<String, Object> body = postModelToParams(post, isConflictResolution);
 
         final WPComGsonRequest<PostWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 PostWPComRestResponse.class,
@@ -608,7 +613,7 @@ public class PostRestClient extends BaseWPComRestClient {
         return post;
     }
 
-    private Map<String, Object> postModelToParams(PostModel post) {
+    private Map<String, Object> postModelToParams(PostModel post, boolean isConflictResolution) {
         Map<String, Object> params = new HashMap<>();
 
         params.put("status", StringUtils.notNullStr(post.getStatus()));
@@ -616,7 +621,11 @@ public class PostRestClient extends BaseWPComRestClient {
         params.put("content", StringUtils.notNullStr(post.getContent()));
         params.put("excerpt", StringUtils.notNullStr(post.getExcerpt()));
         params.put("slug", StringUtils.notNullStr(post.getSlug()));
-        params.put("if_not_modified_since", post.getLastModified());
+
+        // if isConflictResolution is true we do not want to send "if_not_modified_since"
+        if (!isConflictResolution) {
+            params.put("if_not_modified_since", post.getLastModified());
+        }
 
         if (post.getAuthorId() > 0) {
             params.put("author", String.valueOf(post.getAuthorId()));

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -415,6 +415,7 @@ public class PostStore extends Store {
         UNSUPPORTED_ACTION,
         UNAUTHORIZED,
         INVALID_RESPONSE,
+        OLD_REVISION,
         GENERIC_ERROR;
 
         public static PostErrorType fromString(String string) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -424,14 +424,14 @@ public class PostStore extends Store {
             this.mStringValue = stringValue;
         }
 
-        public String getStringValue() {
+        @NonNull @Override public String toString() {
             return this.mStringValue;
         }
 
         public static PostErrorType fromString(String string) {
             if (string != null) {
                 for (PostErrorType v : PostErrorType.values()) {
-                    if (string.equalsIgnoreCase(v.getStringValue())) {
+                    if (string.equalsIgnoreCase(v.toString())) {
                         return v;
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -410,18 +410,28 @@ public class PostStore extends Store {
     }
 
     public enum PostErrorType {
-        UNKNOWN_POST,
-        UNKNOWN_POST_TYPE,
-        UNSUPPORTED_ACTION,
-        UNAUTHORIZED,
-        INVALID_RESPONSE,
-        OLD_REVISION,
-        GENERIC_ERROR;
+        UNKNOWN_POST("unknown_post"),
+        UNKNOWN_POST_TYPE("unknown_post_type"),
+        UNSUPPORTED_ACTION("unsupported_action"),
+        UNAUTHORIZED("unauthorized"),
+        INVALID_RESPONSE("invalid_response"),
+        OLD_REVISION("old-revision"), // Custom string value
+        GENERIC_ERROR("generic_error");
+
+        private final String mStringValue;
+
+        PostErrorType(String stringValue) {
+            this.mStringValue = stringValue;
+        }
+
+        public String getStringValue() {
+            return this.mStringValue;
+        }
 
         public static PostErrorType fromString(String string) {
             if (string != null) {
                 for (PostErrorType v : PostErrorType.values()) {
-                    if (string.equalsIgnoreCase(v.name())) {
+                    if (string.equalsIgnoreCase(v.getStringValue())) {
                         return v;
                     }
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -169,7 +169,7 @@ public class PostStore extends Store {
         public boolean isFirstTimePublish;
 
         // if this is true, the post will overwrite the existing one, even if it is not the last revision
-        public boolean isConflictResolution;
+        public boolean shouldSkipConflictResolutionCheck;
 
         public RemotePostPayload(PostModel post, SiteModel site) {
             this.post = post;
@@ -1133,7 +1133,7 @@ public class PostStore extends Store {
                     payload.post,
                     payload.site,
                     payload.isFirstTimePublish,
-                    payload.isConflictResolution
+                    payload.shouldSkipConflictResolutionCheck
             );
         } else {
             // TODO: check for WP-REST-API plugin and use it here

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1085,6 +1085,10 @@ public class PostStore extends Store {
 
     private void handlePushPostCompleted(RemotePostPayload payload) {
         if (payload.isError()) {
+            if (payload.error.type == PostErrorType.OLD_REVISION) {
+                payload.post.setStatus(PostStatus.OLD_REVISION.toString());
+                updatePost(payload.post, false);
+            }
             OnPostUploaded onPostUploaded = new OnPostUploaded(payload.post, payload.isFirstTimePublish);
             onPostUploaded.error = payload.error;
             emitChange(onPostUploaded);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1085,10 +1085,6 @@ public class PostStore extends Store {
 
     private void handlePushPostCompleted(RemotePostPayload payload) {
         if (payload.isError()) {
-            if (payload.error.type == PostErrorType.OLD_REVISION) {
-                payload.post.setStatus(PostStatus.OLD_REVISION.toString());
-                updatePost(payload.post, false);
-            }
             OnPostUploaded onPostUploaded = new OnPostUploaded(payload.post, payload.isFirstTimePublish);
             onPostUploaded.error = payload.error;
             emitChange(onPostUploaded);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1250,6 +1250,22 @@ public class PostStore extends Store {
         mPostSqlUtils.insertOrUpdateLocalRevision(localRevision, localDiffs);
     }
 
+    public void removeLocalRevision(PostModel post) {
+        post.setDateLocallyChanged((DateTimeUtils.iso8601UTCFromDate(new Date())));
+        int rowsAffected = mPostSqlUtils.insertOrUpdatePostOverwritingLocalChanges(post);
+        CauseOfOnPostChanged causeOfChange = new CauseOfOnPostChanged.UpdatePost(
+                post.getId(),
+                post.getRemotePostId(),
+                false
+        );
+        OnPostChanged onPostChanged = new OnPostChanged(causeOfChange, rowsAffected);
+        emitChange(onPostChanged);
+
+        mDispatcher.dispatch(ListActionBuilder.newListDataInvalidatedAction(
+                PostListDescriptor.calculateTypeIdentifier(post.getLocalSiteId())));
+    }
+
+
 
     public RevisionModel getLocalRevision(SiteModel site, PostModel post) {
         List<LocalRevisionModel> localRevisions = mPostSqlUtils.getLocalRevisions(site, post);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -168,6 +168,9 @@ public class PostStore extends Store {
         public SiteModel site;
         public boolean isFirstTimePublish;
 
+        // if this is true, the post will overwrite the existing one, even if it is not the last revision
+        public boolean isConflictResolution;
+
         public RemotePostPayload(PostModel post, SiteModel site) {
             this.post = post;
             this.site = site;
@@ -1126,7 +1129,12 @@ public class PostStore extends Store {
 
     private void pushPost(RemotePostPayload payload) {
         if (payload.site.isUsingWpComRestApi()) {
-            mPostRestClient.pushPost(payload.post, payload.site, payload.isFirstTimePublish);
+            mPostRestClient.pushPost(
+                    payload.post,
+                    payload.site,
+                    payload.isFirstTimePublish,
+                    payload.isConflictResolution
+            );
         } else {
             // TODO: check for WP-REST-API plugin and use it here
             PostModel postToPush = payload.post;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/UploadStore.java
@@ -259,6 +259,15 @@ public class UploadStore extends Store {
         return null;
     }
 
+    public void clearUploadErrorForPost(PostImmutableModel postModel) {
+        if (postModel == null) return;
+        PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(postModel.getId());
+        if (postUploadModel != null) {
+            postUploadModel.setPostError(null);
+            UploadSqlUtils.insertOrUpdatePost(postUploadModel);
+        }
+    }
+
     public float getUploadProgressForMedia(MediaModel mediaModel) {
         MediaUploadModel mediaUploadModel = UploadSqlUtils.getMediaUploadModelForLocalId(mediaModel.getId());
         if (mediaUploadModel != null) {


### PR DESCRIPTION
This PR contains the modifications needed for the new post conflict handling. Specs [here](https://jetpackmobile.wordpress.com/2024/02/09/pt-offline-mode-sync-issues/#comment-9638). 

To test this PR use this companion WordPress-Android PR [Sync issues: Post conflict handling](https://github.com/wordpress-mobile/WordPress-Android/pull/20552)