### PR TITLE
Utilities to improve observing products

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -41,7 +41,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 200
+        return 201
     }
 
     override fun getDbName(): String {
@@ -2003,6 +2003,9 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 199 -> migrate(version) {
                     db.execSQL("ALTER TABLE PostModel ADD DB_TIMESTAMP INTEGER")
+                }
+                200 -> migrate(version) {
+                    db.execSQL("ALTER TABLE WCProductModel ADD IS_SAMPLE_PRODUCT BOOLEAN")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
@@ -4,7 +4,6 @@ import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.wordpress.android.fluxc.model.WCProductModel.AddOnsMetadataKeys
-import org.wordpress.android.fluxc.model.WCProductModel.OtherKeys
 import org.wordpress.android.fluxc.model.WCProductModel.QuantityRulesMetadataKeys
 import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.fluxc.utils.EMPTY_JSON_ARRAY
@@ -31,7 +30,6 @@ class StripProductMetaData @Inject internal constructor(private val gson: Gson) 
             add(AddOnsMetadataKeys.ADDONS_METADATA_KEY)
             addAll(QuantityRulesMetadataKeys.ALL_KEYS)
             addAll(SubscriptionMetadataKeys.ALL_KEYS)
-            add(OtherKeys.HEAD_START_POST)
             add(WCMetaData.BundleMetadataKeys.BUNDLE_MIN_SIZE)
             add(WCMetaData.BundleMetadataKeys.BUNDLE_MAX_SIZE)
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -111,6 +111,9 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var bundledItems = ""
     @Column var compositeComponents = ""
     @Column var specialStockStatus = ""
+    @Column var isSampleProduct = false
+        @JvmName("setIsSampleProduct")
+        set
 
     val attributeList: Array<ProductAttribute>
         get() = Gson().fromJson(attributes, Array<ProductAttribute>::class.java) ?: emptyArray()
@@ -119,11 +122,6 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
         get() = Gson().fromJson(metadata, Array<WCMetaData>::class.java)
             ?.find { it.key == ADDONS_METADATA_KEY }
             ?.addons
-
-    val isSampleProduct: Boolean
-        get() = Gson().fromJson(metadata, Array<WCMetaData>::class.java)
-            ?.any { it.key == OtherKeys.HEAD_START_POST && it.value == "_hs_extra" }
-            ?: false
 
     val isConfigurable: Boolean
         get() = when (type) {
@@ -616,9 +614,5 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
             GROUP_OF_QUANTITY,
             ALLOW_COMBINATION
         )
-    }
-
-    object OtherKeys {
-        const val HEAD_START_POST = "_headstart_post"
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -173,6 +173,13 @@ data class ProductApiResponse(
             bundledItems = response.bundled_items?.toString() ?: ""
             compositeComponents = response.composite_components?.toString() ?: ""
             metadata = response.metadata?.toString() ?: ""
+            isSampleProduct = response.metadata?.any {
+                val metaDataEntry = if (it.isJsonObject) it.asJsonObject else null
+                metaDataEntry?.let { json ->
+                    json.getString(WCMetaData.KEY) == "_headstart_post"
+                        && json.getString(WCMetaData.VALUE) == "_hs_extra"
+                } ?: false
+            } ?: false
 
             response.dimensions?.asJsonObject?.let { json ->
                 length = json.getString("length") ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
@@ -64,6 +65,7 @@ object ProductSqlUtils {
             .mapLatest {
                 getProductCountForSite(site, filterOptions, excludeSampleProducts)
             }
+            .distinctUntilChanged()
             .flowOn(Dispatchers.IO)
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -981,9 +981,10 @@ class WCProductStore @Inject constructor(
     fun observeProducts(
         site: SiteModel,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
-        filterOptions: Map<ProductFilterOption, String> = emptyMap()
+        filterOptions: Map<ProductFilterOption, String> = emptyMap(),
+        limit: Int? = null
     ): Flow<List<WCProductModel>> =
-        ProductSqlUtils.observeProducts(site, sortType, filterOptions)
+        ProductSqlUtils.observeProducts(site, sortType, filterOptions, limit)
 
     fun observeProductsCount(
         site: SiteModel,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -982,14 +982,25 @@ class WCProductStore @Inject constructor(
         site: SiteModel,
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         filterOptions: Map<ProductFilterOption, String> = emptyMap(),
+        excludeSampleProducts: Boolean = false,
         limit: Int? = null
-    ): Flow<List<WCProductModel>> =
-        ProductSqlUtils.observeProducts(site, sortType, filterOptions, limit)
+    ): Flow<List<WCProductModel>> = ProductSqlUtils.observeProducts(
+        site = site,
+        sortType = sortType,
+        filterOptions = filterOptions,
+        excludeSampleProducts = excludeSampleProducts,
+        limit = limit
+    )
 
     fun observeProductsCount(
         site: SiteModel,
-        filterOptions: Map<ProductFilterOption, String> = emptyMap()
-    ): Flow<Long> = ProductSqlUtils.observeProductsCount(site, filterOptions)
+        filterOptions: Map<ProductFilterOption, String> = emptyMap(),
+        excludeSampleProducts: Boolean = false
+    ): Flow<Long> = ProductSqlUtils.observeProductsCount(
+        site = site,
+        filterOptions = filterOptions,
+        excludeSampleProducts = excludeSampleProducts
+    )
 
     fun observeVariations(site: SiteModel, productId: Long): Flow<List<WCProductVariationModel>> =
         ProductSqlUtils.observeVariations(site, productId)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -985,6 +985,11 @@ class WCProductStore @Inject constructor(
     ): Flow<List<WCProductModel>> =
         ProductSqlUtils.observeProducts(site, sortType, filterOptions)
 
+    fun observeProductsCount(
+        site: SiteModel,
+        filterOptions: Map<ProductFilterOption, String> = emptyMap()
+    ): Flow<Long> = ProductSqlUtils.observeProductsCount(site, filterOptions)
+
     fun observeVariations(site: SiteModel, productId: Long): Flow<List<WCProductVariationModel>> =
         ProductSqlUtils.observeVariations(site, productId)
 


### PR DESCRIPTION
This PR introduces three changes:

1. Ability to observe products count.
2. Ability to limit number of returned products when observing changes. This should help reducing the changes of getting `SQLiteBlobTooBigExceptions` peaMlT-8i-p2
3. Ability to exclude sample products in the SQL query instead of doing a runtime filtrage, this was needed to support the point 2, and it should also bring some improvements.

Check https://github.com/woocommerce/woocommerce-android/pull/11380 for testing.