### PR TITLE
Add stock status filterable values

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
@@ -10,7 +10,7 @@ enum class CoreProductStockStatus(val value: String) {
     ON_BACK_ORDER("onbackorder");
 
     companion object {
-        private val valueMap = values().associateBy(CoreProductStockStatus::value)
+        private val valueMap = entries.associateBy(CoreProductStockStatus::value)
         val ALL_VALUES = valueMap.keys
 
         /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/CoreProductStockStatus.kt
@@ -13,6 +13,7 @@ enum class CoreProductStockStatus(val value: String) {
         private val valueMap = entries.associateBy(CoreProductStockStatus::value)
         val ALL_VALUES = valueMap.keys
 
+        val FILTERABLE_VALUES = setOf(IN_STOCK, OUT_OF_STOCK, ON_BACK_ORDER)
         /**
          * Convert the base value into the associated CoreProductStockStatus object
          */


### PR DESCRIPTION
### Description
This small PR adds the `FILTERABLE_VALUES` variable, which contains all stock status filterable values. We will use this new list in the Woo app to filter products by stock status.

### Testing
No need; this PR only adds a new variable