### PR TITLE
Fixes: try to catch exception for fun getListItems()

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/ListItemSqlUtils.kt
@@ -6,6 +6,8 @@ import com.yarolegovich.wellsql.SelectQuery
 import com.yarolegovich.wellsql.WellSql
 import org.wordpress.android.fluxc.model.list.ListItemModel
 import org.wordpress.android.fluxc.persistence.WellSqlConfig.Companion.SQLITE_MAX_VARIABLE_NUMBER
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -24,8 +26,19 @@ class ListItemSqlUtils @Inject constructor() {
 
     /**
      * This function returns a list of [ListItemModel] records for the given [listId].
+     * It catches exceptions that occur during the database query and handles them.
      */
-    fun getListItems(listId: Int): List<ListItemModel> = getListItemsQuery(listId).asModel
+    @Suppress("TooGenericExceptionCaught")
+    fun getListItems(listId: Int): List<ListItemModel> {
+        return try {
+            // Attempt to execute the query and map the result to models
+            getListItemsQuery(listId).asModel
+        } catch (e: Exception) {
+            // Handle exceptions that might occur
+            AppLog.e(T.DB, "Error fetching items for listId: $listId", e)
+            emptyList()
+        }
+    }
 
     /**
      * This function returns the number of records a list has for the given [listId].


### PR DESCRIPTION
This PR tries to fix this Sentry [issue](https://a8c.sentry.io/issues/5027795583/?project=5731682&referrer=github_integration). 

It seems that sometime an `CursorWindowAllocationException` occurs when `ListItemSqlUtils.getListItems()` is called.

I was not able to replicate the crash. 

The CursorWindowAllocationException we are encountering, particularly when using WellSql, typically indicates that the size of the data being fetched into a single CursorWindow from the database exceeds the available limit, which is typically around 2 MB on older devices and 4 MB on newer ones. 

This issue usually can occur if the query results include large amounts of data per row, such as large text fields or binary data (e.g., images, blobs). This seems not to be the case here. 

Added a log so we can track this in the future. 

### Testing steps
A code check should be enough. 


