### PR TITLE
[Woo] Simplify MetaData delete API

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/metadata/CustomFieldsViewModel.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/metadata/CustomFieldsViewModel.kt
@@ -34,7 +34,7 @@ class CustomFieldsViewModel(
             parentItemType = parentItemType,
             insertedMetadata = emptyList(),
             updatedMetadata = emptyList(),
-            deletedMetadata = emptyList()
+            deletedMetadataIds = emptyList()
         )
     )
 
@@ -51,7 +51,7 @@ class CustomFieldsViewModel(
             ),
             pendingUpdateRequest
         ) { customFields, pendingUpdateRequest ->
-            customFields.filterNot { it in pendingUpdateRequest.deletedMetadata }
+            customFields.filterNot { it.id in pendingUpdateRequest.deletedMetadataIds }
                 .map { field ->
                     pendingUpdateRequest.updatedMetadata.find { it.key == field.key }
                         ?: field
@@ -64,7 +64,7 @@ class CustomFieldsViewModel(
             pendingUpdateRequest.map {
                 it.insertedMetadata.isNotEmpty() ||
                     it.updatedMetadata.isNotEmpty() ||
-                    it.deletedMetadata.isNotEmpty()
+                    it.deletedMetadataIds.isNotEmpty()
             }
         ) { loadingState, metaData, hasChanges ->
             when (loadingState) {
@@ -74,7 +74,7 @@ class CustomFieldsViewModel(
                     onDelete = { field ->
                         pendingUpdateRequest.update {
                             it.copy(
-                                deletedMetadata = it.deletedMetadata + field
+                                deletedMetadataIds = it.deletedMetadataIds + field.id
                             )
                         }
                     },
@@ -136,7 +136,7 @@ class CustomFieldsViewModel(
                         it.copy(
                             insertedMetadata = emptyList(),
                             updatedMetadata = emptyList(),
-                            deletedMetadata = emptyList()
+                            deletedMetadataIds = emptyList()
                         )
                     }
                     loadingState.value = LoadingState.Loaded

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/UpdateMetadataRequest.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/UpdateMetadataRequest.kt
@@ -5,7 +5,7 @@ data class UpdateMetadataRequest(
     val parentItemType: MetaDataParentItemType,
     val insertedMetadata: List<WCMetaData> = emptyList(),
     val updatedMetadata: List<WCMetaData> = emptyList(),
-    val deletedMetadata: List<WCMetaData> = emptyList(),
+    val deletedMetadataIds: List<Long> = emptyList(),
 ) {
     init {
         // The ID of inserted metadata is ignored, so to ensure that there is no data loss here,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/WCMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/WCMetaData.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.model.metadata.WCMetaDataValue.JsonArrayValue
 import org.wordpress.android.fluxc.model.metadata.WCMetaDataValue.JsonObjectValue
 import org.wordpress.android.fluxc.model.metadata.WCMetaDataValue.WCMetaDataValueJsonAdapter
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.HtmlUtils
 
 data class WCMetaData(
     @SerializedName(ID)
@@ -39,10 +40,10 @@ data class WCMetaData(
         get() = value.stringValue.orEmpty()
 
     val valueStrippedHtml: String
-        get() = valueAsString.replace(htmlRegex, "")
+        get() = HtmlUtils.fastStripHtml(valueAsString)
 
     val isHtml: Boolean
-        get() = valueAsString.contains(htmlRegex)
+        get() = valueAsString != valueStrippedHtml
 
     val isJson: Boolean
         get() = value is JsonObjectValue || value is JsonArrayValue
@@ -63,10 +64,6 @@ data class WCMetaData(
         const val VALUE = "value"
         private const val DISPLAY_KEY = "display_key"
         private const val DISPLAY_VALUE = "display_value"
-
-        private val htmlRegex by lazy {
-            Regex("<[^>]+>")
-        }
 
         val SUPPORTED_KEYS: Set<String> = buildSet {
             add(SubscriptionMetadataKeys.SUBSCRIPTION_RENEWAL)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/metadata/MetaDataRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/metadata/MetaDataRestClient.kt
@@ -59,10 +59,10 @@ internal class MetaDataRestClient @Inject internal constructor(
         request.updatedMetadata.forEach {
             metaDataJson.add(it.toJson())
         }
-        request.deletedMetadata.forEach {
+        request.deletedMetadataIds.forEach {
             metaDataJson.add(
                 JsonObject().apply {
-                    addProperty(WCMetaData.ID, it.id)
+                    addProperty(WCMetaData.ID, it)
                     add(WCMetaData.VALUE, JsonNull.INSTANCE)
                 }
             )


### PR DESCRIPTION
This PR adds 2 changes:

1. Fixes an issue with `valueStrippedHtml` by switching to using `HtmlUtils#fastStripHtml` from the utils library, the issue was discussed [here](https://github.com/woocommerce/woocommerce-android/pull/12406#discussion_r1729207495).
2. Simplifies the update request by requiring only the `ids` of the deleted items instead of the full item, this will allow for a better usage in the app.

##### Testing
There is nothing really to test here, as these are just minor changes, so code review should be enough, but feel free to test the following if needed:
1. The custom fields screen in the example app (can be accessed from Woo -> Orders -> View Custom Fields)
2. This WCAndroid [PR](https://github.com/woocommerce/woocommerce-android/pull/12566) steps.