### PR TITLE
[Bug] Add null check if response is null.

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -781,7 +781,10 @@ public class PostRestClient extends BaseWPComRestClient {
         return params;
     }
 
-    private RevisionsModel revisionsResponseToRevisionsModel(RevisionsResponse response) {
+    private RevisionsModel revisionsResponseToRevisionsModel(@Nullable RevisionsResponse response) {
+        if (response == null) {
+            return new RevisionsModel(new ArrayList<>());
+        }
         ArrayList<RevisionModel> revisions = new ArrayList<>();
         for (DiffResponse diffResponse : response.getDiffs()) {
             RevisionResponse revision = response.getRevisions().get(Integer.toString(diffResponse.getTo()));


### PR DESCRIPTION
[Issue](https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/3024)

## What

This PR fixes a bug where fetching the revision history of a post can possibly be null. I'm not clear on how it's possible. But forced a null `revisionsResponseToRevisionsModel` and can reproduce the crash. The simplest solution is to null check. Outside of that, I could not reproduce the crash organically.

## Test

- [ ] Make sure builds pass
- [ ] Use [this PR in WP-Android](https://github.com/wordpress-mobile/WordPress-Android/pull/20926) to test the change itself.

