### PR TITLE
Orders: expose a function to observe orders' count

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
@@ -73,6 +73,9 @@ abstract class OrdersDao {
     @Query("SELECT COUNT(*) FROM OrderEntity WHERE localSiteId = :localSiteId AND status IN (:status)")
     abstract fun observeOrderCountForSite(localSiteId: LocalId, status: List<String>): Flow<Int>
 
+    @Query("SELECT COUNT(*) FROM OrderEntity WHERE localSiteId = :localSiteId")
+    abstract fun observeOrderCountForSite(localSiteId: LocalId): Flow<Int>
+
     @Query("DELETE FROM OrderEntity WHERE localSiteId = :localSiteId AND orderId = :orderId")
     abstract suspend fun deleteOrder(localSiteId: LocalId, orderId: Long)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDaoDecorator.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDaoDecorator.kt
@@ -107,8 +107,13 @@ class OrdersDaoDecorator @Inject constructor(
     fun getOrderCountForSite(localSiteId: LocalOrRemoteId.LocalId): Int =
         ordersDao.getOrderCountForSite(localSiteId)
 
-    fun observeOrderCountForSite(localSiteId: LocalOrRemoteId.LocalId, status: List<String>): Flow<Int> =
-        ordersDao.observeOrderCountForSite(localSiteId, status)
+    fun observeOrderCountForSite(localSiteId: LocalOrRemoteId.LocalId, status: List<String>?): Flow<Int> {
+        return if (status == null) {
+            ordersDao.observeOrderCountForSite(localSiteId)
+        } else {
+            ordersDao.observeOrderCountForSite(localSiteId, status)
+        }
+    }
 
     suspend fun deleteOrder(localSiteId: LocalOrRemoteId.LocalId, orderId: Long) {
         ordersDao.deleteOrder(localSiteId, orderId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -394,11 +394,11 @@ class WCOrderStore @Inject constructor(
      * Observe the changes to the number of orders for a given [SiteModel]
      *
      * @param site the current site
-     * @param statuses a list of statuses to filter the list of orders
+     * @param statuses a list of statuses to filter the list of orders, pass null to include all orders
      */
     fun observeOrderCountForSite(
         site: SiteModel,
-        statuses: List<String>
+        statuses: List<String>? = null
     ): Flow<Int> = ordersDaoDecorator.observeOrderCountForSite(site.localId(), statuses)
 
     fun getOrdersForDescriptor(


### PR DESCRIPTION
This small PR just adds a function to observe the orders' count without having to specify some statuses, this is something we'll need for https://github.com/woocommerce/woocommerce-android/pull/11362