### PR TITLE
Add support to fetch WP media using v2 endpoint

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -979,6 +979,8 @@ public class MediaStore extends Store {
 
         if (payload.site.isUsingWpComRestApi()) {
             mMediaRestClient.fetchMedia(payload.site, payload.media);
+        } else if (payload.site.isJetpackCPConnected()) {
+            mWPComV2MediaRestClient.fetchMedia(payload.site, payload.media);
         } else {
             mMediaXmlrpcClient.fetchMedia(payload.site, payload.media);
         }


### PR DESCRIPTION
Enables fetching media successfully for Jetpack CP sites. 

To be tested with this PR changes: https://github.com/woocommerce/woocommerce-android/pull/12640