### PR TITLE
[Woo] Add store and REST functionality to fetch Google Ads impressions and clicks

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsPrograms.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsPrograms.kt
@@ -24,3 +24,8 @@ data class WCGoogleAdsProgramTotals(
     val sales: Double?,
     val spend: Double?
 )
+
+data class WCGoogleAdsCardStats(
+    val impressions: Double,
+    val clicks: Double
+)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsProgramsMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsProgramsMapper.kt
@@ -36,8 +36,4 @@ class WCGoogleAdsProgramsMapper @Inject constructor() {
             }
         )
     }
-
-    fun mapToImpressionsAndClicks(dto: WCGoogleAdsProgramsDTO): Pair<Double, Double> {
-        return dto.totals?.let { Pair(it.impressions ?: 0.0, it.clicks ?: 0.0) } ?: Pair(0.0, 0.0)
-    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsProgramsMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsProgramsMapper.kt
@@ -36,4 +36,8 @@ class WCGoogleAdsProgramsMapper @Inject constructor() {
             }
         )
     }
+
+    fun mapToImpressionsAndClicks(dto: WCGoogleAdsProgramsDTO): Pair<Double, Double> {
+        return dto.totals?.let { Pair(it.impressions ?: 0.0, it.clicks ?: 0.0) } ?: Pair(0.0, 0.0)
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleAdsProgramsDTO.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleAdsProgramsDTO.kt
@@ -22,5 +22,7 @@ data class GoogleAdsIntervalDTO(
 
 data class GoogleAdsTotalsDTO(
     @SerializedName("sales") val sales: Double?,
-    @SerializedName("spend") val spend: Double?
+    @SerializedName("spend") val spend: Double?,
+    @SerializedName("impressions") val impressions: Double?,
+    @SerializedName("clicks") val clicks: Double?
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
@@ -76,6 +76,29 @@ class WCGoogleRestClient  @Inject constructor(private val wooNetwork: WooNetwork
             else -> WooPayload(response.result)
         }
     }
+
+    suspend fun fetchImpressionsAndClicks(
+        site: SiteModel,
+        startDate: String,
+        endDate: String,
+    ): WooPayload<WCGoogleAdsProgramsDTO> {
+        val url = WOOCOMMERCE.gla.ads.reports.programs.pathNoVersion
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            params = mapOf(
+                "after" to startDate,
+                "before" to endDate,
+                "fields" to "impressions, clicks",
+            ),
+            clazz = WCGoogleAdsProgramsDTO::class.java
+        ).toWooPayload()
+
+        return when {
+            response.isError || response.result == null -> WooPayload(response.error)
+            else -> WooPayload(response.result)
+        }
+    }
 }
 
 /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.store
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.google.WCGoogleAdsCampaign
 import org.wordpress.android.fluxc.model.google.WCGoogleAdsCampaignMapper
