### PR TITLE
[Woo Min/Max Quantities] Add Support to New REST API

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -2012,10 +2012,12 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE WCProductModel ADD MIN_ALLOWED_QUANTITY INTEGER")
                     db.execSQL("ALTER TABLE WCProductModel ADD MAX_ALLOWED_QUANTITY INTEGER")
                     db.execSQL("ALTER TABLE WCProductModel ADD GROUP_OF_QUANTITY INTEGER")
+                    db.execSQL("ALTER TABLE WCProductModel ADD COMBINE_VARIATION_QUANTITIES BOOLEAN")
 
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD MIN_ALLOWED_QUANTITY INTEGER")
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD MAX_ALLOWED_QUANTITY INTEGER")
                     db.execSQL("ALTER TABLE WCProductVariationModel ADD GROUP_OF_QUANTITY INTEGER")
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD OVERRIDE_PRODUCT_QUANTITIES BOOLEAN")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -2012,6 +2012,10 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("ALTER TABLE WCProductModel ADD MIN_ALLOWED_QUANTITY INTEGER")
                     db.execSQL("ALTER TABLE WCProductModel ADD MAX_ALLOWED_QUANTITY INTEGER")
                     db.execSQL("ALTER TABLE WCProductModel ADD GROUP_OF_QUANTITY INTEGER")
+
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD MIN_ALLOWED_QUANTITY INTEGER")
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD MAX_ALLOWED_QUANTITY INTEGER")
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD GROUP_OF_QUANTITY INTEGER")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -41,7 +41,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 201
+        return 202
     }
 
     override fun getDbName(): String {
@@ -2006,6 +2006,12 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
                 200 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("ALTER TABLE WCProductModel ADD IS_SAMPLE_PRODUCT BOOLEAN")
+                }
+
+                201 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductModel ADD MIN_ALLOWED_QUANTITY INTEGER")
+                    db.execSQL("ALTER TABLE WCProductModel ADD MAX_ALLOWED_QUANTITY INTEGER")
+                    db.execSQL("ALTER TABLE WCProductModel ADD GROUP_OF_QUANTITY INTEGER")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
@@ -4,7 +4,6 @@ import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.wordpress.android.fluxc.model.WCProductModel.AddOnsMetadataKeys
-import org.wordpress.android.fluxc.model.WCProductModel.QuantityRulesMetadataKeys
 import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.fluxc.utils.EMPTY_JSON_ARRAY
 import org.wordpress.android.fluxc.utils.isElementNullOrEmpty
