### PR TITLE
Update the site duplication logic to not throw when IDC occurs

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -605,32 +605,6 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testBatchInsertSiteDuplicateWPCom()
-            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        WellSqlTestUtils.setupWordPressComAccount();
-
-        List<SiteModel> siteList = new ArrayList<>();
-        siteList.add(generateTestSite(1, "https://pony1.com", "https://pony1.com/xmlrpc.php", true, true));
-        siteList.add(generateTestSite(2, "https://pony2.com", "https://pony2.com/xmlrpc.php", true, true));
-        siteList.add(generateTestSite(3, "https://pony3.com", "https://pony3.com/xmlrpc.php", true, true));
-        // duplicate with a different id, we should ignore it
-        siteList.add(generateTestSite(4, "https://pony3.com", "https://pony3.com/xmlrpc.php", true, true));
-        siteList.add(generateTestSite(5, "https://pony4.com", "https://pony4.com/xmlrpc.php", true, true));
-        siteList.add(generateTestSite(6, "https://pony5.com", "https://pony5.com/xmlrpc.php", true, true));
-
-        SitesModel sites = new SitesModel(siteList);
-
-        // Use reflection to call a private Store method: equivalent to mSiteStore.updateSites(sites)
-        Method createOrUpdateSites = SiteStore.class.getDeclaredMethod("createOrUpdateSites", SitesModel.class);
-        createOrUpdateSites.setAccessible(true);
-        UpdateSitesResult res = (UpdateSitesResult) createOrUpdateSites.invoke(mSiteStore, sites);
-
-        assertTrue(res.duplicateSiteFound);
-        assertEquals(5, res.rowsAffected);
-        assertEquals(5, mSiteStore.getSitesCount());
-    }
-
-    @Test
     public void testBatchInsertSiteNoDuplicateWPCom()
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         WellSqlTestUtils.setupWordPressComAccount();
@@ -652,36 +626,6 @@ public class SiteStoreUnitTest {
         assertFalse(res.duplicateSiteFound);
         assertEquals(5, res.rowsAffected);
         assertEquals(5, mSiteStore.getSitesCount());
-    }
-
-    @Test
-    public void testSingleInsertSiteDuplicateWPCom()
-            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        WellSqlTestUtils.setupWordPressComAccount();
-
-        List<SiteModel> siteList = new ArrayList<>();
-        siteList.add(generateTestSite(1, "https://pony1.com", "https://pony1.com/xmlrpc.php", true, true));
-        SitesModel sites = new SitesModel(siteList);
-
-        // Insert 1 site
-        Method createOrUpdateSites = SiteStore.class.getDeclaredMethod("createOrUpdateSites", SitesModel.class);
-        createOrUpdateSites.setAccessible(true);
-        UpdateSitesResult res = (UpdateSitesResult) createOrUpdateSites.invoke(mSiteStore, sites);
-
-        assertFalse(res.duplicateSiteFound);
-        assertEquals(1, res.rowsAffected);
-        assertEquals(1, mSiteStore.getSitesCount());
-
-        // Insert same site with different id (considered a duplicate)
-        List<SiteModel> siteList2 = new ArrayList<>();
-        siteList2.add(generateTestSite(2, "https://pony1.com", "https://pony1.com/xmlrpc.php", true, true));
-        SitesModel sites2 = new SitesModel(siteList2);
-        createOrUpdateSites.setAccessible(true);
-        UpdateSitesResult res2 = (UpdateSitesResult) createOrUpdateSites.invoke(mSiteStore, sites2);
-
-        assertTrue(res2.duplicateSiteFound);
-        assertEquals(0, res2.rowsAffected);
-        assertEquals(1, mSiteStore.getSitesCount());
     }
 
     @Test

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
@@ -107,7 +107,7 @@ class SiteSqlUtils
      * 5. Exists in the DB, originally an XML-RPC site, and matches by XMLRPC_URL -> UPDATE
      * 6. Not matching any previous cases -> INSERT
      */
