### PR TITLE
[FluxC] Catch NumberFormatException in PrivateAtomicCookie

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/PrivateAtomicCookie.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/PrivateAtomicCookie.kt
@@ -33,18 +33,18 @@ class PrivateAtomicCookie
     }
 
     private fun isExpiringSoon(): Boolean {
-        if (!exists()) {
-            return true
-        }
-        try {
-            val cookieExpiration: Long = cookie!!.expires.toLong()
-            val currentTime = (System.currentTimeMillis() / MILLIS)
-
-            return currentTime + COOKIE_EXPIRATION_THRESHOLD >= cookieExpiration
-        } catch (e: NumberFormatException) {
-            // we ran into a situation where cookie!!.expires contained "false" resulting
-            // in an exception attempting to convert it to a long
-            return false
+        return if (!exists()) {
+            true
+        } else {
+            try {
+                val cookieExpiration: Long = cookie!!.expires.toLong()
+                val currentTime = (System.currentTimeMillis() / MILLIS)
+                currentTime + COOKIE_EXPIRATION_THRESHOLD >= cookieExpiration
+            } catch (e: NumberFormatException) {
+                // we ran into a situation where cookie!!.expires contained "false" resulting
+                // in an exception attempting to convert it to a long
+                false
+            }
         }
     }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/PrivateAtomicCookie.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/PrivateAtomicCookie.kt
@@ -36,10 +36,16 @@ class PrivateAtomicCookie
         if (!exists()) {
             return true
         }
-        val cookieExpiration: Long = cookie!!.expires.toLong()
-        val currentTime = (System.currentTimeMillis() / MILLIS)
+        try {
+            val cookieExpiration: Long = cookie!!.expires.toLong()
+            val currentTime = (System.currentTimeMillis() / MILLIS)
 
-        return currentTime + COOKIE_EXPIRATION_THRESHOLD >= cookieExpiration
+            return currentTime + COOKIE_EXPIRATION_THRESHOLD >= cookieExpiration
+        } catch (e: NumberFormatException) {
+            // we ran into a situation where cookie!!.expires contained "false" resulting
+            // in an exception attempting to convert it to a long
+            return false
+        }
     }
 
     fun exists(): Boolean {


### PR DESCRIPTION
Fixes #3046

This small PR addresses a crash [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/78bdb05b87cf99c6dddff2158aef10629c9072e2/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/PrivateAtomicCookie.kt#L39) caused by assuming `cookie.expires` is a long (in my case, it was a string containing 'false').

To test, modify [this line](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/be56f1479e1a74e6733fcceb1d7e97b39b51157f/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/PrivateAtomicCookie.kt#L40) to:

```
val cookieExpiration: Long = "false".toLong()
```

Then verify that tests in `PrivateAtomicCookieTest` run without a `NumberFormatException` crash (note that some tests will fail in this situation, but it's the crash we want to prevent).