### PR TITLE
[Login] Revert to using the /token endpoint for the authentication

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/auth/Authenticator.java
@@ -213,12 +213,12 @@ public class Authenticator {
     public static class PasswordRequest extends OauthRequest {
         public PasswordRequest(String appId, String appSecret, String username, String password,
                                Listener listener, ErrorListener errorListener) {
-            super(LOGIN_BASE_ENDPOINT, appId, appSecret, listener, errorListener);
+            super(TOKEN_ENDPOINT, appId, appSecret, listener, errorListener);
             mParams.put(USERNAME_PARAM_NAME, username);
             mParams.put(PASSWORD_PARAM_NAME, password);
             mParams.put(GRANT_TYPE_PARAM_NAME, PASSWORD_GRANT_TYPE);
-            mParams.put(GET_BEARER_TOKEN, "true");
             mParams.put("wpcom_supports_2fa", "true");
+            mParams.put(WITH_AUTH_TYPES, "true");
         }
     }
 
@@ -235,6 +235,7 @@ public class Authenticator {
                 mParams.put("wpcom_resend_otp", "true");
             }
             mParams.put("wpcom_supports_2fa", "true");
+            mParams.put(WITH_AUTH_TYPES, "true");
         }
     }
 


### PR DESCRIPTION
This PR reverts to using the `/token` endpoint for the authentication using WordPress.com instead of the `/wp-login.php?action=login-endpoint`.

The new endpoint is missing a logic to trigger the SMS OTP automatically, and instead defaults to sending a mobile push notification which our apps don't support yet.
You can find more details on this decision here: p1723548882803229/1712217177.026859-slack-C6H8C3G23

### Testing
Check https://github.com/woocommerce/woocommerce-android/pull/12319