### PR TITLE
 Fix order pagination break

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/ListStore.kt
@@ -282,6 +282,7 @@ class ListStore @Inject constructor(
             listItemModel
         }
         listItemSqlUtils.insertItemList(listItems)
+        emitChange(OnListRequiresRefresh(listDescriptor.typeIdentifier))
     }
 
     /**

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/InsertOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/InsertOrder.kt
@@ -52,7 +52,7 @@ class InsertOrder @Inject internal constructor(
         )
         // Re-fetch the list only when at least one of the inserted orders has changed
         if (orderChanged) {
-            dispatcher.dispatch(ListActionBuilder.newListRequiresRefreshAction(listTypeIdentifier))
+            dispatcher.dispatch(ListActionBuilder.newListDataInvalidatedAction(listTypeIdentifier))
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/InsertOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/InsertOrder.kt
@@ -30,7 +30,7 @@ class InsertOrder @Inject internal constructor(
                     order,
                     OrdersDaoDecorator.ListUpdateStrategy.SUPPRESS
                 )
-                if (result != OrdersDaoDecorator.UpdateOrderResult.UNCHANGED) {
+                if (result == OrdersDaoDecorator.UpdateOrderResult.UPDATED) {
                     orderChanged = true
                 }
                 metaDataDao.updateMetaData(


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-android/issues/12491
### Description
Previously, the order list relied on the refresh event to update when changes were detected, leading to inconsistent pagination. This PR addresses the issue by using the invalidate event instead. This ensures that the list is updated only when necessary, improving performance and ensuring a smooth pagination experience.

### Testing 
It is better to test this PR using the [Woo PR](https://github.com/woocommerce/woocommerce-android/pull/12544)