### PR TITLE
[Woo POS][non-simple products] Remove empty filters condition from deleting stale products from database

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1604,8 +1604,7 @@ class WCProductStore @Inject constructor(
                     if (forceRefresh &&
                         offset == 0 &&
                         includedProductIds.isEmpty() &&
-                        excludedProductIds.isEmpty() &&
-                        filterOptions.isEmpty()
+                        excludedProductIds.isEmpty()
                     ) {
                         productStorageHelper.deleteProductsForSite(site)
                     }


### PR DESCRIPTION
### Please review the corresponding [WooCommerce PR](https://github.com/woocommerce/woocommerce-android/pull/13018) after reviewing and merging this one

This PR removes empty filter condition which was one among few conditions we were checking before removing stale products from the database before inserting new ones fetched from the remote.

This was done since for POS, when we fetch products, there always will be filter applied for products (simple + variable) unless we support all types of products in POS. Since from POS, we won't be having an empty filter, the stale products in the database weren't being removed.