### PR TITLE
Add Total Subscribers to SubscriberType

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -272,7 +272,7 @@ class StatsStore
         FILE_DOWNLOADS
     }
 
-    enum class SubscriberType : StatsType { SUBSCRIBERS, TOTAL_SUBSCRIBERS }
+    enum class SubscriberType : StatsType { TOTAL_SUBSCRIBERS, SUBSCRIBERS }
 
     enum class PostDetailType : StatsType {
         POST_HEADER,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -272,7 +272,7 @@ class StatsStore
         FILE_DOWNLOADS
     }
 
-    enum class SubscriberType : StatsType { SUBSCRIBERS, TOTAL_FOLLOWERS }
+    enum class SubscriberType : StatsType { SUBSCRIBERS, TOTAL_SUBSCRIBERS }
 
     enum class PostDetailType : StatsType {
         POST_HEADER,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -272,7 +272,7 @@ class StatsStore
         FILE_DOWNLOADS
     }
 
-    enum class SubscriberType : StatsType { SUBSCRIBERS }
+    enum class SubscriberType : StatsType { SUBSCRIBERS, TOTAL_FOLLOWERS }
 
     enum class PostDetailType : StatsType {
         POST_HEADER,


### PR DESCRIPTION
This PR adds `TOTAL_SUBSCRIBERS` to `SubscriberType` which is used by the Total Subscribers card. This can be tested via: https://github.com/wordpress-mobile/WordPress-Android/pull/20732