### PR TITLE
Add jetpack to plugins

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -73,6 +73,7 @@ open class WooCommerceStore @Inject constructor(
         WOO_PRODUCT_BUNDLES("woocommerce-product-bundles/woocommerce-product-bundles"),
         WOO_COMPOSITE_PRODUCTS("woocommerce-composite-products/woocommerce-composite-products"),
         WOO_SQUARE("woocommerce-square/woocommerce-square"),
+        JETPACK("jetpack/jetpack"),
     }
 
     companion object {


### PR DESCRIPTION
Woo PR https://github.com/woocommerce/woocommerce-android/pull/11288

### Why
The session stats of Analytics Hub require the Jetpack plugin to be installed and activated.

### Description
This PR adds Jetpack to the list of plugins of WooCommerceStore so we can check the Jetpack status from Woo.

### Testing
These changes don't need testing