### PR TITLE
Remove temporary log lines used to capture string error message

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/upload/MediaUploadModelTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/upload/MediaUploadModelTest.java
@@ -1,10 +1,8 @@
 package org.wordpress.android.fluxc.upload;
 
 import android.text.TextUtils;
-import android.util.Log;
 
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.wordpress.android.fluxc.model.MediaUploadModel;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
@@ -40,7 +38,6 @@ public class MediaUploadModelTest {
 
     @Test
     public void testMediaError() {
-        Mockito.mockStatic(Log.class);
         MediaUploadModel mediaUploadModel = new MediaUploadModel(1);
 
         assertNull(mediaUploadModel.getMediaError());

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -34,7 +34,6 @@ import org.wordpress.android.fluxc.store.media.MediaErrorSubType.MalformedMediaA
 import org.wordpress.android.fluxc.utils.MediaUtils;
 import org.wordpress.android.fluxc.utils.MimeType;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
 
 import java.io.IOException;
 import java.net.ConnectException;
@@ -529,7 +528,6 @@ public class MediaStore extends Store {
         @NonNull
         public static MediaErrorType fromString(@Nullable String string) {
             if (string != null) {
-                AppLog.e(T.API, "Media Error Type Conversion From: " + string);
                 for (MediaErrorType v : MediaErrorType.values()) {
                     if (string.equalsIgnoreCase(v.name())) {
                         return v;

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java
@@ -53,7 +53,6 @@ import org.wordpress.android.fluxc.store.ListStore.ListErrorType;
 import org.wordpress.android.fluxc.store.ListStore.ListItemsRemovedPayload;
 import org.wordpress.android.fluxc.utils.ObjectsUtils;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.ArrayList;
@@ -436,7 +435,6 @@ public class PostStore extends Store {
 
         public static PostErrorType fromString(String string) {
             if (string != null) {
-                AppLog.e(T.API, "Post Error Type Conversion From: " + string);
                 for (PostErrorType v : PostErrorType.values()) {
                     if (string.equalsIgnoreCase(v.toString())) {
                         return v;


### PR DESCRIPTION
This PR reverts the log line added in #3009. These were temporary log messages used to investigate a user issue. They are no longer needed.

See conversation p1714119618977609-slack-C0180B5PR for more details of the issue.