### PR TITLE
Fix shipping methods migration

### DIFF
--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/35.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/35.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 35,
-    "identityHash": "2b2e3799733db41ef697c524296acc82",
+    "identityHash": "a01f7f90e7751f29876dda9a73c49ccc",
     "entities": [
       {
         "tableName": "AddonEntity",
@@ -1657,45 +1657,12 @@
         },
         "indices": [],
         "foreignKeys": []
-      },
-      {
-        "tableName": "ShippingMethod",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `localSiteId` INTEGER NOT NULL, `title` TEXT NOT NULL, PRIMARY KEY(`localSiteId`, `id`))",
-        "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "localSiteId",
-            "columnName": "localSiteId",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "title",
-            "columnName": "title",
-            "affinity": "TEXT",
-            "notNull": true
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "localSiteId",
-            "id"
-          ],
-          "autoGenerate": false
-        },
-        "indices": [],
-        "foreignKeys": []
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2b2e3799733db41ef697c524296acc82')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a01f7f90e7751f29876dda9a73c49ccc')"
     ]
   }
 }

--- a/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
+++ b/plugins/woocommerce/src/androidTest/java/org/wordpress/android/fluxc/persistence/MigrationTests.kt
@@ -295,6 +295,22 @@ class MigrationTests {
         }
     }
 
+    @Test
+    fun testMigration34to35() {
+        helper.apply {
+            createDatabase(TEST_DB, 34).close()
+            runMigrationsAndValidate(TEST_DB, 35, false)
+        }
+    }
+
+    @Test
+    fun testMigration35to36() {
+        helper.apply {
+            createDatabase(TEST_DB, 35).close()
+            runMigrationsAndValidate(TEST_DB, 36, false)
+        }
+    }
+
     companion object {
         private const val TEST_DB = "migration-test"
     }


### PR DESCRIPTION
### Description 

This PR reverts the unnecessary changes on the DB v35 schema that caused the DB Migration to fail

### Testing

1. Install Woo version 18.6 and log in into the app
2. Install Woo version 18.7 and check that the app doesn't crash
