### PR TITLE
Handle low memory errors while uploading logs

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.store.EncryptedLogStore.OnEncryptedLogUploade
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError.InvalidRequest
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError.MissingFile
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError.NoConnection
+import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError.OutOfMemoryException
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError.TooManyRequests
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError.Unknown
 import org.wordpress.android.fluxc.store.EncryptedLogStore.UploadEncryptedLogError.UnsatisfiedLinkException
@@ -162,6 +163,8 @@ class EncryptedLogStore @Inject constructor(
             }
         } catch (e: UnsatisfiedLinkError) {
             handleFailedUpload(encryptedLog, UnsatisfiedLinkException)
+        } catch (e: OutOfMemoryError) {
+            handleFailedUpload(encryptedLog, OutOfMemoryException)
         }
     }
 
@@ -312,6 +315,7 @@ class EncryptedLogStore @Inject constructor(
         object NoConnection : UploadEncryptedLogError()
         object MissingFile : UploadEncryptedLogError()
         object UnsatisfiedLinkException : UploadEncryptedLogError()
+        object OutOfMemoryException : UploadEncryptedLogError()
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -225,7 +225,7 @@ class EncryptedLogStore @Inject constructor(
     private fun mapUploadEncryptedLogError(error: UploadEncryptedLogError): EncryptedLogUploadFailureType {
         return when (error) {
             NoConnection, TooManyRequests -> CONNECTION_FAILURE
-            InvalidRequest, MissingFile, UnsatisfiedLinkException -> IRRECOVERABLE_FAILURE
+            InvalidRequest, MissingFile, UnsatisfiedLinkException, OutOfMemoryException -> IRRECOVERABLE_FAILURE
             is Unknown -> if ((HTTP_STATUS_CODE_500..HTTP_STATUS_CODE_599).contains(error.statusCode)) {
                 CONNECTION_FAILURE
             } else {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt
@@ -224,30 +224,12 @@ class EncryptedLogStore @Inject constructor(
 
     private fun mapUploadEncryptedLogError(error: UploadEncryptedLogError): EncryptedLogUploadFailureType {
         return when (error) {
-            is NoConnection -> {
+            NoConnection, TooManyRequests -> CONNECTION_FAILURE
+            InvalidRequest, MissingFile, UnsatisfiedLinkException -> IRRECOVERABLE_FAILURE
+            is Unknown -> if ((HTTP_STATUS_CODE_500..HTTP_STATUS_CODE_599).contains(error.statusCode)) {
                 CONNECTION_FAILURE
-            }
-            is TooManyRequests -> {
-                CONNECTION_FAILURE
-            }
-            is InvalidRequest -> {
-                IRRECOVERABLE_FAILURE
-            }
-            is MissingFile -> {
-                IRRECOVERABLE_FAILURE
-            }
-            is UnsatisfiedLinkException -> {
-                IRRECOVERABLE_FAILURE
-            }
-            is Unknown -> {
-                when {
-                    (HTTP_STATUS_CODE_500..HTTP_STATUS_CODE_599).contains(error.statusCode) -> {
-                        CONNECTION_FAILURE
-                    }
-                    else -> {
-                        CLIENT_FAILURE
-                    }
-                }
+            } else {
+                CLIENT_FAILURE
             }
         }
     }


### PR DESCRIPTION
Fixes #3010

This addresses low-memory error cases during log uploads.

When there is low memory on the device and there is a log file with a large size that needs to be uploaded, the app crashes.  Although this doesn't happen frequently, when it does occur for a user, it tends to happen repeatedly for that user. This PR resolves this issue by treating it as an `IRRECOVERABLE_FAILURE` and deleting the log file.

It's hard to test it. But I'd like you to review the solution.