### PR TITLE
Fix empty db case of followers

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
@@ -115,6 +115,10 @@ class FollowersStore
         sqlUtils: InsightsSqlUtils<FollowersResponse>
     ) = coroutineEngine.run(STATS, this, "getFollowers") {
         val followerResponses = sqlUtils.selectAll(site)
-        insightsMapper.mapAndMergeFollowersModels(followerResponses, followerType, cacheMode)
+        if (followerResponses.isEmpty()) {
+            null
+        } else {
+            insightsMapper.mapAndMergeFollowersModels(followerResponses, followerType, cacheMode)
+        }
     }
 }


### PR DESCRIPTION
When the db is empty `FollowersStore.getFollowers()` was returning an empty list. Now it will return null to differentiate empty db case. 
This can be tested via https://github.com/wordpress-mobile/WordPress-Android/pull/20776