### PR TITLE
Post conflict resolution for self-hosted sites

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
 import org.wordpress.android.fluxc.network.HTTPAuthManager;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.xmlrpc.BaseXMLRPCClient;
+import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCFault;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.fluxc.network.xmlrpc.XMLRPCUtils;
 import org.wordpress.android.fluxc.store.PostStore;
@@ -225,17 +226,26 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         add(request);
     }
 
-    public void pushPost(final PostModel post, final SiteModel site, boolean isFirstTimePublish) {
-        pushPostInternal(post, site, false, isFirstTimePublish);
+    public void pushPost(
+            final PostModel post,
+            final SiteModel site,
+            boolean isFirstTimePublish,
+            boolean shouldSkipConflictResolutionCheck
+    ) {
+        pushPostInternal(post, site, false, isFirstTimePublish, shouldSkipConflictResolutionCheck);
     }
 
     public void restorePost(final PostModel post, final SiteModel site) {
-        pushPostInternal(post, site, true, false);
+        pushPostInternal(post, site, true, false, true);
     }
 
-    private void pushPostInternal(final PostModel post, final SiteModel site, final boolean isRestoringPost,
-                                  final boolean isFirstTimePublish) {
-        Map<String, Object> contentStruct = postModelToContentStruct(post);
+    private void pushPostInternal(
+            final PostModel post,
+            final SiteModel site,
+            final boolean isRestoringPost,
+            final boolean isFirstTimePublish,
+            boolean shouldSkipConflictResolutionCheck) {
+        Map<String, Object> contentStruct = postModelToContentStruct(post, shouldSkipConflictResolutionCheck);
 
         if (post.isLocalDraft()) {
             // For first time publishing, set the comment status (open or closed) to the default value for the site
@@ -462,7 +472,10 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         return post;
     }
 
-    private static Map<String, Object> postModelToContentStruct(PostModel post) {
+    private static Map<String, Object> postModelToContentStruct(
+            PostModel post,
+            boolean shouldSkipConflictResolutionCheck
+    ) {
         Map<String, Object> contentStruct = new HashMap<>();
 
         // Post format
@@ -477,6 +490,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         contentStruct.put("post_type", post.isPage() ? "page" : "post");
         contentStruct.put("post_title", post.getTitle());
 
+
         String dateCreated = post.getDateCreated();
         Date date = DateTimeUtils.dateUTCFromIso8601(dateCreated);
         if (date != null) {
@@ -484,6 +498,18 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
             // Redundant, but left in just in case
             // Note: XML-RPC sends the same value for dateCreated and date_created_gmt in the first place
             contentStruct.put("post_date_gmt", date);
+        }
+
+        // Should only send "if_not_modified_since" when we want to run the conflict resolution check on the BE
+        // For instance, we have showed the conflict resolution dialog and the user wants to push their local changes;
+        // setting this field to true, would not add the modified date and won't trigger a check for latest version
+        // on the remote host.
+        if (!shouldSkipConflictResolutionCheck) {
+            String dateLastModifiedStr = post.getLastModified();
+            Date dateLastModified = DateTimeUtils.dateUTCFromIso8601(dateLastModifiedStr);
+            if (dateLastModified != null) {
+                contentStruct.put("if_not_modified_since", dateLastModified);
+            }
         }
 
         // We are not adding `lastModified` date to the params because that should be updated by the server when there
@@ -656,6 +682,13 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         // 404 - "Invalid attachment ID." (invalid featured image)
         // TODO: Check the error message and flag this as UNKNOWN_POST if applicable
         // Convert GenericErrorType to PostErrorType where applicable
+
+        if (error.volleyError.getCause() instanceof XMLRPCFault) {
+            int code = ((XMLRPCFault) error.volleyError.getCause()).getFaultCode();
+            if (code == 409) {
+                return new PostError(PostErrorType.OLD_REVISION, error.message);
+            }
+        }
         switch (error.type) {
             case AUTHORIZATION_REQUIRED:
                 return new PostError(PostErrorType.UNAUTHORIZED, error.message);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -683,12 +683,18 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         // TODO: Check the error message and flag this as UNKNOWN_POST if applicable
         // Convert GenericErrorType to PostErrorType where applicable
 
-        if (error.volleyError.getCause() instanceof XMLRPCFault) {
-            int code = ((XMLRPCFault) error.volleyError.getCause()).getFaultCode();
-            if (code == 409) {
-                return new PostError(PostErrorType.OLD_REVISION, error.message);
+        // Handles specific XMLRPC faults with precise error codes
+        if (error.volleyError != null && error.volleyError.getCause() instanceof XMLRPCFault) {
+            XMLRPCFault fault = (XMLRPCFault) error.volleyError.getCause();
+            if (fault != null) {
+                int code = fault.getFaultCode();
+                if (code == 409) {
+                    return new PostError(PostErrorType.OLD_REVISION, error.message);
+                }
             }
         }
+
+        // Handles general network errors based on type
         switch (error.type) {
             case AUTHORIZATION_REQUIRED:
                 return new PostError(PostErrorType.UNAUTHORIZED, error.message);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -1142,7 +1142,11 @@ public class PostStore extends Store {
             if (TextUtils.isEmpty(postToPush.getStatus())) {
                 postToPush.setStatus(PostStatus.PUBLISHED.toString());
             }
-            mPostXMLRPCClient.pushPost(postToPush, payload.site, payload.isFirstTimePublish);
+            mPostXMLRPCClient.pushPost(
+                    postToPush,
+                    payload.site,
+                    payload.isFirstTimePublish,
+                    payload.shouldSkipConflictResolutionCheck);
         }
     }
 


### PR DESCRIPTION
This PR contains the modifications needed for the new post conflict handling for the self-hosted sites that use XML-RPC calls. We are adding the `if_not_modified_since` parameter to the wp.edit call so we can get the 409 error code when there is a more recent revision of the post that we try to update. 

Specs pcdRpT-5ID-p2#comment-9638.

WP Companion PR: https://github.com/wordpress-mobile/WordPress-Android/pull/20651

## To Test:
- Check out trunk branch of the Jetpack and WordPress app. Replace FluxC hash with the one produced by this PR and build. 

### Test Post version forced write on top of web (existing logic)
- Login with a self-hosted site that has posts. You can create a new self-hosted site using this [tool](https://jurassic.ninja/). 
- Navigate to Me > Debug Settings
- Disable the `sync_publishing` flag and restart the app
- Navigate to back to My Site > Post
- Tap the publish tab and then tap a post to open the edit view
- PAUSE - GO TO YOUR LAPTOP
- Open a browser and navigate to the same WordPress site
- Open the same post and make an edit (remember what you changed)
- Tap the "update" button to save it and back out of the editor
- GO BACK TO YOUR DEVICE
- Make a change to the post you have in the edit view
- Tap "Update" to save the post to the server
- ✅ Verify the post did update (snackbar)
- GO BACK TO THE LAPTOP
- Tap view on the same post you just edited via the app
- ✅ Verify the changes you made on the device have overwritten the changes you made on your laptop
- Repeat this test for Jetpack and Wordpress

### Test Post version did not write on top of web (new logic)
- Navigate to Me > Debug Settings
- Enabled the `sync_publishing` flag and restart the app 
- Navigate to back to My Site > Post
- Tap the publish tab and then tap a post to open the edit view
- PAUSE - GO TO YOUR LAPTOP
- Open a browser and navigate to the same WordPress site
- Open the same post and make an edit (remember what you changed)
- Tap the "update" button to save it and back out of the editor
- GO BACK TO YOUR DEVICE
- Make a change to the post you have in the edit view
- Tap "Update" to save the post to the server
- ✅ Verify the post did not update and the post list shows "Version Conflict" within the post row
- GO BACK TO THE LAPTOP
- Tap view on the same post you just edited via the app
- ✅ Verify the changes you made on the device did not overwrite the changes you made on your laptop
- Repeat this test for Jetpack and Wordpress

### Test Conflict Resolution dialog is shown
- Continue from the last step of test "Post version did not write on top of web (new logic)"
- On the post list, tap on the post that shows "Version Conflict"
- ✅ Verify the conflict resolution overlay is shown
- Tap local version
- ✅ Verify the local version has been applied
- Repeat the scenario in  test "Post version did not write on top of web (new logic)" to get into a Version Conflict again. Then repeat this test and tap web version in the conflict resolution dialog.

-----

## Regression Notes

1. Potential unintended areas of impact
The post is not updated properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Relied upon existing automated post tests

-----

## PR Submission Checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): No UI components were changed with this PR
- [x] WordPress.com sites and self-hosted Jetpack sites.