### PR TITLE
Add log lines to capture the string error message

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/upload/MediaUploadModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/MediaUploadModelTest.java
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.upload;
 
 import android.text.TextUtils;
+import android.util.Log;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.wordpress.android.fluxc.model.MediaUploadModel;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
@@ -38,6 +40,7 @@ public class MediaUploadModelTest {
 
     @Test
     public void testMediaError() {
+        Mockito.mockStatic(Log.class);
         MediaUploadModel mediaUploadModel = new MediaUploadModel(1);
 
         assertNull(mediaUploadModel.getMediaError());

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
@@ -1,11 +1,5 @@
 package org.wordpress.android.fluxc.upload;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import android.text.TextUtils;
 
 import org.junit.Test;
@@ -15,6 +9,12 @@ import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class PostUploadModelTest {
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
@@ -1,22 +1,20 @@
 package org.wordpress.android.fluxc.upload;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import android.text.TextUtils;
-import android.util.Log;
 
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.wordpress.android.fluxc.model.PostUploadModel;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class PostUploadModelTest {
     @Test
@@ -57,7 +55,6 @@ public class PostUploadModelTest {
 
     @Test
     public void testPostError() {
-        Mockito.mockStatic(Log.class);
         PostUploadModel postUploadModel = new PostUploadModel(1);
 
         assertNull(postUploadModel.getPostError());

--- a/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/PostUploadModelTest.java
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.upload;
 
 import android.text.TextUtils;
+import android.util.Log;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.wordpress.android.fluxc.model.PostUploadModel;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.PostStore.PostErrorType;
@@ -55,6 +57,7 @@ public class PostUploadModelTest {
 
     @Test
     public void testPostError() {
+        Mockito.mockStatic(Log.class);
         PostUploadModel postUploadModel = new PostUploadModel(1);
 
         assertNull(postUploadModel.getPostError());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -34,6 +34,7 @@ import org.wordpress.android.fluxc.store.media.MediaErrorSubType.MalformedMediaA
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.fluxc.utils.MimeType;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 
 import java.io.IOException;
 import java.net.ConnectException;
@@ -528,6 +529,7 @@ public class MediaStore extends Store {
         @NonNull
         public static MediaErrorType fromString(@Nullable String string) {
             if (string != null) {
+                AppLog.e(T.API, "Media Error Type Conversion From: " + string);
                 for (MediaErrorType v : MediaErrorType.values()) {
                     if (string.equalsIgnoreCase(v.name())) {
                         return v;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -53,6 +53,7 @@ import org.wordpress.android.fluxc.store.ListStore.ListErrorType;
 import org.wordpress.android.fluxc.store.ListStore.ListItemsRemovedPayload;
 import org.wordpress.android.fluxc.utils.ObjectsUtils;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.ArrayList;
@@ -435,6 +436,7 @@ public class PostStore extends Store {
 
         public static PostErrorType fromString(String string) {
             if (string != null) {
+                AppLog.e(T.API, "Post Error Type Conversion From: " + string);
                 for (PostErrorType v : PostErrorType.values()) {
                     if (string.equalsIgnoreCase(v.toString())) {
                         return v;


### PR DESCRIPTION
To assist in troubleshooting a user issue related to publishing a post with media, this PR adds a log line in each of the following:
- MediaStore
- PostStore

The error message the user is experiencing is attached below, which appears to be shown after a media/post upload. This particular message is also the default message if we can't convert the server "string" message to a recognizable error. The intention is to use the next beta to capture the logs, and then remove the log lines before the beta turns into prod.

<img width="450" height="300" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-FluxC-Android/assets/506707/edb1da8f-9a6e-4582-8291-51a8e026d77a">

See conversation p1714119618977609-slack-C0180B5PR for more details of the issue.

If you believe this is a bad idea, then raise a flag and close the PR without approving/merging. There is no companion WP app.

