### PR TITLE
Ensure we order the campaigns based on numerical order of campaignId

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/blaze/BlazeCampaignsDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/blaze/BlazeCampaignsDao.kt
@@ -22,16 +22,16 @@ abstract class BlazeCampaignsDao {
         return campaigns.map { it.toDomainModel() }
     }
 
-    @Query("SELECT * from BlazeCampaigns WHERE `siteId` = :siteId ORDER BY startTime DESC")
+    @Query("SELECT * from BlazeCampaigns WHERE `siteId` = :siteId ORDER BY CAST(campaignId AS int) DESC")
     abstract fun getCampaigns(siteId: Long): List<BlazeCampaignEntity>
 
-    @Query("SELECT * from BlazeCampaigns WHERE `siteId` = :siteId")
+    @Query("SELECT * from BlazeCampaigns WHERE `siteId` = :siteId ORDER BY CAST(campaignId AS int) DESC")
     abstract fun observeCampaigns(siteId: Long): Flow<List<BlazeCampaignEntity>>
 
-    @Query("SELECT * from BlazeCampaigns WHERE `siteId` = :siteId ORDER BY startTime DESC LIMIT 1")
+    @Query("SELECT * from BlazeCampaigns WHERE `siteId` = :siteId ORDER BY CAST(campaignId AS int) DESC LIMIT 1")
     abstract fun getMostRecentCampaignForSite(siteId: Long): BlazeCampaignEntity?
 
-    @Query("SELECT * from BlazeCampaigns WHERE `siteId` = :siteId ORDER BY startTime DESC LIMIT 1")
+    @Query("SELECT * from BlazeCampaigns WHERE `siteId` = :siteId ORDER BY CAST(campaignId AS int) DESC LIMIT 1")
     abstract fun observeMostRecentCampaignForSite(siteId: Long): Flow<BlazeCampaignEntity?>
 
     @Transaction


### PR DESCRIPTION
**Part of:** [campaignId](https://github.com/woocommerce/woocommerce-android/issues/11321)

In this previous PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3032 I removed ordering the Blaze campaigns by start date on the DB query. However, I didn't do the same for the rest of the campaign queries. After some more testing I also noticed that relying on the order in which the items where returned by the API was not a good a idea, as this order is sometimes overridden. 

So this PR ensures that we always order the campaigns by the most recently created one. For that we use the `campaignId` column value, which is currently saved as a string but its value is an integer. This integer is always incremental, so the numerical order based on this field `campaignId` should be enough to order the campaigns by most recently created.

This changes can be tested in this PR: https://github.com/woocommerce/woocommerce-android/pull/11737