### PR TITLE
Offline mode: conflict on scheduled posts

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -636,9 +636,9 @@ public class PostRestClient extends BaseWPComRestClient {
         // setting this field to true, would not add the modified date and won't trigger a check for latest version
         // on the remote host.
         if (!shouldSkipConflictResolutionCheck) {
-            String lastModified = (lastModifiedForConflictResolution != null) ?
-                    lastModifiedForConflictResolution :
-                    post.getLastModified();
+            String lastModified = (lastModifiedForConflictResolution != null)
+                    ? lastModifiedForConflictResolution
+                    : post.getLastModified();
             params.put("if_not_modified_since", lastModified);
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -310,7 +310,8 @@ public class PostRestClient extends BaseWPComRestClient {
             final PostModel post,
             final SiteModel site,
             final boolean isFirstTimePublish,
-            final boolean shouldSkipConflictResolutionCheck
+            final boolean shouldSkipConflictResolutionCheck,
+            final String lastModifiedForConflictResolution
     ) {
         String url;
 
@@ -320,7 +321,11 @@ public class PostRestClient extends BaseWPComRestClient {
             url = WPCOMREST.sites.site(site.getSiteId()).posts.post(post.getRemotePostId()).getUrlV1_2();
         }
 
-        Map<String, Object> body = postModelToParams(post, shouldSkipConflictResolutionCheck);
+        Map<String, Object> body = postModelToParams(
+                post,
+                shouldSkipConflictResolutionCheck,
+                lastModifiedForConflictResolution
+        );
 
         final WPComGsonRequest<PostWPComRestResponse> request = WPComGsonRequest.buildPostRequest(url, body,
                 PostWPComRestResponse.class,
@@ -613,7 +618,11 @@ public class PostRestClient extends BaseWPComRestClient {
         return post;
     }
 
-    private Map<String, Object> postModelToParams(PostModel post, boolean shouldSkipConflictResolutionCheck) {
+    private Map<String, Object> postModelToParams(
+            PostModel post,
+            boolean shouldSkipConflictResolutionCheck,
+            @Nullable String lastModifiedForConflictResolution
+    ) {
         Map<String, Object> params = new HashMap<>();
 
         params.put("status", StringUtils.notNullStr(post.getStatus()));
@@ -627,7 +636,10 @@ public class PostRestClient extends BaseWPComRestClient {
         // setting this field to true, would not add the modified date and won't trigger a check for latest version
         // on the remote host.
         if (!shouldSkipConflictResolutionCheck) {
-            params.put("if_not_modified_since", post.getLastModified());
+            String lastModified = (lastModifiedForConflictResolution != null) ?
+                    lastModifiedForConflictResolution :
+                    post.getLastModified();
+            params.put("if_not_modified_since", lastModified);
         }
 
         if (post.getAuthorId() > 0) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -519,9 +519,9 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
         // setting this field to true, would not add the modified date and won't trigger a check for latest version
         // on the remote host.
         if (!shouldSkipConflictResolutionCheck) {
-            String dateLastModifiedStr = (lastModifiedForConflictResolution != null) ?
-                    lastModifiedForConflictResolution :
-                    post.getLastModified();
+            String dateLastModifiedStr = (lastModifiedForConflictResolution != null)
+                    ? lastModifiedForConflictResolution
+                    : post.getLastModified();
             Date dateLastModified = DateTimeUtils.dateUTCFromIso8601(dateLastModifiedStr);
             if (dateLastModified != null) {
                 contentStruct.put("if_not_modified_since", dateLastModified);

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -171,6 +171,8 @@ public class PostStore extends Store {
         // if this is true, the post will overwrite the existing one, even if it is not the last revision
         public boolean shouldSkipConflictResolutionCheck;
 
+        public String lastModifiedForConflictResolution;
+
         public RemotePostPayload(PostModel post, SiteModel site) {
             this.post = post;
             this.site = site;
@@ -1133,7 +1135,8 @@ public class PostStore extends Store {
                     payload.post,
                     payload.site,
                     payload.isFirstTimePublish,
-                    payload.shouldSkipConflictResolutionCheck
+                    payload.shouldSkipConflictResolutionCheck,
+                    payload.lastModifiedForConflictResolution
             );
         } else {
             // TODO: check for WP-REST-API plugin and use it here
@@ -1146,7 +1149,8 @@ public class PostStore extends Store {
                     postToPush,
                     payload.site,
                     payload.isFirstTimePublish,
-                    payload.shouldSkipConflictResolutionCheck);
+                    payload.shouldSkipConflictResolutionCheck,
+                    payload.lastModifiedForConflictResolution);
         }
     }
 


### PR DESCRIPTION
This PR tries to resolve the post conflict resolution issue with the scheduled posts by adjusting the `if_not_modified_since` field. Normally, when a post is scheduled for the future, both the `dateCreated` and `lastModified` fields are set to the future publication date, as returned by the backend. This setup can prevent effective post-conflict resolution. This PR introduces an additional field in the payload that is used to override the `lastModified` value. By setting a past date in `if_not_modified_since`, it ensures that the conflict resolution mechanism can operate correctly.

WP Companion PR: https://github.com/wordpress-mobile/WordPress-Android/pull/20710

## To Test:
- Check our trunk branch of the Jetpack and WordPress app. Replace FluxC hash with the one produced by this PR and build.

### Test Post version forced write on top of web (existing logic)
- Log in to a WordPress.com site on a browser via your laptop
- Login to the same site via the app.
- Navigate to Me > Debug Settings
- Disable the `sync_publishing` flag and restart the app
- Create a new post, tap publish, chose a future date instead of publish now, tap the schedule now button
- On the app, open the newly scheduled post for edit, add some new content - STOP
- On your laptop, edit the scheduled post and UPDATE (do not change the publish date)
- On the app, tap the Schedule button, do not change any of the publishing details, just tap the SCHEDULE NOW button
- Notice that the app does not identify the conflict and the web is overwritten

### Test Post version did not write on top of web (new logic)
- Navigate to Me > Debug Settings
- Enabled the `sync_publishing` flag and restart the app 
- Create a new post, tap publish, chose a future date instead of publish now, tap the schedule now button
- On the app, open the newly scheduled post for edit, add some new content - STOP
- On your laptop, edit the scheduled post and UPDATE (do not change the publish date)
- On the app, tap the Schedule button, do not change any of the publishing details, just tap the SCHEDULE NOW button
- Notice that the app identifies the conflict and "Version Conflict" label appears for the post. 

### Repeat the above steps for a self-hosted site. You can create a new self-hosted site using this [tool](https://jurassic.ninja/). 

### Repeat the above steps for a page.
-----

## Regression Notes

1. Potential unintended areas of impact
The scheduled post or page is not updated properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Relied upon existing automated post tests

-----

## PR Submission Checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): No UI components were changed with this PR
- [x] WordPress.com sites and self-hosted Jetpack sites.