### PR TITLE
Add "all" type option to followers endpoint

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/stats/InsightsStoreTest.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.AllTimeSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.CommentsInsightsSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.DetailedPostStatsSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.EmailFollowersSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.FollowersSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.LatestPostDetailSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.PublicizeSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.TagsSqlUtils
@@ -82,6 +83,8 @@ class InsightsStoreTest {
     @Mock lateinit var todayInsightsRestClient: TodayInsightsRestClient
     @Mock lateinit var allTimeSqlUtils: AllTimeSqlUtils
     @Mock lateinit var commentInsightsSqlUtils: CommentsInsightsSqlUtils
+    @Mock
+    lateinit var followersSqlUtils: FollowersSqlUtils
     @Mock lateinit var wpComFollowersSqlUtils: WpComFollowersSqlUtils
     @Mock lateinit var emailFollowersSqlUtils: EmailFollowersSqlUtils
     @Mock lateinit var latestPostDetailSqlUtils: LatestPostDetailSqlUtils
@@ -112,11 +115,12 @@ class InsightsStoreTest {
                 initCoroutineEngine()
         )
         followersStore = FollowersStore(
-                followersRestClient,
-                wpComFollowersSqlUtils,
-                emailFollowersSqlUtils,
-                mapper,
-                initCoroutineEngine()
+            followersRestClient,
+            followersSqlUtils,
+            wpComFollowersSqlUtils,
+            emailFollowersSqlUtils,
+            mapper,
+            initCoroutineEngine()
         )
         latestPostStore = LatestPostInsightsStore(
                 latestPostInsightsRestClient,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/stats/InsightsMapper.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.stats.subscribers.PostsModel.PostModel
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.AllTimeInsightsRestClient.AllTimeResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.CommentsRestClient.CommentsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.ALL
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.EMAIL
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.WP_COM
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowersResponse
@@ -152,6 +153,7 @@ class InsightsMapper @Inject constructor(val statsUtils: StatsUtils) {
             }
         }
         val total = when (followerType) {
+            ALL -> response.total
             WP_COM -> response.totalWpCom
             EMAIL -> response.totalEmail
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/FollowersRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/FollowersRestClient.kt
@@ -67,7 +67,7 @@ class FollowersRestClient @Inject constructor(
     }
 
     enum class FollowerType(val path: String) {
-        EMAIL("email"), WP_COM("wpcom")
+        ALL("all"), EMAIL("email"), WP_COM("wpcom")
     }
 
     data class FollowersResponse(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/InsightsSqlUtils.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.COMMENTS_
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.DETAILED_POST_STATS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.EMAILS_SUBSCRIBERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.EMAIL_FOLLOWERS
+import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.FOLLOWERS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.LATEST_POST_DETAIL_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.MOST_POPULAR_INSIGHTS
 import org.wordpress.android.fluxc.persistence.StatsSqlUtils.BlockType.POSTING_ACTIVITY
@@ -143,6 +144,16 @@ constructor(
         statsRequestSqlUtils,
         SUMMARY,
         SummaryResponse::class.java
+    )
+
+    class FollowersSqlUtils @Inject constructor(
+        statsSqlUtils: StatsSqlUtils,
+        statsRequestSqlUtils: StatsRequestSqlUtils
+    ) : InsightsSqlUtils<FollowersResponse>(
+        statsSqlUtils,
+        statsRequestSqlUtils,
+        FOLLOWERS,
+        FollowersResponse::class.java
     )
 
     class WpComFollowersSqlUtils

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/StatsSqlUtils.kt
@@ -169,6 +169,7 @@ class StatsSqlUtils @Inject constructor() {
         POSTING_ACTIVITY,
         FILE_DOWNLOADS,
         SUBSCRIBERS,
+        FOLLOWERS,
         EMAILS_SUBSCRIBERS
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/stats/insights/FollowersStore.kt
@@ -8,11 +8,13 @@ import org.wordpress.android.fluxc.model.stats.LimitMode.All
 import org.wordpress.android.fluxc.model.stats.PagedMode
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType
+import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.ALL
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.EMAIL
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowerType.WP_COM
 import org.wordpress.android.fluxc.network.rest.wpcom.stats.insights.FollowersRestClient.FollowersResponse
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.EmailFollowersSqlUtils
+import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.FollowersSqlUtils
 import org.wordpress.android.fluxc.persistence.InsightsSqlUtils.WpComFollowersSqlUtils
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
@@ -26,11 +28,18 @@ import javax.inject.Singleton
 class FollowersStore
 @Inject constructor(
     private val restClient: FollowersRestClient,
+    private val followersSqlUtils: FollowersSqlUtils,
     private val wpComFollowersSqlUtils: WpComFollowersSqlUtils,
     private val emailFollowersSqlUtils: EmailFollowersSqlUtils,
     private val insightsMapper: InsightsMapper,
     private val coroutineEngine: CoroutineEngine
 ) {
+    suspend fun fetchFollowers(
+        siteModel: SiteModel,
+        fetchMode: PagedMode,
+        forced: Boolean = false
+    ) = fetchFollowers(siteModel, forced, ALL, fetchMode, followersSqlUtils)
+
     suspend fun fetchWpComFollowers(
         siteModel: SiteModel,
         fetchMode: PagedMode,
@@ -99,6 +108,8 @@ class FollowersStore
             else -> OnStatsFetched(StatsError(INVALID_RESPONSE))
         }
     }
+
+    fun getFollowers(site: SiteModel, cacheMode: LimitMode) = getFollowers(site, ALL, cacheMode, followersSqlUtils)
 
     fun getWpComFollowers(site: SiteModel, cacheMode: LimitMode): FollowersModel? {
         return getFollowers(site, WP_COM, cacheMode, wpComFollowersSqlUtils)


### PR DESCRIPTION
Fetching "wpcom" and "email" followers were already added. This PR adds functionality to fetch "all" followers.

Can be tested via https://github.com/wordpress-mobile/WordPress-Android/pull/20789.