@@ -28,7 +27,6 @@ class StripProductMetaData @Inject internal constructor(private val gson: Gson) 
     companion object {
         val SUPPORTED_KEYS: Set<String> = buildSet {
             add(AddOnsMetadataKeys.ADDONS_METADATA_KEY)
-            addAll(QuantityRulesMetadataKeys.ALL_KEYS)
             addAll(SubscriptionMetadataKeys.ALL_KEYS)
             add(WCMetaData.BundleMetadataKeys.BUNDLE_MIN_SIZE)
             add(WCMetaData.BundleMetadataKeys.BUNDLE_MAX_SIZE)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductVariationMetaData.kt
@@ -24,7 +24,6 @@ class StripProductVariationMetaData @Inject internal constructor(private val gso
     companion object {
         val SUPPORTED_KEYS: Set<String> = buildSet {
             addAll(WCProductModel.SubscriptionMetadataKeys.ALL_KEYS)
-            addAll(WCProductVariationModel.QuantityRulesMetadataKeys.ALL_KEYS)
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -608,17 +608,4 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     object AddOnsMetadataKeys {
         const val ADDONS_METADATA_KEY = "_product_addons"
     }
-
-    object QuantityRulesMetadataKeys {
-        const val MINIMUM_ALLOWED_QUANTITY = "minimum_allowed_quantity"
-        const val MAXIMUM_ALLOWED_QUANTITY = "maximum_allowed_quantity"
-        const val GROUP_OF_QUANTITY = "group_of_quantity"
-        const val ALLOW_COMBINATION = "allow_combination"
-        val ALL_KEYS = setOf(
-            MINIMUM_ALLOWED_QUANTITY,
-            MAXIMUM_ALLOWED_QUANTITY,
-            GROUP_OF_QUANTITY,
-            ALLOW_COMBINATION
-        )
-    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -115,6 +115,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var minAllowedQuantity = -1
     @Column var maxAllowedQuantity = -1
     @Column var groupOfQuantity = -1
+    @Column var combineVariationQuantities = false
 
     @Column var isSampleProduct = false
         @JvmName("setIsSampleProduct")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -111,6 +111,11 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var bundledItems = ""
     @Column var compositeComponents = ""
     @Column var specialStockStatus = ""
+
+    @Column var minAllowedQuantity = -1
+    @Column var maxAllowedQuantity = -1
+    @Column var groupOfQuantity = -1
+
     @Column var isSampleProduct = false
         @JvmName("setIsSampleProduct")
         set

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -79,6 +79,7 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     @Column var minAllowedQuantity = -1
     @Column var maxAllowedQuantity = -1
     @Column var groupOfQuantity = -1
+    @Column var overrideProductQuantities = false
 
     @Column var menuOrder = 0
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -154,15 +154,4 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
         val responseType = object : TypeToken<List<ProductVariantOption>>() {}.type
         return gson.fromJson(attributes, responseType) as? List<ProductVariantOption> ?: emptyList()
     }
-
-    object QuantityRulesMetadataKeys {
-        const val MINIMUM_ALLOWED_QUANTITY = "variation_minimum_allowed_quantity"
-        const val MAXIMUM_ALLOWED_QUANTITY = "variation_maximum_allowed_quantity"
-        const val GROUP_OF_QUANTITY = "variation_group_of_quantity"
-        val ALL_KEYS = setOf(
-            MINIMUM_ALLOWED_QUANTITY,
-            MAXIMUM_ALLOWED_QUANTITY,
-            GROUP_OF_QUANTITY
-        )
-    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -76,6 +76,10 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     @Column var width = ""
     @Column var height = ""
 
+    @Column var minAllowedQuantity = -1
+    @Column var maxAllowedQuantity = -1
+    @Column var groupOfQuantity = -1
+
     @Column var menuOrder = 0
 
     @Column var attributes = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -91,7 +91,7 @@ data class ProductApiResponse(
     val min_quantity: String? = null,
     val max_quantity: String? = null,
     val group_of_quantity: String? = null,
-    val combine_variation_quantities: String? = null,
+    val combine_variations: String? = null,
 ) {
     @Suppress("LongMethod", "ComplexMethod")
     fun asProductModel(): WCProductModel {
@@ -182,7 +182,7 @@ data class ProductApiResponse(
             }?.toInt() ?: -1
             groupOfQuantity = response.group_of_quantity?.toInt() ?: -1
 
-            combineVariationQuantities = response.combine_variation_quantities?.let {
+            combineVariationQuantities = response.combine_variations?.let {
                 it == "yes"
             } ?: false
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -91,6 +91,7 @@ data class ProductApiResponse(
     val min_quantity: String? = null,
     val max_quantity: String? = null,
     val group_of_quantity: String? = null,
+    val combine_variation_quantities: String? = null,
 ) {
     @Suppress("LongMethod", "ComplexMethod")
     fun asProductModel(): WCProductModel {
@@ -180,6 +181,11 @@ data class ProductApiResponse(
                 if (it.isEmpty()) "0" else it
             }?.toInt() ?: -1
             groupOfQuantity = response.group_of_quantity?.toInt() ?: -1
+
+            combineVariationQuantities = response.combine_variation_quantities?.let {
+                it == "yes"
+            } ?: false
+
             metadata = response.metadata?.toString() ?: ""
             isSampleProduct = response.metadata?.any {
                 val metaDataEntry = if (it.isJsonObject) it.asJsonObject else null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -88,6 +88,9 @@ data class ProductApiResponse(
     val composite_components: JsonArray? = null,
     val bundle_min_size: String? = null,
     val bundle_max_size: String? = null,
+    val min_quantity: String? = null,
+    val max_quantity: String? = null,
+    val group_of_quantity: String? = null,
 ) {
     @Suppress("LongMethod", "ComplexMethod")
     fun asProductModel(): WCProductModel {
@@ -172,6 +175,11 @@ data class ProductApiResponse(
             groupedProductIds = response.grouped_products?.toString() ?: ""
             bundledItems = response.bundled_items?.toString() ?: ""
             compositeComponents = response.composite_components?.toString() ?: ""
+            minAllowedQuantity = response.min_quantity?.toInt() ?: -1
+            maxAllowedQuantity = response.max_quantity?.let {
+                if (it.isEmpty()) "0" else it
+            }?.toInt() ?: -1
+            groupOfQuantity = response.group_of_quantity?.toInt() ?: -1
             metadata = response.metadata?.toString() ?: ""
             isSampleProduct = response.metadata?.any {
                 val metaDataEntry = if (it.isJsonObject) it.asJsonObject else null

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -52,6 +52,10 @@ class ProductVariationApiResponse : Response {
     var weight: String? = null
     val menu_order: Int = 0
 
+    val min_quantity: String? = null
+    val max_quantity: String? = null
+    val group_of_quantity: String? = null
+
     var dimensions: JsonElement? = null
     var attributes: JsonElement? = null
     var downloads: JsonElement? = null
@@ -117,6 +121,13 @@ class ProductVariationApiResponse : Response {
             }
 
             image = response.image?.toString() ?: ""
+
+            minAllowedQuantity = response.min_quantity?.toInt() ?: -1
+            maxAllowedQuantity = response.max_quantity?.let {
+                if (it.isEmpty()) "0" else it
+            }?.toInt() ?: -1
+            groupOfQuantity = response.group_of_quantity?.toInt() ?: -1
+
             metadata = response.meta_data?.toString()
         }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -55,6 +55,7 @@ class ProductVariationApiResponse : Response {
     val min_quantity: String? = null
     val max_quantity: String? = null
     val group_of_quantity: String? = null
+    val variation_quantity_rules: String? = null
 
     var dimensions: JsonElement? = null
     var attributes: JsonElement? = null
@@ -127,6 +128,9 @@ class ProductVariationApiResponse : Response {
                 if (it.isEmpty()) "0" else it
             }?.toInt() ?: -1
             groupOfQuantity = response.group_of_quantity?.toInt() ?: -1
+            overrideProductQuantities = response.variation_quantity_rules?.let {
+                it == "yes"
+            } ?: false
 
             metadata = response.meta_data?.toString()
         }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/StripProductMetaDataTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/StripProductMetaDataTest.kt
@@ -9,7 +9,6 @@ import org.wordpress.android.fluxc.model.StripProductMetaData
 import org.wordpress.android.fluxc.model.WCMetaData
 import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.fluxc.model.WCProductModel.AddOnsMetadataKeys
-import org.wordpress.android.fluxc.model.WCProductModel.QuantityRulesMetadataKeys
 import org.wordpress.android.fluxc.utils.EMPTY_JSON_ARRAY
 
 class StripProductMetaDataTest {
@@ -76,12 +75,6 @@ class StripProductMetaDataTest {
     fun `assert no regression in subscription metadata`() {
         Assertions.assertThat(StripProductMetaData.SUPPORTED_KEYS)
             .containsAll(SubscriptionMetadataKeys.ALL_KEYS)
-    }
-
-    @Test
-    fun `assert no regression in quantity rules metadata`() {
-        Assertions.assertThat(StripProductMetaData.SUPPORTED_KEYS)
-            .containsAll(QuantityRulesMetadataKeys.ALL_KEYS)
     }
 
     @Test


### PR DESCRIPTION
⚠️  Needed to close: https://github.com/woocommerce/woocommerce-android/pull/11611

This PR adds support to the new REST API for the Min/Max Quantities extension additions (Check docs [here](https://woocommerce.com/document/minmax-quantities/#section-6)). It replaces the old approach based on the products/variations metadata to add the values as json fields.

Specifically we:

- Add new columns in the Product and Product Variations tables of the wellSQL DB
- Migrate DB version
- Add support for the new values in the API Response classes.
- Remove metadata support.


