### PR TITLE
Fixes: publish post when device time is set manually

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -646,7 +646,9 @@ public class PostRestClient extends BaseWPComRestClient {
             params.put("author", String.valueOf(post.getAuthorId()));
         }
 
-        if (!TextUtils.isEmpty(post.getDateCreated())) {
+        if (!TextUtils.isEmpty(post.getDateCreated())
+            && post.getStatus().equals(PostStatus.SCHEDULED.toString())
+        ) {
             params.put("date", post.getDateCreated());
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -507,7 +507,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         String dateCreated = post.getDateCreated();
         Date date = DateTimeUtils.dateUTCFromIso8601(dateCreated);
-        if (date != null) {
+        if (date != null && post.getStatus().equals(PostStatus.SCHEDULED.toString())) {
             contentStruct.put("post_date", date);
             // Redundant, but left in just in case
             // Note: XML-RPC sends the same value for dateCreated and date_created_gmt in the first place


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/issues/17375 

This PR attempts to resolve the issue described above. If a user disables automatic time synchronization and sets the time approximately ten minutes ahead, for example, then when they create a new post and try to publish it immediately, the post gets scheduled to be published in the future. This happens because we are sending a "date" parameter to the backend.

The solution proposed here sends the date parameter only when it is actually needed, which is when the user explicitly wants to schedule the post for a future time. This way, the backend uses its own time to determine the time of the post's publication.

### Testing Steps:

1. Install the app and choose a WP.com site.
2. On your Android device, disable auto time sync and set the time approximately ten minutes ahead.
3. Create a new test post and publish it immediately.
4. Verify that the post was published and not scheduled.
5. Go to the post list, select the post, and add some content. Tap "Update."
6. Verify that the post was updated successfully.
7. Create a new post and schedule it for a future date.
8. Verify that the post was scheduled successfully.
9. Create a new post and tap "Save" on the menu.
10. Verify that the post was successfully saved in the drafts.
11. Go to a published post and tap "Trash."
12. Verify that the post was successfully moved to trashed posts.
13. Go to the trashed posts, find the post that you trashed, and tap "Move to Draft" to restore it.
14. Verify that the post was moved to drafts.
15. Go to the trashed posts, tap on a post, and choose "Delete Permanently."
16. Verify that the post was permanently deleted.
17. Please repeat all the above steps for a self-hosted site. You can create one with the https://jurassic.ninja/ tool.







 