### PR TITLE
Get cached visitor stats

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -210,6 +210,32 @@ class WCStatsStore @Inject constructor(
         } ?: return mapOf()
     }
 
+    fun getNewVisitorStats(
+        granularity: StatsGranularity,
+        startDate: String,
+        endDate: String,
+        site: SiteModel
+    ): Map<String, Int> {
+        val quantity = getVisitorStatsQuantity(granularity, startDate, endDate)
+        val date = DateUtils.getDateTimeForSite(site, DATE_FORMAT_DAY, endDate)
+        val rawStats = WCVisitorStatsSqlUtils.getNewRawVisitorStatsForSiteGranularityQuantityAndDate(
+            site, granularity, quantity.toString(), date, true
+        )
+        rawStats?.let { visitorStatsModel ->
+            val periodIndex = visitorStatsModel.getIndexForField(WCNewVisitorStatsModel.VisitorStatsField.PERIOD)
+            val fieldIndex = visitorStatsModel.getIndexForField(WCNewVisitorStatsModel.VisitorStatsField.VISITORS)
+            return if (periodIndex == -1 || fieldIndex == -1) {
+                mapOf()
+            } else {
+                getVisitorsMap(
+                    periodIndex = periodIndex,
+                    fieldIndex = fieldIndex,
+                    dataList = visitorStatsModel.dataList
+                )
+            }
+        } ?: return mapOf()
+    }
+
     private fun getVisitorsMap(
         periodIndex: Int, fieldIndex: Int, dataList: List<List<Any>>
     ): Map<String, Int> {


### PR DESCRIPTION
### Why
As part of the new Background Tasks projects we aim to improve performance by displaying cached data by default.

### Description
This small PR adds the `getNewVisitorStats` function so we can get cached visitor stats before making a request to the API.

### Testing
It is better to test this PR along side the [Woo PR.](https://github.com/woocommerce/woocommerce-android/pull/12003)