### PR TITLE
Remote config crash when retrieving integer value

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -590,7 +590,9 @@ class ActivityLogRestClientTest {
                 eq(ActivitiesResponse::class.java),
                 eq(false),
                 any(),
-                eq(false))
+                eq(false),
+                customGsonBuilder = anyOrNull()
+        )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)
         return response
@@ -609,7 +611,9 @@ class ActivityLogRestClientTest {
                 eq(RewindStatusResponse::class.java),
                 eq(false),
                 any(),
-                eq(false))).thenReturn(response)
+                eq(false),
+                customGsonBuilder = anyOrNull()
+        )).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)
         return response
     }
@@ -693,7 +697,9 @@ class ActivityLogRestClientTest {
                 eq(Array<BackupDownloadStatusResponse>::class.java),
                 eq(false),
                 any(),
-                eq(false))).thenReturn(response)
+                eq(false),
+                customGsonBuilder = anyOrNull()
+        )).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)
         return response
     }
@@ -710,7 +716,9 @@ class ActivityLogRestClientTest {
                 eq(ActivityTypesResponse::class.java),
                 eq(false),
                 any(),
-                eq(false))
+                eq(false),
+                customGsonBuilder = anyOrNull()
+        )
         ).thenReturn(response)
         return response
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
@@ -571,8 +571,8 @@ class CommentsRestClientTest {
                         eq(kclass),
                         any(),
                         any(),
-                        any()
-
+                        any(),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         return response

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
@@ -13,6 +13,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -397,7 +398,8 @@ class CardsRestClientTest {
                         eq(CardsResponse::class.java),
                         eq(false),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClientTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
@@ -174,7 +175,8 @@ class ExperimentRestClientTest {
                         eq(FetchAssignmentsResponse::class.java),
                         eq(false),
                         any(),
-                        eq(true)
+                        eq(true),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClientTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -182,7 +183,8 @@ class FeatureFlagsRestClientTest {
                 eq(Map::class.java),
                 eq(false),
                 any(),
-                eq(false)
+                eq(false),
+                customGsonBuilder = anyOrNull()
             )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClientTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -137,7 +138,7 @@ class RemoteConfigRestClientTest {
                 eq(false),
                 any(),
                 eq(false),
-                any()
+                customGsonBuilder = anyOrNull()
             )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClientTest.kt
@@ -136,7 +136,8 @@ class RemoteConfigRestClientTest {
                 eq(Map::class.java),
                 eq(false),
                 any(),
-                eq(false)
+                eq(false),
+                any()
             )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
@@ -85,7 +86,8 @@ class PlanOffersRestClientTest {
                         eq(PlanOffersResponse::class.java),
                         eq(false),
                         any(),
-                        eq(true)
+                        eq(true),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/products/ProductsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/products/ProductsRestClientTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
@@ -90,7 +91,8 @@ class ProductsRestClientTest {
                         eq(ProductsResponse::class.java),
                         eq(false),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/reactnative/ReactNativeWPComRestClientTest.kt
@@ -125,7 +125,8 @@ class ReactNativeWPComRestClientTest {
                 url,
                 params,
                 JsonElement::class.java,
-                true)
+                true,
+        )
         ).thenReturn(expectedRestCallResponse)
 
         val actual = subject.getRequest(url, params, successHandler, errorHandler)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
@@ -422,7 +422,8 @@ class ScanRestClientTest {
                         eq(ScanStateResponse::class.java),
                         eq(false),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)
@@ -506,7 +507,8 @@ class ScanRestClientTest {
                         eq(FixThreatsStatusResponse::class.java),
                         eq(false),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         return response

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -666,7 +666,8 @@ class SiteRestClientTest {
                         eq(clazz),
                         any(),
                         any(),
-                        any()
+                        any(),
+                        customGsonBuilder = anyOrNull()
 
                 )
         ).thenReturn(response)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/XPostsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/XPostsRestClientTest.kt
@@ -33,7 +33,7 @@ internal class XPostsRestClientTest {
                         mapOf("decode_html" to "true"),
                         Array<XPostSiteModel>::class.java,
                         true,
-                        60000
+                        60000,
                 )
         )
                 .thenReturn(expected)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -510,7 +511,8 @@ class InsightsRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/MostPopularRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/MostPopularRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -101,7 +102,8 @@ class MostPopularRestClientTest {
                         eq(MostPopularResponse::class.java),
                         eq(true),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PostingActivityRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PostingActivityRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -118,7 +119,8 @@ class PostingActivityRestClientTest {
                         eq(PostingActivityResponse::class.java),
                         eq(true),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -98,7 +99,8 @@ class SummaryRestClientTest {
                 eq(SummaryResponse::class.java),
                 eq(false),
                 any(),
-                eq(false)
+                eq(false),
+                customGsonBuilder = anyOrNull()
             )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/SubscribersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/SubscribersRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -144,7 +145,8 @@ class SubscribersRestClientTest {
                 eq(clazz),
                 eq(cachingEnabled),
                 any(),
-                eq(false)
+                eq(false),
+                customGsonBuilder = anyOrNull()
             )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -172,7 +173,8 @@ class AuthorsRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClientTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -218,7 +219,8 @@ class ClicksRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -168,7 +169,8 @@ class CountryViewsRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/FileDownloadsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/FileDownloadsRestClientTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -172,7 +173,8 @@ class FileDownloadsRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -168,7 +169,8 @@ class PostAndPageViewsRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
@@ -312,7 +312,8 @@ class ReferrersRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -168,7 +169,8 @@ class SearchTermsRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClientTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -172,7 +173,8 @@ class VideoPlaysRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClientTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -162,7 +163,8 @@ class VisitAndViewsRestClientTest {
                         eq(kclass),
                         eq(cachingEnabled),
                         any(),
-                        eq(false)
+                        eq(false),
+                        customGsonBuilder = anyOrNull()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/GsonRequest.java
@@ -33,6 +33,8 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
     private final Map<String, String> mParams;
     private final Map<String, Object> mBody;
 
+    private final GsonBuilder mCustomGsonBuilder;
+
     protected GsonRequest(int method, Map<String, String> params, Map<String, Object> body, String url, Class<T> clazz,
                        Type type, Listener<T> listener, BaseErrorListener errorListener) {
         super(method, url, errorListener);
@@ -46,7 +48,25 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
         mClass = clazz;
         mType = type;
         mListener = listener;
-        mGson = setupGsonBuilder().create();
+        mCustomGsonBuilder = null;
+        mGson = getDefaultGsonBuilder().create();
+        mParams = params;
+        mBody = body;
+    }
+
+    protected GsonRequest(int method, Map<String, String> params, Map<String, Object> body, String url, Class<T> clazz,
+                          Type type, Listener<T> listener, BaseErrorListener errorListener,
+                          GsonBuilder customGsonBuilder) {
+        super(method, url, errorListener);
+        if (method == Method.POST && body == null && (params == null || params.size() == 0)) {
+            body = new HashMap<>();
+        }
+
+        mClass = clazz;
+        mType = type;
+        mListener = listener;
+        mCustomGsonBuilder = customGsonBuilder;
+        mGson = (customGsonBuilder != null ? customGsonBuilder : getDefaultGsonBuilder()).create();
         mParams = params;
         mBody = body;
     }
@@ -101,7 +121,7 @@ public abstract class GsonRequest<T> extends BaseRequest<T> {
         }
     }
 
-    private GsonBuilder setupGsonBuilder() {
+    public static GsonBuilder getDefaultGsonBuilder() {
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.setLenient();
         gsonBuilder.registerTypeHierarchyAdapter(JsonObjectOrFalse.class, new JsonObjectOrFalseDeserializer());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/NumberAwareMapDeserializer.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/NumberAwareMapDeserializer.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.fluxc.network.rest
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import java.lang.reflect.Type
+
+/**
+ * A custom deserializer for JSON objects into Maps that is aware of number types.
+ * This deserializer ensures that numbers are correctly parsed and converted to the appropriate
+ * type (e.g., integer, long, double) based on their value.
+ */
+class NumberAwareMapDeserializer : JsonDeserializer<Map<*, *>> {
+    @Suppress("TooGenericExceptionCaught","NestedBlockDepth")
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Map<*, *> {
+        val map: MutableMap<Any, Any?> = HashMap()
+        try {
+            val jsonObject = json.asJsonObject
+            for ((key, value) in jsonObject.entrySet()) {
+                if (key !is String) {
+                    throw JsonParseException("Invalid key type: ${key::class.java}")
+                }
+                if (value.isJsonPrimitive) {
+                    val primitive = value.asJsonPrimitive
+                    if (primitive.isNumber) {
+                        map[key] = convertNumber(primitive.asNumber)
+                    } else if (primitive.isBoolean) {
+                        map[key] = primitive.asBoolean
+                    } else {
+                        map[key] = primitive.asString
+                    }
+                } else if (value.isJsonObject) {
+                    map[key] = context.deserialize<Map<*, *>>(value, Map::class.java)
+                } else if (value.isJsonArray) {
+                    map[key] = context.deserialize<List<*>>(value, List::class.java)
+                } else {
+                    map[key] = null
+                }
+            }
+        } catch (e: Exception) {
+            throw JsonParseException("Error deserializing JSON to Map", e)
+        }
+        return map
+    }
+
+    private fun convertNumber(numberValue: Number): Number {
+        return when {
+            numberValue is Long && numberValue in Integer.MIN_VALUE..Integer.MAX_VALUE -> numberValue.toInt()
+            numberValue is Double && numberValue.toDouble() % 1 == 0.0 -> numberValue.toLong()
+            else -> numberValue
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequest.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 
 import com.android.volley.Response.Listener;
 import com.android.volley.toolbox.HttpHeaderParser;
+import com.google.gson.GsonBuilder;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -56,7 +57,13 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
     private WPComGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
                              Class<T> clazz, Type type, Listener<T> listener, BaseErrorListener errorListener) {
         super(method, params, body, url, clazz, type, listener, errorListener);
-        // Add the parameters to the URL regardless what the request method is
+        addQueryParameters(params);
+    }
+
+    private WPComGsonRequest(int method, String url, Map<String, String> params, Map<String, Object> body,
+                             Class<T> clazz, Type type, Listener<T> listener, BaseErrorListener errorListener,
+                             GsonBuilder customGsonBuilder) {
+        super(method, params, body, url, clazz, type, listener, errorListener, customGsonBuilder);
         addQueryParameters(params);
     }
 
@@ -78,6 +85,22 @@ public class WPComGsonRequest<T> extends GsonRequest<T> {
                                                           Listener<T> listener, WPComErrorListener errorListener) {
         return new WPComGsonRequest<>(Method.GET, url, params, null, null, type, listener,
                 wrapInBaseListener(errorListener));
+    }
+
+    // Overloaded method to include custom GsonBuilder
+    public static <T> WPComGsonRequest<T> buildGetRequest(String url, Map<String, String> params, Class<T> clazz,
+                                                          Listener<T> listener, WPComErrorListener errorListener,
+                                                          GsonBuilder customGsonBuilder) {
+        return new WPComGsonRequest<>(Method.GET, url, params, null, clazz, null, listener,
+                wrapInBaseListener(errorListener), customGsonBuilder);
+    }
+
+    // Overloaded method to include custom GsonBuilder
+    public static <T> WPComGsonRequest<T> buildGetRequest(String url, Map<String, String> params, Type type,
+                                                          Listener<T> listener, WPComErrorListener errorListener,
+                                                          GsonBuilder customGsonBuilder) {
+        return new WPComGsonRequest<>(Method.GET, url, params, null, null, type, listener,
+                wrapInBaseListener(errorListener), customGsonBuilder);
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom
 
 import com.android.volley.RetryPolicy
+import com.google.gson.GsonBuilder
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
@@ -27,9 +28,10 @@ class WPComGsonRequestBuilder
         params: Map<String, String>,
         clazz: Class<T>,
         listener: (T) -> Unit,
-        errorListener: (WPComGsonNetworkError) -> Unit
+        errorListener: (WPComGsonNetworkError) -> Unit,
+        customGsonBuilder: GsonBuilder? = null
     ): WPComGsonRequest<T> {
-        return WPComGsonRequest.buildGetRequest(url, params, clazz, listener, errorListener)
+        return WPComGsonRequest.buildGetRequest(url, params, clazz, listener, errorListener, customGsonBuilder)
     }
 
     /**
@@ -46,13 +48,14 @@ class WPComGsonRequestBuilder
         clazz: Class<T>,
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        forced: Boolean = false
+        forced: Boolean = false,
+        customGsonBuilder: GsonBuilder? = null
     ) = suspendCancellableCoroutine<Response<T>> { cont ->
         val request = WPComGsonRequest.buildGetRequest(url, params, clazz, {
             cont.resume(Success(it))
         }, {
             cont.resume(Error(it))
-        })
+        }, customGsonBuilder)
         cont.invokeOnCancellation { request.cancel() }
         if (enableCaching) {
             request.enableCaching(cacheTimeToLive)
@@ -76,9 +79,10 @@ class WPComGsonRequestBuilder
         params: Map<String, String>,
         type: Type,
         listener: (T) -> Unit,
-        errorListener: (WPComGsonNetworkError) -> Unit
+        errorListener: (WPComGsonNetworkError) -> Unit,
+        customGsonBuilder: GsonBuilder? = null
     ): WPComGsonRequest<T> {
-        return WPComGsonRequest.buildGetRequest(url, params, type, listener, errorListener)
+        return WPComGsonRequest.buildGetRequest(url, params, type, listener, errorListener, customGsonBuilder)
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClient.kt
@@ -45,7 +45,7 @@ class RemoteConfigRestClient @Inject constructor(
             Map::class.java,
             customGsonBuilder = customGsonBuilder
         )
-        Log.d("myTest", "fetchRemoteConfig(): response = $response")
+
         return when (response) {
             is Response.Success -> buildRemoteConfigFetchedPayload(response.data)
             is Response.Error -> RemoteConfigFetchedPayload(response.error.toRemoteConfigError())
@@ -54,9 +54,6 @@ class RemoteConfigRestClient @Inject constructor(
 
     private fun buildRemoteConfigFetchedPayload(featureFlags: Map<*, *>?)
         : RemoteConfigFetchedPayload {
-        featureFlags?.forEach {
-            Log.d("myTest", "buildRemoteConfigFetchedPayload(): key: " + it.key + " value: " + it.value )
-        }
         return RemoteConfigFetchedPayload(featureFlags?.map { e ->
                 e.key.toString() to e.value.toString()
         }?.toMap())

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClient.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.mobile
 
 import android.content.Context
-import android.util.Log
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/NumberAwareMapDeserializerTest.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/NumberAwareMapDeserializerTest.kt
@@ -1,0 +1,78 @@
+package org.wordpress.android.fluxc.network.rest
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParseException
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NumberAwareMapDeserializerTest {
+
+    private val gson: Gson = GsonBuilder()
+        .registerTypeAdapter(Map::class.java, NumberAwareMapDeserializer())
+        .create()
+
+    @Test
+    fun testDeserializeSimpleMap() {
+        val json = """{"key1": "value1", "key2": 2, "key3": true}"""
+        val result: Map<*, *> = gson.fromJson(json, Map::class.java)
+
+        assertEquals("value1", result["key1"])
+        assertEquals(2, result["key2"])
+        assertEquals(true, result["key3"])
+    }
+
+    @Test
+    fun testDeserializeNestedMap() {
+        val json = """{"key1": {"nestedKey1": "nestedValue1", "nestedKey2": 5}}"""
+        val result: Map<*, *> = gson.fromJson(json, Map::class.java)
+
+        val nestedMap = result["key1"] as Map<*, *>
+        assertEquals("nestedValue1", nestedMap["nestedKey1"])
+        assertEquals(5, nestedMap["nestedKey2"])
+    }
+
+    @Test
+    fun testDeserializeArray() {
+        val json = """{"key1": [1, 2, 3], "key2": ["a", "b", "c"]}"""
+        val result: Map<*, *> = gson.fromJson(json, Map::class.java)
+
+        val array1 = result["key1"] as List<*>
+        val array2 = result["key2"] as List<*>
+        assertArrayEquals(arrayOf(1, 2, 3), array1.toTypedArray())
+        assertArrayEquals(arrayOf("a", "b", "c"), array2.toTypedArray())
+    }
+
+    @Test
+    fun testDeserializeNumbers() {
+        val json = """{"intKey": 2147483647, "longKey": 2147483648, "doubleKey": 1.5, "wholeDoubleKey": 3.0}"""
+        val result: Map<*, *> = gson.fromJson(json, Map::class.java)
+
+        assertEquals(2147483647, result["intKey"])
+        assertEquals(2147483648L, result["longKey"])
+        assertEquals(1.5, result["doubleKey"])
+        assertEquals(3L, result["wholeDoubleKey"])
+    }
+
+    @Test(expected = JsonParseException::class)
+    fun testInvalidKeyType() {
+        val json = """{"key1": "value1", "key2": 2, "key3"}""" // Malformed JSON
+        gson.fromJson(json, Map::class.java)
+    }
+
+    @Test(expected = JsonParseException::class)
+    fun testInvalidJson() {
+        val json = """{"key1": "value1", "key2":}""" // Malformed JSON
+        gson.fromJson(json, Map::class.java)
+    }
+
+    @Test
+    fun testNullValue() {
+        val json = """{"key1": null}"""
+        val result: Map<*, *> = gson.fromJson(json, Map::class.java)
+
+        assertNull(result["key1"])
+    }
+}

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/NumberAwareMapDeserializerTest.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/NumberAwareMapDeserializerTest.kt
@@ -9,7 +9,6 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 class NumberAwareMapDeserializerTest {
-
     private val gson: Gson = GsonBuilder()
         .registerTypeAdapter(Map::class.java, NumberAwareMapDeserializer())
         .create()


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/issues/20857

Please read the above issue's description for context.

It seems that the issue we’re experiencing, where integer fields are being converted to doubles, is due to the deserialization process within the Gson library. Gson has a tendency to treat all numbers as doubles when deserializing generic Map objects, which is what we are seeing.

A new custom NumberAwareMapDeserializer was created which ensures that numbers are correctly parsed and converted to the appropriate type (e.g., integer, long, double) based on their value.

A minor refactoring was needed so this is used only for remote config calls. 

Testing steps: Use this [WordPress PR](https://github.com/wordpress-mobile/WordPress-Android/pull/20868). 