### PR TITLE
Issue/11802 update jetpack ai query impl

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/JetpackAIFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/JetpackAIFragment.kt
@@ -130,7 +130,7 @@ class JetpackAIFragment : StoreSelectingFragment() {
 
     private fun setJetpackAIQueryQuestionButton() {
         jetpack_ai_query_question.setOnClickListener {
-            siteStore.sites[0].let {
+           selectedSite?.let {
                 lifecycleScope.launch {
                     val question = "What is WooCommerce?"
                     prependToLog("Loading Jetpack AI Query... $question")

--- a/example/src/main/java/org/wordpress/android/fluxc/example/JetpackAIFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/JetpackAIFragment.kt
@@ -10,9 +10,9 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_jetpackai.*
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.example.ui.StoreSelectingFragment
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIQueryResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsResponse.Success
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIQueryResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAITranscriptionResponse
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.jetpackai.JetpackAIStore
@@ -43,8 +43,9 @@ class JetpackAIFragment : StoreSelectingFragment() {
 
         setHaikuButton()
         setTranscribeAudioButton()
-        setJetpackAIQueryButton()
+        setJetpackAIQueryVoiceToContentButton()
         setJetpackAIAssistantFeatureButton()
+        setJetpackAIQueryQuestionButton()
     }
 
     private fun setHaikuButton() {
@@ -97,8 +98,8 @@ class JetpackAIFragment : StoreSelectingFragment() {
         }
     }
 
-    private fun setJetpackAIQueryButton() {
-        jetpack_ai_query.setOnClickListener {
+    private fun setJetpackAIQueryVoiceToContentButton() {
+        jetpack_ai_query_voice_to_content.setOnClickListener {
             siteStore.sites[0].let {
                 lifecycleScope.launch {
                     val result = store.fetchJetpackAIQuery(
@@ -115,7 +116,36 @@ class JetpackAIFragment : StoreSelectingFragment() {
                             val content = result.choices[0].message?.content
                             content?.let {
                                 prependToLog("Jetpack AI Query Processed:\n$content}")
-                            }?:prependToLog("Error post processing - content is null")
+                            } ?: prependToLog("Error post processing - content is null")
+                        }
+
+                        is JetpackAIQueryResponse.Error -> {
+                            prependToLog("Error post processing: ${result.message}")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun setJetpackAIQueryQuestionButton() {
+        jetpack_ai_query_question.setOnClickListener {
+            siteStore.sites[0].let {
+                lifecycleScope.launch {
+                    val question = "What is WooCommerce?"
+                    prependToLog("Loading Jetpack AI Query... $question")
+                    val result = store.fetchJetpackAIQuery(
+                        site = it,
+                        question = question,
+                        feature = "fluxc-example-question",
+                        stream = false,
+                    )
+                    when (result) {
+                        is JetpackAIQueryResponse.Success -> {
+                            val content = result.choices[0].message?.content
+                            content?.let {
+                                prependToLog("Jetpack AI Query Processed:\n$content}")
+                            } ?: prependToLog("Error post processing - content is null")
                         }
 
                         is JetpackAIQueryResponse.Error -> {

--- a/example/src/main/res/layout/fragment_jetpackai.xml
+++ b/example/src/main/res/layout/fragment_jetpackai.xml
@@ -6,6 +6,7 @@
     android:layout_margin="@dimen/activity_start_end_margin"
     tools:context="org.wordpress.android.fluxc.example.DomainsFragment"
     tools:ignore="HardcodedText">
+
     <LinearLayout
         android:id="@+id/buttonContainer"
         android:layout_width="match_parent"
@@ -25,7 +26,7 @@
             android:text="Transcribe Audio" />
 
         <Button
-            android:id="@+id/jetpack_ai_query"
+            android:id="@+id/jetpack_ai_query_voice_to_content"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Voice to Content - AI Query" />
@@ -35,6 +36,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="AI Assistant Feature" />
+
+        <Button
+            android:id="@+id/jetpack_ai_query_question"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Question - AI Query" />
 
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-android/issues/11802

Adds new functions to use the endpoint `/jetpack-ai-query` for asking questions. The new functions can be tested using FluxC sample app: 


https://github.com/wordpress-mobile/WordPress-FluxC-Android/assets/2663464/69b3990c-ef88-426c-8a34-22af12364a34

Changes can also be tested as part of [this PR](https://github.com/woocommerce/woocommerce-android/pull/11819) where we started using the new endpoint for AI features in WooCommerce app. 

For context. There was already an existing method `JetpackAIRestClient` to send queries to `/jetpack-ai-query` endpoint. This method was intended to be used for `voice-to-content` feature in Jetpack app. But after multiple testing I wasn't able to re use the existing implementation to make it work for our purpose of asking questions to Jetpack AI, so I've provided an additional implementation to do this. 



