### PR TITLE
Add support for creating Blaze campaigns with custom cta_text field

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/store/blaze/BlazeCampaignsStoreTest.kt
@@ -402,7 +402,8 @@ class BlazeCampaignsStoreTest {
         val suggestions = List(10) {
             BlazeAdSuggestion(
                 tagLine = it.toString(),
-                description = "Ad $it"
+                description = "Ad $it",
+                ctaText = "CTA $it"
             )
         }
 

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeAdSuggestion.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeAdSuggestion.kt
@@ -2,5 +2,6 @@ package org.wordpress.android.fluxc.model.blaze
 
 data class BlazeAdSuggestion(
     val tagLine: String,
-    val description: String
+    val description: String,
+    val ctaText: String
 )

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
@@ -12,6 +12,7 @@ data class BlazeCampaignCreationRequest(
     val paymentMethodId: String,
     val tagLine: String,
     val description: String,
+    val ctaText: String,
     val startDate: Date,
     val endDate: Date,
     val budget: BlazeCampaignCreationRequestBudget,

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
@@ -366,11 +366,14 @@ private class BlazeAdSuggestionListResponse(
         val siteName: String,
         @SerializedName("text_snippet")
         val textSnippet: String,
+        @SerializedName("cta_text")
+        val ctaText: String,
     ) {
         fun toDomainModel(): BlazeAdSuggestion {
             return BlazeAdSuggestion(
                 tagLine = siteName,
-                description = textSnippet
+                description = textSnippet,
+                ctaText = ctaText
             )
         }
     }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
@@ -234,6 +234,7 @@ class BlazeCreationRestClient @Inject constructor(
             ),
             "site_name" to request.tagLine,
             "text_snippet" to request.description,
+            "cta_text" to request.ctaText,
             "target_url" to request.targetUrl,
             "url_params" to request.urlParams.entries.joinToString(separator = "&") { "${it.key}=${it.value}" },
             "main_image" to JsonObject().apply {


### PR DESCRIPTION
Adds a new field `cta_text` to Blaze API

- `/suggestions` response to load the suggested texts for the ad cta
- `POST /campaign` to create campaigns specifying the `cta_text`

Changes can be tested here: https://github.com/woocommerce/woocommerce-android/pull/12899