### PR TITLE
Revert "[ANR fix] Move UserAgent initialization to a background thread"

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/di/AppConfigModule.java
@@ -15,8 +15,6 @@ import org.wordpress.android.util.AppLog.T;
 
 import java.lang.reflect.Field;
 
-import javax.inject.Singleton;
-
 import dagger.Module;
 import dagger.Provides;
 
@@ -43,7 +41,6 @@ public class AppConfigModule {
     }
 
     @Provides
-    @Singleton
     public UserAgent provideUserAgent(Context appContext) {
         return new UserAgent(appContext, "fluxc-example-android");
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
@@ -2,45 +2,13 @@ package org.wordpress.android.fluxc.network
 
 import android.content.Context
 import android.webkit.WebSettings
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PackageUtils
 
-@Suppress("MemberNameEqualsClassName")
-class UserAgent @JvmOverloads constructor(
-    private val appContext: Context?,
-    private val appName: String,
-    bgDispatcher: CoroutineDispatcher = Dispatchers.Default
-) {
-    /**
-     * User-Agent string when making HTTP connections, for both API traffic and WebViews.
-     * Appends "[appName]/version" to WebView's default User-Agent string for the webservers
-     * to get the full feature list of the browser and serve content accordingly, e.g.:
-     *    "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
-     *    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
-     *    wp-android/4.7"
-     */
-    var userAgent: String = getAppNameVersion()
-        private set
-
-    private val coroutineScope = CoroutineScope(bgDispatcher)
+@SuppressWarnings("SwallowedException", "TooGenericExceptionCaught", "MemberNameEqualsClassName")
+class UserAgent(appContext: Context?, appName: String) {
+    val userAgent: String
 
     init {
-        coroutineScope.launch {
-            initUserAgent()
-        }
-    }
-
-    /**
-     * Initializes the User-Agent string.
-     * This method will be called asynchronously to avoid blocking the main thread,
-     * because `WebSettings.getDefaultUserAgent()` can be slow.
-     */
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    private fun initUserAgent() {
         // Device's default User-Agent string.
         // E.g.:
         //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
@@ -50,17 +18,17 @@ class UserAgent @JvmOverloads constructor(
         } catch (e: RuntimeException) {
             // `getDefaultUserAgent()` can throw an Exception
             // see: https://github.com/wordpress-mobile/WordPress-Android/issues/20147#issuecomment-1961238187
-            AppLog.e(
-                AppLog.T.UTILS,
-                "Error getting the user's default User-Agent, ${e.stackTraceToString()}"
-            )
-            return
+            ""
         }
-
-        userAgent = "$defaultUserAgent ${getAppNameVersion()}"
+        // User-Agent string when making HTTP connections, for both API traffic and WebViews.
+        // Appends "wp-android/version" to WebView's default User-Agent string for the webservers
+        // to get the full feature list of the browser and serve content accordingly, e.g.:
+        //    "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
+        //    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
+        //    wp-android/4.7"
+        val appWithVersion = "$appName/${PackageUtils.getVersionName(appContext)}"
+        userAgent = if (defaultUserAgent.isNotEmpty()) "$defaultUserAgent $appWithVersion" else appWithVersion
     }
-
-    private fun getAppNameVersion() = "$appName/${PackageUtils.getVersionName(appContext)}"
 
     override fun toString(): String = userAgent
 }

--- a/fluxc/src/test/java/org/wordpress/android/fluxc/network/UserAgentTest.kt
+++ b/fluxc/src/test/java/org/wordpress/android/fluxc/network/UserAgentTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.fluxc.network
 
 import android.webkit.WebSettings
-import kotlinx.coroutines.Dispatchers
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mockStatic
@@ -23,8 +22,7 @@ class UserAgentTest {
     fun testUserAgent() = withMockedPackageUtils {
         mockStatic(WebSettings::class.java).use {
             whenever(WebSettings.getDefaultUserAgent(context)).thenReturn(USER_AGENT)
-            // Use the Unconfined dispatcher to allow the test to run synchronously
-            val result = UserAgent(context, APP_NAME, bgDispatcher = Dispatchers.Unconfined)
+            val result = UserAgent(context, APP_NAME)
             assertEquals("$USER_AGENT $APP_NAME/$APP_VERSION", result.toString())
         }
     }
@@ -33,8 +31,7 @@ class UserAgentTest {
     fun testDefaultUserAgentFailure() = withMockedPackageUtils {
         mockStatic(WebSettings::class.java).use {
             whenever(WebSettings.getDefaultUserAgent(context)).thenThrow(RuntimeException(""))
-            // Use the Unconfined dispatcher to allow the test to run synchronously
-            val result = UserAgent(context, APP_NAME, bgDispatcher = Dispatchers.Unconfined)
+            val result = UserAgent(context, APP_NAME)
             assertEquals("$APP_NAME/$APP_VERSION", result.toString())
         }
     }


### PR DESCRIPTION
In WCAndroid, we are getting some crashes related to WebView usage from multiple processes since 19.7, which was the version where we introduced the change of #3067.

The changes of the linked PR shouldn't cause these crashes, but we want to experiment with reverting them to confirm if there are any unwanted side effects that they caused.

For more information on the crashes, check peaMlT-Tk-p2

### Testing
I think green CI should be enough for this, ~~and we don't need a PR to update FluxC on WCAndroid either, it will be done by the release manager during the code freeze.~~ scratch this, I'll create a PR to update the reference on WCAndroid to make sure a release note about the change is included, I'll do it when this PR is merged.