### PR TITLE
[Woo] Fix Site Credentials login when site discovery fails and site has http to https redirection

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticator.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/CookieNonceAuthenticator.kt
@@ -10,7 +10,6 @@ import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.FailedRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.Unknown
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.tools.CoroutineEngine
-import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
@@ -135,7 +134,7 @@ class CookieNonceAuthenticator @Inject constructor(
         url: String
     ): String {
         return discoveryWPAPIRestClient.discoverWPAPIBaseURL(url) // discover rest api endpoint
-            ?: url.slashJoin("wp-json/") // fallback to ".../wp-json/" if discovery fails
+            ?: WPAPIDiscoveryUtils.buildDefaultRESTBaseUrl(url)
     }
 
     sealed interface CookieNonceAuthenticationResult {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIDiscoveryUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIDiscoveryUtils.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.fluxc.network.rest.wpapi
+
+import org.wordpress.android.fluxc.utils.extensions.slashJoin
+import org.wordpress.android.util.UrlUtils
+
+internal object WPAPIDiscoveryUtils {
+    fun buildDefaultRESTBaseUrl(
+        url: String
+    ): String {
+        val urlWithoutScheme = UrlUtils.removeScheme(url)
+        val httpsUrl = UrlUtils.addUrlSchemeIfNeeded(urlWithoutScheme, true)
+
+        // fallback to ".../wp-json/"
+        return httpsUrl.slashJoin("wp-json")
+    }
+}

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIDiscoveryUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIDiscoveryUtils.kt
@@ -10,6 +10,8 @@ internal object WPAPIDiscoveryUtils {
         val urlWithoutScheme = UrlUtils.removeScheme(url)
         val httpsUrl = UrlUtils.addUrlSchemeIfNeeded(urlWithoutScheme, true)
 
+        // TODO investigate the possibility to use `/?rest_route=` instead,
+        //  `/wp-json` works only when permalinks are enabled, where `/?rest_route=` works without them
         // fallback to ".../wp-json/"
         return httpsUrl.slashJoin("wp-json")
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -9,11 +9,11 @@ import org.wordpress.android.fluxc.network.discovery.DiscoveryUtils
 import org.wordpress.android.fluxc.network.discovery.DiscoveryWPAPIRestClient
 import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.BaseWPAPIRestClient
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIDiscoveryUtils
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
-import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 import javax.inject.Named
@@ -102,6 +102,6 @@ class SiteWPAPIRestClient @Inject constructor(
         url: String
     ): String {
         return discoveryWPAPIRestClient.discoverWPAPIBaseURL(url) // discover rest api endpoint
-            ?: url.slashJoin("wp-json/") // fallback to ".../wp-json/" if discovery fails
+            ?: WPAPIDiscoveryUtils.buildDefaultRESTBaseUrl(url)
     }
 }


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/11931

This PR updates the logic of site discovery used to infer the `SiteModel#wpApiRestUrl` to use `https` by default when the automatic discovery fails, this fixes login issues for sites with non-working discovery (non-standard `Link` header) and `http` to `https` redirection, for more information, please check peaMlT-Kc-p2

For tests, please check the PR https://github.com/woocommerce/woocommerce-android/pull/12033