### PR TITLE
Put params in the body not in query

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -2,7 +2,6 @@
 
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
-import android.net.Uri
 import com.google.gson.JsonElement
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction
@@ -875,17 +874,11 @@ class OrderRestClient @Inject constructor(
             forceNew?.let { put("force_new", it.toString()) }
         }
 
-        val url = Uri.parse(WOOCOMMERCE.orders.id(orderId).receipt.pathV3)
-            .buildUpon().apply {
-                params.forEach { (key, value) ->
-                    appendQueryParameter(key, value)
-                }
-            }.build().toString()
-
         val response = wooNetwork.executePostGsonRequest(
             site = site,
-            path = url,
-            clazz = OrderReceiptResponse::class.java
+            path = WOOCOMMERCE.orders.id(orderId).receipt.pathV3,
+            clazz = OrderReceiptResponse::class.java,
+            body = params
         )
 
         return response.toWooPayload { it }


### PR DESCRIPTION
closes: https://github.com/woocommerce/woocommerce-android/issues/11418

As we found out JP tunnel doesn't pass POST requests with query params. That PR moves params to the body.

To test:
* Use composite build with the Woo app
* Login to a store via a WP.com account
* Orders -> Completed Order -> See receipts
* Notice that  it does work now