### PR TITLE
[Woo: GLA Analytics] Extend Google Programs endpoint

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsPrograms.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsPrograms.kt
@@ -22,7 +22,10 @@ data class WCGoogleAdsProgramInterval(
 
 data class WCGoogleAdsProgramTotals(
     val sales: Double?,
-    val spend: Double?
+    val spend: Double?,
+    val impressions: Double?,
+    val clicks: Double?,
+    val conversions: Double?
 )
 
 data class WCGoogleAdsCardStats(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsProgramsMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/google/WCGoogleAdsProgramsMapper.kt
@@ -15,7 +15,10 @@ class WCGoogleAdsProgramsMapper @Inject constructor() {
                     },
                     subtotal = WCGoogleAdsProgramTotals(
                         sales = it.subtotals?.sales,
-                        spend = it.subtotals?.spend
+                        spend = it.subtotals?.spend,
+                        impressions = it.subtotals?.impressions,
+                        clicks = it.subtotals?.clicks,
+                        conversions = it.subtotals?.conversions
                     )
                 )
             },
@@ -24,14 +27,20 @@ class WCGoogleAdsProgramsMapper @Inject constructor() {
                     interval = it.interval,
                     subtotal = WCGoogleAdsProgramTotals(
                         sales = it.subtotals?.sales,
-                        spend = it.subtotals?.spend
+                        spend = it.subtotals?.spend,
+                        impressions = it.subtotals?.impressions,
+                        clicks = it.subtotals?.clicks,
+                        conversions = it.subtotals?.conversions
                     )
                 )
             },
             totals = dto.totals?.let {
                 WCGoogleAdsProgramTotals(
                     sales = it.sales,
-                    spend = it.spend
+                    spend = it.spend,
+                    impressions = it.impressions,
+                    clicks = it.clicks,
+                    conversions = it.conversions
                 )
             }
         )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleAdsProgramsDTO.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleAdsProgramsDTO.kt
