### PR TITLE
Order form is dropping second last names unexpectedly

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -286,9 +286,22 @@ class WCCustomerMapperTest {
         val result = mapper.mapToModel(site, customerDTO)
 
         // then
-        with(result) {
-            assertEquals("firstname", firstName)
-        }
+        assertEquals("firstname", result.firstName)
+    }
+
+    @Test
+    fun `given customer name as null, then first name returns empty string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = null)
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("", result.firstName)
     }
 
     @Test

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -305,6 +305,21 @@ class WCCustomerMapperTest {
     }
 
     @Test
+    fun `given customer name with no space, then first name returns full string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "firstnamelastname")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("firstnamelastname", result.firstName)
+    }
+
+    @Test
     fun `given customer name, then last name is properly assigned`() {
         // given
         val siteId = 23

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -348,4 +348,19 @@ class WCCustomerMapperTest {
         // then
         assertEquals("", result.lastName)
     }
+
+    @Test
+    fun `given customer name has no space, then last name returns empty string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "firstnamelastname")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("", result.lastName)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -280,7 +280,7 @@ class WCCustomerMapperTest {
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
-        val customerDTO = CustomerFromAnalyticsDTO(name = "firstname with a very long last name")
+        val customerDTO = CustomerFromAnalyticsDTO(name = "firstname lastname")
 
         // when
         val result = mapper.mapToModel(site, customerDTO)
@@ -288,6 +288,23 @@ class WCCustomerMapperTest {
         // then
         with(result) {
             assertEquals("firstname", firstName)
+        }
+    }
+
+    @Test
+    fun `given customer name, then last name is properly assigned`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "firstname lastname")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        with(result) {
+            assertEquals("lastname", lastName)
         }
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -363,4 +363,19 @@ class WCCustomerMapperTest {
         // then
         assertEquals("", result.lastName)
     }
+
+    @Test
+    fun `given customer name has multiple spaces, then first name returns proper string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "firstname and a very long last name")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("firstname", result.firstName)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -438,4 +438,19 @@ class WCCustomerMapperTest {
         // then
         assertEquals("firstname", result.firstName)
     }
+
+    @Test
+    fun `given customer name has multiple in between space, then last name returns proper string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "  firstname   and  a   very  long last name")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("and a very long last name", result.lastName)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -275,7 +275,6 @@ class WCCustomerMapperTest {
     }
 
     @Test
-    @Suppress("LongMethod")
     fun `given customer name, then first name is properly assigned`() {
         // given
         val siteId = 23

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -378,4 +378,19 @@ class WCCustomerMapperTest {
         // then
         assertEquals("firstname", result.firstName)
     }
+
+    @Test
+    fun `given customer name has multiple spaces, then last name returns proper string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "firstname and a very long last name")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("and a very long last name", result.lastName)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -331,8 +331,21 @@ class WCCustomerMapperTest {
         val result = mapper.mapToModel(site, customerDTO)
 
         // then
-        with(result) {
-            assertEquals("lastname", lastName)
-        }
+        assertEquals("lastname", result.lastName)
+    }
+
+    @Test
+    fun `given customer name as null, then last name returns empty string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = null)
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("", result.lastName)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -408,4 +408,19 @@ class WCCustomerMapperTest {
         // then
         assertEquals("firstname", result.firstName)
     }
+
+    @Test
+    fun `given customer name has trailing space, then last name returns proper string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "firstname and a very long last name  ")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("and a very long last name", result.lastName)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -451,6 +451,6 @@ class WCCustomerMapperTest {
         val result = mapper.mapToModel(site, customerDTO)
 
         // THEN
-        assertEquals("and a very long last name", result.lastName)
+        assertEquals("and  a   very  long last name", result.lastName)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -276,181 +276,181 @@ class WCCustomerMapperTest {
 
     @Test
     fun `given customer name, then first name is properly assigned`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "firstname lastname")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("firstname", result.firstName)
     }
 
     @Test
     fun `given customer name as null, then first name returns empty string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = null)
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("", result.firstName)
     }
 
     @Test
     fun `given customer name with no space, then first name returns full string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "firstnamelastname")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("firstnamelastname", result.firstName)
     }
 
     @Test
     fun `given customer name, then last name is properly assigned`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "firstname lastname")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("lastname", result.lastName)
     }
 
     @Test
     fun `given customer name as null, then last name returns empty string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = null)
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("", result.lastName)
     }
 
     @Test
     fun `given customer name has no space, then last name returns empty string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "firstnamelastname")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("", result.lastName)
     }
 
     @Test
     fun `given customer name has multiple spaces, then first name returns proper string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "firstname and a very long last name")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("firstname", result.firstName)
     }
 
     @Test
     fun `given customer name has multiple spaces, then last name returns proper string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "firstname and a very long last name")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("and a very long last name", result.lastName)
     }
 
     @Test
     fun `given customer name has leading space, then first name returns proper string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "  firstname and a very long last name")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("firstname", result.firstName)
     }
 
     @Test
     fun `given customer name has trailing space, then last name returns proper string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "firstname and a very long last name  ")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("and a very long last name", result.lastName)
     }
 
     @Test
     fun `given customer name has multiple in between space, then first name returns proper string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "  firstname   and  a   very  long last name")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("firstname", result.firstName)
     }
 
     @Test
     fun `given customer name has multiple in between space, then last name returns proper string`() {
-        // given
+        // GIVEN
         val siteId = 23
         val site = SiteModel().apply { id = siteId }
 
         val customerDTO = CustomerFromAnalyticsDTO(name = "  firstname   and  a   very  long last name")
 
-        // when
+        // WHEN
         val result = mapper.mapToModel(site, customerDTO)
 
-        // then
+        // THEN
         assertEquals("and a very long last name", result.lastName)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -423,4 +423,19 @@ class WCCustomerMapperTest {
         // then
         assertEquals("and a very long last name", result.lastName)
     }
+
+    @Test
+    fun `given customer name has multiple in between space, then first name returns proper string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "  firstname   and  a   very  long last name")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("firstname", result.firstName)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -273,4 +273,22 @@ class WCCustomerMapperTest {
         // THEN
         assertThat(result.isPayingCustomer).isEqualTo(false)
     }
