### PR TITLE
[Woo POS][non-simple products] Integrate include_types parameter for products endpoint

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -849,4 +849,11 @@ class WCProductStoreTest {
             WCProductStore.IncludeType.fromValue("external")
         ).isEqualTo(WCProductStore.IncludeType.External)
     }
+
+    @Test
+    fun `given include_type grouped, then return type Grouped` () {
+        assertThat(
+            WCProductStore.IncludeType.fromValue("grouped")
+        ).isEqualTo(WCProductStore.IncludeType.Grouped)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -856,4 +856,11 @@ class WCProductStoreTest {
             WCProductStore.IncludeType.fromValue("grouped")
         ).isEqualTo(WCProductStore.IncludeType.Grouped)
     }
+
+    @Test
+    fun `given include_type empty, then return type null` () {
+        assertThat(
+            WCProductStore.IncludeType.fromValue("")
+        ).isNull()
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -842,4 +842,11 @@ class WCProductStoreTest {
             WCProductStore.IncludeType.fromValue("variable")
         ).isEqualTo(WCProductStore.IncludeType.Variable)
     }
+
+    @Test
+    fun `given include_type external, then return type External` () {
+        assertThat(
+            WCProductStore.IncludeType.fromValue("external")
+        ).isEqualTo(WCProductStore.IncludeType.External)
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -863,4 +863,11 @@ class WCProductStoreTest {
             WCProductStore.IncludeType.fromValue("")
         ).isNull()
     }
+
+    @Test
+    fun `given include_type invalid, then return type null` () {
+        assertThat(
+            WCProductStore.IncludeType.fromValue("invalid")
+        ).isNull()
+    }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -27,12 +27,12 @@ import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.ProductWithMetaData
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
+import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -829,5 +829,10 @@ class WCProductStoreTest {
         assertThat(storedProduct).isNotNull
         assertThat(storedProduct?.product).isEqualTo(product)
         assertThat(storedProduct?.metaData).isEqualTo(metadata)
+    }
+
+    @Test
+    fun `given include_type simple, then return type Simple` () {
+        assertThat(WCProductStore.IncludeType.fromValue("simple")).isEqualTo(WCProductStore.IncludeType.Simple)
     }
 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/product/WCProductStoreTest.kt
@@ -27,12 +27,12 @@ import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.ProductWithMetaData
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.model.WCProductCategoryModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductReviewModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel.ProductVariantOption
-import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -834,5 +834,12 @@ class WCProductStoreTest {
     @Test
     fun `given include_type simple, then return type Simple` () {
         assertThat(WCProductStore.IncludeType.fromValue("simple")).isEqualTo(WCProductStore.IncludeType.Simple)
+    }
+
+    @Test
+    fun `given include_type variable, then return type Variable` () {
+        assertThat(
+            WCProductStore.IncludeType.fromValue("variable")
+        ).isEqualTo(WCProductStore.IncludeType.Variable)
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -534,7 +534,8 @@ class ProductRestClient @Inject constructor(
         excludedProductIds: List<Long>? = null,
         searchQuery: String? = null,
         skuSearchOptions: SkuSearchOptions = SkuSearchOptions.Disabled,
-        filterOptions: Map<ProductFilterOption, String>? = null
+        filterOptions: Map<ProductFilterOption, String>? = null,
+        includeTypes: List<WCProductStore.IncludeType> = emptyList()
     ): WooPayload<List<ProductWithMetaData>> {
         val params = buildProductParametersMap(
             pageSize = pageSize,
@@ -544,7 +545,8 @@ class ProductRestClient @Inject constructor(
             skuSearchOptions = skuSearchOptions,
             includedProductIds = includedProductIds,
             excludedProductIds = excludedProductIds,
-            filterOptions = filterOptions
+            filterOptions = filterOptions,
+            includeTypes = includeTypes,
         )
 
         val url = WOOCOMMERCE.products.pathV3
@@ -585,7 +587,8 @@ class ProductRestClient @Inject constructor(
         skuSearchOptions: SkuSearchOptions,
         includedProductIds: List<Long>? = null,
         excludedProductIds: List<Long>? = null,
-        filterOptions: Map<ProductFilterOption, String>? = null
+        filterOptions: Map<ProductFilterOption, String>? = null,
+        includeTypes: List<WCProductStore.IncludeType> = emptyList()
     ): MutableMap<String, String> {
         fun ProductSorting.asOrderByParameter() = when (this) {
             TITLE_ASC, TITLE_DESC -> "title"
@@ -601,7 +604,8 @@ class ProductRestClient @Inject constructor(
             "per_page" to pageSize.toString(),
             "orderby" to sortType.asOrderByParameter(),
             "order" to sortType.asSortOrderParameter(),
-            "offset" to offset.toString()
+            "offset" to offset.toString(),
+            "include_types" to includeTypes.joinToString(",") { it.value }
         )
 
         includedProductIds?.let { includedIds ->

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -81,6 +81,23 @@ class WCProductStore @Inject constructor(
         const val VARIATIONS_CREATION_LIMIT = 100
     }
 
+    sealed class IncludeType(val value: String) {
+        data object Simple : IncludeType("simple")
+        data object Variable : IncludeType("variable")
+        data object External : IncludeType("external")
+        data object Grouped : IncludeType("grouped")
+
+        companion object {
+            fun fromValue(value: String): IncludeType? = when (value) {
+                "simple" -> Simple
+                "variable" -> Variable
+                "external" -> External
+                "grouped" -> Grouped
+                else -> null
+            }
+        }
+    }
+
     /**
      * Defines the filter options currently supported in the app
      */
@@ -1586,6 +1603,7 @@ class WCProductStore @Inject constructor(
         includedProductIds: List<Long> = emptyList(),
         excludedProductIds: List<Long> = emptyList(),
         filterOptions: Map<ProductFilterOption, String> = emptyMap(),
+        includeTypes: List<IncludeType> = emptyList(),
         forceRefresh: Boolean = true
     ): WooResult<Boolean> {
         return coroutineEngine.withDefaultContext(API, this, "fetchProducts") {
@@ -1596,7 +1614,8 @@ class WCProductStore @Inject constructor(
                 sortType = sortType,
                 includedProductIds = includedProductIds,
                 excludedProductIds = excludedProductIds,
-                filterOptions = filterOptions
+                filterOptions = filterOptions,
+                includeTypes = includeTypes,
             )
             when {
                 response.isError -> WooResult(response.error)


### PR DESCRIPTION
### NOTE: Please review [this WooCommerce PR](https://github.com/woocommerce/woocommerce-android/pull/13072) as soon as you merge this change

This PR integrates `include_types` parameter for the product endpoint. This parameter helps especially in POS to include only product types that are compatible.

Here's the backend PR for more context: https://github.com/woocommerce/woocommerce/pull/52994