### PR TITLE
Add new objective parameter to create campaign request

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
@@ -20,7 +20,8 @@ data class BlazeCampaignCreationRequest(
     val mainImage: MediaModel,
     val targetingParameters: BlazeTargetingParameters?,
     val timeZoneId: String = TimeZone.getDefault().id,
-    val isEndlessCampaign: Boolean
+    val isEndlessCampaign: Boolean,
+    val objectiveId: String
 )
 
 data class BlazeCampaignCreationRequestBudget(

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
@@ -248,7 +248,8 @@ class BlazeCreationRestClient @Inject constructor(
                     "page_topics" to it.topics
                 ).filterNotNull()
             },
-            "is_evergreen" to request.isEndlessCampaign
+            "is_evergreen" to request.isEndlessCampaign,
+            "objective" to request.objectiveId
         ).filterNotNull()
 
         val response = wpComNetwork.executePostGsonRequest(


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/12660
Adds new objective parameter to create campaign request.

Nothing to test for now. Ensuring all checks are green should be enough. 