### PR TITLE
Issue/11558 fetch product sales reports

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/products/WooProductsFragment.kt
@@ -31,7 +31,7 @@ import org.wordpress.android.fluxc.model.WCProductImageModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.WCAddonsStore
-import org.wordpress.android.fluxc.store.WCProductStockReportStore
+import org.wordpress.android.fluxc.store.WCProductReportsStore
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.AddProductTagsPayload
 import org.wordpress.android.fluxc.store.WCProductStore.DeleteProductPayload
@@ -64,7 +64,7 @@ class WooProductsFragment : StoreSelectingFragment() {
     @Inject lateinit var addonsStore: WCAddonsStore
     @Inject internal lateinit var wooCommerceStore: WooCommerceStore
     @Inject internal lateinit var mediaStore: MediaStore
-    @Inject internal lateinit var productStockReportStore: WCProductStockReportStore
+    @Inject internal lateinit var productStockReportStore: WCProductReportsStore
 
     private var pendingFetchSingleProductShippingClassRemoteId: Long? = null
 

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -117,6 +117,7 @@
 /subscriptions/<id>/
 
 /reports/products
+/reports/variations
 
 /options
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
@@ -5,6 +5,8 @@ import com.google.gson.annotations.SerializedName
 data class ReportsProductApiResponse(
     @SerializedName("product_id")
     val productId: Long? = null,
+    @SerializedName("variation_id")
+    val variationId: Long? = null,
     @SerializedName("items_sold")
     val itemsSold: Int? = null,
     @SerializedName("net_revenue")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsProductApiResponse.kt
@@ -36,7 +36,7 @@ data class ProductStockItemApiResponse(
     @SerializedName("id")
     val productId: Long? = null,
     @SerializedName("parent_id")
-    val parentId: Int? = null, // When the product is a variation, this is the parent product ID
+    val parentId: Long? = null, // When the product is a variation, this is the parent product ID
     @SerializedName("name")
     val name: String? = null,
     @SerializedName("stock_status")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.reports
 
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.utils.toWooPayload
@@ -71,6 +72,28 @@ class ReportsRestClient @Inject constructor(private val wooNetwork: WooNetwork) 
         productIds: List<Long>
     ): WooPayload<Array<ReportsProductApiResponse>> {
         val url = WOOCOMMERCE.reports.products.pathV4Analytics
+        val response = fetchSales(endDate, startDate, productIds, site, url)
+        return response.toWooPayload()
+    }
+
+    suspend fun fetchProductVariationsSalesReport(
+        site: SiteModel,
+        startDate: String,
+        endDate: String,
+        productIds: List<Long>
+    ): WooPayload<Array<ReportsProductApiResponse>> {
+        val url = WOOCOMMERCE.reports.variations.pathV4Analytics
+        val response = fetchSales(endDate, startDate, productIds, site, url)
+        return response.toWooPayload()
+    }
+
+    private suspend fun fetchSales(
+        endDate: String,
+        startDate: String,
+        productIds: List<Long>,
+        site: SiteModel,
+        url: String
+    ): WPAPIResponse<Array<ReportsProductApiResponse>> {
         val parameters = mapOf(
             "before" to endDate,
             "after" to startDate,
@@ -88,6 +111,6 @@ class ReportsRestClient @Inject constructor(private val wooNetwork: WooNetwork) 
             clazz = Array<ReportsProductApiResponse>::class.java,
             params = parameters
         )
-        return response.toWooPayload()
+        return response
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
@@ -72,7 +72,14 @@ class ReportsRestClient @Inject constructor(private val wooNetwork: WooNetwork) 
         productIds: List<Long>
     ): WooPayload<Array<ReportsProductApiResponse>> {
         val url = WOOCOMMERCE.reports.products.pathV4Analytics
-        val response = fetchSales(endDate, startDate, productIds, site, url)
+        val response = fetchSales(
+            endDate = endDate,
+            startDate = startDate,
+            productIds = productIds,
+            site = site,
+            url = url,
+            quantity = productIds.size
+        )
         return response.toWooPayload()
     }
 
@@ -80,29 +87,39 @@ class ReportsRestClient @Inject constructor(private val wooNetwork: WooNetwork) 
         site: SiteModel,
         startDate: String,
         endDate: String,
-        productIds: List<Long>
+        variationIds: List<Long>
     ): WooPayload<Array<ReportsProductApiResponse>> {
         val url = WOOCOMMERCE.reports.variations.pathV4Analytics
-        val response = fetchSales(endDate, startDate, productIds, site, url)
+        val response = fetchSales(
+            endDate = endDate,
+            startDate = startDate,
+            variationIds = variationIds,
+            site = site,
+            url = url,
+            quantity = variationIds.size
+        )
         return response.toWooPayload()
     }
 
     private suspend fun fetchSales(
         endDate: String,
         startDate: String,
-        productIds: List<Long>,
+        productIds: List<Long> = emptyList(),
+        variationIds: List<Long> = emptyList(),
         site: SiteModel,
-        url: String
+        url: String,
+        quantity: Int
     ): WPAPIResponse<Array<ReportsProductApiResponse>> {
         val parameters = mapOf(
             "before" to endDate,
             "after" to startDate,
-            "productIds" to productIds.joinToString(","),
+            "products" to productIds.joinToString(","),
+            "variations" to variationIds.joinToString(","),
             "extended_info" to "true",
             "orderby" to "items_sold",
             "order" to "desc",
             "page" to "1",
-            "per_page" to productIds.size.toString()
+            "per_page" to quantity.toString()
         )
 
         val response = wooNetwork.executeGetGsonRequest(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/reports/ReportsRestClient.kt
@@ -63,4 +63,31 @@ class ReportsRestClient @Inject constructor(private val wooNetwork: WooNetwork) 
 
         return response.toWooPayload()
     }
+
+    suspend fun fetchProductSalesReport(
+        site: SiteModel,
+        startDate: String,
+        endDate: String,
+        productIds: List<Long>
+    ): WooPayload<Array<ReportsProductApiResponse>> {
+        val url = WOOCOMMERCE.reports.products.pathV4Analytics
+        val parameters = mapOf(
+            "before" to endDate,
+            "after" to startDate,
+            "productIds" to productIds.joinToString(","),
+            "extended_info" to "true",
+            "orderby" to "items_sold",
+            "order" to "desc",
+            "page" to "1",
+            "per_page" to productIds.size.toString()
+        )
+
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<ReportsProductApiResponse>::class.java,
+            params = parameters
+        )
+        return response.toWooPayload()
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -175,7 +175,7 @@ class WCLeaderboardsStore @Inject constructor(
         productVariationIds: List<Long>
     ): WooResult<Array<ReportsProductApiResponse>> =
         coroutineEngine.withDefaultContext(API, this, "fetchProductVariationsSalesReport") {
-            reportsRestClient.fetchProductSalesReport(
+            reportsRestClient.fetchProductVariationsSalesReport(
                 site,
                 startDate,
                 endDate,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -168,6 +168,21 @@ class WCLeaderboardsStore @Inject constructor(
             )
         }.asWooResult()
 
+    suspend fun fetchProductVariationsSalesReport(
+        site: SiteModel,
+        startDate: String,
+        endDate: String,
+        productVariationIds: List<Long>
+    ): WooResult<Array<ReportsProductApiResponse>> =
+        coroutineEngine.withDefaultContext(API, this, "fetchProductVariationsSalesReport") {
+            reportsRestClient.fetchProductSalesReport(
+                site,
+                startDate,
+                endDate,
+                productVariationIds
+            )
+        }.asWooResult()
+
     fun invalidateTopPerformers(site: SiteModel) {
         coroutineEngine.launch(AppLog.T.DB, this, "Invalidating top performer products") {
             val invalidatedTopPerformers =

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCLeaderboardsStore.kt
@@ -11,14 +11,12 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsApiResponse.Type.PRODUCTS
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.leaderboards.LeaderboardsRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsProductApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsRestClient
 import org.wordpress.android.fluxc.persistence.dao.TopPerformerProductsDao
 import org.wordpress.android.fluxc.persistence.entity.TopPerformerProductEntity
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.DateUtils
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.AppLog.T.API
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -152,36 +150,6 @@ class WCLeaderboardsStore @Inject constructor(
             else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
         }
     }
-
-    suspend fun fetchProductSalesReport(
-        site: SiteModel,
-        startDate: String,
-        endDate: String,
-        productIds: List<Long>
-    ): WooResult<Array<ReportsProductApiResponse>> =
-        coroutineEngine.withDefaultContext(API, this, "fetchProductSalesReport") {
-            reportsRestClient.fetchProductSalesReport(
-                site,
-                startDate,
-                endDate,
-                productIds
-            )
-        }.asWooResult()
-
-    suspend fun fetchProductVariationsSalesReport(
-        site: SiteModel,
-        startDate: String,
-        endDate: String,
-        productVariationIds: List<Long>
-    ): WooResult<Array<ReportsProductApiResponse>> =
-        coroutineEngine.withDefaultContext(API, this, "fetchProductVariationsSalesReport") {
-            reportsRestClient.fetchProductVariationsSalesReport(
-                site,
-                startDate,
-                endDate,
-                productVariationIds
-            )
-        }.asWooResult()
 
     fun invalidateTopPerformers(site: SiteModel) {
         coroutineEngine.launch(AppLog.T.DB, this, "Invalidating top performer products") {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductReportsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductReportsStore.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStockStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ProductStockItemApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsProductApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsRestClient
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog.T.API
@@ -11,7 +12,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WCProductStockReportStore @Inject constructor(
+class WCProductReportsStore @Inject constructor(
     private val reportsRestClient: ReportsRestClient,
     private val coroutineEngine: CoroutineEngine,
 ) {
@@ -32,6 +33,36 @@ class WCProductStockReportStore @Inject constructor(
                 stockStatus = stockStatus.value,
                 page = page,
                 quantity = quantity
+            )
+        }.asWooResult()
+
+    suspend fun fetchProductSalesReport(
+        site: SiteModel,
+        startDate: String,
+        endDate: String,
+        productIds: List<Long>
+    ): WooResult<Array<ReportsProductApiResponse>> =
+        coroutineEngine.withDefaultContext(API, this, "fetchProductSalesReport") {
+            reportsRestClient.fetchProductSalesReport(
+                site,
+                startDate,
+                endDate,
+                productIds
+            )
+        }.asWooResult()
+
+    suspend fun fetchProductVariationsSalesReport(
+        site: SiteModel,
+        startDate: String,
+        endDate: String,
+        productVariationIds: List<Long>
+    ): WooResult<Array<ReportsProductApiResponse>> =
+        coroutineEngine.withDefaultContext(API, this, "fetchProductVariationsSalesReport") {
+            reportsRestClient.fetchProductVariationsSalesReport(
+                site,
+                startDate,
+                endDate,
+                productVariationIds
             )
         }.asWooResult()
 }


### PR DESCRIPTION
This PR adds the endpoints needed to fetch product sales stats for products and variation products. These endpoints are needed to display the new dashboard product stock card: 

![Screenshot 2024-05-30 at 23 29 48](https://github.com/wordpress-mobile/WordPress-FluxC-Android/assets/2663464/77134721-dafe-41c0-9549-d251673eae39)

The changes can be tested using [this PR](https://github.com/woocommerce/woocommerce-android/pull/11631)