### PR TITLE
Disable failing test

### DIFF
--- a/tests/api/src/test/java/APITesting_WCGateway.java
+++ b/tests/api/src/test/java/APITesting_WCGateway.java
@@ -1,4 +1,5 @@
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -31,6 +32,7 @@ public class APITesting_WCGateway {
     }
 
     @Test
+    @Ignore("Failing in recent trunk. See commit 8776bc1")
     public void canGetAllPaymentGateways() {
         given().
             spec(this.mRequestSpec).


### PR DESCRIPTION
[The latest commit in trunk](https://github.com/wordpress-mobile/WordPress-FluxC-Android/commit/8776bc183e07d46d50f892690205f177b11fe052) has a test breaking that has nothing to do with the work being added (likely caused by flaky API).

I'm disabling it for now to not block development. Discussed also in Slack p1719494017818699-slack-CGPNUU63E