### PR TITLE
Allow identifying black-flagged websites when fetching WPCom site info

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/activity/ActivityLogRestClientTest.kt
@@ -591,7 +591,8 @@ class ActivityLogRestClientTest {
                 eq(false),
                 any(),
                 eq(false),
-                customGsonBuilder = anyOrNull()
+                customGsonBuilder = anyOrNull(),
+                authenticatedRequest = any()
         )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)
@@ -612,7 +613,8 @@ class ActivityLogRestClientTest {
                 eq(false),
                 any(),
                 eq(false),
-                customGsonBuilder = anyOrNull()
+                customGsonBuilder = anyOrNull(),
+                authenticatedRequest = any()
         )).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)
         return response
@@ -698,7 +700,8 @@ class ActivityLogRestClientTest {
                 eq(false),
                 any(),
                 eq(false),
-                customGsonBuilder = anyOrNull()
+                customGsonBuilder = anyOrNull(),
+                authenticatedRequest = any()
         )).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)
         return response
@@ -717,7 +720,8 @@ class ActivityLogRestClientTest {
                 eq(false),
                 any(),
                 eq(false),
-                customGsonBuilder = anyOrNull()
+                customGsonBuilder = anyOrNull(),
+                authenticatedRequest = any()
         )
         ).thenReturn(response)
         return response

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/bloggingprompts/BloggingPromptsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/bloggingprompts/BloggingPromptsRestClientTest.kt
@@ -212,7 +212,8 @@ class BloggingPromptsRestClientTest {
                 eq(BloggingPromptsListResponseTypeToken.type),
                 eq(false),
                 any(),
-                eq(false)
+                eq(false),
+                authenticatedRequest = any()
             )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/comments/CommentsRestClientTest.kt