+import org.wordpress.android.fluxc.model.google.WCGoogleAdsCardStats
 import org.wordpress.android.fluxc.model.google.WCGoogleAdsPrograms
 import org.wordpress.android.fluxc.model.google.WCGoogleAdsProgramsMapper
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
@@ -93,7 +94,7 @@ class WCGoogleStore @Inject constructor(
         site: SiteModel,
         startDate: String,
         endDate: String
-    ): WooResult<Pair<Double, Double>> =
+    ): WooResult<WCGoogleAdsCardStats> =
         coroutineEngine.withDefaultContext(API, this, "fetchImpressionsAndClicks") {
             val response = restClient.fetchImpressionsAndClicks(site, startDate, endDate)
 
@@ -106,7 +107,12 @@ class WCGoogleStore @Inject constructor(
             val impressions = totals?.impressions
 
             if (clicks != null && impressions != null) {
-                WooResult(Pair(impressions, clicks))
+                WooResult(
+                    WCGoogleAdsCardStats(
+                        clicks = clicks,
+                        impressions = impressions
+                    )
+                )
             } else {
                 WooResult(
                     WooError(WooErrorType.INVALID_RESPONSE, GenericErrorType.INVALID_RESPONSE)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -42,28 +42,29 @@ class WCGoogleStore @Inject constructor(
             }
         }
 
-/**
- * Fetches the Google Ads campaigns.
- *
- * @param excludeRemovedCampaigns Exclude removed (deleted) campaigns from being fetched.
- * @return WooResult<List<WCGoogleAdsCampaign>> a list of Google Ads campaigns. Optionally,
- * passes error, too.
- */
-suspend fun fetchGoogleAdsCampaigns(
-    site: SiteModel,
-    excludeRemovedCampaigns: Boolean = true
-): WooResult<List<WCGoogleAdsCampaign>> =
-    coroutineEngine.withDefaultContext(API, this, "fetchGoogleAdsCampaigns") {
-        val response = restClient.fetchGoogleAdsCampaigns(site, excludeRemovedCampaigns)
-        when {
-            response.isError -> WooResult(response.error)
-            response.result != null -> {
-                val campaigns = response.result.map { campaignMapper.mapToModel(it) }
-                WooResult(campaigns)
+    /**
+     * Fetches the Google Ads campaigns.
+     *
+     * @param excludeRemovedCampaigns Exclude removed (deleted) campaigns from being fetched.
+     * @return WooResult<List<WCGoogleAdsCampaign>> a list of Google Ads campaigns. Optionally,
+     * passes error, too.
+     */
+    suspend fun fetchGoogleAdsCampaigns(
+        site: SiteModel,
+        excludeRemovedCampaigns: Boolean = true
+    ): WooResult<List<WCGoogleAdsCampaign>> =
+        coroutineEngine.withDefaultContext(API, this, "fetchGoogleAdsCampaigns") {
+            val response = restClient.fetchGoogleAdsCampaigns(site, excludeRemovedCampaigns)
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> {
+                    val campaigns = response.result.map { campaignMapper.mapToModel(it) }
+                    WooResult(campaigns)
+                }
+
+                else -> WooResult(emptyList())
             }
-            else -> WooResult(emptyList())
         }
-    }
 
     suspend fun fetchAllPrograms(
         site: SiteModel,
@@ -92,18 +93,22 @@ suspend fun fetchGoogleAdsCampaigns(
         site: SiteModel,
         startDate: String,
         endDate: String
-    ) : WooResult<Pair<Double, Double>> =
+    ): WooResult<Pair<Double, Double>> =
         coroutineEngine.withDefaultContext(API, this, "fetchImpressionsAndClicks") {
-            val response = restClient.fetchImpressionsAndClicks(
-                site = site,
-                startDate = startDate,
-                endDate = endDate
-            )
+            val response = restClient.fetchImpressionsAndClicks(site, startDate, endDate)
 
-            when {
-                response.isError -> WooResult(response.error)
-                response.result != null -> WooResult(programsMapper.mapToImpressionsAndClicks(response.result))
-                else -> WooResult(
+            if (response.isError) {
+                return@withDefaultContext WooResult(response.error)
+            }
+
+            val totals = response.result?.totals
+            val clicks = totals?.clicks
+            val impressions = totals?.impressions
+
+            if (clicks != null && impressions != null) {
+                WooResult(Pair(impressions, clicks))
+            } else {
+                WooResult(
                     WooError(WooErrorType.INVALID_RESPONSE, GenericErrorType.INVALID_RESPONSE)
                 )
             }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -88,6 +88,27 @@ suspend fun fetchGoogleAdsCampaigns(
             }
         }
 
+    suspend fun fetchImpressionsAndClicks(
+        site: SiteModel,
+        startDate: String,
+        endDate: String
+    ) : WooResult<Pair<Double, Double>> =
+        coroutineEngine.withDefaultContext(API, this, "fetchImpressionsAndClicks") {
+            val response = restClient.fetchImpressionsAndClicks(
+                site = site,
+                startDate = startDate,
+                endDate = endDate
+            )
+
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> WooResult(programsMapper.mapToImpressionsAndClicks(response.result))
+                else -> WooResult(
+                    WooError(WooErrorType.INVALID_RESPONSE, GenericErrorType.INVALID_RESPONSE)
+                )
+            }
+        }
+
     enum class MetricType(val parameterName: String) {
         SALES("sales"),
         SPEND("spend"),


### PR DESCRIPTION
This PR updates `WCGoogleStore` with a function to fetch impressions and clicks, with the matching REST client function.

Technically this hits the same endpoint as the existing `fetchAllPrograms()` function. However, I found its `restClient.fetchAllPrograms()` functionality to only support one field at a time, while for my work I need to get multiple fields at once (impressions and clicks). Another reason for adding separate function is because the existing function is being used in a separate, ongoing project, and I don't want to introduce breaking changes.

To test, please use the WooCommerce PR: https://github.com/woocommerce/woocommerce-android/pull/12030