### PR TITLE
[Voice to Content] Implement Jetpack ai-assistant-feature endpoint

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/JetpackAIFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/JetpackAIFragment.kt
@@ -44,6 +44,7 @@ class JetpackAIFragment : StoreSelectingFragment() {
         setHaikuButton()
         setTranscribeAudioButton()
         setJetpackAIQueryButton()
+        setJetpackAIAssistantFeatureButton()
     }
 
     private fun setHaikuButton() {
@@ -119,6 +120,18 @@ class JetpackAIFragment : StoreSelectingFragment() {
                             prependToLog("Error post processing: ${result.message}")
                         }
                     }
+                }
+            }
+        }
+    }
+
+    private fun setJetpackAIAssistantFeatureButton() {
+        jetpack_ai_assistant_feature.setOnClickListener {
+            siteStore.sites[0].let {
+                lifecycleScope.launch {
+                    val result = store.fetchJetpackAIAssistantFeature(site = it)
+
+                    prependToLog("Jetpack AI Assistant Feature:\n$result")
                 }
             }
         }

--- a/example/src/main/res/layout/fragment_jetpackai.xml
+++ b/example/src/main/res/layout/fragment_jetpackai.xml
@@ -30,5 +30,11 @@
             android:layout_height="wrap_content"
             android:text="Voice to Content - AI Query" />
 
+        <Button
+            android:id="@+id/jetpack_ai_assistant_feature"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="AI Assistant Feature" />
+
     </LinearLayout>
 </ScrollView>

--- a/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -77,3 +77,4 @@
 
 /jetpack-ai-transcription
 /jetpack-ai-query
+/sites/$site/jetpack-ai/ai-assistant-feature

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/jetpackai/JetpackAIAssistantFeature.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/jetpackai/JetpackAIAssistantFeature.kt
@@ -1,0 +1,42 @@
+package org.wordpress.android.fluxc.model.jetpackai
+
+data class UsagePeriod(
+    val currentStart: String,
+    val nextStart: String,
+    val requestsCount: Int,
+)
+
+data class Tier(
+    val slug: String,
+    val limit: Int,
+    val value: Int,
+    val readableLimit: String?
+)
+
+data class JetpackAiLogoGenerator(
+    val logo: Int
+)
+
+data class FeaturedPostImage(
+    val image: Int
+)
+
+data class Costs(
+    val jetpackAiLogoGenerator: JetpackAiLogoGenerator,
+    val featuredPostImage: FeaturedPostImage
+)
+
+data class JetpackAIAssistantFeature(
+    val hasFeature: Boolean,
+    val isOverLimit: Boolean,
+    val requestsCount: Int,
+    val requestsLimit: Int,
+    val usagePeriod: UsagePeriod?,
+    val siteRequireUpgrade: Boolean,
+    val upgradeType: String,
+    val currentTier: Tier?,
+    val nextTier: Tier?,
+    val tierPlans: List<Tier>,
+    val tierPlansEnabled: Boolean,
+    val costs: Costs?
+)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIAssistantFeatureDto.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIAssistantFeatureDto.kt
@@ -63,7 +63,6 @@ data class FeaturedPostImageDto(
             image = image
         )
     }
