### PR TITLE
Adds new campaign_id field to map from push notification payload

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
@@ -50,7 +50,8 @@ data class FormattableMeta(
         @SerializedName("user") val user: Long? = null,
         @SerializedName("comment") val comment: Long? = null,
         @SerializedName("post") val post: Long? = null,
-        @SerializedName("order") val order: Long? = null
+        @SerializedName("order") val order: Long? = null,
+        @SerializedName("campaign_id") val campaignId: Long? = null
     )
 
     data class Links(


### PR DESCRIPTION
Maps the `campaign_id` field from the push notification payload, needed to handle taps on Blaze push notifications. 

Changes to this PR can be tested in the following PR: https://github.com/woocommerce/woocommerce-android/pull/12564