### PR TITLE
Adds missing provider method for new Objective DAO

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/module/DatabaseModule.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.persistence.RemoteConfigDao
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase
 import org.wordpress.android.fluxc.persistence.WPAndroidDatabase.Companion.buildDb
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao
+import org.wordpress.android.fluxc.persistence.blaze.BlazeObjectivesDao
 import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingDao
 import org.wordpress.android.fluxc.persistence.bloggingprompts.BloggingPromptsDao
 import org.wordpress.android.fluxc.persistence.comments.CommentsDao
@@ -93,6 +94,12 @@ class DatabaseModule {
     @Provides
     fun provideBlazeTargetingDao(wpAndroidDatabase: WPAndroidDatabase): BlazeTargetingDao {
         return wpAndroidDatabase.blazeTargetingDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideBlazeObjectivesDao(wpAndroidDatabase: WPAndroidDatabase): BlazeObjectivesDao {
+        return wpAndroidDatabase.blazeObjectivesDao()
     }
 
     @Singleton

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WPAndroidDatabase.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.persistence.PlanOffersDao.PlanOfferId
 import org.wordpress.android.fluxc.persistence.RemoteConfigDao.RemoteConfig
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao.BlazeCampaignEntity
+import org.wordpress.android.fluxc.persistence.blaze.BlazeObjectivesDao
 import org.wordpress.android.fluxc.persistence.blaze.BlazeObjectivesDao.BlazeCampaignObjectiveEntity
 import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingDao
 import org.wordpress.android.fluxc.persistence.blaze.BlazeTargetingDeviceEntity
@@ -100,6 +101,8 @@ abstract class WPAndroidDatabase : RoomDatabase() {
     abstract fun blazeTargetingDao(): BlazeTargetingDao
 
     abstract fun jetpackSocialDao(): JetpackSocialDao
+
+    abstract fun blazeObjectivesDao(): BlazeObjectivesDao
 
     @Suppress("MemberVisibilityCanBePrivate")
     companion object {


### PR DESCRIPTION

###Description

Just fixing some missing provider method to be able to inject the new `BlazeObjectivesDao`. 

`BlazeObjectivesDao` is not used in WooCommerce `trunk` code yet. So there's no risk of any feature breaking. However this changes are needed to compile WooCommerce app when targeting the latest FluxC `trunk` changeset. So it is mandatory to merge this PR before the next cde freeze process is triggered. 

Nothing to test. 

**Extra context**: I merged [this PR earlier today](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3095). Everything compiled and worked as expected. However, I applied a last minute refactor to FluxC PR, and missed adding the changes added here. While FluxC sample app would still compile, WooCommerce app won't if it targets the lastest FluxC `trunk`. 