### PR TITLE
[Build] Update Kotlin to 1.9.25 (++)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ allprojects {
         debug = false
     }
 
-    tasks.withType(KotlinCompile).all {
+    tasks.withType(KotlinCompile).configureEach {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     // Those declarations are just a workaround for a false-positive Kotlin Gradle Plugin warning
     // https://youtrack.jetbrains.com/issue/KT-46200
@@ -56,6 +58,12 @@ allprojects {
         ignoreFailures = false
         parallel = true
         debug = false
+    }
+
+    tasks.withType(KotlinCompile).all {
+        kotlinOptions {
+            jvmTarget = JavaVersion.VERSION_1_8
+        }
     }
 }
 

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -15,10 +15,6 @@ coroutines:
   GlobalCoroutineUsage:
     active: true
 
-potential-bugs:
-  MissingWhenCase:
-    allowElseExpression: false
-
 style:
   DataClassShouldBeImmutable:
     active: true

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/utils/ListStoreConnectedTestHelper.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/utils/ListStoreConnectedTestHelper.kt
@@ -25,7 +25,7 @@ internal class ListStoreConnectedTestHelper(private val listStore: ListStore) {
      *
      * It uses a default [Lifecycle] instance which will NOT be destroyed throughout the test.
      */
-    fun <LIST_DESCRIPTOR : ListDescriptor, ITEM_IDENTIFIER, LIST_ITEM> getList(
+    fun <LIST_DESCRIPTOR : ListDescriptor, ITEM_IDENTIFIER, LIST_ITEM : Any> getList(
         listDescriptor: LIST_DESCRIPTOR,
         dataSource: ListItemDataSourceInterface<LIST_DESCRIPTOR, ITEM_IDENTIFIER, LIST_ITEM>,
         lifecycle: Lifecycle = SimpleTestLifecycle().lifecycle

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -305,6 +305,8 @@ class MainFragment : Fragment() {
                 AuthenticationErrorType.UNSUPPORTED_RESPONSE_TYPE,
                 AuthenticationErrorType.EMAIL_LOGIN_NOT_ALLOWED,
                 AuthenticationErrorType.GENERIC_ERROR,
+                AuthenticationErrorType.NEEDS_SECURITY_KEY -> Unit // Do nothing
+                AuthenticationErrorType.WEBAUTHN_FAILED -> Unit // Do nothing
                 null -> {
                     // Show Toast "Network Error"?
                 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ReactNativeFragment.kt
@@ -83,6 +83,7 @@ class ReactNativeFragment : Fragment() {
                         AppLog.i(AppLog.T.API, "Request result: ${response.result}")
                     }
                     is Error -> prependToLog("Request to '$path' failed: ${response.error.message}")
+                    null -> Unit // Do nothing
                 }
             }
         }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/stats/WooRevenueStatsFragment.kt
@@ -305,6 +305,9 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
             WCStatsAction.FETCH_REVENUE_STATS_AVAILABILITY -> {
                 prependToLog("Revenue stats available for site ${site?.name}: ${event.availability}")
             }
+            WCStatsAction.FETCH_NEW_VISITOR_STATS -> Unit // Do nothing
+            WCStatsAction.FETCHED_REVENUE_STATS_AVAILABILITY -> Unit // Do nothing
+            null -> Unit // Do nothing
         }
     }
 
@@ -343,6 +346,9 @@ class WooRevenueStatsFragment : StoreSelectingFragment() {
                     }
                 }
             }
+            WCStatsAction.FETCH_REVENUE_STATS_AVAILABILITY -> Unit // Do nothing
+            WCStatsAction.FETCHED_REVENUE_STATS_AVAILABILITY -> Unit // Do nothing
+            null -> Unit // Do nothing
         }
     }
 }

--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/wooadmin/WooAdminFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/wooadmin/WooAdminFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
-import com.google.gson.Gson
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.example.databinding.FragmentWooAdminBinding
 import org.wordpress.android.fluxc.example.prependToLog
