### PR TITLE
Fix issue of deserializing `/wp/v2/media` response when having an empty `media_details.sizes` property

### DIFF
--- a/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaWPRestResponse.kt
+++ b/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaWPRestResponse.kt
@@ -6,6 +6,7 @@ import com.google.gson.annotations.SerializedName
 import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
+import org.wordpress.android.fluxc.network.rest.JsonObjectOrEmptyArray
 import org.wordpress.android.fluxc.network.rest.wpcom.media.MediaWPComRestResponse
 import org.wordpress.android.util.DateTimeUtils
 import java.text.SimpleDateFormat
@@ -45,7 +46,7 @@ data class MediaWPRESTResponse(
         val medium: ImageSize?,
         val thumbnail: ImageSize?,
         val full: ImageSize?
-    )
+    ): JsonObjectOrEmptyArray()
 
     data class ImageSize(
         val path: String?,


### PR DESCRIPTION
Part of fixing https://github.com/woocommerce/woocommerce-android/issues/12989

This PR adds a fix to the issue of parsing the `/wp/v2/media` response when `media_details.sizes` contains an array instead of the expected object type.

To test: https://github.com/woocommerce/woocommerce-android/pull/12990