### PR TITLE
[Google for Woo] Store and REST client functionality to fetch campaign lists.

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/WooCommerceFragment.kt
@@ -234,8 +234,9 @@ class WooCommerceFragment : StoreSelectingFragment() {
             replaceFragment(WooAdminFragment())
         }
 
-        woo_gla_google_ads_status.setOnClickListener {
+        woo_google_ads_status.setOnClickListener {
             selectedSite?.let { selectedSite ->
+                prependToLog("Fetching Google Ads connection status...")
                 coroutineScope.launch {
                     val result = withContext(Dispatchers.Default) {
                         wooGoogleStore.isGoogleAdsAccountConnected(selectedSite)
@@ -246,6 +247,29 @@ class WooCommerceFragment : StoreSelectingFragment() {
                     result.model?.let {
                         prependToLog("Google Ads connection status: $it")
                     } ?: prependToLog("Couldn't fetch Google Ads connection status.")
+                }
+            } ?: showNoWCSitesToast()
+        }
+
+        woo_google_ads_campaigns.setOnClickListener {
+            selectedSite?.let { selectedSite ->
+                prependToLog("Fetching Google Ads campaigns...")
+                coroutineScope.launch {
+                    val result = withContext(Dispatchers.Default) {
+                        wooGoogleStore.fetchGoogleAdsCampaigns(selectedSite)
+                    }
+                    result.error?.let {
+                        prependToLog("Error in fetchGoogleAdsCampaigns: ${it.type} - ${it.message}")
+                    }
+                    result.model?.let { campaigns ->
+                        prependToLog("Fetched ${campaigns.size} Google Ads campaigns")
+                        campaigns.forEach { campaign ->
+                            prependToLog("Campaign ID: ${campaign.id}, " +
+                                "Name: ${campaign.name}, " +
+                                "Status: ${campaign.status}"
+                            )
+                        }
+                    } ?: prependToLog("Couldn't fetch Google Ads campaigns.")
                 }
             } ?: showNoWCSitesToast()
         }

--- a/example/src/main/res/layout/fragment_woocommerce.xml
+++ b/example/src/main/res/layout/fragment_woocommerce.xml
@@ -148,10 +148,17 @@
             android:text="WooCommerce Admin" />
 
         <Button
-            android:id="@+id/woo_gla_google_ads_status"
+            android:id="@+id/woo_google_ads_status"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Google Listing and Ads: Check Google Ads Connection Status" />
+            android:text="Google for Woo: Check Google Ads Connection" />
+
+        <Button
+            android:id="@+id/woo_google_ads_campaigns"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Google for Woo: Fetch Campaigns List" />
+
 
     </LinearLayout>
 </ScrollView>

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -125,3 +125,4 @@
 /shipping_methods/<id>#String
 
 /gla/ads/connection
+/gla/ads/campaigns

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsCampaign.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsCampaign.kt
@@ -6,8 +6,8 @@ data class WCGoogleAdsCampaign(
     val status: Status?,
     val type: String?,
     val amount: Double?,
-    val country: String?,
-    val targetedLocations: List<String>?
+    val countryISOCode: String?,
+    val targetedCountryISOCodes: List<String>?
 ) {
     enum class Status {
         ENABLED,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsCampaign.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsCampaign.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.fluxc.model.google
+
+data class WCGoogleAdsCampaign(
+    val id: Long?,
+    val name: String?,
+    val status: Status?,
+    val type: String?,
+    val amount: Double?,
+    val country: String?,
+    val targetedLocations: List<String>?
+) {
+    enum class Status {
+        ENABLED,
+        DISABLED,
+        REMOVED
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsCampaignMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsCampaignMapper.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.fluxc.model.google
+
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.WCGoogleAdsCampaignDTO
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+
+class WCGoogleAdsCampaignMapper @Inject constructor() {
+    fun mapToModel(dto: WCGoogleAdsCampaignDTO): WCGoogleAdsCampaign {
+        return WCGoogleAdsCampaign(
+            id = dto.id,
+            name = dto.name,
+            status = dto.status?.let {
+                try {
+                    WCGoogleAdsCampaign.Status.valueOf(it.uppercase())
+                } catch (e: IllegalArgumentException) {
+                    AppLog.w(
+                        AppLog.T.API,
+                        "Unknown campaign status returned: `$it`, defaulting to DISABLED " +
+                        e.message
+                    )
+                    WCGoogleAdsCampaign.Status.DISABLED
+                }
+            },
+            type = dto.rawType,
+            amount = dto.amount,
+            country = dto.country,
+            targetedLocations = dto.targetedLocations
+        )
+    }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsCampaignMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsCampaignMapper.kt
@@ -23,8 +23,8 @@ class WCGoogleAdsCampaignMapper @Inject constructor() {
             },
             type = dto.rawType,
             amount = dto.amount,
-            country = dto.country,
-            targetedLocations = dto.targetedLocations
+            countryISOCode = dto.country,
+            targetedCountryISOCodes = dto.targetedLocations
         )
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleAdsCampaignDTO.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleAdsCampaignDTO.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.google
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.network.Response
+
+data class WCGoogleAdsCampaignDTO(
+    @SerializedName("id") val id: Long? = null,
+    @SerializedName("name") val name: String? = null,
+    @SerializedName("status") val status: String? = null,
+    @SerializedName("type") val rawType: String? = null,
+    @SerializedName("amount") val amount: Double? = null,
+    @SerializedName("country") val country: String? = null,
+    @SerializedName("targeted_locations") val targetedLocations: List<String>? = null
+) : Response

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
@@ -31,6 +31,21 @@ class WCGoogleRestClient  @Inject constructor(private val wooNetwork: WooNetwork
             else -> WooPayload(false)
         }
     }
+
+    suspend fun fetchGoogleAdsCampaigns(site: SiteModel): WooPayload<List<WCGoogleAdsCampaignDTO>> {
+        val url = WOOCOMMERCE.gla.ads.campaigns.pathNoVersion
+        val result = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<WCGoogleAdsCampaignDTO>::class.java
+        ).toWooPayload()
+
+        return when {
+            result.isError -> WooPayload(result.error)
+            result.result != null -> WooPayload(result.result.toList())
+            else -> WooPayload(emptyList())
+        }
+    }
 }
 
 /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
@@ -32,11 +32,16 @@ class WCGoogleRestClient  @Inject constructor(private val wooNetwork: WooNetwork
         }
     }
 
-    suspend fun fetchGoogleAdsCampaigns(site: SiteModel): WooPayload<List<WCGoogleAdsCampaignDTO>> {
+    suspend fun fetchGoogleAdsCampaigns(
+        site: SiteModel,
+        excludeRemovedCampaigns: Boolean = true
+    ): WooPayload<List<WCGoogleAdsCampaignDTO>> {
         val url = WOOCOMMERCE.gla.ads.campaigns.pathNoVersion
+        val params = mapOf("exclude_removed" to excludeRemovedCampaigns.toString())
         val result = wooNetwork.executeGetGsonRequest(
             site = site,
             path = url,
+            params = params,
             clazz = Array<WCGoogleAdsCampaignDTO>::class.java
         ).toWooPayload()
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -36,22 +36,26 @@ class WCGoogleStore @Inject constructor(
             }
         }
 
-    /**
-     * Fetches the Google Ads campaigns.
-     *
-     * @return WooResult<List<WCGoogleAdsCampaign>> a list of Google Ads campaigns. Optionally,
-     * passes error, too.
-     */
-    suspend fun fetchGoogleAdsCampaigns(site: SiteModel): WooResult<List<WCGoogleAdsCampaign>> =
-        coroutineEngine.withDefaultContext(API, this, "fetchGoogleAdsCampaigns") {
-            val response = restClient.fetchGoogleAdsCampaigns(site)
-            when {
-                response.isError -> WooResult(response.error)
-                response.result != null -> {
-                    val campaigns = response.result.map { mapper.mapToModel(it) }
-                    WooResult(campaigns)
-                }
-                else -> WooResult(emptyList())
+/**
+ * Fetches the Google Ads campaigns.
+ *
+ * @param excludeRemovedCampaigns Exclude removed (deleted) campaigns from being fetched.
+ * @return WooResult<List<WCGoogleAdsCampaign>> a list of Google Ads campaigns. Optionally,
+ * passes error, too.
+ */
+suspend fun fetchGoogleAdsCampaigns(
+    site: SiteModel,
+    excludeRemovedCampaigns: Boolean = true
+): WooResult<List<WCGoogleAdsCampaign>> =
+    coroutineEngine.withDefaultContext(API, this, "fetchGoogleAdsCampaigns") {
+        val response = restClient.fetchGoogleAdsCampaigns(site, excludeRemovedCampaigns)
+        when {
+            response.isError -> WooResult(response.error)
+            response.result != null -> {
+                val campaigns = response.result.map { mapper.mapToModel(it) }
+                WooResult(campaigns)
             }
+            else -> WooResult(emptyList())
         }
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.fluxc.store
 
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.google.WCGoogleAdsCampaign
+import org.wordpress.android.fluxc.model.google.WCGoogleAdsCampaignMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.WCGoogleRestClient
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -15,7 +17,8 @@ import javax.inject.Singleton
 @Singleton
 class WCGoogleStore @Inject constructor(
     private val restClient: WCGoogleRestClient,
-    private val coroutineEngine: CoroutineEngine
+    private val coroutineEngine: CoroutineEngine,
+    private val mapper: WCGoogleAdsCampaignMapper
 ) {
     /**
      * Checks the connection status of the Google Ads account used in the plugin.
@@ -31,5 +34,24 @@ class WCGoogleStore @Inject constructor(
                 response.result != null -> response.asWooResult()
                 else -> WooResult(false)
             }
-    }
+        }
+
+    /**
+     * Fetches the Google Ads campaigns.
+     *
+     * @return WooResult<List<WCGoogleAdsCampaign>> a list of Google Ads campaigns. Optionally,
+     * passes error, too.
+     */
+    suspend fun fetchGoogleAdsCampaigns(site: SiteModel): WooResult<List<WCGoogleAdsCampaign>> =
+        coroutineEngine.withDefaultContext(API, this, "fetchGoogleAdsCampaigns") {
+            val response = restClient.fetchGoogleAdsCampaigns(site)
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> {
+                    val campaigns = response.result.map { mapper.mapToModel(it) }
+                    WooResult(campaigns)
+                }
+                else -> WooResult(emptyList())
+            }
+        }
 }


### PR DESCRIPTION
This PR adds the functionality to fetch Google Ads Campaigns list.

To test:
1. You need to prepare a test site with the Google Listings & Ads plugin setup and activated with existing campaigns. Warning that this might be a bit time consuming if it's your first time (about 30 minutes). Setup guide is available here pe5sF9-2Qo-p2
2. Run Example app, and login to the test site,
3. Go to Woo, then select the site,
4. Scroll down to the end and tap the **Google For Woo: Fetch Campaigns List** button,
5. It should list the existing campaigns if they exist in your test site,
6. Switch to a different site with no Google Listings & Ads plugin
7. Test the same button and it should show the error message.