### PR TITLE
[Better Errors] Detect Invalid Credentials scenario

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
@@ -22,6 +22,7 @@ sealed interface Nonce {
         CUSTOM_LOGIN_URL,
         CUSTOM_ADMIN_URL,
         INVALID_NONCE,
+        CAPTCHA_ERROR,
         GENERIC_ERROR,
         UNKNOWN
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
@@ -19,10 +19,10 @@ sealed interface Nonce {
     enum class CookieNonceErrorType {
         NOT_AUTHENTICATED,
         INVALID_RESPONSE,
+        INVALID_CREDENTIALS,
         CUSTOM_LOGIN_URL,
         CUSTOM_ADMIN_URL,
         INVALID_NONCE,
-        CAPTCHA_ERROR,
         GENERIC_ERROR,
         UNKNOWN
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -145,4 +145,11 @@ class NonceRestClient @Inject constructor(
         return HtmlUtils.fastStripHtml(errorHtml)
             .trim(' ', '\n')
     }
+
+    private fun hasInvalidCredentialsPattern(htmlResponse: String) =
+        htmlResponse.contains(INVALID_CREDENTIAL_HTML_PATTERN)
+
+    companion object {
+        const val INVALID_CREDENTIAL_HTML_PATTERN = "document.querySelector('form').classList.add('shake')"
+    }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -69,11 +69,18 @@ class NonceRestClient @Inject constructor(
                 // that it's an authentication issue, otherwise we'll assume it's an invalid response
                 val errorMessage = extractErrorMessage(response.data.orEmpty())
 
+                val errorType = if (hasInvalidCredentialsPattern(response.data.orEmpty())) {
+                    Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
+                } else if (errorMessage != null) {
+                    Nonce.CookieNonceErrorType.NOT_AUTHENTICATED
+                } else {
+                    Nonce.CookieNonceErrorType.INVALID_RESPONSE
+                }
+
                 FailedRequest(
                     timeOfResponse = currentTimeProvider.currentDate().time,
                     username = username,
-                    type = if (errorMessage != null) Nonce.CookieNonceErrorType.NOT_AUTHENTICATED
-                    else Nonce.CookieNonceErrorType.INVALID_RESPONSE,
+                    type = errorType,
                     errorMessage = errorMessage
                 )
             }


### PR DESCRIPTION
Fix issue https://github.com/woocommerce/woocommerce-android/issues/10975

# Why

This PR tries to identify invalid credential errors when logging in with site credentials, in order to not navigate the user to the app password tutorial when is not really needed.

# How

When logging in with site credentials there is no way to properly tell if an error message is an invalid credentials error.
However, the server injects a `shake` pattern when an invalid credential error is found.

For the time being, we will use that pattern as a guess for an invalid credential error message.

https://github.com/WordPress/WordPress/blob/master/wp-login.php#L65-L67

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.