### PR TITLE
[Woo] Add the product global unique id property

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -2115,8 +2115,8 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
 
                 205 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
-                    db.execSQL("ALTER TABLE WCProductModel ADD GLOBAL_UNIQUE_ID STRING")
-                    db.execSQL("ALTER TABLE WCProductVariationModel ADD GLOBAL_UNIQUE_ID STRING")
+                    db.execSQL("ALTER TABLE WCProductModel ADD GLOBAL_UNIQUE_ID TEXT")
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD GLOBAL_UNIQUE_ID TEXT")
                 }
             }
         }

--- a/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -41,7 +41,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 205
+        return 206
     }
 
     override fun getDbName(): String {
@@ -2112,6 +2112,11 @@ open class WellSqlConfig : DefaultWellConfig {
                     db.execSQL("DROP TABLE WCProductModel")
 
                     db.execSQL("ALTER TABLE WCProductModel_temp RENAME TO WCProductModel")
+                }
+
+                205 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
+                    db.execSQL("ALTER TABLE WCProductModel ADD GLOBAL_UNIQUE_ID STRING")
+                    db.execSQL("ALTER TABLE WCProductVariationModel ADD GLOBAL_UNIQUE_ID STRING")
                 }
             }
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -44,6 +44,7 @@ data class WCProductModel(@PrimaryKey @Column private var id: Int = 0) : Identif
     @Column var description = ""
     @Column var shortDescription = ""
     @Column var sku = ""
+    @Column var globalUniqueId = ""
 
     @Column var price = ""
     @Column var regularPrice = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -34,6 +34,7 @@ data class WCProductVariationModel(@PrimaryKey @Column private var id: Int = 0) 
     @Column var description = ""
     @Column var permalink = ""
     @Column var sku = ""
+    @Column var globalUniqueId = ""
     @Column var status = ""
 
     @Column var price = ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -25,7 +25,7 @@ data class ProductApiResponse(
     val description: String? = null,
     val short_description: String? = null,
     val sku: String? = null,
-    val globalUniqueId: String? = null,
+    val global_unique_id: String? = null,
     val price: String? = null,
     val regular_price: String? = null,
     val sale_price: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -25,6 +25,7 @@ data class ProductApiResponse(
     val description: String? = null,
     val short_description: String? = null,
     val sku: String? = null,
+    val globalUniqueId: String? = null,
     val price: String? = null,
     val regular_price: String? = null,
     val sale_price: String? = null,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductDtoMapper.kt
@@ -40,6 +40,7 @@ class ProductDtoMapper @Inject constructor(
             description = dto.description ?: ""
             shortDescription = dto.short_description ?: ""
             sku = dto.sku ?: ""
+            globalUniqueId = dto.globalUniqueId ?: ""
 
             price = dto.price ?: ""
             regularPrice = dto.regular_price ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductDtoMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductDtoMapper.kt
@@ -40,7 +40,7 @@ class ProductDtoMapper @Inject constructor(
             description = dto.description ?: ""
             shortDescription = dto.short_description ?: ""
             sku = dto.sku ?: ""
-            globalUniqueId = dto.globalUniqueId ?: ""
+            globalUniqueId = dto.global_unique_id ?: ""
 
             price = dto.price ?: ""
             regularPrice = dto.regular_price ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -1850,6 +1850,9 @@ class ProductRestClient @Inject constructor(
         if (storedWCProductModel.sku != updatedProductModel.sku) {
             body["sku"] = updatedProductModel.sku
         }
+        if (storedWCProductModel.globalUniqueId != updatedProductModel.globalUniqueId) {
+            body["global_unique_id"] = updatedProductModel.globalUniqueId
+        }
         if (storedWCProductModel.status != updatedProductModel.status) {
             body["status"] = updatedProductModel.status
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -12,7 +12,7 @@ class ProductVariationApiResponse : Response {
     var description: String? = null
     var permalink: String? = null
     var sku: String? = null
-    var globalUniqueId: String? = null
+    var global_unique_id: String? = null
     var status: String? = null
     var price: String? = null
     var regular_price: String? = null
@@ -76,7 +76,7 @@ class ProductVariationApiResponse : Response {
             status = response.status ?: ""
             description = response.description ?: ""
             sku = response.sku ?: ""
-            globalUniqueId = response.globalUniqueId ?: ""
+            globalUniqueId = response.global_unique_id ?: ""
 
             price = response.price ?: ""
             regularPrice = response.regular_price ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationApiResponse.kt
@@ -12,6 +12,7 @@ class ProductVariationApiResponse : Response {
     var description: String? = null
     var permalink: String? = null
     var sku: String? = null
+    var globalUniqueId: String? = null
     var status: String? = null
     var price: String? = null
     var regular_price: String? = null
@@ -75,6 +76,7 @@ class ProductVariationApiResponse : Response {
             status = response.status ?: ""
             description = response.description ?: ""
             sku = response.sku ?: ""
+            globalUniqueId = response.globalUniqueId ?: ""
 
             price = response.price ?: ""
             regularPrice = response.regular_price ?: ""

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
@@ -38,6 +38,9 @@ object ProductVariationMapper {
         if (storedVariationModel.sku != updatedVariationModel.sku) {
             body["sku"] = updatedVariationModel.sku
         }
+        if (storedVariationModel.globalUniqueId != storedVariationModel.globalUniqueId) {
+            body["global_unique_id"] = updatedVariationModel.globalUniqueId
+        }
         if (storedVariationModel.status != updatedVariationModel.status) {
             body["status"] = updatedVariationModel.status
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductVariationMapper.kt
@@ -38,7 +38,7 @@ object ProductVariationMapper {
         if (storedVariationModel.sku != updatedVariationModel.sku) {
             body["sku"] = updatedVariationModel.sku
         }
-        if (storedVariationModel.globalUniqueId != storedVariationModel.globalUniqueId) {
+        if (storedVariationModel.globalUniqueId != updatedVariationModel.globalUniqueId) {
             body["global_unique_id"] = updatedVariationModel.globalUniqueId
         }
         if (storedVariationModel.status != updatedVariationModel.status) {


### PR DESCRIPTION
With this PR we add support for the product's global unique identifier. Specifically we:

- Add new columns in the Product and Product Variations tables of the well SQL DB
- Migrate DB version
- Add support for the new value in the API Response classes.
- Add new value on the update requests.
