### PR TITLE
Include productId and customerId on order list id

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCOrderListDescriptor.kt
@@ -20,13 +20,15 @@ data class WCOrderListDescriptor(
 
     override val uniqueIdentifier: ListDescriptorUniqueIdentifier by lazy {
         ListDescriptorUniqueIdentifier(
-                ("woo-site-order-list-${site.id}" +
-                        "-sf${statusFilter.orEmpty()}" +
-                        "-sq${searchQuery.orEmpty()}" +
-                        "-bf${beforeFilter.orEmpty()}" +
-                        "-af${afterFilter.orEmpty()}" +
-                        "-efo$excludeFutureOrders"
-                        ).hashCode()
+            ("woo-site-order-list-${site.id}" +
+                    "-sf${statusFilter.orEmpty()}" +
+                    "-sq${searchQuery.orEmpty()}" +
+                    "-bf${beforeFilter.orEmpty()}" +
+                    "-af${afterFilter.orEmpty()}" +
+                    "-p${productId ?: ""}" +
+                    "-c${customerId ?: ""}" +
+                    "-efo$excludeFutureOrders"
+                    ).hashCode()
         )
     }
 


### PR DESCRIPTION
### Description
This pull request introduces changes to the ListDescriptorUniqueIdentifier calculation to include both productId and customerId fields. This improvement will:

- Improve cache utilization: By incorporating `productId` and `customerId`, the identifier will now uniquely represent lists based on these filters. This allows us to determine if cached data can be reused for specific product-customer combinations, potentially reducing API calls.
- Enhance list differentiation: The updated identifier will clearly distinguish between lists with and without `productId` and `customerId` filters.

### Testing
It is better to test this PR using the [Woo PR](https://github.com/woocommerce/woocommerce-android/pull/12094)