### PR TITLE
Make objective field nullable

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
@@ -21,7 +21,7 @@ data class BlazeCampaignCreationRequest(
     val targetingParameters: BlazeTargetingParameters?,
     val timeZoneId: String = TimeZone.getDefault().id,
     val isEndlessCampaign: Boolean,
-    val objectiveId: String
+    val objectiveId: String?
 )
 
 data class BlazeCampaignCreationRequestBudget(


### PR DESCRIPTION
Makes objective field nullable to avoid sending `objective = ""` values when attempting to create a Blaze campaign from Woo mobile. Sending `objective = ""` will make the API request fail. 