### PR TITLE
Keep image url authorisation headers when redirecting

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/OkHttpClientModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/OkHttpClientModule.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.fluxc.module;
 
 import org.wordpress.android.fluxc.network.BaseRequest;
+import org.wordpress.android.fluxc.network.CustomRedirectInterceptor;
 import org.wordpress.android.fluxc.network.MemorizingTrustManager;
-import org.wordpress.android.fluxc.utils.WPUrlUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -22,11 +22,8 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.Multibinds;
 import okhttp3.CookieJar;
-import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
 import okhttp3.internal.tls.OkHostnameVerifier;
 
 @Module
@@ -55,28 +52,8 @@ public abstract class OkHttpClientModule {
     public static OkHttpClient provideCustomRedirectsOkHttpClientBuilder(
             @Named("custom-ssl") final OkHttpClient okHttpRegularClient) {
         OkHttpClient.Builder builder = okHttpRegularClient.newBuilder().followRedirects(false);
-        builder.addInterceptor(chain -> {
-            Request originalRequest = chain.request();
-            Response response = chain.proceed(originalRequest);
-            if (response.isRedirect()) {
-                String location = response.header("Location");
-                if (location != null && !location.isEmpty()) {
-                    Request.Builder newBuilder = originalRequest.newBuilder().url(location);
-
-                    // Remove the authorization header if the hosts' TLD and SLD are not the same
-                    String originalHost = originalRequest.url().host();
-                    HttpUrl redirectHttpUrl = HttpUrl.parse(location);
-                    String redirectHost = (redirectHttpUrl != null) ? redirectHttpUrl.host() : "";
-                    if (!WPUrlUtils.tldAndSldAreEqual(originalHost, redirectHost)) {
-                        newBuilder.removeHeader("Authorization");
-                    }
-
-                    Request newRequest = newBuilder.build();
-                    return chain.proceed(newRequest);
-                }
-            }
-            return response;
-        });
+        CustomRedirectInterceptor customRedirectInterceptor = new CustomRedirectInterceptor();
+        builder.addInterceptor(customRedirectInterceptor);
         return builder.build();
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -82,8 +82,9 @@ public class ReleaseNetworkModule {
     @Singleton
     @Named("custom-ssl-custom-redirects")
     @Provides
-    public RequestQueue provideRequestQueueCustomSSLWithRedirects(@Named("custom-ssl-custom-redirects") OkHttpClient okHttpClient,
-                                                                  Context appContext) {
+    public RequestQueue provideRequestQueueCustomSSLWithRedirects(
+            @Named("custom-ssl-custom-redirects") OkHttpClient okHttpClient,
+            Context appContext) {
         return newRequestQueue(okHttpClient, appContext);
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/ReleaseNetworkModule.java
@@ -80,6 +80,14 @@ public class ReleaseNetworkModule {
     }
 
     @Singleton
+    @Named("custom-ssl-custom-redirects")
+    @Provides
+    public RequestQueue provideRequestQueueCustomSSLWithRedirects(@Named("custom-ssl-custom-redirects") OkHttpClient okHttpClient,
+                                                                  Context appContext) {
+        return newRequestQueue(okHttpClient, appContext);
+    }
+
+    @Singleton
     @Named("no-cookies")
     @Provides
     public RequestQueue provideRequestQueueNoCookies(@Named("no-cookies") OkHttpClient okHttpClient,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptor.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptor.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.fluxc.network
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Request
+import okhttp3.Response
+
+class CustomRedirectInterceptor : Interceptor {
+    override fun intercept(chain: Chain): Response {
+        val originalRequest = chain.request()
+        val response = chain.proceed(originalRequest)
+        if (response.isRedirect) {
+            val newRequest = getRedirectRequest(originalRequest, response)
+            if (newRequest != null) {
+                return chain.proceed(newRequest)
+            }
+        }
+        return response
+    }
+
+    fun getRedirectRequest(originalRequest: Request, redirectResponse: Response): Request? {
+        val location = redirectResponse.header("Location")
+        if (!location.isNullOrEmpty()) {
+            val newBuilder: Request.Builder = originalRequest.newBuilder().url(location)
+
+            // Remove the authorization header if the hosts' TLD and SLD are not the same
+            val originalHost = originalRequest.url.host
+            val redirectHttpUrl = location.toHttpUrlOrNull()
+            val redirectHost = redirectHttpUrl?.host ?: ""
+            if (!tldAndSldAreEqual(originalHost, redirectHost)) {
+                newBuilder.removeHeader("Authorization")
+            }
+
+            return newBuilder.build()
+        }
+        return null
+    }
+
+    private fun tldAndSldAreEqual(domain1: String, domain2: String): Boolean {
+        val parts1 = domain1.split("\\.".toRegex())
+        val parts2 = domain2.split("\\.".toRegex())
+        return if (parts1.size < 2 || parts2.size < 2) {
+            false
+        } else {
+            parts1[parts1.size - 1] == parts2[parts2.size - 1]
+                && parts1[parts1.size - 2] == parts2[parts2.size - 2]
+        }
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.utils;
 
+import androidx.annotation.NonNull;
+
 import com.android.volley.VolleyError;
 
 import org.json.JSONException;
@@ -43,6 +45,16 @@ public class WPUrlUtils {
             return false;
         }
         return uri.getHost().endsWith(".wordpress.com") || uri.getHost().equals("wordpress.com");
+    }
+
+    public static boolean tldAndSldAreEqual(@NonNull String domain1, @NonNull String domain2) {
+        String[] parts1 = domain1.split("\\.");
+        String[] parts2 = domain2.split("\\.");
+        if (parts1.length < 2 || parts2.length < 2) {
+            return false;
+        }
+        return parts1[parts1.length - 1].equals(parts2[parts2.length - 1])
+               && parts1[parts1.length - 2].equals(parts2[parts2.length - 2]);
     }
 
     public static boolean isGravatar(URL url) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/utils/WPUrlUtils.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.utils;
 
-import androidx.annotation.NonNull;
-
 import com.android.volley.VolleyError;
 
 import org.json.JSONException;
@@ -45,16 +43,6 @@ public class WPUrlUtils {
             return false;
         }
         return uri.getHost().endsWith(".wordpress.com") || uri.getHost().equals("wordpress.com");
-    }
-
-    public static boolean tldAndSldAreEqual(@NonNull String domain1, @NonNull String domain2) {
-        String[] parts1 = domain1.split("\\.");
-        String[] parts2 = domain2.split("\\.");
-        if (parts1.length < 2 || parts2.length < 2) {
-            return false;
-        }
-        return parts1[parts1.length - 1].equals(parts2[parts2.length - 1])
-               && parts1[parts1.length - 2].equals(parts2[parts2.length - 2]);
     }
 
     public static boolean isGravatar(URL url) {

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptorTest.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptorTest.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.fluxc.network
+
+import okhttp3.*
+import okhttp3.Response
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CustomRedirectInterceptorTest {
+    private val interceptor = CustomRedirectInterceptor()
+
+    @Test
+    fun `interceptor removes Authorization header when TLD and SLD are not the same`() {
+        val originalRequest = Request.Builder()
+            .url("https://original.com")
+            .header("Authorization", "Bearer token")
+            .build()
+        val redirectResponse = Response.Builder()
+            .request(originalRequest)
+            .protocol(Protocol.HTTP_1_1)
+            .code(302)
+            .message("Redirect")
+            .header("Location", "https://redirect.com")
+            .build()
+
+        val redirectRequest = interceptor.getRedirectRequest(originalRequest, redirectResponse)
+
+        assertNull(redirectRequest?.headers("Authorization")?.firstOrNull())
+    }
+
+    @Test
+    fun `interceptor keeps Authorization header when TLD and SLD are the same`() {
+        val originalRequest = Request.Builder()
+            .url("https://original.com")
+            .header("Authorization", "Bearer token")
+            .build()
+        val redirectResponse = Response.Builder()
+            .request(originalRequest)
+            .protocol(Protocol.HTTP_1_1)
+            .code(302)
+            .message("Redirect")
+            .header("Location", "https://original.com")
+            .build()
+
+        val redirectRequest = interceptor.getRedirectRequest(originalRequest, redirectResponse)
+
+        assertEquals(redirectRequest?.headers("Authorization")?.firstOrNull(), "Bearer token")
+    }
+}


### PR DESCRIPTION
## Description
This PR adds a custom `OkHttpClient` intercepting the redirects and keeping the Authorisation headers when the TLD and SLD of the original url and the redirect url are the same. This was needed since a new image resource redirection was failing on wordpress.com for private sites because of an [okhttp limitation](https://github.com/square/okhttp/issues/2937).

## To test
See https://github.com/wordpress-mobile/WordPress-Android/pull/20876