+
+    @Test
+    @Suppress("LongMethod")
+    fun `given customer name, then first name is properly assigned`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "firstname with a very long last name")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        with(result) {
+            assertEquals("firstname", firstName)
+        }
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/model/customer/WCCustomerMapperTest.kt
@@ -393,4 +393,19 @@ class WCCustomerMapperTest {
         // then
         assertEquals("and a very long last name", result.lastName)
     }
+
+    @Test
+    fun `given customer name has leading space, then first name returns proper string`() {
+        // given
+        val siteId = 23
+        val site = SiteModel().apply { id = siteId }
+
+        val customerDTO = CustomerFromAnalyticsDTO(name = "  firstname and a very long last name")
+
+        // when
+        val result = mapper.mapToModel(site, customerDTO)
+
+        // then
+        assertEquals("firstname", result.firstName)
+    }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
@@ -122,8 +122,6 @@ class WCCustomerMapper @Inject constructor() {
         this?.trim()?.replace("\\s+".toRegex(), " ")?.substringBefore(" ") ?: ""
 
     private fun String?.lastNameFromName(): String =
-        this?.trim()?.replace("\\s+".toRegex(), " ")?.substringAfter(
-            " ", ""
-        ) ?: ""
+        this?.trim()?.replace("\\s+".toRegex(), " ")?.substringAfter(" ", "") ?: ""
 
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
@@ -117,6 +117,7 @@ class WCCustomerMapper @Inject constructor() {
         }
     }
 
+    // Please refer WCCustomerMapperTest file which serves as documentation of how this function behaves.
     private fun String?.firstNameFromName(): String =
         this?.trim()?.replace("\\s+".toRegex(), " ")?.substringBefore(" ") ?: ""
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
@@ -119,8 +119,8 @@ class WCCustomerMapper @Inject constructor() {
 
     // Please refer WCCustomerMapperTest file which serves as documentation of how this function behaves.
     private fun String?.firstNameFromName(): String =
-        this?.trim()?.replace("\\s+".toRegex(), " ")?.substringBefore(" ") ?: ""
+        this?.trim()?.substringBefore(' ')?.trim().orEmpty()
 
     private fun String?.lastNameFromName(): String =
-        this?.trim()?.replace("\\s+".toRegex(), " ")?.substringAfter(" ", "") ?: ""
+        this?.trim()?.substringAfter(' ', "")?.trim().orEmpty()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
@@ -122,6 +122,8 @@ class WCCustomerMapper @Inject constructor() {
         this?.trim()?.replace("\\s+".toRegex(), " ")?.substringBefore(" ") ?: ""
 
     private fun String?.lastNameFromName(): String =
-        this?.trim()?.replace("\\s+".toRegex(), " ")?.substringAfter(" ", "") ?: ""
+        this?.trim()?.replace("\\s+".toRegex(), " ")?.substringAfter(
+            " ", ""
+        ) ?: ""
 
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
@@ -123,5 +123,4 @@ class WCCustomerMapper @Inject constructor() {
 
     private fun String?.lastNameFromName(): String =
         this?.trim()?.replace("\\s+".toRegex(), " ")?.substringAfter(" ", "") ?: ""
-
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
@@ -117,6 +117,7 @@ class WCCustomerMapper @Inject constructor() {
         }
     }
 
-    private fun String?.firstNameFromName() = this?.split(" ")?.firstOrNull() ?: ""
-    private fun String?.lastNameFromName() = this?.split(" ")?.lastOrNull() ?: ""
+    private fun String?.firstNameFromName() = this?.substringBefore(" ") ?: ""
+
+    private fun String?.lastNameFromName() = this?.substringAfter(" ", "") ?: ""
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/customer/WCCustomerMapper.kt
@@ -117,7 +117,10 @@ class WCCustomerMapper @Inject constructor() {
         }
     }
 
-    private fun String?.firstNameFromName() = this?.substringBefore(" ") ?: ""
+    private fun String?.firstNameFromName(): String =
+        this?.trim()?.replace("\\s+".toRegex(), " ")?.substringBefore(" ") ?: ""
 
-    private fun String?.lastNameFromName() = this?.substringAfter(" ", "") ?: ""
+    private fun String?.lastNameFromName(): String =
+        this?.trim()?.replace("\\s+".toRegex(), " ")?.substringAfter(" ", "") ?: ""
+
 }


### PR DESCRIPTION
closes [#11236](https://github.com/woocommerce/woocommerce-android/issues/11236)

This PR fixes the logic to retrieve first name and last name given customer full name.

**Before this PR**, we were considering first word to be the first name and last word to be the last name. This caused problem when there were multiple words in customers name. 
`Full Name` : `Firstname and a very long last name`
`firstname` : `Firstname`
 `lastname` : `name`

**After this PR**, we are considering first word to be the first name and all other words as last names
`Full Name` : `Firstname and a very long last name`
`firstname` : `Firstname`
`lastname` : `and a very long last name`


https://github.com/user-attachments/assets/a4f62ddf-13d3-4e0d-ae1c-d5143a024c02


