### PR TITLE
[Dependency Update] Update `a8c-ci-toolkit` to 3.4.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.15.0
+    - automattic/a8c-ci-toolkit#3.4.2
   # Common artifact paths used across steps
   - &artifact_paths
     - "**/build/test-results/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,9 +3,6 @@
 
 # Nodes with values to reuse in the pipeline.
 common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
   # Common artifact paths used across steps
   - &artifact_paths
     - "**/build/test-results/**/*"
@@ -21,7 +18,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     notify:
       - github_commit_status:
           context: "Gradle Wrapper Validation"
@@ -40,7 +37,7 @@ steps:
           cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
           ./gradlew checkstyle
         artifact_paths: *artifact_paths
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
               context: "checkstyle"
@@ -50,7 +47,7 @@ steps:
           cp gradle.properties-example gradle.properties && cp -a example/properties-example/ example/properties/
           ./gradlew detekt
         artifact_paths: *artifact_paths
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
               context: "detekt"
@@ -61,7 +58,7 @@ steps:
           ./gradlew lintRelease || (grep -A20 -B2 'severity="Error"' */build/**/*.xml; exit 1);
           find . -iname "*XMLRPCClient*java" | xargs grep getSiteId && (echo "You should not use _getSiteId_ in a XMLRPClient, did you mean _selfHostedId_?" && exit 1) || exit 0;
         artifact_paths: *artifact_paths
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
               context: "Lint"
@@ -75,7 +72,7 @@ steps:
       - label: "🔬 Unit Test"
         command: .buildkite/unit-tests.sh
         artifact_paths: *artifact_paths
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
               context: "Unit Test"
@@ -83,7 +80,7 @@ steps:
       - label: "🔬 WooCommerce Tests"
         command: .buildkite/woocommerce-tests.sh
         artifact_paths: *artifact_paths
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
               context: "WooCommerce Tests"
@@ -95,7 +92,7 @@ steps:
     key: connected-tests
     command: .buildkite/connected-tests.sh
     artifact_paths: *artifact_paths
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     notify:
       - github_commit_status:
           context: "Publish :fluxc-build-connected-tests"
@@ -112,7 +109,7 @@ steps:
       - label: "🚀 Publish :fluxc-annotations"
         key: "publish-fluxc-annotations"
         command: .buildkite/publish-fluxc-annotations.sh
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
               context: "Publish :fluxc-annotations"
@@ -122,7 +119,7 @@ steps:
         depends_on:
           - "publish-fluxc-annotations"
         command: .buildkite/publish-fluxc-processor.sh
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
               context: "Publish :fluxc-processor"
@@ -133,7 +130,7 @@ steps:
           - "publish-fluxc-processor"
           - "publish-fluxc-annotations"
         command: .buildkite/publish-fluxc.sh
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - github_commit_status:
               context: "Publish :fluxc"
@@ -145,7 +142,7 @@ steps:
           - "publish-fluxc-annotations"
           - "publish-fluxc"
         command: .buildkite/publish-plugins-woocommerce.sh
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
         - github_commit_status:
             context: "Publish :plugins:woocommerce"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+ # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+ # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"


### PR DESCRIPTION
### Description

This PR updates `a8c-ci-toolkit` to [3.4.2](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/3.4.2).

FYI: The breaking change in `3.0.0` is due to removing the `nvm_install` command, but this repo doesn't use that anywhere anyway. As such, it is safe to apply this update.

### Testing Instructions

- Make sure CI is green (🟢).