### PR TITLE
Update WCOrderStore to support updating payment method

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -217,16 +217,18 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
     }
 
     @Test
-    fun testOrderStatusUpdateSuccess() = runBlocking {
+    fun testOrderStatusAndPaymentMethodUpdateSuccess() = runBlocking {
         val originalOrder = OrderEntity(
             localSiteId = siteModel.localId(),
             status = CoreOrderStatus.PROCESSING.value,
             orderId = 88,
-            total = "15.00"
+            total = "15.00",
+            paymentMethod = "cheque",
+            paymentMethodTitle = "Check payments"
         )
 
         interceptor.respondWith("wc-order-update-response-success.json")
-        val payload = orderRestClient.updateOrderStatus(
+        val payload = orderRestClient.updateOrderStatusAndPaymentMethod(
                 originalOrder, siteModel, CoreOrderStatus.REFUNDED.value
         )
 
@@ -235,11 +237,13 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
             assertEquals(siteModel.id, order.localSiteId.value)
             assertEquals(originalOrder.orderId, order.orderId)
             assertEquals(CoreOrderStatus.REFUNDED.value, order.status)
+            assertEquals(originalOrder.paymentMethod, order.paymentMethod)
+            assertEquals(originalOrder.paymentMethodTitle, order.paymentMethodTitle)
         }
     }
 
     @Test
-    fun testOrderStatusUpdateError() = runBlocking {
+    fun testOrderStatusAndPaymentMethodUpdateError() = runBlocking {
         val originalOrder = OrderEntity(
             localSiteId = siteModel.localId(),
             status = CoreOrderStatus.PROCESSING.value,
@@ -253,7 +257,7 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         }
 
         interceptor.respondWithError(errorJson, 400)
-        val payload = orderRestClient.updateOrderStatus(
+        val payload = orderRestClient.updateOrderStatusAndPaymentMethod(
             originalOrder, siteModel, CoreOrderStatus.REFUNDED.value
         )
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/OrderTestUtils.kt
@@ -32,7 +32,9 @@ object OrderTestUtils {
         orderId: Long,
         orderStatus: String = CoreOrderStatus.PROCESSING.value,
         siteId: Int = 6,
-        modified: String = "1955-11-05T14:15:00Z"
+        modified: String = "1955-11-05T14:15:00Z",
+        paymentMethod: String = "",
+        paymentMethodTitle: String = ""
     ): OrderEntity {
         return OrderEntity(
             orderId = orderId,
@@ -42,7 +44,9 @@ object OrderTestUtils {
             dateCreated = "1955-11-05T14:15:00Z",
             datePaid = "1956-11-05T14:15:00Z",
             currency = "USD",
-            total = "10.0"
+            total = "10.0",
+            paymentMethod = paymentMethod,
+            paymentMethodTitle = paymentMethodTitle,
         )
     }
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -589,8 +589,23 @@ class OrderRestClient @Inject constructor(
         }
     }
 
-    suspend fun updateOrderStatus(orderToUpdate: OrderEntity, site: SiteModel, status: String) =
-        updateOrder(orderToUpdate, site, mapOf("status" to status))
+    suspend fun updateOrderStatusAndPaymentMethod(
+        orderToUpdate: OrderEntity,
+        site: SiteModel,
+        status: String,
+        paymentMethodId: String? = null,
+        paymentMethodTitle: String? = null,
+    ) {
+        val updatePayload = mutableMapOf<String, Any>()
+        updatePayload["status"] = status
+        paymentMethodId?.let {
+            updatePayload["payment_method"] = paymentMethodId
+        }
+        paymentMethodTitle?.let {
+            updatePayload["payment_method_title"] = paymentMethodTitle
+        }
+        updateOrder(orderToUpdate, site, updatePayload)
+    }
 
     suspend fun updateCustomerOrderNote(
         orderToUpdate: OrderEntity,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -595,7 +595,7 @@ class OrderRestClient @Inject constructor(
         status: String,
         paymentMethodId: String? = null,
         paymentMethodTitle: String? = null,
-    ) {
+    ): RemoteOrderPayload.Updating {
         val updatePayload = mutableMapOf<String, Any>()
         updatePayload["status"] = status
         paymentMethodId?.let {
@@ -604,7 +604,7 @@ class OrderRestClient @Inject constructor(
         paymentMethodTitle?.let {
             updatePayload["payment_method_title"] = paymentMethodTitle
         }
-        updateOrder(orderToUpdate, site, updatePayload)
+        return updateOrder(orderToUpdate, site, updatePayload)
     }
 
     suspend fun updateCustomerOrderNote(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -662,7 +662,13 @@ class WCOrderStore @Inject constructor(
                 // Ensure the code gets executed even when the VM dies - eg. when the client app marks an order as
                 // completed and navigates to a different screen.
                 val remoteUpdateResult: OnOrderChanged = withContext(NonCancellable) {
-                    val remotePayload = wcOrderRestClient.updateOrderStatus(orderModel, site, newStatus.statusKey)
+                    val remotePayload = wcOrderRestClient.updateOrderStatusAndPaymentMethod(
+                        orderModel,
+                        site,
+                        newStatus.statusKey,
+                        paymentMethodId,
+                        paymentMethodTitle
+                    )
                     if (remotePayload.isError) {
                         revertOrderStatus(remotePayload)
                     } else {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -632,8 +632,17 @@ class WCOrderStore @Inject constructor(
         orderId: Long,
         site: SiteModel,
         newStatus: WCOrderStatusModel
+    ): Flow<UpdateOrderResult> =
+        updateOrderStatusAndPaymentMethod(orderId, site, newStatus, null, null)
+
+    suspend fun updateOrderStatusAndPaymentMethod(
+        orderId: Long,
+        site: SiteModel,
+        newStatus: WCOrderStatusModel,
+        paymentMethodId: String?,
+        paymentMethodTitle: String?,
     ): Flow<UpdateOrderResult> {
-        return coroutineEngine.flowWithDefaultContext(API, this, "updateOrderStatus") {
+        return coroutineEngine.flowWithDefaultContext(API, this, "updateOrderStatusAndPaymentMethod") {
             val orderModel = ordersDaoDecorator.getOrder(orderId, site.localId())
 
             if (orderModel != null) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -672,7 +672,7 @@ class WCOrderStore @Inject constructor(
                         newPaymentMethodTitle,
                     )
                     if (remotePayload.isError) {
-                        revertOptimisticUpdate(remotePayload)
+                        revertOptimisticOrderUpdate(remotePayload)
                     } else {
                         ordersDaoDecorator.insertOrUpdateOrder(
                             remotePayload.order,
@@ -1016,7 +1016,7 @@ class WCOrderStore @Inject constructor(
         emitChange(onOrderChanged)
     }
 
-    private suspend fun revertOptimisticUpdate(payload: RemoteOrderPayload.Updating): OnOrderChanged {
+    private suspend fun revertOptimisticOrderUpdate(payload: RemoteOrderPayload.Updating): OnOrderChanged {
         optimisticallyUpdateOrder(
             payload.order.orderId,
             payload.order.localSiteId,


### PR DESCRIPTION
This PR enables the client app to update not just the order status but also the `payment_method` and `payment_method_title`. This is used by the Woo app to set the payment method when an order is marked as paid with cash.

To test:
Automated tests + [testing the PR in Woo](https://github.com/woocommerce/woocommerce-android/pull/12067) should be enough.

[More info can be found on the PR in Woo.](https://github.com/woocommerce/woocommerce-android/pull/12067)