### PR TITLE
[Voice to Content] Endpoint adjustments

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/jetpackai/JetpackAIAssistantFeature.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/jetpackai/JetpackAIAssistantFeature.kt
@@ -34,6 +34,7 @@ data class JetpackAIAssistantFeature(
     val usagePeriod: UsagePeriod?,
     val siteRequireUpgrade: Boolean,
     val upgradeType: String,
+    val upgradeUrl: String?,
     val currentTier: Tier?,
     val nextTier: Tier?,
     val tierPlans: List<Tier>,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIAssistantFeatureDto.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/jetpackai/JetpackAIAssistantFeatureDto.kt
@@ -94,6 +94,8 @@ data class JetpackAIAssistantFeatureDto(
     val siteRequireUpgrade: Boolean?,
     @SerializedName("upgrade-type")
     val upgradeType: String?,
+    @SerializedName("upgrade-url")
+    val upgradeUrl: String?,
     @SerializedName("current-tier")
     val currentTier: TierDto?,
     @SerializedName("next-tier")
@@ -114,6 +116,7 @@ data class JetpackAIAssistantFeatureDto(
             usagePeriod = usagePeriod?.toUsagePeriod(),
             siteRequireUpgrade = siteRequireUpgrade ?: false,
             upgradeType = upgradeType.orEmpty(),
+            upgradeUrl = upgradeUrl, // Can be null
             currentTier = currentTier?.toTier(),
             nextTier = nextTier?.toTier(),
             tierPlans = tierPlans?.map { it.toTier() } ?: emptyList(),


### PR DESCRIPTION
Addresses the following issues
https://github.com/Automattic/wordpress-mobile/issues/111
https://github.com/Automattic/wordpress-mobile/issues/76

This PR updates the following voice to content endpoints

1. Extracts the `upgrade-url` from the ai-assistant-feature endpoint and adds it to the JetpackAIAssistantFeature model
2. Refactors the `JetpackAIQueryDto` to allow null in choices. This is because gson.toJson doesn't enforce Kotlin's nullability rule, so it is possible for choices to be null. If there is no choices list, then we don't have any content - this is an error.

Test using the companion WP PR (tbd) 