### PR TITLE
Fetch orders first page

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -291,7 +291,6 @@ class OrderRestClient @Inject constructor(
     suspend fun fetchOrdersListFirstPage(
         listDescriptor: WCOrderListDescriptor
     ): WooPayload<List<Pair<OrderEntity, List<OrderMetaDataEntity>>>> {
-
         val url = WOOCOMMERCE.orders.pathV3
         val networkPageSize = listDescriptor.config.networkPageSize
         val params = mutableMapOf(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Shipping
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDtoMapper.Companion.toDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.fluxc.persistence.entity.OrderMetaDataEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingResponsePayload
@@ -283,6 +284,38 @@ class OrderRestClient @Inject constructor(
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderListAction(payload))
                 }
+            }
+        }
+    }
+
+    suspend fun fetchOrdersListFirstPage(
+        listDescriptor: WCOrderListDescriptor
+    ): WooPayload<List<Pair<OrderEntity, List<OrderMetaDataEntity>>>> {
+
+        val url = WOOCOMMERCE.orders.pathV3
+        val networkPageSize = listDescriptor.config.networkPageSize
+        val params = mutableMapOf(
+            "per_page" to networkPageSize.toString(),
+            "offset" to "0",
+            "_fields" to ORDER_FIELDS
+        ).putIfNotEmpty(
+            "search" to listDescriptor.searchQuery,
+            "before" to listDescriptor.beforeFilter,
+            "after" to listDescriptor.afterFilter,
+            "customer" to listDescriptor.customerId?.toString(),
+            "product" to listDescriptor.productId?.toString(),
+            "exclude" to listDescriptor.excludedIds?.joinToString(),
+            "status" to listDescriptor.statusFilter.takeUnless { it.isNullOrBlank() }
+        )
+
+        return wooNetwork.executeGetGsonRequest(
+            site = listDescriptor.site,
+            path = url,
+            clazz = Array<OrderDto>::class.java,
+            params = params
+        ).toWooPayload {
+            it.map { orderDto ->
+                orderDtoMapper.toDatabaseEntity(orderDto, listDescriptor.site.localId())
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -51,6 +51,7 @@ import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@Suppress("LargeClass", "LongParameterList", "TooManyFunctions")
 @Singleton
 class WCOrderStore @Inject constructor(
     dispatcher: Dispatcher,
@@ -1113,6 +1114,7 @@ class WCOrderStore @Inject constructor(
             }
 
             ordersDaoDecorator.deleteOrdersForSite(listDescriptor.site.localId())
+            @Suppress("SpreadOperator")
             insertOrder(listDescriptor.site.localId(), *result.toTypedArray())
             WooResult(orders)
         }


### PR DESCRIPTION
Close: https://github.com/woocommerce/woocommerce-android/issues/11792

### Description 
This pull request introduces functionality to fetch and cache the first page of the order list.

- New Function: saveListFetched is added to ListStore. This function persists the fetched list model and its corresponding list items for later retrieval.
- Data Fetching: The fetchOrdersListFirstPage function retrieves the initial page of the order list based on the provided list descriptor.
- Data Persistence: Fetched data is stored in both the WCOrderSummaryModel and the OrderEntity database table for efficient access.

#### Benefits:

- Improved Performance: By caching the first page, subsequent requests can potentially be served from cache, reducing API calls and load times.
- Enhanced User Experience: Faster loading of the initial order list page can improve the overall user experience.

### Testing
It is better to test these changes using the Woo PR