@@ -572,7 +572,8 @@ class CommentsRestClientTest {
                         any(),
                         any(),
                         any(),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         return response

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/dashboard/CardsRestClientTest.kt
@@ -400,7 +400,8 @@ class CardsRestClientTest {
                         eq(false),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/experiments/ExperimentRestClientTest.kt
@@ -176,7 +176,8 @@ class ExperimentRestClientTest {
                         eq(false),
                         any(),
                         eq(true),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/FeatureFlagsRestClientTest.kt
@@ -212,7 +212,8 @@ class FeatureFlagsRestClientTest {
                 eq(false),
                 any(),
                 eq(false),
-                customGsonBuilder = anyOrNull()
+                customGsonBuilder = anyOrNull(),
+                authenticatedRequest = any()
             )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/mobile/RemoteConfigRestClientTest.kt
@@ -138,7 +138,8 @@ class RemoteConfigRestClientTest {
                 eq(false),
                 any(),
                 eq(false),
-                customGsonBuilder = anyOrNull()
+                customGsonBuilder = anyOrNull(),
+                authenticatedRequest = any()
             )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/planoffers/PlanOffersRestClientTest.kt
@@ -87,7 +87,8 @@ class PlanOffersRestClientTest {
                         eq(false),
                         any(),
                         eq(true),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/products/ProductsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/products/ProductsRestClientTest.kt
@@ -92,7 +92,8 @@ class ProductsRestClientTest {
                         eq(false),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
     }

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/scan/ScanRestClientTest.kt
@@ -423,7 +423,8 @@ class ScanRestClientTest {
                         eq(false),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)
@@ -508,7 +509,8 @@ class ScanRestClientTest {
                         eq(false),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         return response

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -667,8 +667,8 @@ class SiteRestClientTest {
                         any(),
                         any(),
                         any(),
-                        customGsonBuilder = anyOrNull()
-
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         return response

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/InsightsRestClientTest.kt
@@ -512,7 +512,8 @@ class InsightsRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/MostPopularRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/MostPopularRestClientTest.kt
@@ -103,7 +103,8 @@ class MostPopularRestClientTest {
                         eq(true),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PostingActivityRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/PostingActivityRestClientTest.kt
@@ -120,7 +120,8 @@ class PostingActivityRestClientTest {
                         eq(true),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/insights/SummaryRestClientTest.kt
@@ -100,7 +100,8 @@ class SummaryRestClientTest {
                 eq(false),
                 any(),
                 eq(false),
-                customGsonBuilder = anyOrNull()
+                customGsonBuilder = anyOrNull(),
+                authenticatedRequest = any()
             )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/SubscribersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/subscribers/SubscribersRestClientTest.kt
@@ -146,7 +146,8 @@ class SubscribersRestClientTest {
                 eq(cachingEnabled),
                 any(),
                 eq(false),
-                customGsonBuilder = anyOrNull()
+                customGsonBuilder = anyOrNull(),
+                authenticatedRequest = any()
             )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/AuthorsRestClientTest.kt
@@ -174,7 +174,8 @@ class AuthorsRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ClicksRestClientTest.kt
@@ -220,7 +220,8 @@ class ClicksRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/CountryViewsRestClientTest.kt
@@ -170,7 +170,8 @@ class CountryViewsRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/FileDownloadsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/FileDownloadsRestClientTest.kt
@@ -174,7 +174,8 @@ class FileDownloadsRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/PostAndPageViewsRestClientTest.kt
@@ -170,7 +170,8 @@ class PostAndPageViewsRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/ReferrersRestClientTest.kt
@@ -313,7 +313,8 @@ class ReferrersRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/SearchTermsRestClientTest.kt
@@ -170,7 +170,8 @@ class SearchTermsRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VideoPlaysRestClientTest.kt
@@ -174,7 +174,8 @@ class VideoPlaysRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClientTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/stats/time/VisitAndViewsRestClientTest.kt
@@ -164,7 +164,8 @@ class VisitAndViewsRestClientTest {
                         eq(cachingEnabled),
                         any(),
                         eq(false),
-                        customGsonBuilder = anyOrNull()
+                        customGsonBuilder = anyOrNull(),
+                        authenticatedRequest = any()
                 )
         ).thenReturn(response)
         whenever(site.siteId).thenReturn(siteId)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/WPComGsonRequestBuilder.kt
@@ -49,7 +49,8 @@ class WPComGsonRequestBuilder
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
         forced: Boolean = false,
-        customGsonBuilder: GsonBuilder? = null
+        customGsonBuilder: GsonBuilder? = null,
+        authenticatedRequest: Boolean = true
     ) = suspendCancellableCoroutine<Response<T>> { cont ->
         val request = WPComGsonRequest.buildGetRequest(url, params, clazz, {
             cont.resume(Success(it))
@@ -63,7 +64,11 @@ class WPComGsonRequestBuilder
         if (forced) {
             request.setShouldForceUpdate()
         }
-        restClient.add(request)
+        if (authenticatedRequest) {
+            restClient.add(request)
+        } else {
+            restClient.addUnauthedRequest(request)
+        }
     }
 
     /**
@@ -99,7 +104,8 @@ class WPComGsonRequestBuilder
         type: Type,
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        forced: Boolean = false
+        forced: Boolean = false,
+        authenticatedRequest: Boolean = true
     ) = suspendCancellableCoroutine<Response<T>> { cont ->
         val request = WPComGsonRequest.buildGetRequest<T>(url, params, type, {
             cont.resume(Success(it))
@@ -113,7 +119,11 @@ class WPComGsonRequestBuilder
         if (forced) {
             request.setShouldForceUpdate()
         }
-        restClient.add(request)
+        if (authenticatedRequest) {
+            restClient.add(request)
+        } else {
+            restClient.addUnauthedRequest(request)
+        }
     }
 
     /**

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -720,8 +720,12 @@ class SiteRestClient @Inject constructor(
 
         return when (response) {
             is Error -> {
-                val siteError = SiteError(INVALID_SITE)
-                ConnectSiteInfoPayload(siteUrl, siteError)
+                val siteErrorType = when (response.error.apiError) {
+                    "connection_disabled" -> SiteErrorType.WPCOM_SITE_SUSPENDED
+                    else -> INVALID_SITE
+                }
+
+                ConnectSiteInfoPayload(siteUrl, SiteError(siteErrorType))
             }
             is Success -> {
                 response.data.toConnectSiteInfoPayload(siteUrl)

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -896,7 +896,14 @@ open class SiteStore @Inject constructor(
     )
 
     enum class SiteErrorType {
-        INVALID_SITE, UNKNOWN_SITE, DUPLICATE_SITE, INVALID_RESPONSE, UNAUTHORIZED, NOT_AUTHENTICATED, GENERIC_ERROR
+        INVALID_SITE,
+        UNKNOWN_SITE,
+        DUPLICATE_SITE,
+        INVALID_RESPONSE,
+        UNAUTHORIZED,
+        NOT_AUTHENTICATED,
+        GENERIC_ERROR,
+        WPCOM_SITE_SUSPENDED
     }
 
     enum class AllDomainsErrorType {

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -402,8 +402,7 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    data class ConnectSiteInfoPayload
-    @JvmOverloads constructor(
+    data class ConnectSiteInfoPayload @JvmOverloads constructor(
         @JvmField val url: String,
         @JvmField val exists: Boolean = false,
         @JvmField val isWordPress: Boolean = false,
@@ -1859,6 +1858,12 @@ open class SiteStore @Inject constructor(
 
     private fun fetchConnectSiteInfo(payload: String) {
         siteRestClient.fetchConnectSiteInfo(payload)
+    }
+
+    suspend fun fetchConnectSiteInfoSync(siteUrl: String): ConnectSiteInfoPayload {
+        return coroutineEngine.withDefaultContext(T.API, this, "Fetch Connect Site Info") {
+            siteRestClient.fetchConnectSiteInfoSync(siteUrl)
+        }
     }
 
     private fun handleFetchedConnectSiteInfo(payload: ConnectSiteInfoPayload) {


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-android/issues/12775

This PR updates the error parsing of the `/connect/site-info` endpoint handler to expose specific error type when the site is suspended (black-flagged).

The PR also adds a coroutine based implementation of the `fetchConnectSiteInfo` function.

### Testing
1. DM me to share with a suspended website (or the steps to create one)
2. Open the example app.
3. Tap on "Signed-out actions"
4. Tap on "Connect site info"
5. Enter the site URL
6. Confirm the error: "WPCOM_SITE_SUSPENDED" is logged