### PR TITLE
[Dependency Analysis] Remove Unused Dependencies

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -107,8 +107,6 @@ dependencies {
     implementation sharedLibs.androidx.recyclerview
     implementation sharedLibs.androidx.constraintlayout
     implementation sharedLibs.androidx.annotation
-    implementation sharedLibs.androidx.arch.core.common
-    implementation sharedLibs.androidx.arch.core.runtime
     implementation sharedLibs.androidx.lifecycle.runtime.ktx
 
     implementation(sharedLibs.wordpress.utils) {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -119,9 +119,8 @@ dependencies {
 
     implementation sharedLibs.google.gson
 
-    implementation sharedLibs.androidx.room.runtime
-    kapt sharedLibs.androidx.room.compiler
-    implementation sharedLibs.androidx.room.ktx
+    testImplementation sharedLibs.androidx.room.runtime
+    androidTestImplementation sharedLibs.androidx.room.runtime
     androidTestImplementation sharedLibs.androidx.room.testing
 
     // Dagger

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -142,7 +142,6 @@ dependencies {
 
     androidTestImplementation sharedLibs.assertj.core
     androidTestImplementation sharedLibs.androidx.arch.core.testing
-    kaptAndroidTest sharedLibs.google.dagger.compiler
     androidTestCompileOnly sharedLibs.glassfish.javax.annotation
     // Test orchestrator
     androidTestImplementation sharedLibs.androidx.test.runner

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -140,7 +140,6 @@ dependencies {
     testImplementation sharedLibs.assertj.core
     testImplementation sharedLibs.androidx.arch.core.testing
 
-    androidTestImplementation sharedLibs.mockito.android
     androidTestImplementation sharedLibs.assertj.core
     androidTestImplementation sharedLibs.androidx.arch.core.testing
     kaptAndroidTest sharedLibs.google.dagger.compiler

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation project(':plugins:woocommerce')
 
     implementation sharedLibs.androidx.appcompat
-    implementation sharedLibs.androidx.legacy.support.v4
+    implementation sharedLibs.androidx.swiperefreshlayout
     implementation sharedLibs.androidx.recyclerview
     implementation sharedLibs.androidx.constraintlayout
     implementation sharedLibs.androidx.annotation

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_Base.java
@@ -24,8 +24,6 @@ public class MockedStack_Base {
 
     @Before
     public void setUp() throws Exception {
-        // Needed for Mockito
-        System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
         mAppContext = getInstrumentation().getTargetContext().getApplicationContext();
 
         mMockedNetworkAppComponent = DaggerMockedNetworkAppComponent.builder()

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_Base.java
@@ -47,8 +47,6 @@ public class ReleaseStack_Base {
     }
 
     protected void setUp(boolean reset) throws Exception {
-        // Needed for Mockito
-        System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
         mAppContext = getInstrumentation().getTargetContext().getApplicationContext();
 
         mReleaseStackAppComponent = DaggerReleaseStack_AppComponent.builder()

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -1,7 +1,5 @@
 plugins {
     id "java"
-    alias(sharedLibs.plugins.kotlin.jvm)
-    alias(sharedLibs.plugins.kotlin.kapt)
     alias(sharedLibs.plugins.automattic.publishToS3)
 }
 
@@ -16,23 +14,8 @@ java {
 dependencies {
     implementation fluxcAnnotationsProjectDependency
     implementation sharedLibs.google.autoService
-    kapt sharedLibs.google.autoService
+    annotationProcessor sharedLibs.google.autoService
     implementation sharedLibs.squareup.javapoet
-}
-
-dependencyAnalysis {
-    issues {
-        onUnusedDependencies {
-            exclude("org.jetbrains.kotlin:kotlin-stdlib")
-            exclude("com.google.auto.service:auto-service")
-        }
-        onUnusedAnnotationProcessors {
-            exclude("com.google.auto.service:auto-service")
-        }
-        onRedundantPlugins {
-            exclude("kotlin-kapt")
-        }
-    }
 }
 
 project.afterEvaluate {

--- a/fluxc-processor/build.gradle
+++ b/fluxc-processor/build.gradle
@@ -20,6 +20,21 @@ dependencies {
     implementation sharedLibs.squareup.javapoet
 }
 
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            exclude("org.jetbrains.kotlin:kotlin-stdlib")
+            exclude("com.google.auto.service:auto-service")
+        }
+        onUnusedAnnotationProcessors {
+            exclude("com.google.auto.service:auto-service")
+        }
+        onRedundantPlugins {
+            exclude("kotlin-kapt")
+        }
+    }
+}
+
 project.afterEvaluate {
     publishing {
         publications {

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -63,8 +63,6 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
-    implementation sharedLibs.androidx.recyclerview
-
     implementation sharedLibs.androidx.exifinterface
     implementation sharedLibs.androidx.security.crypto
 

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     kapt fluxcProcessorProjectDependency
 
     // External libs
-    api sharedLibs.eventbus
+    api sharedLibs.eventbus.java
     api sharedLibs.squareup.okhttp3
     implementation sharedLibs.squareup.okhttp3.urlconnection
     api sharedLibs.volley

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -115,7 +115,6 @@ dependencies {
     testImplementation sharedLibs.mockito.core
     testImplementation sharedLibs.mockito.kotlin
     testImplementation sharedLibs.mockito.inline
-    testImplementation sharedLibs.assertj.core
 
     lintChecks sharedLibs.wordpress.lint
 }

--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -63,7 +63,6 @@ android.buildTypes.all { buildType ->
 }
 
 dependencies {
-    implementation sharedLibs.androidx.appcompat
     implementation sharedLibs.androidx.recyclerview
 
     implementation sharedLibs.androidx.exifinterface

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "35-35f85606e5be4c3cb535c33e374425dc5ae95eb9"
+def catalogVersion = "35-d9f9cc5702f71c2047f9782bbb64b488ee673bf4"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.20.0"
+def catalogVersion = "35-d825593561a33ec42fc9dd71c2caa49b452aad95"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "35-d9f9cc5702f71c2047f9782bbb64b488ee673bf4"
+def catalogVersion = "1.21.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "35-d825593561a33ec42fc9dd71c2caa49b452aad95"
+def catalogVersion = "35-35f85606e5be4c3cb535c33e374425dc5ae95eb9"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {


### PR DESCRIPTION
Project Thread: paaHJt-6YV-p2
Depends On:
- [x] [ADC#35](https://github.com/Automattic/android-dependency-catalog/pull/35)
- [x] Update ADC to `1.21.0`

### Description

Based on the `unused` related advises generated by the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin, this PR removes all unused dependencies from this project.

FYI: As part of this change, the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin got also updated to its latest [1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330) version.

### Testing Steps

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise remaining within both reports, JSON and txt included:
        - `build-health-report.json` -> Search for `unusedCount`
        - `build-health-report.txt` -> Search for `unused`
    - Check the manually triggered [scheduled build](https://buildkite.com/automattic/wordpress-fluxc-android/builds/3804) and verify that everything works as expected with this newer version of the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin ([1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330)).
3. Testing:
    - Smoke test the `FluxC Example` app, try out all available screens and functionality. Verify everything is working as expected.
    - Also, if you want to be thorough about reviewing the changes, you could quickly smoke test, either the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and/or [WCAndroid](https://github.com/woocommerce/woocommerce-android), with this version of `FluxC`, or via composite builds, and see if it works as expected.