### PR TITLE
[Blaze] Fix date formatting for the campaign creation request

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.utils.extensions.filterNotNull
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 class BlazeCreationRestClient @Inject constructor(
@@ -192,12 +193,11 @@ class BlazeCreationRestClient @Inject constructor(
         }
     }
 
-    @SuppressLint("SimpleDateFormat")
     suspend fun createCampaign(
         site: SiteModel,
         request: BlazeCampaignCreationRequest
     ): BlazePayload<BlazeCampaignModel> {
-        val dateFormatter = SimpleDateFormat("yyyy-MM-dd")
+        val dateFormatter = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT)
         val body = mutableMapOf(
             "origin" to request.origin,
             "origin_version" to request.originVersion,


### PR DESCRIPTION
For fixing: https://github.com/woocommerce/woocommerce-android/issues/12370

This PR updates the date formatting of the dates in the Blaze campaign creation request to always use regular Arabic numerals and thus respecting the ISO date format.

For testing, please check https://github.com/woocommerce/woocommerce-android/pull/12372
