### PR TITLE
Fix the 2FA login on the example app

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -177,7 +177,13 @@ class MainFragment : Fragment() {
     }
 
     private fun signIn2fa(twoStepCode: String) {
-        authenticateTwoFactorPayload?.twoStepCode = twoStepCode
+        authenticateTwoFactorPayload = AuthenticateTwoFactorPayload(
+            authenticatePayload?.username.orEmpty(),
+            authenticatePayload?.password.orEmpty(),
+            twoStepCode,
+            true
+        )
+
         dispatcher.dispatch(AuthenticationActionBuilder
             .newAuthenticateTwoFactorAction(authenticateTwoFactorPayload))
     }
@@ -365,6 +371,12 @@ class MainFragment : Fragment() {
                     " - rowsAffected: " + event.rowsAffected
             )
         }
+    }
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onTwoFactorAuthStarted(event: AccountStore.OnTwoFactorAuthStarted) {
+        show2faDialog()
     }
 
     private fun prependToLog(s: String) = (activity as MainExampleActivity).prependToLog(s)

--- a/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/MainFragment.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnDiscoveryResponse
+import org.wordpress.android.fluxc.store.AccountStore.OnTwoFactorAuthStarted
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.SiteStore.FetchWPAPISitePayload
@@ -375,7 +376,7 @@ class MainFragment : Fragment() {
 
     @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onTwoFactorAuthStarted(event: AccountStore.OnTwoFactorAuthStarted) {
+    fun onTwoFactorAuthStarted(event: OnTwoFactorAuthStarted) {
         show2faDialog()
     }
 


### PR DESCRIPTION
This PR fixes the 2FA login on the example app, this is done by listening for the event `OnTwoFactorAuthStarted` that was added when we added support for passkeys.

Disclaimer: I didn't handle any edge cases, and I'm not very familiar with this part. But given this is just the example app we use for testing, I think the risks are low.

#### Testing
1. Enable 2FA on a WordPress.com account (regular WordPress.com account).
2. Open the example app.
3. Attempt login, and confirm it works without issues.