### PR TITLE
[Mobile Payments] Add support for pending_verification account status

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCPaymentAccountResult.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCPaymentAccountResult.kt
@@ -115,7 +115,12 @@ data class WCPaymentAccountResult(
         /**
          * This state occurs when the self-hosted site responded in a way we don't recognize.
          */
-        UNKNOWN;
+        UNKNOWN,
+
+        /**
+         * This state occurs when the account is early in an account's lifetime.
+         */
+        PENDING_VERIFICATION;
 
         class Deserializer : JsonDeserializer<WCPaymentAccountStatus> {
             override fun deserialize(
@@ -133,6 +138,7 @@ data class WCPaymentAccountResult(
                         "rejected.listed" -> REJECTED_LISTED
                         "rejected.other" -> REJECTED_OTHER
                         "NOACCOUNT", "" -> NO_ACCOUNT
+                        "pending_verification" -> PENDING_VERIFICATION
                         else -> UNKNOWN
                     }
         }


### PR DESCRIPTION
Partially addresses this issue:
https://github.com/woocommerce/woocommerce-android/issues/12328

This PR addresses the issue where users see a generic "Unable to verify" error during the WooPayments onboarding process when their account status is `pending_verification`. 

Can be tested locally by targeting the artifact like this:
https://github.com/woocommerce/woocommerce-android/pull/12330/files#r1717463731