### PR TITLE
Do not alter context in `CoroutineEngine#flowWithDefaultContext`

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/CoroutineEngine.kt
@@ -45,9 +45,8 @@ open class CoroutineEngine
         loggedMessage: String,
         block: suspend FlowCollector<RESULT_TYPE>.() -> Unit
     ): Flow<RESULT_TYPE> {
-        val safeContext = context.minusKey(Job) // Remove Job from context to make it safe for flows
         return flow { block() }
-            .flowOn(safeContext)
+            .flowOn(context)
             .onStart { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Started") }
             .onEach { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage OnEvent: $it") }
             .onCompletion { appLog.d(tag, "${caller.javaClass.simpleName}: $loggedMessage Completed") }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.store
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineScope
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -37,6 +36,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import kotlin.coroutines.EmptyCoroutineContext
 
 @ExperimentalCoroutinesApi
 class OrderUpdateStoreTest {
@@ -55,7 +55,7 @@ class OrderUpdateStoreTest {
         setMocks.invoke()
         sut = OrderUpdateStore(
                 coroutineEngine = CoroutineEngine(
-                        TestCoroutineScope().coroutineContext,
+                        EmptyCoroutineContext,
                         mock()
                 ),
                 wcOrderRestClient = orderRestClient,


### PR DESCRIPTION
This PR is a review suggestion for #3059 .

I thought it'll be easier to propose a change than to discuss it without code.

### Description

`CoroutineEngine#flowWithDefaultContext` doesn't communicate that it'll change context, and it's not something that API consumers can predict without going into implementation details.

I think it'll be better to not alter `CoroutineContext` in this method. For the failing test, we'll use `EmptyCoroutineContext` which is default context for `TestCoroutineScope`, but doesn't contain job.

Anyway, `TestCoroutineScope().coroutineContext` shouldn't be used in the first place as

> Accessing this property in general code is not recommended for any purposes except accessing the Job instance for advanced usages.

