### PR TITLE
Disable WooCommerce API tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -77,13 +77,13 @@ steps:
           - github_commit_status:
               context: "Unit Test"
 
-      - label: "🔬 WooCommerce Tests"
-        command: .buildkite/woocommerce-tests.sh
-        artifact_paths: *artifact_paths
-        plugins: [$CI_TOOLKIT]
-        notify:
-          - github_commit_status:
-              context: "WooCommerce Tests"
+#      - label: "🔬 WooCommerce Tests"
+#        command: .buildkite/woocommerce-tests.sh
+#        artifact_paths: *artifact_paths
+#        plugins: [$CI_TOOLKIT]
+#        notify:
+#          - github_commit_status:
+#              context: "WooCommerce Tests"
 
   ############################
   # Connected Tests


### PR DESCRIPTION
The website used for the tests is down, to unblock PRs, we are disabling all of the `WooCommerce Tests` temporarily.

see p1721048180229249-slack-CGPNUU63E