### PR TITLE
Fix load more

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListState.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/list/ListState.kt
@@ -21,6 +21,7 @@ enum class ListState(val value: Int) {
     fun isLoadingMore() = this == LOADING_MORE
 
     companion object {
-        val defaultState = ListState.NEEDS_REFRESH
+        val defaultState = NEEDS_REFRESH
+        val notExpiredStates = setOf(CAN_LOAD_MORE, FETCHED)
     }
 }


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-android/issues/12491

### Description
> Moreover, it seems that afterwards it sometimes stops loading more pages.

This PR fixes an issue that prevented loading more orders (stopped the pagination) when scrolling the orders list after a certain time. 

On the previous version of the orders list screen, we always refreshed the orders list when entering the screen. This behavior ensured that we always had fresh data when displaying the screen. 

The order pagination saves the current list state in the local DB. Because the list state is saved in the local DB, there could be times when the app saved an intermediary state, for example, Fetching the first page, and the app closed before the final state was saved (can-load-more or fetched). To prevent inconsistent states on the `getListState` function, a timeout was added to check for more than 1 minute states. If the state was older than 1 minute, the function returned a `need-to-refresh state.`

> On the previous version of the orders list screen, we always refreshed the orders list when entering the screen. 

We changed the always refreshed orders list with the background tasks project. Now, we rely more on cached data on the local DB, meaning that final states (can-load-more, fetched) can live longer than 1 minute. 

This PR updates the `getListState` logic so the timeout does not affect final states. The plan is that on Woo, we will implement the logic to expire these final states.


### Testing
It is better to test this PR with the [Woo PR](https://github.com/woocommerce/woocommerce-android/pull/12545)