### PR TITLE
Merge Release/2.77.1 to trunk

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -2004,7 +2004,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 199 -> migrate(version) {
                     db.execSQL("ALTER TABLE PostModel ADD DB_TIMESTAMP INTEGER")
                 }
-                200 -> migrate(version) {
+                200 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD IS_SAMPLE_PRODUCT BOOLEAN")
                 }
             }


### PR DESCRIPTION
This just contains the code from #3000, which made release `2.77.1` of FluxC to fix a crash in WordPress-Android. 

It would be great to have a review by someone in the WooCommerce team before merging this to `trunk`, just to double check everything still works as expected, since the fixed issue was introduced by https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2995.

For the reviewers: once it's tested in Woo, feel free to merge this directly.