### PR TITLE
fix: Update published post date

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/post/PostRestClient.java
@@ -657,9 +657,7 @@ public class PostRestClient extends BaseWPComRestClient {
             params.put("author", String.valueOf(post.getAuthorId()));
         }
 
-        if (!TextUtils.isEmpty(post.getDateCreated())
-            && post.getStatus().equals(PostStatus.SCHEDULED.toString())
-        ) {
+        if (!TextUtils.isEmpty(post.getDateCreated())) {
             params.put("date", post.getDateCreated());
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/post/PostXMLRPCClient.java
@@ -507,7 +507,7 @@ public class PostXMLRPCClient extends BaseXMLRPCClient {
 
         String dateCreated = post.getDateCreated();
         Date date = DateTimeUtils.dateUTCFromIso8601(dateCreated);
-        if (date != null && post.getStatus().equals(PostStatus.SCHEDULED.toString())) {
+        if (date != null) {
             contentStruct.put("post_date", date);
             // Redundant, but left in just in case
             // Note: XML-RPC sends the same value for dateCreated and date_created_gmt in the first place


### PR DESCRIPTION
## Related PRs

* https://github.com/wordpress-mobile/WordPress-Android/pull/21036

## Description

Relates to https://github.com/wordpress-mobile/WordPress-Android/issues/21001. 

Reverts the changes in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3003 which addressed https://github.com/wordpress-mobile/WordPress-Android/issues/17375. However, those changes introduced a regression in the form of https://github.com/wordpress-mobile/WordPress-Android/issues/21001. 

I was unable to quickly identify a simple solution that solved both the original bug and the regression. Therefore, I opted to merely revert the changes, as https://github.com/wordpress-mobile/WordPress-Android/issues/17375 seems like an outlier, requiring an inaccurate system time by disabling the device's automatic clock synchronization. 

## Testing Instructions

See https://github.com/wordpress-mobile/WordPress-Android/issues/21001. 