@@ -16,7 +15,6 @@ import javax.inject.Inject
 
 class WooAdminFragment : StoreSelectingFragment() {
     @Inject internal lateinit var wooAdminStore: WooAdminStore
-    private val gson = Gson()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/example/src/main/java/org/wordpress/android/fluxc/example/utils/ViewGroupExt.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/utils/ViewGroupExt.kt
@@ -11,5 +11,7 @@ fun ViewGroup.toggleSiteDependentButtons(enabled: Boolean = true) =
 
 fun ViewGroup.childViewsAsSequence(): Sequence<View> =
         mutableListOf<View>().apply {
-            (0 until childCount).forEach { add(getChildAt(it)) }
+                for (it in 0 until childCount) {
+                        add(getChildAt(it))
+                }
         }.asSequence()

--- a/fluxc-annotations/build.gradle
+++ b/fluxc-annotations/build.gradle
@@ -8,8 +8,8 @@ java {
     withJavadocJar()
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 project.afterEvaluate {
     publishing {

--- a/fluxc-annotations/build.gradle
+++ b/fluxc-annotations/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+
     withSourcesJar()
     withJavadocJar()
 }
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
 
 project.afterEvaluate {
     publishing {

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -10,8 +10,8 @@ java {
     withJavadocJar()
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
     implementation fluxcAnnotationsProjectDependency

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -6,12 +6,12 @@ plugins {
 }
 
 java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+
     withSourcesJar()
     withJavadocJar()
 }
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
     implementation fluxcAnnotationsProjectDependency

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/27.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/27.json
@@ -83,10 +83,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "localSiteId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -139,10 +139,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [
           {
@@ -181,10 +181,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [],
         "foreignKeys": [
@@ -237,10 +237,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [],
         "foreignKeys": [
@@ -377,10 +377,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [],
         "foreignKeys": []
@@ -415,11 +415,11 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "siteLocalId",
             "type"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -490,10 +490,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "date"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -534,10 +534,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "key"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -578,10 +578,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "key"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -628,10 +628,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "remoteSiteId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -666,10 +666,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "domain"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -752,11 +752,11 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "siteId",
             "campaignId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [
           {
@@ -831,10 +831,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "siteLocalId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -863,10 +863,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -895,10 +895,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -927,10 +927,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []

--- a/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/27.json
+++ b/fluxc/schemas/org.wordpress.android.fluxc.persistence.WPAndroidDatabase/27.json
@@ -83,10 +83,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "localSiteId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -139,10 +139,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [
           {
@@ -181,10 +181,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [],
         "foreignKeys": [
@@ -237,10 +237,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [],
         "foreignKeys": [
@@ -377,10 +377,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -415,11 +415,11 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "siteLocalId",
             "type"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -490,10 +490,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "date"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -534,10 +534,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "key"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -578,10 +578,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "key"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -628,10 +628,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "remoteSiteId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -666,10 +666,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "domain"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -752,11 +752,11 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "siteId",
             "campaignId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [
           {
@@ -831,10 +831,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "siteLocalId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -863,10 +863,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -895,10 +895,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -927,10 +927,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -7,10 +7,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import okhttp3.Call
@@ -98,7 +97,7 @@ abstract class BaseWPV2MediaRestClient constructor(
             media.setUploadState(FAILED)
             val payload = ProgressPayload(media, 1f, false, error)
             try {
-                sendBlocking(payload)
+                trySendBlocking(payload)
                 close()
             } catch (e: CancellationException) {
                 // Do nothing (the flow has been cancelled)
@@ -146,7 +145,7 @@ abstract class BaseWPV2MediaRestClient constructor(
                             val uploadedMedia = res.toMediaModel(site.id)
                             val payload = ProgressPayload(uploadedMedia, 1f, true, false)
                             try {
-                                sendBlocking(payload)
+                                trySendBlocking(payload)
                                 close()
                             } catch (e: CancellationException) {
                                 // Do nothing (the flow has been cancelled)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -110,7 +110,7 @@ abstract class BaseWPV2MediaRestClient constructor(
                 if (!isClosedForSend) {
                     val payload = ProgressPayload(media, progress, false, null)
                     try {
-                        offer(payload)
+                        trySend(payload).isSuccess
                     } catch (e: CancellationException) {
                         // Do nothing (the flow has been cancelled)
                     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersDao.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/PlanOffersDao.kt
@@ -4,7 +4,7 @@ import androidx.room.Dao
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.ForeignKey.CASCADE
+import androidx.room.ForeignKey.Companion.CASCADE
 import androidx.room.Index
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -87,7 +87,7 @@ class ListStore @Inject constructor(
      * @return A [PagedListWrapper] that provides all the necessary information to consume a list such as its data,
      * whether the first page is being fetched, whether there are any errors etc. in `LiveData` format.
      */
-    fun <LIST_DESCRIPTOR : ListDescriptor, ITEM_IDENTIFIER, LIST_ITEM> getList(
+    fun <LIST_DESCRIPTOR : ListDescriptor, ITEM_IDENTIFIER, LIST_ITEM : Any> getList(
         listDescriptor: LIST_DESCRIPTOR,
         dataSource: ListItemDataSourceInterface<LIST_DESCRIPTOR, ITEM_IDENTIFIER, LIST_ITEM>,
         lifecycle: Lifecycle
@@ -117,7 +117,7 @@ class ListStore @Inject constructor(
      * A helper function that creates a [PagedList] [LiveData] for the given [LIST_DESCRIPTOR], [dataSource] and the
      * [PagedListFactory].
      */
-    private fun <LIST_DESCRIPTOR : ListDescriptor, ITEM_IDENTIFIER, LIST_ITEM> createPagedListLiveData(
+    private fun <LIST_DESCRIPTOR : ListDescriptor, ITEM_IDENTIFIER, LIST_ITEM : Any> createPagedListLiveData(
         listDescriptor: LIST_DESCRIPTOR,
         dataSource: ListItemDataSourceInterface<LIST_DESCRIPTOR, ITEM_IDENTIFIER, LIST_ITEM>,
         pagedListFactory: PagedListFactory<LIST_DESCRIPTOR, ITEM_IDENTIFIER, LIST_ITEM>

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
@@ -45,9 +45,8 @@ open class CoroutineEngine
         loggedMessage: String,
         block: suspend FlowCollector<RESULT_TYPE>.() -> Unit
     ): Flow<RESULT_TYPE> {
-        val safeContext = context.minusKey(Job) // Remove Job from context to make it safe for flows
         return flow { block() }
-            .flowOn(safeContext)
+            .flowOn(context)
             .onStart { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Started") }
             .onEach { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage OnEvent: $it") }
             .onCompletion { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Completed") }

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptorTest.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/CustomRedirectInterceptorTest.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.fluxc.network
 
-import okhttp3.*
+import okhttp3.Request
 import okhttp3.Response
-import org.junit.Assert.*
+import okhttp3.Protocol
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner

--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/37.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/37.json
@@ -106,10 +106,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "addonLocalId"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [
           {
@@ -178,10 +178,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "addonOptionLocalId"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [
           {
@@ -364,11 +364,11 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "id",
             "localSiteId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -397,12 +397,12 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "couponId",
             "localSiteId",
             "email"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": [
@@ -451,10 +451,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "globalGroupLocalId"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -513,11 +513,11 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "noteId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -859,11 +859,11 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "orderId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [
           {
@@ -922,12 +922,12 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "orderId",
             "id"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [
           {
@@ -1029,10 +1029,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "localId"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [
           {
@@ -1114,11 +1114,11 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "remoteId",
             "inboxNoteLocalId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [
           {
@@ -1205,12 +1205,12 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "datePeriod",
             "productId",
             "localSiteId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -1233,10 +1233,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "localSiteId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -1301,11 +1301,11 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "id",
             "localSiteId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -1364,10 +1364,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "localSiteId"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -1462,10 +1462,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [],
         "foreignKeys": [
@@ -1512,10 +1512,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [],
         "foreignKeys": [
@@ -1592,10 +1592,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": true,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": true
+          ]
         },
         "indices": [],
         "foreignKeys": [
@@ -1648,12 +1648,12 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "date",
             "granularity"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -1682,11 +1682,11 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "id"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -1805,11 +1805,11 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "id"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []

--- a/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/37.json
+++ b/plugins/woocommerce/schemas/org.wordpress.android.fluxc.persistence.WCAndroidDatabase/37.json
@@ -106,10 +106,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "addonLocalId"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [
           {
@@ -178,10 +178,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "addonOptionLocalId"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [
           {
@@ -364,11 +364,11 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "id",
             "localSiteId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -397,12 +397,12 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "couponId",
             "localSiteId",
             "email"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": [
@@ -451,10 +451,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "globalGroupLocalId"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [],
         "foreignKeys": []
@@ -513,11 +513,11 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "noteId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -859,11 +859,11 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "orderId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [
           {
@@ -922,12 +922,12 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "orderId",
             "id"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [
           {
@@ -1029,10 +1029,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "localId"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [
           {
@@ -1114,11 +1114,11 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "remoteId",
             "inboxNoteLocalId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [
           {
@@ -1205,12 +1205,12 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "datePeriod",
             "productId",
             "localSiteId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -1233,10 +1233,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "localSiteId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -1301,11 +1301,11 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "id",
             "localSiteId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -1364,10 +1364,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "localSiteId"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -1462,10 +1462,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [],
         "foreignKeys": [
@@ -1512,10 +1512,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [],
         "foreignKeys": [
@@ -1592,10 +1592,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
           "columnNames": [
             "id"
-          ]
+          ],
+          "autoGenerate": true
         },
         "indices": [],
         "foreignKeys": [
@@ -1648,12 +1648,12 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "date",
             "granularity"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -1682,11 +1682,11 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "id"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []
@@ -1805,11 +1805,11 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
           "columnNames": [
             "localSiteId",
             "id"
-          ]
+          ],
+          "autoGenerate": false
         },
         "indices": [],
         "foreignKeys": []

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingPackageCustoms.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingPackageCustoms.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.model.shippinglabels
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.model.shippinglabels.WCContentType.Other
 import java.math.BigDecimal
 
 data class WCShippingPackageCustoms(
@@ -15,11 +16,11 @@ data class WCShippingPackageCustoms(
     @SerializedName("items") val customsItems: List<WCCustomsItem>?
 ) {
     init {
-        if (contentsType == WCContentType.Other && contentsExplanation.isNullOrEmpty()) {
-            throw IllegalArgumentException("you have to specify contentsExplanation when the contentsType is Other")
+        require(!(contentsType == Other && contentsExplanation.isNullOrEmpty())) {
+            "you have to specify contentsExplanation when the contentsType is Other"
         }
-        if (restrictionType == WCRestrictionType.Other && restrictionComments.isNullOrEmpty()) {
-            throw IllegalArgumentException("you have to specify restrictionComments when the restrictionType is Other")
+        require(!(restrictionType == WCRestrictionType.Other && restrictionComments.isNullOrEmpty())) {
+            "you have to specify restrictionComments when the restrictionType is Other"
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderMetaDataDao.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.persistence.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
-import androidx.room.OnConflictStrategy.REPLACE
+import androidx.room.OnConflictStrategy.Companion.REPLACE
 import androidx.room.Query
 import androidx.room.Transaction
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrderNotesDao.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.persistence.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
-import androidx.room.OnConflictStrategy.REPLACE
+import androidx.room.OnConflictStrategy.Companion.REPLACE
 import androidx.room.Query
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/OrdersDao.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.persistence.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
-import androidx.room.OnConflictStrategy.REPLACE
+import androidx.room.OnConflictStrategy.Companion.REPLACE
 import androidx.room.Query
 import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/AddonEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/AddonEntity.kt
@@ -4,7 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.ForeignKey.CASCADE
+import androidx.room.ForeignKey.Companion.CASCADE
 import androidx.room.PrimaryKey
 import androidx.room.Relation
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/AddonOptionEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/AddonOptionEntity.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.persistence.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.ForeignKey.CASCADE
+import androidx.room.ForeignKey.Companion.CASCADE
 import androidx.room.PrimaryKey
 import org.wordpress.android.fluxc.persistence.entity.AddonEntity.LocalPriceType
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/WooPaymentsDepositsOverviewEntity.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/WooPaymentsDepositsOverviewEntity.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.persistence.entity
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.ForeignKey.CASCADE
+import androidx.room.ForeignKey.Companion.CASCADE
 import androidx.room.PrimaryKey
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -518,8 +518,8 @@ class WCShippingLabelStore @Inject constructor(
         site: SiteModel,
         customPackages: List<CustomPackage> = emptyList(),
         predefinedPackages: List<PredefinedOption> = emptyList()): WooResult<Boolean> {
-        if (customPackages.isEmpty() && predefinedPackages.isEmpty()) {
-            throw IllegalArgumentException("customPackages and predefinedPackages can't both be an empty list.")
+        require(!(customPackages.isEmpty() && predefinedPackages.isEmpty())) {
+            "customPackages and predefinedPackages can't both be an empty list."
         }
 
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "createPackages") {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -178,6 +178,7 @@ class WCStatsStore @Inject constructor(
             WCStatsAction.FETCHED_REVENUE_STATS_AVAILABILITY -> handleFetchRevenueStatsAvailabilityCompleted(
                     action.payload as FetchRevenueStatsAvailabilityResponsePayload
             )
+            WCStatsAction.FETCH_NEW_VISITOR_STATS -> Unit // Do nothing
         }
     }
 

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/CouponsDaoTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/persistence/dao/CouponsDaoTest.kt
@@ -132,7 +132,7 @@ class CouponsDaoTest {
     }
 
     companion object {
-        fun generateCouponEntity(id: Long = 0) = CouponEntity(
+        fun generateCouponEntity() = CouponEntity(
             id = RemoteId(1),
             localSiteId = LocalId(1),
             amount = BigDecimal(5),

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.store
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -37,6 +36,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import kotlin.coroutines.EmptyCoroutineContext
 
 @ExperimentalCoroutinesApi
 class OrderUpdateStoreTest {
@@ -55,7 +55,7 @@ class OrderUpdateStoreTest {
         setMocks.invoke()
         sut = OrderUpdateStore(
                 coroutineEngine = CoroutineEngine(
-                        TestCoroutineScope().coroutineContext,
+                        EmptyCoroutineContext,
                         mock()
                 ),
                 wcOrderRestClient = orderRestClient,

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "34-cbb5a77cabf0aa7d8de773c2a87671d094785b00"
+def catalogVersion = "1.18.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.17.0"
+def catalogVersion = "34-cbb5a77cabf0aa7d8de773c2a87671d094785b00"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {
@@ -46,7 +46,6 @@ dependencyResolutionManagement {
             version("apache-commons-text", "1.10.0")
             version("facebook-flipper", "0.51.0")
             version("facebook-soloader", "0.9.0")
-            version("kotlinx-coroutines", "1.3.9")
         }
     }
 }


### PR DESCRIPTION
Depends On:
 - [x] [ADC#34](https://github.com/Automattic/android-dependency-catalog/pull/34)
 - [x] Update ADC to `1.18.0`

### Description

This PR updates Kotlin to [1.9.25](https://github.com/JetBrains/kotlin/releases/tag/v1.9.25).

This update isn't that necessary, but should be considered anyway as it will do the following:
- Align this library, to that Kotlin version, which is already used by most of this library's clients and libraries.
- Unblock the usage of the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin for this project.
- Prepares this project for the Kotlin 2+ major update.

FYI: Since updating Kotlin alone wasn't enough, due to various build failures, this update also incorporates the below 4 additional updates:
- `detekt` -> [1.23.6](https://github.com/detekt/detekt/releases/tag/v1.23.6)
- `androidx-room` -> [2.6.1](https://developer.android.com/jetpack/androidx/releases/room#2.6.1)
- `dagger` -> [2.51.1](https://github.com/google/dagger/releases/tag/dagger-2.51)
- `kotlinx-coroutines` -> [1.8.1](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.8.1)

### Test

- Smoke test the `FluxC Example` app, try out all available screens and functionality. Verify everything is working as expected.
- In addition to that, please be thorough about reviewing this `Kotlin` and 4 extra updates, by quickly smoke test both, the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and [WCAndroid](https://github.com/woocommerce/woocommerce-android), with this version of `FluxC`, or via composite builds, and see if everything is working as expected.