### PR TITLE
[Deps] Add Back EventBus Android Dependency

### DIFF
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     kapt fluxcProcessorProjectDependency
 
     // External libs
+    api sharedLibs.eventbus.android
     api sharedLibs.eventbus.java
     api sharedLibs.squareup.okhttp3
     implementation sharedLibs.squareup.okhttp3.urlconnection
@@ -117,6 +118,15 @@ dependencies {
     testImplementation sharedLibs.mockito.inline
 
     lintChecks sharedLibs.wordpress.lint
+}
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise the app will crash with a runtime exception.
+            exclude(sharedLibs.eventbus.android.get().module.toString())
+        }
+    }
 }
 
 project.afterEvaluate {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "37-60706ff1696294a115fe5fec00dd35e4c1c1bf4f"
+def catalogVersion = "1.23.1"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'com.gradle.enterprise' version '3.9'
 }
 
-def catalogVersion = "1.22.0"
+def catalogVersion = "37-60706ff1696294a115fe5fec00dd35e4c1c1bf4f"
 dependencyResolutionManagement {
     repositories {
         exclusiveContent {


### PR DESCRIPTION
Depends On:

- [x] [ADC#37](https://github.com/Automattic/android-dependency-catalog/pull/37)
- [x] Update ADC to [1.23.0](https://github.com/Automattic/android-dependency-catalog/releases/tag/1.23.0) -> [1.23.1](https://github.com/Automattic/android-dependency-catalog/releases/tag/1.23.1)

### Description

This PR adds back the main `EventBus` dependency, which is `Android` related.

This dependency was incorrectly removed and replaced by its corresponding `eventbus-java` transitive dependency, assuming that is not required. However, after further testing it was revealed that this parent `eventbus` dependency, which is actually `android` specific is indeed necessary. If it is not provided on the classpath then an app will crash with the below runtime exception:

```
java.lang.RuntimeException: Unable to create application xyz: java.lang .RuntimeException:
It looks like you are using EventBus on Android, make sure to add the "eventbus" Android
library to your dependencies.
```

For more info see:
- [EventBus.register(...)](https://github.com/greenrobot/EventBus/blob/0194926b3bcf70cc0d7bfd3c5da16708dd5ab876/EventBus/src/org/greenrobot/eventbus/EventBus.java#L143-L147)
- [!AndroidDependenciesDetector.areAndroidComponentsAvailable()](https://github.com/greenrobot/EventBus/blob/0194926b3bcf70cc0d7bfd3c5da16708dd5ab876/EventBus/src/org/greenrobot/eventbus/android/AndroidDependenciesDetector.java#L25-L36)

### Testing Instructions

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise related to `eventbus`.
2. Testing:
    - Smoke test the `FluxC Example` app, try out all available screens and functionality. Verify everything is working as expected.
    - Also, if you want to be thorough about reviewing the changes, you could quickly smoke test, either the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and/or [WCAndroid](https://github.com/woocommerce/woocommerce-android), with this version of `FluxC`, or via composite builds, and see if it works as expected.