### PR TITLE
Coupons/fetch reports

### DIFF
--- a/example/src/main/res/layout/fragment_woo_coupons.xml
+++ b/example/src/main/res/layout/fragment_woo_coupons.xml
@@ -62,6 +62,14 @@
             android:text="Fetch Coupon Report" />
 
         <Button
+            android:id="@+id/btnFetchMostActiveCoupons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:enabled="false"
+            android:text="Fetch most active coupons" />
+
+        <Button
             android:id="@+id/btnUpdateCoupon"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -38,53 +38,41 @@ enum class WooErrorType {
     RESOURCE_ALREADY_EXISTS
 }
 
-fun WPComGsonNetworkError.toWooError(): WooError {
-    val type = when (type) {
-        TIMEOUT -> WooErrorType.TIMEOUT
-        NO_CONNECTION,
-        SERVER_ERROR,
-        INVALID_SSL_CERTIFICATE,
-        NETWORK_ERROR -> WooErrorType.API_ERROR
-        PARSE_ERROR,
-        CENSORED,
-        INVALID_RESPONSE -> WooErrorType.INVALID_RESPONSE
-        HTTP_AUTH_ERROR,
-        AUTHORIZATION_REQUIRED,
-        NOT_AUTHENTICATED -> WooErrorType.AUTHORIZATION_REQUIRED
-        NOT_FOUND -> WooErrorType.INVALID_ID
-        UNKNOWN, null -> {
-            when (apiError) {
-                "rest_invalid_param" -> WooErrorType.INVALID_PARAM
-                "rest_no_route" -> WooErrorType.PLUGIN_NOT_ACTIVE
-                else -> WooErrorType.GENERIC_ERROR
-            }
-        }
-    }
-    return WooError(type, this.type, message)
-}
+fun WPComGsonNetworkError.toWooError() = WooError(
+    type = type.getWooErrorType(apiError),
+    original = type,
+    message = message
+)
 
