### PR TITLE
Endpoint: Action send order details

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCOrdersTest.kt
@@ -568,6 +568,15 @@ class MockedStack_WCOrdersTest : MockedStack_Base() {
         )
     }
 
+    @Test
+    fun testSendOrderReceipt() = runBlocking {
+        interceptor.respondWith("wc-order-action-send-order-details-success.json")
+
+        val result = orderRestClient.sendOrderReceipt(siteModel, 0)
+
+        assertFalse(result.isError)
+    }
+
     @Suppress("unused")
     @Subscribe
     fun onAction(action: Action<*>) {

--- a/example/src/androidTest/resources/wc-order-action-send-order-details-success.json
+++ b/example/src/androidTest/resources/wc-order-action-send-order-details-success.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "message": "Order details email sent to customer."
+  }
+}

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -592,6 +592,19 @@ class WCOrderStoreTest {
         }
     }
 
+    @Test
+    fun testSendOrderReceipt() {
+        runBlocking {
+            val orderModel = OrderTestUtils.generateSampleOrder(42)
+            val site = SiteModel().apply { id = orderModel.localSiteId.value }
+            val orderId = 42L
+
+            orderStore.sendOrderReceipt(site, orderId)
+
+            verify(orderRestClient).sendOrderReceipt(site, orderId)
+        }
+    }
+
     private fun setupMissingOrders(): MutableMap<WCOrderSummaryModel, OrderEntity?> {
         return mutableMapOf<WCOrderSummaryModel, OrderEntity?>().apply {
             (21L..30L).forEach { index ->

--- a/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -5,6 +5,7 @@
 /orders/<id>/shipment-trackings/<tracking>#String/
 /orders/<id>/shipment-trackings/providers/
 /orders/<id>/receipt/
+/orders/<id>/actions/send_order_details
 
 /products/<id>/
 /products/<id>/variations/

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -1023,6 +1023,19 @@ class OrderRestClient @Inject constructor(
         return response.toWooPayload { it }
     }
 
+    suspend fun sendOrderReceipt(
+        site: SiteModel,
+        orderId: Long,
+    ): WooPayload<Unit> {
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = WOOCOMMERCE.orders.id(orderId).actions.send_order_details.pathV3,
+            clazz = Unit::class.java,
+        )
+
+        return response.toWooPayload { it }
+    }
+
     private suspend fun doFetchOrderCount(site: SiteModel, filterByStatus: String?): FetchOrdersCountResponsePayload {
         val url = WOOCOMMERCE.reports.orders.totals.pathV3
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -728,6 +728,14 @@ class WCOrderStore @Inject constructor(
         forceNew
     )
 
+    suspend fun sendOrderReceipt(
+        site: SiteModel,
+        orderId: Long,
+    ) = wcOrderRestClient.sendOrderReceipt(
+        site,
+        orderId
+    )
+
     private suspend fun optimisticallyUpdateOrder(
         orderId: Long,
         localSiteId: LocalId,


### PR DESCRIPTION
`orders/{order_id}/actions/send_order_details` endpoint implementation


https://github.com/woocommerce/woocommerce-android/issues/13019