### PR TITLE
Update Compose in the example app to use the Android Dependency Catalog

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -142,6 +142,7 @@ dependencies {
     testImplementation sharedLibs.assertj.core
     testImplementation sharedLibs.androidx.arch.core.testing
 
+    implementation platform(sharedLibs.androidx.compose.bom)
     implementation sharedLibs.androidx.compose.material
     implementation sharedLibs.androidx.compose.ui.tooling
 
@@ -161,9 +162,6 @@ dependencies {
     debugImplementation sharedLibs.facebook.flipper.network.plugin
 
     // Coroutines
-    implementation platform("androidx.compose:compose-bom:2024.04.00")
-    implementation 'androidx.compose.material:material'
-
     implementation sharedLibs.kotlinx.coroutines.core
     implementation sharedLibs.kotlinx.coroutines.android
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -71,7 +71,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.15"
+        kotlinCompilerExtensionVersion = sharedLibs.versions.androidx.compose.compiler.get()
     }
 
     sourceSets {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "36-097c1d950e18bd5ef4ea6802e777340e4ce2b6ce"
+def catalogVersion = "1.22.0"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.21.0"
+def catalogVersion = "36-097c1d950e18bd5ef4ea6802e777340e4ce2b6ce"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {


### PR DESCRIPTION
This PR updates the Android Dependency Catalog, and then Compose to use it.

⚠️ Don't merge until https://github.com/Automattic/android-dependency-catalog/pull/36 is merged

### Testing
Successful compilation is enough, on my side I already tested the changes using the steps of this [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3084)