-fun WPAPINetworkError.toWooError(): WooError {
-    val type = when (type) {
-        TIMEOUT -> WooErrorType.TIMEOUT
-        NO_CONNECTION,
-        SERVER_ERROR,
-        INVALID_SSL_CERTIFICATE,
-        NETWORK_ERROR -> WooErrorType.API_ERROR
-        PARSE_ERROR,
-        CENSORED,
-        INVALID_RESPONSE -> WooErrorType.INVALID_RESPONSE
-        HTTP_AUTH_ERROR,
-        AUTHORIZATION_REQUIRED,
-        NOT_AUTHENTICATED -> WooErrorType.AUTHORIZATION_REQUIRED
-        NOT_FOUND -> WooErrorType.INVALID_ID
-        UNKNOWN, null -> {
-            when (errorCode) {
-                "rest_invalid_param" -> WooErrorType.INVALID_PARAM
-                "rest_no_route" -> WooErrorType.PLUGIN_NOT_ACTIVE
-                "woocommerce_rest_invalid_coupon" -> WooErrorType.INVALID_COUPON
-                else -> WooErrorType.GENERIC_ERROR
-            }
+fun WPAPINetworkError.toWooError() = WooError(
+    type = type.getWooErrorType(errorCode),
+    original = type,
+    message = message
+)
+
+private fun GenericErrorType?.getWooErrorType(apiError: String?) = when (this) {
+    TIMEOUT -> WooErrorType.TIMEOUT
+    NO_CONNECTION,
+    SERVER_ERROR,
+    INVALID_SSL_CERTIFICATE,
+    NETWORK_ERROR -> WooErrorType.API_ERROR
+
+    PARSE_ERROR,
+    CENSORED,
+    INVALID_RESPONSE -> WooErrorType.INVALID_RESPONSE
+
+    HTTP_AUTH_ERROR,
+    AUTHORIZATION_REQUIRED,
+    NOT_AUTHENTICATED -> WooErrorType.AUTHORIZATION_REQUIRED
+
+    NOT_FOUND -> WooErrorType.INVALID_ID
+
+    UNKNOWN, null -> {
+        when (apiError) {
+            "rest_invalid_param" -> WooErrorType.INVALID_PARAM
+            "rest_no_route" -> WooErrorType.PLUGIN_NOT_ACTIVE
+            "woocommerce_rest_invalid_coupon" -> WooErrorType.INVALID_COUPON
+            else -> WooErrorType.GENERIC_ERROR
         }
     }
-    return WooError(type, this.type, message)
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
-import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.AUTHORIZATION_REQUIRED
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.CENSORED
@@ -33,7 +32,7 @@ enum class WooErrorType {
     INVALID_RESPONSE,
     AUTHORIZATION_REQUIRED,
     INVALID_PARAM,
-    PLUGIN_NOT_ACTIVE,
+    API_NOT_FOUND,
     EMPTY_RESPONSE,
     INVALID_COUPON,
     RESOURCE_ALREADY_EXISTS
@@ -68,7 +67,7 @@ private fun GenericErrorType?.getWooErrorType(apiError: String?) = when (this) {
 
     NOT_FOUND -> {
         when (apiError) {
-            "rest_no_route" -> WooErrorType.PLUGIN_NOT_ACTIVE
+            "rest_no_route" -> WooErrorType.API_NOT_FOUND
             else -> WooErrorType.INVALID_ID
         }
     }
@@ -76,7 +75,7 @@ private fun GenericErrorType?.getWooErrorType(apiError: String?) = when (this) {
     UNKNOWN, null -> {
         when (apiError) {
             "rest_invalid_param" -> WooErrorType.INVALID_PARAM
-            "rest_no_route" -> WooErrorType.PLUGIN_NOT_ACTIVE
+            "rest_no_route" -> WooErrorType.API_NOT_FOUND
             "woocommerce_rest_invalid_coupon" -> WooErrorType.INVALID_COUPON
             else -> WooErrorType.GENERIC_ERROR
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.AUTHORIZATION_REQUIRED
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.CENSORED
@@ -65,7 +66,12 @@ private fun GenericErrorType?.getWooErrorType(apiError: String?) = when (this) {
     AUTHORIZATION_REQUIRED,
     NOT_AUTHENTICATED -> WooErrorType.AUTHORIZATION_REQUIRED
 
-    NOT_FOUND -> WooErrorType.INVALID_ID
+    NOT_FOUND -> {
+        when (apiError) {
+            "rest_no_route" -> WooErrorType.PLUGIN_NOT_ACTIVE
+            else -> WooErrorType.INVALID_ID
+        }
+    }
 
     UNKNOWN, null -> {
         when (apiError) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.fluxc.utils.extensions.filterNotNull
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -141,15 +142,25 @@ class CouponRestClient @Inject constructor(
     suspend fun fetchCouponsReports(
         site: SiteModel,
         couponsIds: LongArray = longArrayOf(),
-        after: Date
+        orderBy: CouponsReportOrderBy = CouponsReportOrderBy.CouponId,
+        orderDescending: Boolean = true,
+        page: Int = 1,
+        perPage: Int? = null,
+        before: Date? = null,
+        after: Date? = null
     ): WooPayload<List<CouponReportDto>> {
         val url = WOOCOMMERCE.reports.coupons.pathV4Analytics
         val dateFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT)
 
         val params = mapOf(
-            "after" to dateFormatter.format(after),
+            "orderby" to orderBy.value,
+            "order" to if (orderDescending) "desc" else "asc",
+            "page" to page.toString(),
+            "per_page" to perPage?.toString(),
+            "before" to before?.let { dateFormatter.format(it) },
+            "after" to after?.let { dateFormatter.format(it) },
             "coupons" to couponsIds.joinToString(",")
-        )
+        ).filterNotNull()
 
         val response = wooNetwork.executeGetGsonRequest(
             site = site,
@@ -182,6 +193,13 @@ class CouponRestClient @Inject constructor(
                 else -> WooPayload(it.result.first())
             }
         }
+    }
+
+    enum class CouponsReportOrderBy(val value: String) {
+        CouponId("coupon_id"),
+        Code("code"),
+        Amount("amount"),
+        OrdersCount("orders_count")
     }
 
     @Suppress("ComplexMethod")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/coupons/CouponRestClient.kt
@@ -23,7 +23,8 @@ class CouponRestClient @Inject constructor(
         site: SiteModel,
         page: Int,
         pageSize: Int,
-        searchQuery: String? = null
+        searchQuery: String? = null,
+        couponIds: List<Long> = emptyList()
     ): WooPayload<Array<CouponDto>> {
         val url = WOOCOMMERCE.coupons.pathV3
 
@@ -35,6 +36,9 @@ class CouponRestClient @Inject constructor(
                 put("per_page", pageSize.toString())
                 searchQuery?.let {
                     put("search", searchQuery)
+                }
+                couponIds.takeIf { it.isNotEmpty() }?.let {
+                    put("include", it.joinToString(","))
                 }
             },
             clazz = Array<CouponDto>::class.java

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/CouponsDao.kt
@@ -19,6 +19,10 @@ interface CouponsDao {
     fun observeCoupons(localSiteId: LocalId): Flow<List<CouponWithEmails>>
 
     @Transaction
+    @Query("SELECT * FROM Coupons WHERE localSiteId = :localSiteId AND id IN (:couponIds) ORDER BY dateCreated DESC")
+    fun observeCoupons(localSiteId: LocalId, couponIds: List<Long>): Flow<List<CouponWithEmails>>
+
+    @Transaction
     @Query("SELECT * FROM Coupons " +
         "WHERE localSiteId = :localSiteId AND id IN (:couponIds) ORDER BY dateCreated DESC"
     )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
@@ -44,7 +44,8 @@ class CouponStore @Inject constructor(
         site: SiteModel,
         page: Int = DEFAULT_PAGE,
         pageSize: Int = DEFAULT_PAGE_SIZE,
-        couponIds: List<Long> = emptyList()
+        couponIds: List<Long> = emptyList(),
+        deleteOldData: Boolean = page == 1
     ): WooResult<Boolean> {
         return coroutineEngine.withDefaultContext(API, this, "fetchCoupons") {
             val response = restClient.fetchCoupons(
@@ -57,8 +58,7 @@ class CouponStore @Inject constructor(
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
                     database.executeInTransaction {
-                        // clear the table if the 1st page is requested
-                        if (page == 1) {
+                        if (deleteOldData) {
                             couponsDao.deleteAllCoupons(site.localId())
                         }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.store
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
@@ -152,9 +151,16 @@ class CouponStore @Inject constructor(
     suspend fun getCoupon(site: SiteModel, couponId: Long) =
         couponsDao.getCoupon(site.localId(), RemoteId(couponId))
 
-    @ExperimentalCoroutinesApi
-    fun observeCoupons(site: SiteModel): Flow<List<CouponWithEmails>> =
-        couponsDao.observeCoupons(site.localId()).distinctUntilChanged()
+    fun observeCoupons(
+        site: SiteModel,
+        couponIds: List<Long> = emptyList()
+    ): Flow<List<CouponWithEmails>> {
+        return if (couponIds.isEmpty()) {
+            couponsDao.observeCoupons(site.localId())
+        } else {
+            couponsDao.observeCoupons(site.localId(), couponIds)
+        }.distinctUntilChanged()
+    }
 
     suspend fun fetchCouponReport(site: SiteModel, couponId: Long): WooResult<CouponReport> =
         coroutineEngine.withDefaultContext(T.API, this, "fetchCouponReport") {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
@@ -257,6 +257,10 @@ class CouponStore @Inject constructor(
         }
     }
 
+    suspend fun getCoupons(site: SiteModel, couponIds: List<Long>): List<CouponWithEmails> {
+        return couponsDao.getCoupons(site.localId(), couponIds.map { RemoteId(it) })
+    }
+
     data class CouponSearchResult(
         val coupons: List<CouponWithEmails>,
         val canLoadMore: Boolean

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/CouponStore.kt
@@ -43,10 +43,16 @@ class CouponStore @Inject constructor(
     suspend fun fetchCoupons(
         site: SiteModel,
         page: Int = DEFAULT_PAGE,
-        pageSize: Int = DEFAULT_PAGE_SIZE
+        pageSize: Int = DEFAULT_PAGE_SIZE,
+        couponIds: List<Long> = emptyList()
     ): WooResult<Boolean> {
         return coroutineEngine.withDefaultContext(API, this, "fetchCoupons") {
-            val response = restClient.fetchCoupons(site, page, pageSize)
+            val response = restClient.fetchCoupons(
+                site = site,
+                page = page,
+                pageSize = pageSize,
+                couponIds = couponIds
+            )
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {


### PR DESCRIPTION
⚠️ This has a breaking change, please don't merge, I'll handle merging when all PRs are ready.

Closes https://github.com/woocommerce/woocommerce-android/issues/11518

This PR adds the networking implementation needed for the coupons card in the dynamic dashboard.

#### Testing
1. Open the example app.
2. Click on Woo then on Coupons.
3. Select a site.
4. Click on "Fetch the most active coupons"
5. Confirm the 3 most active coupons in the last month are printed to the console.

Also check https://github.com/woocommerce/woocommerce-android/pull/11531 for testing the other changes.