### PR TITLE
[Custom Fields] Store Json values

### DIFF
--- a/example/src/main/java/org/wordpress/android/fluxc/example/ui/metadata/CustomFieldsFragment.kt
+++ b/example/src/main/java/org/wordpress/android/fluxc/example/ui/metadata/CustomFieldsFragment.kt
@@ -173,8 +173,10 @@ private fun ContentView(state: CustomFieldsState.Loaded) {
                     )
                 }
                 Spacer(modifier = Modifier.weight(1f))
-                IconButton({ fieldBeingEdited = customField }) {
-                    Icon(Icons.Default.Edit, contentDescription = "Edit")
+                if (!customField.isJson) {
+                    IconButton({ fieldBeingEdited = customField }) {
+                        Icon(Icons.Default.Edit, contentDescription = "Edit")
+                    }
                 }
                 IconButton({ state.onDelete(customField) }) {
                     Icon(Icons.Default.Delete, contentDescription = "Delete")

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/StripProductMetaData.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 
 class StripProductMetaData @Inject internal constructor() {
     operator fun invoke(metaData: List<WCMetaData>): List<WCMetaData> {
-        return metaData.filter { !it.isJson || SUPPORTED_KEYS.contains(it.key) }
+        return metaData.filter { it.isDisplayable || SUPPORTED_KEYS.contains(it.key) }
     }
 
     companion object {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/WCMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/WCMetaData.kt
@@ -65,12 +65,6 @@ data class WCMetaData(
         private const val DISPLAY_KEY = "display_key"
         private const val DISPLAY_VALUE = "display_value"
 
-        val SUPPORTED_KEYS: Set<String> = buildSet {
-            add(SubscriptionMetadataKeys.SUBSCRIPTION_RENEWAL)
-            add(BundleMetadataKeys.BUNDLED_ITEM_ID)
-            addAll(OrderAttributionInfoKeys.ALL_KEYS)
-        }
-
         internal fun fromJson(json: JsonElement): WCMetaData? = runCatching {
             val jsonObject = json.asJsonObject
             WCMetaData(

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -15,7 +15,10 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                 lineItems = gson.toJson(fatModel.getLineItemList().map { lineItemDto: LineItem ->
                     lineItemDto.copy(
                         metaData = lineItemDto.metaData
-                            ?.filter { it.isDisplayable || it.key in WCMetaData.SUPPORTED_KEYS }
+                            ?.filter {
+                                it.isDisplayable
+                                    || it.key == WCMetaData.BundleMetadataKeys.BUNDLED_ITEM_ID
+                            }
                     )
                 }),
                 shippingLines = gson.toJson(fatModel.getShippingLineList()),

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
@@ -1,13 +1,22 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.order
 
 import org.wordpress.android.fluxc.model.metadata.WCMetaData
+import org.wordpress.android.fluxc.model.metadata.WCMetaData.OrderAttributionInfoKeys
+import org.wordpress.android.fluxc.model.metadata.WCMetaData.SubscriptionMetadataKeys
 import javax.inject.Inject
 
 class StripOrderMetaData @Inject internal constructor() {
+    companion object {
+        private val SUPPORTED_KEYS: Set<String> = buildSet {
+            add(SubscriptionMetadataKeys.SUBSCRIPTION_RENEWAL)
+            addAll(OrderAttributionInfoKeys.ALL_KEYS)
+        }
+    }
+
     operator fun invoke(metaData: List<WCMetaData>): List<WCMetaData> {
         return metaData
             .filter {
-                (it.isDisplayable || it.key in WCMetaData.SUPPORTED_KEYS)
+                (it.isDisplayable || it.key in SUPPORTED_KEYS)
                         && !it.isJson
             }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaData.kt
@@ -16,8 +16,7 @@ class StripOrderMetaData @Inject internal constructor() {
     operator fun invoke(metaData: List<WCMetaData>): List<WCMetaData> {
         return metaData
             .filter {
-                (it.isDisplayable || it.key in SUPPORTED_KEYS)
-                        && !it.isJson
+                it.isDisplayable || it.key in SUPPORTED_KEYS
             }
     }
 }

--- a/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaDataTest.kt
+++ b/plugins/woocommerce/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderMetaDataTest.kt
@@ -45,7 +45,7 @@ class StripOrderMetaDataTest {
     }
 
     @Test
-    fun `when Metadata value contains JSON, then remove it from the list`() {
+    fun `when Metadata value contains JSON and is displayable, then keep it in the list`() {
         // Given
         val rawMetadata = listOf(
             WCMetaData(
@@ -64,15 +64,7 @@ class StripOrderMetaDataTest {
         val result = sut(rawMetadata)
 
         // Then
-        assertThat(result).isEqualTo(
-            listOf(
-                WCMetaData(
-                    id = 2L,
-                    key = "valid key",
-                    value = "valid value"
-                )
-            )
-        )
+        assertThat(result.size).isEqualTo(2)
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-android/issues/12696

This PR adds logic to store the JSON custom fields, this is needed because we will allow merchants to see those values in read-only mode in the app.

### Testing
1. You'll need to perform an API request to your website to add some json values:
```
POST {site}/wc/v3/orders/{orderId}

{
    "meta_data": [
        {
            "key": "json_object",
            "value": {
                "Key": "Value"
            }
        },
        {
            "key": "json_array",
            "value": [
                {
                    "Key": "Value"
                }
            ]
        }
    ]
}
```
2. Open the example app and sign in if needed.
3. Tap on Woo, then select the store.
4. Tap on Orders then select the store.
5. Tap on "View custom fields"
6. Confirm that the json values are shown, and not editable from the app.