-
 }
 
 data class CostsDto(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIAssistantFeatureDto.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIAssistantFeatureDto.kt
@@ -1,0 +1,125 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.jetpackai
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.model.jetpackai.Costs
+import org.wordpress.android.fluxc.model.jetpackai.FeaturedPostImage
+import org.wordpress.android.fluxc.model.jetpackai.JetpackAIAssistantFeature
+import org.wordpress.android.fluxc.model.jetpackai.JetpackAiLogoGenerator
+import org.wordpress.android.fluxc.model.jetpackai.Tier
+import org.wordpress.android.fluxc.model.jetpackai.UsagePeriod
+
+data class UsagePeriodDto(
+    @SerializedName("current-start")
+    val currentStart: String?,
+    @SerializedName("next-start")
+    val nextStart: String?,
+    @SerializedName("requests-count")
+    val requestsCount: Int?,
+) {
+    fun toUsagePeriod(): UsagePeriod {
+        return UsagePeriod(
+            currentStart = currentStart.orEmpty(),
+            nextStart = nextStart.orEmpty(),
+            requestsCount = requestsCount ?: 0
+        )
+    }
+}
+
+data class TierDto(
+    @SerializedName("slug")
+    val slug: String?,
+    @SerializedName("limit")
+    val limit: Int?,
+    @SerializedName("value")
+    val value: Int?,
+    @SerializedName("readable-limit")
+    val readableLimit: String?
+) {
+    fun toTier(): Tier {
+        return Tier(
+            slug = slug.orEmpty(),
+            limit = limit ?: 0,
+            value = value ?: 0,
+            readableLimit = readableLimit
+        )
+    }
+}
+
+data class JetpackAiLogoGeneratorDto(
+    @SerializedName("logo") val logo: Int
+) {
+    fun toJetpackAiLogoGenerator(): JetpackAiLogoGenerator {
+        return JetpackAiLogoGenerator(
+            logo = logo
+        )
+    }
+}
+
+data class FeaturedPostImageDto(
+    @SerializedName("image") val image: Int
+) {
+    fun toFeaturedPostImage(): FeaturedPostImage {
+        return FeaturedPostImage(
+            image = image
+        )
+    }
+
+}
+
+data class CostsDto(
+    @SerializedName("jetpack-ai-logo-generator")
+    val jetpackAiLogoGenerator: JetpackAiLogoGeneratorDto,
+    @SerializedName("featured-post-image")
+    val featuredPostImage: FeaturedPostImageDto
+) {
+    fun toCosts(): Costs {
+        return Costs(
+            jetpackAiLogoGenerator = jetpackAiLogoGenerator.toJetpackAiLogoGenerator(),
+            featuredPostImage = featuredPostImage.toFeaturedPostImage()
+        )
+    }
+}
+
+data class JetpackAIAssistantFeatureDto(
+    @SerializedName("has-feature")
+    val hasFeature: Boolean?,
+    @SerializedName("is-over-limit")
+    val isOverLimit: Boolean?,
+    @SerializedName("requests-count")
+    val requestsCount: Int?,
+    @SerializedName("requests-limit")
+    val requestsLimit: Int?,
+    @SerializedName("usage-period")
+    val usagePeriod: UsagePeriodDto?,
+    @SerializedName("site-require-upgrade")
+    val siteRequireUpgrade: Boolean?,
+    @SerializedName("upgrade-type")
+    val upgradeType: String?,
+    @SerializedName("current-tier")
+    val currentTier: TierDto?,
+    @SerializedName("next-tier")
+    val nextTier: TierDto?,
+    @SerializedName("tier-plans")
+    val tierPlans: List<TierDto>?,
+    @SerializedName("tier-plans-enabled")
+    val tierPlansEnabled: Boolean?,
+    @SerializedName("costs")
+    val costs: CostsDto?
+) {
+    fun toJetpackAIAssistantFeature(): JetpackAIAssistantFeature {
+        return JetpackAIAssistantFeature(
+            hasFeature = hasFeature ?: false,
+            isOverLimit = isOverLimit ?: false,
+            requestsCount = requestsCount ?: 0,
+            requestsLimit = requestsLimit ?: 0,
+            usagePeriod = usagePeriod?.toUsagePeriod(),
+            siteRequireUpgrade = siteRequireUpgrade ?: false,
+            upgradeType = upgradeType.orEmpty(),
+            currentTier = currentTier?.toTier(),
+            nextTier = nextTier?.toTier(),
+            tierPlans = tierPlans?.map { it.toTier() } ?: emptyList(),
+            tierPlansEnabled = tierPlansEnabled ?: false,
+            costs = costs?.toCosts()
+        )
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIAssistantFeatureResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIAssistantFeatureResponse.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.jetpackai
+
+import org.wordpress.android.fluxc.model.jetpackai.JetpackAIAssistantFeature
+
+sealed class JetpackAIAssistantFeatureResponse {
+    data class Success(val model: JetpackAIAssistantFeature) : JetpackAIAssistantFeatureResponse()
+    data class Error(
+        val type: JetpackAIAssistantFeatureErrorType,
+        val message: String? = null
+    ) : JetpackAIAssistantFeatureResponse()
+}
+
+enum class JetpackAIAssistantFeatureErrorType {
+    API_ERROR,
+    AUTH_ERROR,
+    GENERIC_ERROR,
+    INVALID_RESPONSE,
+    TIMEOUT,
+    NETWORK_ERROR
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIRestClient.kt
@@ -180,6 +180,39 @@ class JetpackAIRestClient @Inject constructor(
         }
     }
 
+    /**
+     * Fetches Jetpack AI Assistant feature for site
+     *
+     * @param site  The SiteModel for which the Jetpack AI Assistant feature is fetched
+     */
+    @Suppress("LongParameterList")
+    suspend fun fetchJetpackAiAssistantFeature(
+        site: SiteModel
+    ): JetpackAIAssistantFeatureResponse {
+        val url = WPCOMV2.sites.site(site.siteId).jetpack_ai.ai_assistant_feature.url
+
+        val response = wpComGsonRequestBuilder.syncGetRequest(
+            restClient = this,
+            url = url,
+            params = emptyMap(),
+            clazz = JetpackAIAssistantFeatureDto::class.java,
+        )
+
+        return when (response) {
+            is Response.Success -> {
+                JetpackAIAssistantFeatureResponse.Success(
+                    response.data.toJetpackAIAssistantFeature()
+                )
+            }
+            is Response.Error -> {
+                JetpackAIAssistantFeatureResponse.Error(
+                    response.error.toJetpackAIAssistantFeatureError(),
+                    response.error.message
+                )
+            }
+        }
+    }
+
     internal  data class JetpackAIJWTTokenDto(
         @SerializedName ("success") val success: Boolean,
         @SerializedName("token") val token: String
@@ -295,5 +328,22 @@ class JetpackAIRestClient @Inject constructor(
             GenericErrorType.NOT_AUTHENTICATED -> JetpackAIQueryErrorType.AUTH_ERROR
             GenericErrorType.UNKNOWN -> JetpackAIQueryErrorType.GENERIC_ERROR
             null -> JetpackAIQueryErrorType.GENERIC_ERROR
+        }
+    private fun WPComGsonNetworkError.toJetpackAIAssistantFeatureError() =
+        when (type) {
+            GenericErrorType.TIMEOUT -> JetpackAIAssistantFeatureErrorType.TIMEOUT
+            GenericErrorType.NO_CONNECTION,
+            GenericErrorType.INVALID_SSL_CERTIFICATE,
+            GenericErrorType.NETWORK_ERROR -> JetpackAIAssistantFeatureErrorType.NETWORK_ERROR
+            GenericErrorType.SERVER_ERROR -> JetpackAIAssistantFeatureErrorType.API_ERROR
+            GenericErrorType.PARSE_ERROR,
+            GenericErrorType.NOT_FOUND,
+            GenericErrorType.CENSORED,
+            GenericErrorType.INVALID_RESPONSE -> JetpackAIAssistantFeatureErrorType.INVALID_RESPONSE
+            GenericErrorType.HTTP_AUTH_ERROR,
+            GenericErrorType.AUTHORIZATION_REQUIRED,
+            GenericErrorType.NOT_AUTHENTICATED -> JetpackAIAssistantFeatureErrorType.AUTH_ERROR
+            GenericErrorType.UNKNOWN -> JetpackAIAssistantFeatureErrorType.GENERIC_ERROR
+            null -> JetpackAIAssistantFeatureErrorType.GENERIC_ERROR
         }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/jetpackai/JetpackAIStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/jetpackai/JetpackAIStore.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.store.jetpackai
 
 import org.wordpress.android.fluxc.model.JWTToken
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIAssistantFeatureResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsErrorType.AUTH_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsResponse
@@ -276,5 +277,16 @@ class JetpackAIStore @Inject constructor(
             }
             else -> result
         }
+    }
+
+    @Suppress("LongParameterList")
+    suspend fun fetchJetpackAIAssistantFeature(
+        site: SiteModel,
+    ): JetpackAIAssistantFeatureResponse = coroutineEngine.withDefaultContext(
+        tag = AppLog.T.API,
+        caller = this,
+        loggedMessage = "fetch Jetpack AI Assistant Feature"
+    ) {
+        jetpackAIRestClient.fetchJetpackAiAssistantFeature(site)
     }
 }


### PR DESCRIPTION
This PR implements the Jetpack AI Assistant feature endpoint. See https://github.com/Automattic/wordpress-mobile/issues/106

**Changes include**
- Add the endpoint call to `JetpackAIRestClient`
- Add entry point into `JetpackAIStore`
- Add response and model objects
- Update the `example` project to make a call to the endpoint

> [!IMPORTANT]
> **Merge Instractions**
> Ensure parent [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3019) has been merged into trunk. The issue/v2c-ai-assistant-feature branch was created from branch issue/v2c-jetpack-ai-query-endpoint
> Remove the not ready for merge label

See [WP Companion PR](https://github.com/wordpress-mobile/WordPress-Android/pull/20885) for testing instructions

Part of https://github.com/Automattic/wordpress-mobile/issues/79