### PR TITLE
Blaze API response type change

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeAdForecast.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeAdForecast.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.model.blaze
 
 data class BlazeAdForecast(
-    val minImpressions: Int,
-    val maxImpressions: Int,
+    val minImpressions: Long,
+    val maxImpressions: Long,
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
@@ -341,8 +341,8 @@ private class BlazeAdSuggestionListResponse(
 }
 
 private class BlazeAdForecastNetworkModel(
-    @SerializedName("total_impressions_min") val minImpressions: Int,
-    @SerializedName("total_impressions_max") val maxImpressions: Int,
+    @SerializedName("total_impressions_min") val minImpressions: Long,
+    @SerializedName("total_impressions_max") val maxImpressions: Long,
 ) {
     fun toDomainModel(): BlazeAdForecast = BlazeAdForecast(
         minImpressions = minImpressions,


### PR DESCRIPTION
The PR changes the Blaze ad forecast API response of 2 parameters fron `int` to `long` because it turned out the values can be bigger than 32-bit integers. There is nothing to test.

Fixes woocommerce/woocommerce-android#11230