### PR TITLE
Add "stats/emails/summary" endpoint

### DIFF
--- a/fluxc-processor/src/main/resources/wp-com-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-endpoints.txt
@@ -138,6 +138,7 @@
 /sites/$site/stats/streak
 /sites/$site/stats/file-downloads
 /sites/$site/stats/subscribers
+/sites/$site/stats/emails/summary
 
 /sites/$site/post/$post_ID/diffs
 /sites/$site/page/$post_ID/diffs

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/subscribers/PostsModel.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/subscribers/PostsModel.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.fluxc.model.stats.subscribers
+
+data class PostsModel(val posts: List<PostModel>) {
+    data class PostModel(val id: Long, val href: String, val title: String, val opens: Int, val clicks: Int)
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/EmailsRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/EmailsRestClient.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.stats.subscribers
+
+import android.content.Context
+import com.android.volley.RequestQueue
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Error
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
+import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
+import org.wordpress.android.fluxc.store.StatsStore.FetchStatsPayload
+import org.wordpress.android.fluxc.store.toStatsError
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class EmailsRestClient @Inject constructor(
+    dispatcher: Dispatcher,
+    private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    appContext: Context?,
+    @Named("regular") requestQueue: RequestQueue,
+    accessToken: AccessToken,
+    userAgent: UserAgent
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
+    suspend fun fetchEmailsSummary(
+        site: SiteModel,
+        quantity: Int,
+        sortField: SortField,
+        forced: Boolean
+    ): FetchStatsPayload<EmailsSummaryResponse> {
+        val url = WPCOMREST.sites.site(site.siteId).stats.emails.summary.urlV1_1
+
+        val params = mapOf(
+            "quantity" to quantity.toString(),
+            "sort_field" to sortField.toString(),
+            "sort_order" to "desc"
+        )
+
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+            this,
+            url,
+            params,
+            EmailsSummaryResponse::class.java,
+            enableCaching = false,
+            forced = forced
+        )
+        return when (response) {
+            is Success -> FetchStatsPayload(response.data)
+            is Error -> FetchStatsPayload(response.error.toStatsError())
+        }
+    }
+
+    enum class SortField(val sortField: String) { POST_ID("post_id"), OPENS("opens") }
+
+    data class EmailsSummaryResponse(@SerializedName("posts") val posts: List<Post>) {
+        data class Post(
+            @SerializedName("id") val id: Long?,
+            @SerializedName("href") val href: String?,
+            @SerializedName("title") val title: String?,
+            @SerializedName("opens") val opens: Int?,
+            @SerializedName("clicks") val clicks: Int?
+        )
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -12,10 +12,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.PublicizeRe
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.SummaryRestClient.SummaryResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TagsRestClient.TagsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.TodayInsightsRestClient.VisitResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.subscribers.EmailsRestClient.EmailsSummaryResponse
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.ALL_TIME_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.COMMENTS_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.DETAILED_POST_STATS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.EMAILS_SUBSCRIBERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.EMAIL_FOLLOWERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.LATEST_POST_DETAIL_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.MOST_POPULAR_INSIGHTS
@@ -196,5 +198,15 @@ constructor(
             statsRequestSqlUtils,
             POSTING_ACTIVITY,
             PostingActivityResponse::class.java
+    )
+
+    class EmailsSqlUtils @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<EmailsSummaryResponse>(
+        statsSqlUtils,
+        statsRequestSqlUtils,
+        EMAILS_SUBSCRIBERS,
+        EmailsSummaryResponse::class.java
     )
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -168,6 +168,7 @@ class StatsSqlUtils @Inject constructor() {
         PUBLICIZE_INSIGHTS,
         POSTING_ACTIVITY,
         FILE_DOWNLOADS,
-        SUBSCRIBERS
+        SUBSCRIBERS,
+        EMAILS_SUBSCRIBERS
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -272,7 +272,7 @@ class StatsStore
         FILE_DOWNLOADS
     }
 
-    enum class SubscriberType : StatsType { SUBSCRIBERS }
+    enum class SubscriberType : StatsType { SUBSCRIBERS, EMAILS }
 
     enum class PostDetailType : StatsType {
         POST_HEADER,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/subscribers/EmailsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/subscribers/EmailsStore.kt
@@ -1,0 +1,52 @@
+package org.wordpress.android.fluxc.store.stats.subscribers
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.stats.InsightsMapper
+import org.wordpress.android.fluxc.model.stats.LimitMode
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.subscribers.EmailsRestClient
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.EmailsSqlUtils
+import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
+import org.wordpress.android.fluxc.store.StatsStore.StatsError
+import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog.T.STATS
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EmailsStore @Inject constructor(
+    private val restClient: EmailsRestClient,
+    private val sqlUtils: EmailsSqlUtils,
+    private val insightsMapper: InsightsMapper,
+    private val coroutineEngine: CoroutineEngine
+) {
+    suspend fun fetchEmails(
+        siteModel: SiteModel,
+        limitMode: LimitMode.Top,
+        sortField: EmailsRestClient.SortField,
+        forced: Boolean = false
+    ) = coroutineEngine.withDefaultContext(STATS, this, "fetchEmails") {
+        if (!forced && sqlUtils.hasFreshRequest(siteModel, limitMode.limit)) {
+            return@withDefaultContext OnStatsFetched(getEmails(siteModel, limitMode, sortField), cached = true)
+        }
+
+        val response = restClient.fetchEmailsSummary(siteModel, limitMode.limit, sortField, forced)
+        return@withDefaultContext when {
+            response.isError -> OnStatsFetched(response.error)
+            response.response != null -> {
+                sqlUtils.insert(siteModel, response.response, requestedItems = limitMode.limit)
+                OnStatsFetched(insightsMapper.map(response.response, limitMode, sortField))
+            }
+
+            else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
+        }
+    }
+
+    fun getEmails(
+        site: SiteModel,
+        cacheMode: LimitMode,
+        sortField: EmailsRestClient.SortField
+    ) = coroutineEngine.run(STATS, this, "getEmails") {
+        sqlUtils.select(site)?.let { insightsMapper.map(it, cacheMode, sortField) }
+    }
+}


### PR DESCRIPTION
This adds "stats/emails/summary" endpoint. 

**endpoint:** `https://public-api.wordpress.com/rest/v1.1/sites/{siteId}/stats/emails/summary?quantity=300&sort_field=post_id&sort_order=desc`
params: `quantity`, `sort_field=post_id`, `sort_field=opens`
response: 
```
{
  "posts": [
    {
      "id": 1,
      "href": "http://url1",
      "date": "2024-04-29 12:00:00",
      "title": "title1",
      "type": "post",
      "opens": 10,
      "clicks": 20
    },
    {
      "id": 2,
      "href": "http://url2",
      "date": "2024-04-28 12:00:00",
      "title": "title2",
      "type": "post",
      "opens": 30,
      "clicks": 40
    }
  ]
}
```

This can be tested via https://github.com/wordpress-mobile/WordPress-Android/pull/20728.