### PR TITLE
[Woo: Google Listings and Ads] Create store and add functionality to check Google Ads connection status

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.example.ui.storecreation.WooStoreCreationFrag
 import org.wordpress.android.fluxc.example.ui.taxes.WooTaxFragment
 import org.wordpress.android.fluxc.example.ui.wooadmin.WooAdminFragment
 import org.wordpress.android.fluxc.store.WCDataStore
+import org.wordpress.android.fluxc.store.WCGoogleStore
 import org.wordpress.android.fluxc.store.WCUserStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.AppLog
@@ -41,6 +42,7 @@ class WooCommerceFragment : StoreSelectingFragment() {
     @Inject lateinit var wooCommerceStore: WooCommerceStore
     @Inject lateinit var wooDataStore: WCDataStore
     @Inject lateinit var wooUserStore: WCUserStore
+    @Inject lateinit var wooGoogleStore: WCGoogleStore
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
@@ -230,6 +232,22 @@ class WooCommerceFragment : StoreSelectingFragment() {
 
         woo_admin.setOnClickListener {
             replaceFragment(WooAdminFragment())
+        }
+
+        woo_gla_google_ads_status.setOnClickListener {
+            selectedSite?.let { selectedSite ->
+                coroutineScope.launch {
+                    val result = withContext(Dispatchers.Default) {
+                        wooGoogleStore.fetchGoogleAdsConnectionStatus(selectedSite)
+                    }
+                    result.error?.let {
+                        prependToLog("Error in fetchGoogleAdsConnectionStatus: ${it.type} - ${it.message}")
+                    }
+                    result.model?.let {
+                        prependToLog("Google Ads connection status: $it")
+                    } ?: prependToLog("Couldn't fetch Google Ads connection status.")
+                }
+            } ?: showNoWCSitesToast()
         }
     }
 

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -238,7 +238,7 @@ class WooCommerceFragment : StoreSelectingFragment() {
             selectedSite?.let { selectedSite ->
                 coroutineScope.launch {
                     val result = withContext(Dispatchers.Default) {
-                        wooGoogleStore.fetchGoogleAdsConnectionStatus(selectedSite)
+                        wooGoogleStore.isGoogleAdsAccountConnected(selectedSite)
                     }
                     result.error?.let {
                         prependToLog("Error in fetchGoogleAdsConnectionStatus: ${it.type} - ${it.message}")

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -147,5 +147,11 @@
             android:layout_height="wrap_content"
             android:text="WooCommerce Admin" />
 
+        <Button
+            android:id="@+id/woo_gla_google_ads_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Google Listing and Ads: Check Google Ads Connection Status" />
+
     </LinearLayout>
 </ScrollView>

--- a/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.annotations.endpoint;
 
 public class WCWPAPIEndpoint {
+    private static final String WC_PREFIX = "wc";
+
     private static final String WC_PREFIX_V3 = "wc/v3";
 
     private static final String WC_PREFIX_V1 = "wc/v1";
@@ -49,6 +51,10 @@ public class WCWPAPIEndpoint {
 
     public String getPathV4() {
         return "/" + WC_PREFIX_V4 + mEndpoint;
+    }
+
+    public String getPathNoVersion() {
+        return "/" + WC_PREFIX + mEndpoint;
     }
 
     public String getPathV4Analytics() {

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -123,3 +123,5 @@
 
 /shipping_methods
 /shipping_methods/<id>#String
+
+/gla/ads/connection

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
@@ -1,11 +1,40 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.google
 
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.utils.toWooPayload
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WCGoogleRestClient {
-    fun fetchGoogleAdsConnectionStatus(): WooPayload<Boolean> {
-        return WooPayload(false)
+class WCGoogleRestClient  @Inject constructor(private val wooNetwork: WooNetwork) {
+    companion object {
+        const val GOOGLE_ADS_CONNECTED_STATUS = "connected"
+    }
+
+    suspend fun fetchGoogleAdsConnectionStatus(
+        site: SiteModel
+    ): WooPayload<Boolean> {
+        val url = WOOCOMMERCE.gla.ads.connection.pathNoVersion
+        val result = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = GoogleAdsConnectionStatusResponse::class.java
+        ).toWooPayload()
+
+        return when {
+            result.isError -> WooPayload(result.error)
+            result.result != null -> WooPayload(result.result.status == GOOGLE_ADS_CONNECTED_STATUS)
+            else -> WooPayload(false)
+        }
     }
 }
+
+data class GoogleAdsConnectionStatusResponse(
+    @SerializedName("status")
+    val status: String
+)
+

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.google
+
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import javax.inject.Singleton
+
+@Singleton
+class WCGoogleRestClient {
+    fun fetchGoogleAdsConnectionStatus(): WooPayload<Boolean> {
+        return WooPayload(false)
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
@@ -33,6 +33,10 @@ class WCGoogleRestClient  @Inject constructor(private val wooNetwork: WooNetwork
     }
 }
 
+/**
+ * Response model for the Google Ads connection status.
+ * The full response has more fields, but for now we only care about the status.
+ */
 data class GoogleAdsConnectionStatusResponse(
     @SerializedName("status")
     val status: String

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -18,11 +18,12 @@ class WCGoogleStore @Inject constructor(
     private val coroutineEngine: CoroutineEngine
 ) {
     /**
-     * Fetches the connection status of the Google Ads account.
+     * Checks the connection status of the Google Ads account used in the plugin.
      *
-     * @return `true` if the connection is successful, `false` otherwise.
+     * @return WooResult<Boolean> true if the account is connected, false otherwise. Optionally,
+     * passes error, too.
      */
-    suspend fun fetchGoogleAdsConnectionStatus(site: SiteModel): WooResult<Boolean> =
+    suspend fun isGoogleAdsAccountConnected(site: SiteModel): WooResult<Boolean> =
         coroutineEngine.withDefaultContext(API, this, "fetchGoogleAdsConnectionStatus") {
             val response = restClient.fetchGoogleAdsConnectionStatus(site)
             when {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.fluxc.store
+
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.WCGoogleRestClient
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog.T.API
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * This store is intended to be used to support the Google Listings and Ads plugin.
+ * https://wordpress.org/plugins/google-listings-and-ads/
+ */
+@Singleton
+class WCGoogleStore @Inject constructor(
+    private val restClient: WCGoogleRestClient,
+    private val coroutineEngine: CoroutineEngine
+) {
+    /**
+     * Fetches the connection status of the Google Ads account.
+     *
+     * @return `true` if the connection is successful, `false` otherwise.
+     */
+    suspend fun fetchGoogleAdsConnectionStatus(): WooResult<Boolean> =
+        coroutineEngine.withDefaultContext(API, this, "fetchGoogleAdsConnectionStatus") {
+            val response = restClient.fetchGoogleAdsConnectionStatus()
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> response.asWooResult()
+                else -> WooResult(false)
+            }
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store
 
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.WCGoogleRestClient
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -21,9 +22,9 @@ class WCGoogleStore @Inject constructor(
      *
      * @return `true` if the connection is successful, `false` otherwise.
      */
-    suspend fun fetchGoogleAdsConnectionStatus(): WooResult<Boolean> =
+    suspend fun fetchGoogleAdsConnectionStatus(site: SiteModel): WooResult<Boolean> =
         coroutineEngine.withDefaultContext(API, this, "fetchGoogleAdsConnectionStatus") {
-            val response = restClient.fetchGoogleAdsConnectionStatus()
+            val response = restClient.fetchGoogleAdsConnectionStatus(site)
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> response.asWooResult()


### PR DESCRIPTION
### Description:

part of https://github.com/woocommerce/woocommerce-android/issues/11808

This PR adds the store and REST client related to Google Listings and Ads plugin. 
The store currently has one functionality, for checking the status of Google Ads account connection.
The REST client also does one thing, fetching the Google Ads connection status.

### To test:
1. You need to prepare a test site with the **Google Listings & Ads plugin** setup and activated. Warning that this might be a bit time consuming if it's your first time (about 30 minutes). Setup guide is available here pe5sF9-2Qo-p2
2. Run Example app, and login to the test site,
3. Go to **Woo**, then select the site,
4. Scroll down to the end and tap the **Google Listing and Ads: Check Ads Connection Status** button,
5. It should say `Google Ads connection status: true` in the log section
6. In wp-admin, go to **Marketing > Google Listings & Ads**, then **Settings**.
7. Disconect the Google Ads account from there,
8. Go back to the button from point 4, tap it again.
9. It should say `Google Ads connection status: false` in the log section
10. (Optional) Try also with another site that doesn't have the plugin setup. The log section should show the error.