### PR TITLE
Add SUBSCRIBERS_CHART as SubscriberType

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -272,7 +272,7 @@ class StatsStore
         FILE_DOWNLOADS
     }
 
-    enum class SubscriberType : StatsType { SUBSCRIBERS_CHART, EMAILS }
+    enum class SubscriberType : StatsType { SUBSCRIBERS_CHART, SUBSCRIBERS, EMAILS }
 
     enum class PostDetailType : StatsType {
         POST_HEADER,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/StatsStore.kt
@@ -272,7 +272,7 @@ class StatsStore
         FILE_DOWNLOADS
     }
 
-    enum class SubscriberType : StatsType { SUBSCRIBERS, EMAILS }
+    enum class SubscriberType : StatsType { SUBSCRIBERS_CHART, EMAILS }
 
     enum class PostDetailType : StatsType {
         POST_HEADER,


### PR DESCRIPTION
This adds SUBSCRIBERS_CHART to `SubscriberType`s to be used in the SUBSCRIBERS tab on the Jetpack app.
This can be tested via https://github.com/wordpress-mobile/WordPress-Android/pull/20735.