### PR TITLE
Split Link header values into different items

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/WPAPIHeadRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/WPAPIHeadRequest.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.discovery
 
-import com.android.volley.Header
 import com.android.volley.NetworkResponse
 import com.android.volley.ParseError
 import com.android.volley.Response
@@ -14,18 +13,18 @@ class WPAPIHeadRequest(
     url: String,
     errorListener: BaseErrorListener,
     private val mListener: Listener<String?>
-) : BaseRequest<List<Header>?>(Method.HEAD, url, errorListener) {
-    override fun deliverResponse(response: List<Header>?) {
-        val endpoint = response?.firstNotNullOfOrNull { extractEndpointFromLinkHeader(it.value) }
+) : BaseRequest<List<String>?>(Method.HEAD, url, errorListener) {
+    override fun deliverResponse(response: List<String>?) {
+        val endpoint = response?.firstNotNullOfOrNull { extractEndpointFromLinkHeader(it) }
         mListener.onResponse(endpoint)
     }
 
-    override fun parseNetworkResponse(response: NetworkResponse): Response<List<Header>?>? {
+    override fun parseNetworkResponse(response: NetworkResponse): Response<List<String>?>? {
         val headers = response.allHeaders
             ?.filter { it.name.equals(LINK_HEADER_NAME, ignoreCase = true) }
             ?.flatMap {
                 it.value.split(",")
-                    .map { value -> Header(LINK_HEADER_NAME, value.trimStart()) }
+                    .map { value -> value.trimStart() }
             }
             ?.ifEmpty { null }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/WPAPIHeadRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/WPAPIHeadRequest.kt
@@ -23,6 +23,10 @@ class WPAPIHeadRequest(
     override fun parseNetworkResponse(response: NetworkResponse): Response<List<Header>?>? {
         val headers = response.allHeaders
             ?.filter { it.name.equals(LINK_HEADER_NAME, ignoreCase = true) }
+            ?.flatMap {
+                it.value.split(",")
+                    .map { value -> Header(LINK_HEADER_NAME, value.trimStart()) }
+            }
             ?.ifEmpty { null }
 
         return if (headers != null) {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -101,7 +101,7 @@ class SiteWPAPIRestClient @Inject constructor(
     private fun discoverApiEndpoint(
         url: String
     ): String {
-        return discoveryWPAPIRestClient.discoverWPAPIBaseURL(url) // discover rest api endpoint
+        return discoveryWPAPIRestClient.discoverWPAPIBaseURL("https://grinderstore.in") // discover rest api endpoint
             ?: WPAPIDiscoveryUtils.buildDefaultRESTBaseUrl(url)
     }
 }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
@@ -101,7 +101,7 @@ class SiteWPAPIRestClient @Inject constructor(
     private fun discoverApiEndpoint(
         url: String
     ): String {
-        return discoveryWPAPIRestClient.discoverWPAPIBaseURL("https://grinderstore.in") // discover rest api endpoint
+        return discoveryWPAPIRestClient.discoverWPAPIBaseURL(url) // discover rest api endpoint
             ?: WPAPIDiscoveryUtils.buildDefaultRESTBaseUrl(url)
     }
 }


### PR DESCRIPTION
This PR fixes a [crash](https://github.com/woocommerce/woocommerce-android/issues/12715) where the result for URl discoverability returns multiple URLs. 

### Description

Full context of the crash and proposed fix can be found here: peaMlT-Vb-p2#comment-2323

### To Reproduce the crash

Apply this patch 

```diff
Subject: [PATCH] Split Link header values into different items
---
Index: fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt	(revision 9a51a9dfcfdb247e15dc14ad025ddee9e3285ff8)
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/site/SiteWPAPIRestClient.kt	(date 1727470975129)
@@ -101,7 +101,7 @@
     private fun discoverApiEndpoint(
         url: String
     ): String {
-        return discoveryWPAPIRestClient.discoverWPAPIBaseURL(url) // discover rest api endpoint
+        return discoveryWPAPIRestClient.discoverWPAPIBaseURL("https://grinderstore.in") // discover rest api endpoint
             ?: WPAPIDiscoveryUtils.buildDefaultRESTBaseUrl(url)
     }
 }

```

1. Run the FluxC Example app
2. Tap on `Sign in & Fetch Sites`
3. Log in using site credentials. Any Jurassic ninja site would do. 
4. Url API discoverability for WP Rest will be triggered. 
5. Wait for 1 second, the app will crash. 

### Testing 

Repeat the steps above but from this branch. The app won't crash. 