### PR TITLE
[ANR fix] Move UserAgent initialization to a background thread

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
@@ -15,6 +15,8 @@ import org.wordpress.android.util.AppLog.T;
 
 import java.lang.reflect.Field;
 
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 
@@ -41,6 +43,7 @@ public class AppConfigModule {
     }
 
     @Provides
+    @Singleton
     public UserAgent provideUserAgent(Context appContext) {
         return new UserAgent(appContext, "fluxc-example-android");
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network
 
 import android.content.Context
 import android.webkit.WebSettings
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -9,9 +10,10 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PackageUtils
 
 @Suppress("MemberNameEqualsClassName")
-class UserAgent(
+class UserAgent @JvmOverloads constructor(
     private val appContext: Context?,
-    private val appName: String
+    private val appName: String,
+    bgDispatcher: CoroutineDispatcher = Dispatchers.Default
 ) {
     /**
      * User-Agent string when making HTTP connections, for both API traffic and WebViews.
@@ -24,7 +26,7 @@ class UserAgent(
     var userAgent: String = getAppNameVersion()
         private set
 
-    private val coroutineScope = CoroutineScope(Dispatchers.Default)
+    private val coroutineScope = CoroutineScope(bgDispatcher)
 
     init {
         coroutineScope.launch {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
@@ -2,13 +2,43 @@ package org.wordpress.android.fluxc.network
 
 import android.content.Context
 import android.webkit.WebSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PackageUtils
 
-@SuppressWarnings("SwallowedException", "TooGenericExceptionCaught", "MemberNameEqualsClassName")
-class UserAgent(appContext: Context?, appName: String) {
-    val userAgent: String
+@Suppress("MemberNameEqualsClassName")
+class UserAgent(
+    private val appContext: Context?,
+    private val appName: String
+) {
+    /**
+     * User-Agent string when making HTTP connections, for both API traffic and WebViews.
+     * Appends "[appName]/version" to WebView's default User-Agent string for the webservers
+     * to get the full feature list of the browser and serve content accordingly, e.g.:
+     *    "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
+     *    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
+     *    wp-android/4.7"
+     */
+    var userAgent: String = getAppNameVersion()
+        private set
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Default)
 
     init {
+        coroutineScope.launch {
+            initUserAgent()
+        }
+    }
+
+    /**
+     * Initializes the User-Agent string.
+     * This method will be called asynchronously to avoid blocking the main thread,
+     * because `WebSettings.getDefaultUserAgent()` can be slow.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun initUserAgent() {
         // Device's default User-Agent string.
         // E.g.:
         //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
@@ -18,17 +48,17 @@ class UserAgent(appContext: Context?, appName: String) {
         } catch (e: RuntimeException) {
             // `getDefaultUserAgent()` can throw an Exception
             // see: https://github.com/wordpress-mobile/WordPress-Android/issues/20147#issuecomment-1961238187
-            ""
+            AppLog.e(
+                AppLog.T.UTILS,
+                "Error getting the user's default User-Agent, ${e.stackTraceToString()}"
+            )
+            return
         }
-        // User-Agent string when making HTTP connections, for both API traffic and WebViews.
-        // Appends "wp-android/version" to WebView's default User-Agent string for the webservers
-        // to get the full feature list of the browser and serve content accordingly, e.g.:
-        //    "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
-        //    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
-        //    wp-android/4.7"
-        val appWithVersion = "$appName/${PackageUtils.getVersionName(appContext)}"
-        userAgent = if (defaultUserAgent.isNotEmpty()) "$defaultUserAgent $appWithVersion" else appWithVersion
+
+        userAgent = "$defaultUserAgent ${getAppNameVersion()}"
     }
+
+    private fun getAppNameVersion() = "$appName/${PackageUtils.getVersionName(appContext)}"
 
     override fun toString(): String = userAgent
 }

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/UserAgentTest.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/UserAgentTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network
 
 import android.webkit.WebSettings
+import kotlinx.coroutines.Dispatchers
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mockStatic
@@ -22,7 +23,8 @@ class UserAgentTest {
     fun testUserAgent() = withMockedPackageUtils {
         mockStatic(WebSettings::class.java).use {
             whenever(WebSettings.getDefaultUserAgent(context)).thenReturn(USER_AGENT)
-            val result = UserAgent(context, APP_NAME)
+            // Use the Unconfined dispatcher to allow the test to run synchronously
+            val result = UserAgent(context, APP_NAME, bgDispatcher = Dispatchers.Unconfined)
             assertEquals("$USER_AGENT $APP_NAME/$APP_VERSION", result.toString())
         }
     }
@@ -31,7 +33,8 @@ class UserAgentTest {
     fun testDefaultUserAgentFailure() = withMockedPackageUtils {
         mockStatic(WebSettings::class.java).use {
             whenever(WebSettings.getDefaultUserAgent(context)).thenThrow(RuntimeException(""))
-            val result = UserAgent(context, APP_NAME)
+            // Use the Unconfined dispatcher to allow the test to run synchronously
+            val result = UserAgent(context, APP_NAME, bgDispatcher = Dispatchers.Unconfined)
             assertEquals("$APP_NAME/$APP_VERSION", result.toString())
         }
     }


### PR DESCRIPTION
This PR updates the `UserAgent` class to move its initialization to a background thread, the goal is to fix this [ANR](https://github.com/woocommerce/woocommerce-android/issues/12039) that we identified in the WCAndroid app.

#### Side effect of this change
With this logic, if we need to access the `userAgent` value before the initialization is done, then we'll use the default value `{appName}/{appVersion}` without the device's user agent value.
But vased on my testing, it seems that this rarely happens, if at all. The initialization is usually done before any API call is made in our apps. And even if this does happen, it should not affect the app's functionality because the default user agent is not necessary for the API calls to work correctly. The user agent value is more important for the `WebView` usage, where it will be already initialized.

#### Testing
1. Start with `trunk`
2. Apply the following patch

<details>
<summary> Patch </summary>

```Patch
Index: example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java	(revision e88dbd62cc22d7d9bbe779b64b7150c6392aa410)
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java	(date 1721983093554)
@@ -14,9 +14,12 @@
 import org.wordpress.android.util.AppLog.T;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
 
 import dagger.Module;
 import dagger.Provides;
+import kotlin.Unit;
+import kotlin.time.MeasureTimeKt;
 
 @Module
 public class AppConfigModule {
@@ -42,7 +45,13 @@
 
     @Provides
     public UserAgent provideUserAgent(Context appContext) {
-        return new UserAgent(appContext, "fluxc-example-android");
+        UserAgent userAgent;
+        long start = System.currentTimeMillis();
+        userAgent = new UserAgent(appContext, "fluxc-example-android");
+        long end = System.currentTimeMillis();
+
+        AppLog.d(T.API, "UserAgent creation took " + (end - start) + "ms");
+        return userAgent;
     }
 
     @Provides
```
</details>

3. Run the example app.
4. Check the log entry that starts with `UserAgent creation took` and note the value.
5. Switch to this branch.
6. Apply the following patch

<details>
<summary> Patch </summary>

```Patch
Index: example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java	(revision fbd4ece0ea54ff210a0633b76c24503b70e77ae0)
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java	(date 1721983129011)
@@ -14,11 +14,14 @@
 import org.wordpress.android.util.AppLog.T;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
+import kotlin.Unit;
+import kotlin.time.MeasureTimeKt;
 
 @Module
 public class AppConfigModule {
@@ -45,7 +48,13 @@
     @Provides
     @Singleton
     public UserAgent provideUserAgent(Context appContext) {
-        return new UserAgent(appContext, "fluxc-example-android");
+        UserAgent userAgent;
+        long start = System.currentTimeMillis();
+        userAgent = new UserAgent(appContext, "fluxc-example-android");
+        long end = System.currentTimeMillis();
+
+        AppLog.d(T.API, "UserAgent creation took " + (end - start) + "ms");
+        return userAgent;
     }
 
     @Provides
```
</details>

8. Run the example app.
9. Note the new value from the log, and confirm it's way shorter.
10. Test some API calls, and confirm there is no regression.
11. Check with Flipper that the UserAgent is still set correctly.

Check also: https://github.com/wordpress-mobile/WordPress-Android/pull/21088 and https://github.com/woocommerce/woocommerce-android/pull/12147