### PR TITLE
[Login] Fix the logic of triggering an SMS OTP 

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -234,6 +234,7 @@ public class Authenticator {
             if (shouldSendTwoStepSMS && TextUtils.isEmpty(twoStepCode)) {
                 mParams.put("wpcom_resend_otp", "true");
             }
+            mParams.put("wpcom_supports_2fa", "true");
         }
     }
 


### PR DESCRIPTION
As identified in https://github.com/woocommerce/woocommerce-android/issues/12304, we have two issues with SMS 2FA. This PR fixes one of them: fix the broken button to trigger sending an SMS notification, the fix is to indicate that our client supports 2fa by passing the argument `wpcom_supports_2fa` with the request.

For the second part, I will create a separate PR as involves some changes to the login library, and this fix is the more urgent one as it should unblock the users when attempting to login.

### Testing
Please check https://github.com/woocommerce/woocommerce-android/pull/12306