-    @Suppress("LongMethod", "ReturnCount")
+    @Suppress("LongMethod", "ReturnCount", "ComplexMethod")
     @Throws(DuplicateSiteException::class)
     fun insertOrUpdateSite(site: SiteModel?): Int {
         if (site == null) {
@@ -176,8 +176,9 @@ class SiteSqlUtils
             if (!siteResult.isEmpty()) {
                 AppLog.d(DB, "Site found using XML-RPC url: " + site.xmlRpcUrl)
                 // Four possibilities here:
-                // 1. DB site is WP.com, new site is WP.com:
-                // Something really weird is happening, this should have been caught earlier --> DuplicateSiteException
+                // 1. DB site is WP.com, new site is WP.com with the same siteId:
+                // The site could be having an "Identity Crisis", while this should be fixed on the site itself,
+                // it shouldn't block sign-in -> proceed
                 // 2. DB site is WP.com, new site is XML-RPC:
                 // It looks like an existing Jetpack-connected site over the REST API was added again as an XML-RPC
                 // Wed don't allow this --> DuplicateSiteException
@@ -186,7 +187,7 @@ class SiteSqlUtils
                 // 4. DB site is XML-RPC, new site is XML-RPC:
                 // An existing self-hosted site was logged-into again, and we couldn't identify it by URL or
                 // by WP.com site ID + URL --> proceed
-                if (siteResult[0].origin == SiteModel.ORIGIN_WPCOM_REST) {
+                if (siteResult[0].origin == SiteModel.ORIGIN_WPCOM_REST && site.origin != SiteModel.ORIGIN_WPCOM_REST) {
                     AppLog.d(DB, "Site is a duplicate")
                     throw DuplicateSiteException
                 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
@@ -172,11 +172,12 @@ class SiteSqlUtils
                     .equals(SiteModelTable.XMLRPC_URL, forcedHttpXmlRpcUrl)
                     .or().equals(SiteModelTable.XMLRPC_URL, forcedHttpsXmlRpcUrl)
                     .endGroup()
-                    .endWhere().asModel
-            if (!siteResult.isEmpty()) {
+                    .endWhere()
+                    .asModel
+            if (siteResult.isNotEmpty()) {
                 AppLog.d(DB, "Site found using XML-RPC url: " + site.xmlRpcUrl)
                 // Four possibilities here:
-                // 1. DB site is WP.com, new site is WP.com with the same siteId:
+                // 1. DB site is WP.com, new site is WP.com with different siteIds:
                 // The site could be having an "Identity Crisis", while this should be fixed on the site itself,
                 // it shouldn't block sign-in -> proceed
                 // 2. DB site is WP.com, new site is XML-RPC:
@@ -187,7 +188,13 @@ class SiteSqlUtils
                 // 4. DB site is XML-RPC, new site is XML-RPC:
                 // An existing self-hosted site was logged-into again, and we couldn't identify it by URL or
                 // by WP.com site ID + URL --> proceed
-                if (siteResult[0].origin == SiteModel.ORIGIN_WPCOM_REST && site.origin != SiteModel.ORIGIN_WPCOM_REST) {
+                if (siteResult[0].origin == SiteModel.ORIGIN_WPCOM_REST && site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+                    AppLog.d(
+                        DB,
+                        "Duplicate WPCom sites with same URLs, it could be an Identity Crisis, insert both sites"
+                    )
+                    siteResult = emptyList()
+                } else if (siteResult[0].origin == SiteModel.ORIGIN_WPCOM_REST) {
                     AppLog.d(DB, "Site is a duplicate")
                     throw DuplicateSiteException
                 }


### PR DESCRIPTION
### Issue
We have a logic that detects duplicate sites when inserting them to the database, this logic is causing an [issue](https://github.com/woocommerce/woocommerce-android/issues/12037) in the WCAndroid app where users with duplicate websites under their WordPress.com account can't login to them, the duplication of WordPress.com sites can happen during an "Identity Crisis" (**IDC**) (PCYsg-Jfw-p2).

This PR fixes the issue by relaxing the condition to allow inserting duplicate websites coming from the WPCom API to allow the login in the client apps.

### Rationale of the change of the PR
Looking at the historic of the logic mentioned above, I believe it was added due to special circumstances in the WordPress app to deal with duplication that could happen when an XMLRPC website gets added later as Jetpack website or the other way around, but for some reason it also checks for duplicates when both websites are coming from the WordPress.com API, and I didn't find an explanation of why this was added.
This logic to prevent adding duplicates is not available in any other client (as far I was able to check), the login works to those duplicated websites work well with Calypso and the iOS apps:

| Calypso | Jetpack iOS app | Woo iOS app |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/4e614399-a009-41ba-85e8-f54ed7d566ec"> | ![IMG_0115](https://github.com/user-attachments/assets/13155df5-4755-4235-9177-1b262f52f69b) | ![IMG_0116](https://github.com/user-attachments/assets/bd3267f3-6483-4517-b2b8-064050164014) |

Given this, I think the Android apps should behave the same, as the backend allows those duplicate websites for a reason (to preserve the user's data after the IDC), we shouldn't lock the users out of signing in to those websites.

### Testing
#### Example app
1. DM and I'll share with you the credentials of an account with IDC.
2. Login using the example app.
3. Go to the Sites screen, and tap on Log Sites.
4. Confirm the site with IDC is listed.

#### WCAndroid
https://github.com/woocommerce/woocommerce-android/pull/12143