### PR TITLE
New dimensions field

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/shippinglabels/WCShippingLabelStoreTest.kt
@@ -386,7 +386,9 @@ class WCShippingLabelStoreTest {
         val expectedResult = WCPackagesResult(
                 listOf(
                         CustomPackage("Krabica", false, "1 x 2 x 3", 1f),
-                        CustomPackage("Obalka", true, "2 x 3 x 4", 5f)
+                        CustomPackage("Obalka", true, "2 x 3 x 4", 5f),
+                        CustomPackage("Flat Box", true, "5 x 6 x 4", 1f),
+                        CustomPackage("Weird Box", false, "0 x 0 x 0", 0f)
                 ),
                 listOf(
                         PredefinedOption("USPS Priority Mail Flat Rate Boxes",

--- a/example/src/test/resources/wc/shipping-labels-packages.json
+++ b/example/src/test/resources/wc/shipping-labels-packages.json
@@ -960,8 +960,24 @@
           "is_user_defined": true,
           "is_letter": true,
           "name": "Obalka",
-          "inner_dimensions": "2 x 3 x 4",
+          "outer_dimensions": "2 x 3 x 4",
           "box_weight": 5,
+          "max_weight": 0
+        },
+        {
+          "is_user_defined": true,
+          "is_letter": true,
+          "name": "Flat Box",
+          "dimensions": "5 x 6 x 4",
+          "box_weight": 1,
+          "max_weight": 0
+        },
+        {
+          "is_user_defined": true,
+          "is_letter": false,
+          "name": "Weird Box",
+          "weird_dimensions": "2 x 3 x 4",
+          "box_weight": 0,
           "max_weight": 0
         }
       ],

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/ShippingLabelRestClient.kt
@@ -368,6 +368,7 @@ class ShippingLabelRestClient @Inject constructor(private val wooNetwork: WooNet
                 val name: String,
                 @SerializedName("inner_dimensions") val innerDimensions: String?,
                 @SerializedName("outer_dimensions") val outerDimensions: String?,
+                @SerializedName("dimensions") val dimensions: String?,
                 @SerializedName("box_weight") val boxWeight: Float?,
                 @SerializedName("max_weight") val maxWeight: Float?,
                 @SerializedName("is_user_defined") val isUserDefined: Boolean?,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -350,7 +350,7 @@ class WCShippingLabelStore @Inject constructor(
             CustomPackage(
                     title = it.name,
                     isLetter = it.isLetter,
-                    dimensions = it.outerDimensions ?: it.innerDimensions ?: "",
+                    dimensions = it.dimensions ?: it.outerDimensions ?: it.innerDimensions ?: "0 x 0 x 0",
                     boxWeight = it.boxWeight ?: 0f
             )
         }


### PR DESCRIPTION
### Description
The new Shipping extension introduced a new field for Custom package dimensions: `dimensions`. This PR adds this new field to the `CustomData` class and uses it when creating a `CustomPackage`, so we don't lose the package information and prevent a crash when the `CustomPackage` dimensions field is empty. Additionally to this changes I also updated the default value we were using for dimensions now instead of the empty string "" we will use "0 x 0 x 0", so that the app won't crash in case of a custom package with empty dimensions.

### Testing
It is best to test these changes using the [Woo PR](https://github.com/woocommerce/woocommerce-android/pull/12584)