@@ -5,7 +5,8 @@ import com.google.gson.annotations.SerializedName
 data class WCGoogleAdsProgramsDTO(
     @SerializedName("campaigns") val campaigns: List<GoogleAdsCampaignDTO>?,
     @SerializedName("intervals") val intervals: List<GoogleAdsIntervalDTO>?,
-    @SerializedName("totals") val totals: GoogleAdsTotalsDTO?
+    @SerializedName("totals") val totals: GoogleAdsTotalsDTO?,
+    @SerializedName("next_page") val nextPageToken: String?
 )
 
 data class GoogleAdsCampaignDTO(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleAdsProgramsDTO.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleAdsProgramsDTO.kt
@@ -25,5 +25,6 @@ data class GoogleAdsTotalsDTO(
     @SerializedName("sales") val sales: Double?,
     @SerializedName("spend") val spend: Double?,
     @SerializedName("impressions") val impressions: Double?,
-    @SerializedName("clicks") val clicks: Double?
+    @SerializedName("clicks") val clicks: Double?,
+    @SerializedName("conversions") val conversions: Double?
 )

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
@@ -57,6 +57,7 @@ class WCGoogleRestClient  @Inject constructor(private val wooNetwork: WooNetwork
         startDate: String,
         endDate: String,
         fields: String,
+        orderBy: String,
     ): WooPayload<WCGoogleAdsProgramsDTO> {
         val url = WOOCOMMERCE.gla.ads.reports.programs.pathNoVersion
         val response = wooNetwork.executeGetGsonRequest(
@@ -66,7 +67,7 @@ class WCGoogleRestClient  @Inject constructor(private val wooNetwork: WooNetwork
                 "after" to startDate,
                 "before" to endDate,
                 "fields" to fields,
-                "orderby" to "sales"
+                "orderby" to orderBy
             ),
             clazz = WCGoogleAdsProgramsDTO::class.java
         ).toWooPayload()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/google/WCGoogleRestClient.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.utils.putIfNotNull
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -58,17 +59,20 @@ class WCGoogleRestClient  @Inject constructor(private val wooNetwork: WooNetwork
         endDate: String,
         fields: String,
         orderBy: String,
+        nextPageToken: String? = null
     ): WooPayload<WCGoogleAdsProgramsDTO> {
         val url = WOOCOMMERCE.gla.ads.reports.programs.pathNoVersion
         val response = wooNetwork.executeGetGsonRequest(
             site = site,
             path = url,
-            params = mapOf(
+            params = mutableMapOf(
                 "after" to startDate,
                 "before" to endDate,
                 "fields" to fields,
                 "orderby" to orderBy
-            ),
+            ).apply {
+                putIfNotNull("page_token" to nextPageToken)
+            },
             clazz = WCGoogleAdsProgramsDTO::class.java
         ).toWooPayload()
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -81,6 +81,7 @@ class WCGoogleStore @Inject constructor(
         coroutineEngine.withDefaultContext(API, this, "fetchAllPrograms") {
             val pages: MutableList<WCGoogleAdsProgramsDTO> = mutableListOf()
             var lastReceivedError: WooError? = null
+            var nextPageToken: String? = null
             var hasMorePages = true
 
             while (hasMorePages) {
@@ -89,15 +90,15 @@ class WCGoogleStore @Inject constructor(
                     startDate = startDate,
                     endDate = endDate,
                     fields = totals.joinToString(",") { it.parameterName },
-                    orderBy = orderBy.parameterName
+                    orderBy = orderBy.parameterName,
+                    nextPageToken = nextPageToken
                 )
 
                 page.takeIf { it.isError.not() }?.result?.let {
                     pages.add(it)
+                    nextPageToken = it.nextPageToken
                     hasMorePages = it.nextPageToken?.isNotEmpty() ?: false
-                } ?: run {
-                    lastReceivedError = page.error
-                }
+                } ?: run { lastReceivedError = page.error }
             }
 
             val response = lastReceivedError?.takeIf { pages.isEmpty() }?.let {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -73,7 +73,8 @@ class WCGoogleStore @Inject constructor(
         startDate: String,
         endDate: String,
         totals: List<TotalsType>,
-        orderBy: TotalsType = SALES
+        orderBy: TotalsType = SALES,
+        nextPageToken: String? = null
     ): WooResult<WCGoogleAdsPrograms?> =
         coroutineEngine.withDefaultContext(API, this, "fetchAllPrograms") {
             val response = restClient.fetchAllPrograms(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -146,8 +146,8 @@ class WCGoogleStore @Inject constructor(
 
     private fun List<WCGoogleAdsProgramsDTO>.mergeData(): WooPayload<WCGoogleAdsProgramsDTO> {
         return WCGoogleAdsProgramsDTO(
-            campaigns = this.flatMap { it.campaigns.orEmpty() },
-            intervals = this.flatMap { it.intervals.orEmpty() },
+            campaigns = flatMap { it.campaigns.orEmpty() },
+            intervals = flatMap { it.intervals.orEmpty() },
             totals = GoogleAdsTotalsDTO(
                 sales = sumOf { it.totals?.sales ?: 0.0 },
                 spend = sumOf { it.totals?.spend ?: 0.0 },

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.WCGoogleRestClient
-import org.wordpress.android.fluxc.store.WCGoogleStore.MetricType.SALES
+import org.wordpress.android.fluxc.store.WCGoogleStore.TotalsType.SALES
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog.T.API
 import javax.inject.Inject
@@ -72,15 +72,15 @@ class WCGoogleStore @Inject constructor(
         site: SiteModel,
         startDate: String,
         endDate: String,
-        metricType: MetricType,
-        orderBy: MetricType = SALES
+        totals: List<TotalsType>,
+        orderBy: TotalsType = SALES
     ): WooResult<WCGoogleAdsPrograms?> =
         coroutineEngine.withDefaultContext(API, this, "fetchAllPrograms") {
             val response = restClient.fetchAllPrograms(
                 site = site,
                 startDate = startDate,
                 endDate = endDate,
-                fields = metricType.parameterName,
+                fields = totals.joinToString(",") { it.parameterName },
                 orderBy = orderBy.parameterName
             )
 
@@ -123,7 +123,7 @@ class WCGoogleStore @Inject constructor(
             }
         }
 
-    enum class MetricType(val parameterName: String) {
+    enum class TotalsType(val parameterName: String) {
         SALES("sales"),
         SPEND("spend"),
         CLICKS("clicks"),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCGoogleStore.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.WCGoogleRestClient
+import org.wordpress.android.fluxc.store.WCGoogleStore.MetricType.SALES
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog.T.API
 import javax.inject.Inject
@@ -71,14 +72,16 @@ class WCGoogleStore @Inject constructor(
         site: SiteModel,
         startDate: String,
         endDate: String,
-        metricType: MetricType
+        metricType: MetricType,
+        orderBy: MetricType = SALES
     ): WooResult<WCGoogleAdsPrograms?> =
         coroutineEngine.withDefaultContext(API, this, "fetchAllPrograms") {
             val response = restClient.fetchAllPrograms(
                 site = site,
                 startDate = startDate,
                 endDate = endDate,
-                fields = metricType.parameterName
+                fields = metricType.parameterName,
+                orderBy = orderBy.parameterName
             )
 
             when {

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/WCGoogleStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/WCGoogleStoreTest.kt
@@ -87,7 +87,10 @@ class WCGoogleStoreTest {
                 intervals = pages.flatMap { it.intervals.orEmpty() },
                 totals = WCGoogleAdsProgramTotals(
                     sales = pages.sumOf { it.totals?.sales ?: 0.0 },
-                    spend = pages.sumOf { it.totals?.spend ?: 0.0 }
+                    spend = pages.sumOf { it.totals?.spend ?: 0.0 },
+                    clicks = pages.sumOf { it.totals?.clicks ?: 0.0 },
+                    impressions = pages.sumOf { it.totals?.impressions ?: 0.0 },
+                    conversions = pages.sumOf { it.totals?.conversions ?: 0.0 }
                 )
 
             )

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/WCGoogleStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/WCGoogleStoreTest.kt
@@ -1,0 +1,172 @@
+package org.wordpress.android.fluxc.store
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.google.WCGoogleAdsCampaignMapper
+import org.wordpress.android.fluxc.model.google.WCGoogleAdsProgramsMapper
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.PARSE_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.GoogleAdsCampaignDTO
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.GoogleAdsTotalsDTO
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.WCGoogleAdsProgramsDTO
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.google.WCGoogleRestClient
+import org.wordpress.android.fluxc.store.WCGoogleStore.TotalsType.CLICKS
+import org.wordpress.android.fluxc.store.WCGoogleStore.TotalsType.SALES
+import org.wordpress.android.fluxc.store.WCGoogleStore.TotalsType.SPEND
+import org.wordpress.android.fluxc.utils.initCoroutineEngine
+
+@ExperimentalCoroutinesApi
+class WCGoogleStoreTest {
+
+    @Mock
+    lateinit var restClient: WCGoogleRestClient
+
+    @Mock
+    lateinit var wcGoogleAdsCampaignMapper: WCGoogleAdsCampaignMapper
+
+    private lateinit var wcGoogleStore: WCGoogleStore
+    private val siteModel = SiteModel()
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        wcGoogleStore = WCGoogleStore(
+            restClient = restClient,
+            coroutineEngine = initCoroutineEngine(),
+            campaignMapper = wcGoogleAdsCampaignMapper,
+            programsMapper = WCGoogleAdsProgramsMapper()
+        )
+    }
+
+    @Test
+    fun `when programs response is a single page, then return the data directly`() = runBlockingTest {
+        // Given
+        val mockPrograms = createProgramsPage()
+        val expectedModel = WCGoogleAdsProgramsMapper().mapToModel(mockPrograms)
+
+        whenever(restClient.fetchAllPrograms(
+            siteModel,
+            "2020-01-01",
+            "2020-12-31",
+            "sales,clicks",
+            "sales",
+            null
+        )).thenReturn(WooPayload(mockPrograms))
+
+        // When
+        val result = wcGoogleStore.fetchAllPrograms(
+            site = siteModel,
+            startDate = "2020-01-01",
+            endDate = "2020-12-31",
+            totals = listOf(SALES, CLICKS)
+        )
+
+        // Then
+        assertFalse(result.isError)
+        assertNotNull(result.model)
+        assertEquals(result.model, expectedModel)
+    }
+
+    @Test
+    fun `when programs response is paginated, requested everything and return the sum`() = runBlockingTest  {
+        // Given
+        val firstPage = createProgramsPage(pageNumber = 1)
+        val pageTwo = createProgramsPage(pageNumber = 2)
+
+        whenever(restClient.fetchAllPrograms(
+            siteModel,
+            "2020-01-01",
+            "2020-12-31",
+            "sales,clicks",
+            "sales",
+            null
+        )).thenReturn(WooPayload(firstPage))
+
+        whenever(restClient.fetchAllPrograms(
+            siteModel,
+            "2020-01-01",
+            "2020-12-31",
+            "sales,clicks",
+            "sales",
+            "nextPageToken"
+        )).thenReturn(WooPayload(null))
+
+        // When
+        val result = wcGoogleStore.fetchAllPrograms(
+            site = siteModel,
+            startDate = "2020-01-01",
+            endDate = "2020-12-31",
+            totals = listOf(SALES, CLICKS)
+        )
+
+        // Then
+        assertFalse(result.isError)
+        assertNotNull(result.model)
+    }
+
+    @Test
+    fun `when programs response is null, then return error`() = runBlockingTest {
+        whenever(restClient.fetchAllPrograms(siteModel, "2020-01-01", "2020-12-31", "sales", "sales", null))
+            .thenReturn(WooPayload(null))
+        val result = wcGoogleStore.fetchAllPrograms(siteModel, "2020-01-01", "2020-12-31", listOf(SALES, SPEND))
+        assertNull(result.model)
+    }
+
+    @Test
+    fun `when programs response is error, then return error`() = runBlockingTest {
+        whenever(restClient.fetchAllPrograms(siteModel, "2020-01-01", "2020-12-31", "sales", "sales", null))
+            .thenReturn(WooPayload(WooError(
+                type = GENERIC_ERROR,
+                original = PARSE_ERROR
+            )))
+        val result = wcGoogleStore.fetchAllPrograms(siteModel, "2020-01-01", "2020-12-31", listOf(SALES))
+        assertTrue(result.isError)
+    }
+
+    private fun createProgramsPage(pageNumber: Int = 1) = WCGoogleAdsProgramsDTO(
+        campaigns = listOf(
+            GoogleAdsCampaignDTO(
+                id = pageNumber.toLong(),
+                name = "campaign${pageNumber}",
+                status = "active",
+                subtotals = GoogleAdsTotalsDTO(
+                    sales = pageNumber * 100.0,
+                    spend = pageNumber * 100.0,
+                    impressions = pageNumber * 100.0,
+                    clicks = pageNumber * 100.0,
+                    conversions = pageNumber * 100.0
+                )
+            ),
+            GoogleAdsCampaignDTO(
+                id = (pageNumber + 1).toLong(),
+                name = "campaign${pageNumber + 1}",
+                status = "active",
+                subtotals = GoogleAdsTotalsDTO(
+                    sales = pageNumber * 200.0,
+                    spend = pageNumber * 200.0,
+                    impressions = pageNumber * 200.0,
+                    clicks = pageNumber * 200.0,
+                    conversions = pageNumber * 200.0
+                )
+            )
+        ),
+        intervals = emptyList(),
+        totals = GoogleAdsTotalsDTO(
+            sales = pageNumber * 100.0,
+            spend = pageNumber * 100.0,
+            impressions = pageNumber * 100.0,
+            clicks = pageNumber * 100.0,
+            conversions = pageNumber * 100.0
+        ),
+        nextPageToken = "nextPageToken"
+    )
+}

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/WCGoogleStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/WCGoogleStoreTest.kt
@@ -24,7 +24,6 @@ import org.wordpress.android.fluxc.utils.initCoroutineEngine
 
 @ExperimentalCoroutinesApi
 class WCGoogleStoreTest {
-
     @Mock
     lateinit var restClient: WCGoogleRestClient
 


### PR DESCRIPTION
Summary
==========
Fix issue https://github.com/woocommerce/woocommerce-android/issues/12071 by updating the Google Programs endpoint with support for:
- Multiple `fields` values
- Pagination support to acquire all the possible data from the store Ads & Listing programs

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.