### PR TITLE
Issue/11558 new stock report endpoint

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -13,6 +13,8 @@
         </value>
       </option>
       <option name="IMPORT_NESTED_CLASSES" value="true" />
+      <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
+      <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="72" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -13,8 +13,6 @@
         </value>
       </option>
       <option name="IMPORT_NESTED_CLASSES" value="true" />
-      <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
-      <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="72" />
@@ -167,12 +165,6 @@
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-      <option name="CALL_PARAMETERS_WRAP" value="5" />
-      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_WRAP" value="5" />
-      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
       <option name="EXTENDS_LIST_WRAP" value="5" />
       <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
       <option name="METHOD_ANNOTATION_WRAP" value="1" />

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -4,38 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.fragment_woo_products.add_new_product
-import kotlinx.android.synthetic.main.fragment_woo_products.add_product_category
-import kotlinx.android.synthetic.main.fragment_woo_products.add_product_tags
-import kotlinx.android.synthetic.main.fragment_woo_products.batch_generate_variations
-import kotlinx.android.synthetic.main.fragment_woo_products.batch_update_variations
-import kotlinx.android.synthetic.main.fragment_woo_products.delete_product
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_all_reviews
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_categories
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_shipping_class
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_shipping_classes
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_sku_availability
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_tags
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_product_variations
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_products
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_products_with_filters
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_review_by_id
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_reviews_for_product
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_single_product
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_single_variation
-import kotlinx.android.synthetic.main.fragment_woo_products.fetch_specific_products
-import kotlinx.android.synthetic.main.fragment_woo_products.load_more_product_categories
-import kotlinx.android.synthetic.main.fragment_woo_products.load_more_product_shipping_classes
-import kotlinx.android.synthetic.main.fragment_woo_products.load_more_product_tags
-import kotlinx.android.synthetic.main.fragment_woo_products.load_more_product_variations
-import kotlinx.android.synthetic.main.fragment_woo_products.observe_product_categories
-import kotlinx.android.synthetic.main.fragment_woo_products.search_products
-import kotlinx.android.synthetic.main.fragment_woo_products.search_products_sku
-import kotlinx.android.synthetic.main.fragment_woo_products.test_add_ons
-import kotlinx.android.synthetic.main.fragment_woo_products.update_product
-import kotlinx.android.synthetic.main.fragment_woo_products.update_product_images
-import kotlinx.android.synthetic.main.fragment_woo_products.update_review_status
-import kotlinx.android.synthetic.main.fragment_woo_products.update_variation
+import kotlinx.android.synthetic.main.fragment_woo_products.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -59,8 +28,10 @@ import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductImageModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.WCAddonsStore
+import org.wordpress.android.fluxc.store.WCProductStockReportStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.DeleteProductPayload
@@ -93,6 +64,7 @@ class WooProductsFragment : StoreSelectingFragment() {
     @Inject lateinit var addonsStore: WCAddonsStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
     @Inject internal lateinit var mediaStore: MediaStore
+    @Inject internal lateinit var productStockReportStore: WCProductStockReportStore
 
     private var pendingFetchSingleProductShippingClassRemoteId: Long? = null
 
@@ -108,7 +80,11 @@ class WooProductsFragment : StoreSelectingFragment() {
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
         inflater.inflate(layout.fragment_woo_products, container, false)
 
     @Suppress("LongMethod", "ComplexMethod")
@@ -117,7 +93,10 @@ class WooProductsFragment : StoreSelectingFragment() {
 
         fetch_single_product.setOnClickListener {
             selectedSite?.let { site ->
-                showSingleLineDialog(activity, "Enter the remoteProductId of product to fetch:") { editText ->
+                showSingleLineDialog(
+                    activity,
+                    "Enter the remoteProductId of product to fetch:"
+                ) { editText ->
                     editText.text.toString().toLongOrNull()?.let { remoteProductId ->
                         prependToLog("Submitting request to fetch product by remoteProductID $remoteProductId")
                         coroutineScope.launch {
@@ -128,7 +107,8 @@ class WooProductsFragment : StoreSelectingFragment() {
                                 )
                             )
 
-                            val product = wcProductStore.getProductByRemoteId(site, result.remoteProductId)
+                            val product =
+                                wcProductStore.getProductByRemoteId(site, result.remoteProductId)
                             product?.let {
                                 val numVariations = it.getVariationIdList().size
                                 if (numVariations > 0) {
@@ -136,7 +116,8 @@ class WooProductsFragment : StoreSelectingFragment() {
                                 } else {
                                     prependToLog("Single product fetched! ${it.name}")
                                 }
-                            } ?: prependToLog("WARNING: Fetched product not found in the local database!")
+                            }
+                                ?: prependToLog("WARNING: Fetched product not found in the local database!")
                         }
                     } ?: prependToLog("No valid remoteOrderId defined...doing nothing")
                 }
@@ -159,12 +140,16 @@ class WooProductsFragment : StoreSelectingFragment() {
                                 coroutineScope.launch {
                                     prependToLog(
                                         "Submitting request to fetch product by " +
-                                                "remoteProductId $productRemoteId, " +
-                                                "remoteVariationProductID $variationId"
+                                            "remoteProductId $productRemoteId, " +
+                                            "remoteVariationProductID $variationId"
                                     )
-                                    val result = wcProductStore.fetchSingleVariation(site, productId, variationId)
+                                    val result = wcProductStore.fetchSingleVariation(
+                                        site,
+                                        productId,
+                                        variationId
+                                    )
                                     prependToLog("Fetching single variation " +
-                                            "${result.error?.let { "failed" } ?: "was successful"}"
+                                        "${result.error?.let { "failed" } ?: "was successful"}"
                                     )
                                     val variation = wcProductStore.getVariationByRemoteId(
                                         site,
@@ -173,7 +158,8 @@ class WooProductsFragment : StoreSelectingFragment() {
                                     )
                                     variation?.let {
                                         prependToLog("Variation with id! ${it.remoteVariationId} found in local db")
-                                    } ?: prependToLog("WARNING: Fetched product not found in the local database!")
+                                    }
+                                        ?: prependToLog("WARNING: Fetched product not found in the local database!")
                                 }
                             } ?: prependToLog("No valid remoteVariationId defined...doing nothing")
                         }
@@ -189,7 +175,11 @@ class WooProductsFragment : StoreSelectingFragment() {
                     "Enter a product SKU:"
                 ) { editText ->
                     val payload = FetchProductSkuAvailabilityPayload(site, editText.text.toString())
-                    dispatcher.dispatch(WCProductActionBuilder.newFetchProductSkuAvailabilityAction(payload))
+                    dispatcher.dispatch(
+                        WCProductActionBuilder.newFetchProductSkuAvailabilityAction(
+                            payload
+                        )
+                    )
                 }
             }
         }
@@ -207,7 +197,10 @@ class WooProductsFragment : StoreSelectingFragment() {
 
         fetch_specific_products.setOnClickListener {
             selectedSite?.let { site ->
-                showSingleLineDialog(activity, "Enter remote product IDs, separated by comma:") { editText ->
+                showSingleLineDialog(
+                    activity,
+                    "Enter remote product IDs, separated by comma:"
+                ) { editText ->
                     val ids = editText.text.toString().replace(" ", "").split(",").mapNotNull {
                         val id = it.toLongOrNull()
                         if (id == null) {
@@ -278,10 +271,15 @@ class WooProductsFragment : StoreSelectingFragment() {
                         coroutineScope.launch {
                             pendingFetchProductVariationsProductRemoteId = id
                             prependToLog("Submitting request to fetch product variations by remoteProductID $id")
-                            val result = wcProductStore.fetchProductVariations(FetchProductVariationsPayload(site, id))
+                            val result = wcProductStore.fetchProductVariations(
+                                FetchProductVariationsPayload(
+                                    site,
+                                    id
+                                )
+                            )
                             prependToLog(
                                 "Fetched ${result.rowsAffected} product variants. " +
-                                        "More variants available ${result.canLoadMore}"
+                                    "More variants available ${result.canLoadMore}"
                             )
                             if (result.canLoadMore) {
                                 pendingFetchSingleProductVariationOffset += result.rowsAffected
@@ -308,7 +306,7 @@ class WooProductsFragment : StoreSelectingFragment() {
                         val result = wcProductStore.fetchProductVariations(payload)
                         prependToLog(
                             "Fetched ${result.rowsAffected} product variants. " +
-                                    "More variants available ${result.canLoadMore}"
+                                "More variants available ${result.canLoadMore}"
                         )
                         if (result.canLoadMore) {
                             pendingFetchSingleProductVariationOffset += result.rowsAffected
@@ -414,7 +412,7 @@ class WooProductsFragment : StoreSelectingFragment() {
                     } else {
                         prependToLog(
                             "Product Review status update failed, " +
-                                    "${result.error.type} ${result.error.message}"
+                                "${result.error.type} ${result.error.message}"
                         )
                     }
                 }
@@ -427,11 +425,16 @@ class WooProductsFragment : StoreSelectingFragment() {
                     activity,
                     "Enter the remoteShippingClassId of the site to fetch:"
                 ) { editText ->
-                    pendingFetchSingleProductShippingClassRemoteId = editText.text.toString().toLongOrNull()
+                    pendingFetchSingleProductShippingClassRemoteId =
+                        editText.text.toString().toLongOrNull()
                     pendingFetchSingleProductShippingClassRemoteId?.let { id ->
                         prependToLog("Submitting request to fetch product shipping class for ID $id")
                         val payload = FetchSingleProductShippingClassPayload(site, id)
-                        dispatcher.dispatch(WCProductActionBuilder.newFetchSingleProductShippingClassAction(payload))
+                        dispatcher.dispatch(
+                            WCProductActionBuilder.newFetchSingleProductShippingClassAction(
+                                payload
+                            )
+                        )
                     } ?: prependToLog("No valid remoteShippingClassId defined...doing nothing")
                 }
             }
@@ -441,7 +444,11 @@ class WooProductsFragment : StoreSelectingFragment() {
             selectedSite?.let { site ->
                 prependToLog("Submitting request to fetch product shipping classes for site ${site.id}")
                 val payload = FetchProductShippingClassListPayload(site)
-                dispatcher.dispatch(WCProductActionBuilder.newFetchProductShippingClassListAction(payload))
+                dispatcher.dispatch(
+                    WCProductActionBuilder.newFetchProductShippingClassListAction(
+                        payload
+                    )
+                )
             }
         }
 
@@ -451,7 +458,11 @@ class WooProductsFragment : StoreSelectingFragment() {
                 val payload = FetchProductShippingClassListPayload(
                     site, offset = pendingFetchProductShippingClassListOffset
                 )
-                dispatcher.dispatch(WCProductActionBuilder.newFetchProductShippingClassListAction(payload))
+                dispatcher.dispatch(
+                    WCProductActionBuilder.newFetchProductShippingClassListAction(
+                        payload
+                    )
+                )
             }
         }
 
@@ -543,7 +554,11 @@ class WooProductsFragment : StoreSelectingFragment() {
                             enteredTagNames.add(tagName2)
                             prependToLog("Submitting request to add product tags for site ${site.id}")
                             val payload = AddProductTagsPayload(site, enteredTagNames)
-                            dispatcher.dispatch(WCProductActionBuilder.newAddProductTagsAction(payload))
+                            dispatcher.dispatch(
+                                WCProductActionBuilder.newAddProductTagsAction(
+                                    payload
+                                )
+                            )
                         } else {
                             prependToLog("Tag name is empty. Doing nothing..")
                         }
@@ -585,7 +600,12 @@ class WooProductsFragment : StoreSelectingFragment() {
         }
 
         add_new_product.setOnClickListener {
-            replaceFragment(WooUpdateProductFragment.newInstance(selectedPos, isAddNewProduct = true))
+            replaceFragment(
+                WooUpdateProductFragment.newInstance(
+                    selectedPos,
+                    isAddNewProduct = true
+                )
+            )
         }
 
         delete_product.setOnClickListener {
@@ -608,6 +628,30 @@ class WooProductsFragment : StoreSelectingFragment() {
 
         batch_generate_variations.setOnClickListener {
             replaceFragment(WooBatchGenerateVariationsFragment.newInstance(selectedPos))
+        }
+
+        fetch_product_stock_report.setOnClickListener {
+            selectedSite?.let { site ->
+                prependToLog(
+                    "Submitting request to fetch product stock for stock status:" +
+                        " ${CoreProductStockStatus.IN_STOCK}"
+                )
+                coroutineScope.launch {
+                    val result = productStockReportStore.fetchProductStockReport(
+                        site,
+                        CoreProductStockStatus.IN_STOCK
+                    )
+                    if (result.isError) {
+                        prependToLog("Fetching product stock failed: ${result.error.message}")
+                    } else {
+                        val productStockItems = result.model!!
+                        prependToLog("Fetched ${productStockItems.size} product stock items")
+                        productStockItems.forEach {
+                            prependToLog("${it.name} has ${it.stockQuantity} in stock")
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -705,7 +749,7 @@ class WooProductsFragment : StoreSelectingFragment() {
                 FETCH_PRODUCT_CATEGORIES -> {
                     prependToLog(
                         "Fetched ${event.rowsAffected} product categories. " +
-                                "More categories available ${event.canLoadMore}"
+                            "More categories available ${event.canLoadMore}"
                     )
 
                     if (event.canLoadMore) {
@@ -759,7 +803,7 @@ class WooProductsFragment : StoreSelectingFragment() {
     private fun checkProductShippingClassesAndLoadMore(event: OnProductShippingClassesChanged) {
         prependToLog(
             "Fetched ${event.rowsAffected} product shipping classes. " +
-                    "More shipping classes available ${event.canLoadMore}"
+                "More shipping classes available ${event.canLoadMore}"
         )
 
         if (event.canLoadMore) {

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -634,12 +634,12 @@ class WooProductsFragment : StoreSelectingFragment() {
             selectedSite?.let { site ->
                 prependToLog(
                     "Submitting request to fetch product stock for stock status:" +
-                        " ${CoreProductStockStatus.IN_STOCK}"
+                        " ${CoreProductStockStatus.LOW_STOCK}"
                 )
                 coroutineScope.launch {
                     val result = productStockReportStore.fetchProductStockReport(
                         site,
-                        CoreProductStockStatus.IN_STOCK
+                        CoreProductStockStatus.LOW_STOCK
                     )
                     if (result.isError) {
                         prependToLog("Fetching product stock failed: ${result.error.message}")

--- a/example/src/main/res/layout/fragment_woo_products.xml
+++ b/example/src/main/res/layout/fragment_woo_products.xml
@@ -1,11 +1,10 @@
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_margin="@dimen/activity_start_end_margin"
-    tools:ignore="HardcodedText"
-    tools:context="org.wordpress.android.fluxc.example.ui.products.WooProductsFragment">
+    tools:context="org.wordpress.android.fluxc.example.ui.products.WooProductsFragment"
+    tools:ignore="HardcodedText">
 
     <LinearLayout
         android:id="@+id/buttonContainer"
@@ -18,91 +17,91 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Single Product"/>
+            android:text="Fetch Single Product" />
 
         <Button
             android:id="@+id/fetch_product_sku_availability"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch SKU Availability"/>
+            android:text="Fetch SKU Availability" />
 
         <Button
             android:id="@+id/fetch_products"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Products"/>
+            android:text="Fetch Products" />
 
         <Button
             android:id="@+id/fetch_products_with_filters"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Products with Filters"/>
+            android:text="Fetch Products with Filters" />
 
         <Button
             android:id="@+id/search_products"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Search Products"/>
+            android:text="Search Products" />
 
         <Button
             android:id="@+id/search_products_sku"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Search Products by SKU"/>
+            android:text="Search Products by SKU" />
 
         <Button
             android:id="@+id/fetch_specific_products"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch specific products"/>
+            android:text="Fetch specific products" />
 
         <Button
             android:id="@+id/fetch_product_variations"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Product Variations"/>
+            android:text="Fetch Product Variations" />
 
         <Button
             android:id="@+id/fetch_single_variation"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Single Variation"/>
+            android:text="Fetch Single Variation" />
 
         <Button
             android:id="@+id/load_more_product_variations"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:text="Load More Variations" />
+            android:text="Load More Variations"
+            android:visibility="gone" />
 
         <Button
             android:id="@+id/fetch_reviews_for_product"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Product Reviews For Product"/>
+            android:text="Fetch Product Reviews For Product" />
 
         <Button
             android:id="@+id/fetch_all_reviews"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Product Reviews For Site"/>
+            android:text="Fetch Product Reviews For Site" />
 
         <Button
             android:id="@+id/fetch_review_by_id"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Product Review by ID"/>
+            android:text="Fetch Product Review by ID" />
 
         <Button
             android:id="@+id/update_review_status"
@@ -116,42 +115,42 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Product Shipping class by ID"/>
+            android:text="Fetch Product Shipping class by ID" />
 
         <Button
             android:id="@+id/fetch_product_shipping_classes"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Product Shipping classes"/>
+            android:text="Fetch Product Shipping classes" />
 
         <Button
             android:id="@+id/load_more_product_shipping_classes"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:text="Load More Shipping classes" />
+            android:text="Load More Shipping classes"
+            android:visibility="gone" />
 
         <Button
             android:id="@+id/fetch_product_categories"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Product Categories"/>
+            android:text="Fetch Product Categories" />
 
         <Button
             android:id="@+id/observe_product_categories"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Observe Product Categories"/>
+            android:text="Observe Product Categories" />
 
         <Button
             android:id="@+id/load_more_product_categories"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:text="Load More Product Categories" />
+            android:text="Load More Product Categories"
+            android:visibility="gone" />
 
         <Button
             android:id="@+id/add_product_category"
@@ -165,21 +164,21 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Update Product Images"/>
+            android:text="Update Product Images" />
 
         <Button
             android:id="@+id/fetch_product_tags"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Fetch Product Tags"/>
+            android:text="Fetch Product Tags" />
 
         <Button
             android:id="@+id/load_more_product_tags"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:text="Load More Product Tags" />
+            android:text="Load More Product Tags"
+            android:visibility="gone" />
 
         <Button
             android:id="@+id/add_product_tags"
@@ -200,41 +199,48 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Update Product"/>
+            android:text="Update Product" />
 
         <Button
             android:id="@+id/update_variation"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Update Variation"/>
+            android:text="Update Variation" />
 
         <Button
             android:id="@+id/add_new_product"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Add new product"/>
+            android:text="Add new product" />
 
         <Button
             android:id="@+id/delete_product"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Delete product"/>
+            android:text="Delete product" />
 
         <Button
             android:id="@+id/batch_update_variations"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Batch update variations"/>
+            android:text="Batch update variations" />
 
         <Button
             android:id="@+id/batch_generate_variations"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:enabled="false"
-            android:text="Batch generate variations"/>
+            android:text="Batch generate variations" />
+
+        <Button
+            android:id="@+id/fetch_product_stock_report"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Fetch product stock report" />
     </LinearLayout>
 </ScrollView>

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -49,6 +49,8 @@
 
 /reports/giftcards/used/stats/
 
+/reports/stock/
+
 /settings/general/
 /settings/products/
 /settings/<group_id>#String/<id>#String

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
@@ -5,6 +5,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
  */
 enum class CoreProductStockStatus(val value: String) {
     IN_STOCK("instock"),
+    LOW_STOCK("lowstock"),
     OUT_OF_STOCK("outofstock"),
     ON_BACK_ORDER("onbackorder");
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
@@ -36,7 +36,7 @@ data class ProductStockItemApiResponse(
     @SerializedName("id")
     val productId: Long? = null,
     @SerializedName("parent_id")
-    val parentId: Int? = null, //When the product is a variation, this is the parent product ID
+    val parentId: Int? = null, // When the product is a variation, this is the parent product ID
     @SerializedName("name")
     val name: String? = null,
     @SerializedName("stock_status")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
@@ -41,6 +41,8 @@ data class ProductStockItemApiResponse(
     val name: String? = null,
     @SerializedName("stock_status")
     val stockStatus: String? = null,
+    @SerializedName("stock_quantity")
+    val stockQuantity: Int? = null,
     @SerializedName("low_stock_amount")
     val lowStockAmount: Int? = null
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
@@ -24,10 +24,23 @@ data class ReportProductItem(
     companion object {
         private val SRC_REGEX = Regex("src=\"(.*?)\"")
     }
-        val imageUrl: String?
+
+    val imageUrl: String?
         get() = imageHTML
             ?.let { SRC_REGEX.find(it)?.value }
             ?.replace("src=", "")
             ?.replace("\"", "")
 }
 
+data class ProductStockItemApiResponse(
+    @SerializedName("id")
+    val productId: Long? = null,
+    @SerializedName("parent_id")
+    val parentId: Int? = null, //When the product is a variation, this is the parent product ID
+    @SerializedName("name")
+    val name: String? = null,
+    @SerializedName("stock_status")
+    val stockStatus: String? = null,
+    @SerializedName("low_stock_amount")
+    val lowStockAmount: Int? = null
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
@@ -14,6 +14,19 @@ class ReportsRestClient @Inject constructor(private val wooNetwork: WooNetwork) 
         endDate: String,
         quantity: Int = 5
     ): WooPayload<Array<ReportsProductApiResponse>> {
+        fun createParameters(
+            startDate: String,
+            endDate: String,
+            quantity: Int
+        ) = mapOf(
+            "before" to endDate,
+            "after" to startDate,
+            "per_page" to quantity.toString(),
+            "extended_info" to "true",
+            "orderby" to "items_sold",
+            "order" to "desc"
+        ).filter { it.value.isNotEmpty() }
+
         val url = WOOCOMMERCE.reports.products.pathV4Analytics
         val parameters = createParameters(startDate, endDate, quantity)
 
@@ -27,16 +40,27 @@ class ReportsRestClient @Inject constructor(private val wooNetwork: WooNetwork) 
         return response.toWooPayload()
     }
 
-    private fun createParameters(
-        startDate: String,
-        endDate: String,
-        quantity: Int
-    ) = mapOf(
-        "before" to endDate,
-        "after" to startDate,
-        "per_page" to quantity.toString(),
-        "extended_info" to "true",
-        "orderby" to "items_sold",
-        "order" to "desc"
-    ).filter { it.value.isNotEmpty() }
+    suspend fun fetchProductStockReport(
+        site: SiteModel,
+        stockStatus: String,
+        page: Int = 1,
+        quantity: Int = 3
+    ): WooPayload<Array<ReportsProductApiResponse>> {
+        val url = WOOCOMMERCE.reports.stock.pathV4Analytics
+        val parameters = mapOf(
+            "page" to page.toString(),
+            "per_page" to quantity.toString(),
+            "type" to stockStatus,
+            "order" to "desc"
+        )
+
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<ReportsProductApiResponse>::class.java,
+            params = parameters
+        )
+
+        return response.toWooPayload()
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
@@ -45,19 +45,19 @@ class ReportsRestClient @Inject constructor(private val wooNetwork: WooNetwork) 
         stockStatus: String,
         page: Int = 1,
         quantity: Int = 3
-    ): WooPayload<Array<ReportsProductApiResponse>> {
+    ): WooPayload<Array<ProductStockItemApiResponse>> {
         val url = WOOCOMMERCE.reports.stock.pathV4Analytics
         val parameters = mapOf(
             "page" to page.toString(),
             "per_page" to quantity.toString(),
-            "type" to stockStatus,
-            "order" to "desc"
+            "order" to "asc",
+            "type" to stockStatus
         )
 
         val response = wooNetwork.executeGetGsonRequest(
             site = site,
             path = url,
-            clazz = Array<ReportsProductApiResponse>::class.java,
+            clazz = Array<ProductStockItemApiResponse>::class.java,
             params = parameters
         )
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
@@ -43,8 +43,8 @@ class ReportsRestClient @Inject constructor(private val wooNetwork: WooNetwork) 
     suspend fun fetchProductStockReport(
         site: SiteModel,
         stockStatus: String,
-        page: Int = 1,
-        quantity: Int = 3
+        page: Int,
+        quantity: Int
     ): WooPayload<Array<ProductStockItemApiResponse>> {
         val url = WOOCOMMERCE.reports.stock.pathV4Analytics
         val parameters = mapOf(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStockReportStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStockReportStore.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ProductStockItemApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsRestClient
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -24,14 +25,14 @@ class WCProductStockReportStore @Inject constructor(
 
     suspend fun fetchProductStockReport(
         site: SiteModel,
-        stockStatus: String,
+        stockStatus: CoreProductStockStatus,
         page: Int = DEFAULT_PAGE,
         quantity: Int = DEFAULT_PAGE_SIZE
     ): WooResult<ProductStockItems> {
         return coroutineEngine.withDefaultContext(API, this, "fetchProductStockReport") {
             val response = reportsRestClient.fetchProductStockReport(
                 site = site,
-                stockStatus = stockStatus,
+                stockStatus = stockStatus.value,
                 page = page,
                 quantity = quantity
             )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStockReportStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStockReportStore.kt
@@ -1,9 +1,6 @@
 package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ProductStockItemApiResponse
@@ -28,21 +25,15 @@ class WCProductStockReportStore @Inject constructor(
         stockStatus: CoreProductStockStatus,
         page: Int = DEFAULT_PAGE,
         quantity: Int = DEFAULT_PAGE_SIZE
-    ): WooResult<ProductStockItems> {
-        return coroutineEngine.withDefaultContext(API, this, "fetchProductStockReport") {
-            val response = reportsRestClient.fetchProductStockReport(
+    ): WooResult<ProductStockItems> =
+        coroutineEngine.withDefaultContext(API, this, "fetchProductStockReport") {
+            reportsRestClient.fetchProductStockReport(
                 site = site,
                 stockStatus = stockStatus.value,
                 page = page,
                 quantity = quantity
             )
-            when {
-                response.isError -> WooResult(response.error)
-                response.result != null -> WooResult(response.result)
-                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
-            }
-        }
-    }
+        }.asWooResult()
 }
 
 typealias ProductStockItems = Array<ProductStockItemApiResponse>

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStockReportStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStockReportStore.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.store
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ProductStockItemApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsRestClient
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog.T.API
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WCProductStockReportStore @Inject constructor(
+    private val reportsRestClient: ReportsRestClient,
+    private val coroutineEngine: CoroutineEngine,
+) {
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 3
+        const val DEFAULT_PAGE = 1
+    }
+
+    suspend fun fetchProductStockReport(
+        site: SiteModel,
+        stockStatus: String,
+        page: Int = DEFAULT_PAGE,
+        quantity: Int = DEFAULT_PAGE_SIZE
+    ): WooResult<ProductStockItems> {
+        return coroutineEngine.withDefaultContext(API, this, "fetchProductStockReport") {
+            val response = reportsRestClient.fetchProductStockReport(
+                site = site,
+                stockStatus = stockStatus,
+                page = page,
+                quantity = quantity
+            )
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> WooResult(response.result)
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+}
+
+typealias ProductStockItems = Array<ProductStockItemApiResponse>


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-android/issues/11558

Adds a new endpoint `/reports/stock/` to fetch the product stock status. 

This endpoint will be used in the dashboard screen for the new product stock status card. The new endpoint will be properly tested in [this PR](https://github.com/woocommerce/woocommerce-android/pull/11582)

For now, it can be tested from the FluxC example app by navigating to `Woo -> Products -> (scroll to the end) Fetch product stock report`


https://github.com/wordpress-mobile/WordPress-FluxC-Android/assets/2663464/b9431ce5-b88c-4dca-8006-082ad33fd709
