### PR TITLE
Add shipping methods endpoint

### DIFF
--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -117,3 +117,5 @@
 /reports/products
 
 /options
+
+/shipping_methods

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -119,3 +119,4 @@
 /options
 
 /shipping_methods
+/shipping_methods/<id>#String


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-android/issues/11391

### Why
As part of the Enhancing Order Shipping Lines pffQ75-m4-p2 we want to enable the shipping method selection.

### Description
This small PR adds the shipping_methods endpoint needed to fetch the store's shipping methods.

### Testing instruction
It is best to test this PR alongside [the Woo PR](https://github.com/woocommerce/woocommerce-android/pull/11478)