### PR TITLE
[Crash Fix] Update Woo-specific migration to run only for WooCommerce

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -2004,7 +2004,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 199 -> migrate(version) {
                     db.execSQL("ALTER TABLE PostModel ADD DB_TIMESTAMP INTEGER")
                 }
-                200 -> migrate(version) {
+                200 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD IS_SAMPLE_PRODUCT BOOLEAN")
                 }
             }


### PR DESCRIPTION
Use `migrateAddOn` for Woo-specific table update.

Otherwise, the `migrate` function causes a crash in any app that uses `FluxC` and doesn't contain the table being updated, which is what is happening on the current version of Jetpack, `24.8-rc-1`, as reported here: p1714495849353259-slack-C0180B5PRJ4

The issue was introduced by https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2995.