### PR TITLE
Woo: Part two for orders/batch endpoint

### DIFF
--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -653,7 +653,7 @@ class WCOrderStoreTest {
     }
 
     @Test
-    fun `given mixed success and failure response when batch updating status then returns successful and failed orders`() {
+    fun `given mixed response when batch updating status then returns successful and failed orders`() {
         runBlocking {
             // Given
             val site = SiteModel().apply { id = 1 }

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -35,7 +35,10 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.BatchOrderApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus.COMPLETED
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
@@ -46,6 +49,7 @@ import org.wordpress.android.fluxc.persistence.dao.OrdersDaoDecorator
 import org.wordpress.android.fluxc.store.InsertOrder
 import org.wordpress.android.fluxc.store.WCOrderFetcher
 import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.BulkUpdateOrderStatusResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsResponsePayload
@@ -602,6 +606,101 @@ class WCOrderStoreTest {
             orderStore.sendOrderReceipt(site, orderId)
 
             verify(orderRestClient).sendOrderReceipt(site, orderId)
+        }
+    }
+
+    @Test
+    fun `given successful response for all orders when batch updating status then returns successful orders`() {
+        runBlocking {
+            // Given
+            val site = SiteModel().apply { id = 1 }
+            val orderIds = listOf(1L, 2L, 3L)
+            val newStatus = COMPLETED.value
+
+            // Create mocked OrderDto objects for success responses
+            val order1 = mock<OrderDto>().apply {
+                whenever(id).thenReturn(1L)
+                whenever(status).thenReturn(COMPLETED.value)
+            }
+            val order2 = mock<OrderDto>().apply {
+                whenever(id).thenReturn(2L)
+                whenever(status).thenReturn(COMPLETED.value)
+            }
+            val order3 = mock<OrderDto>().apply {
+                whenever(id).thenReturn(3L)
+                whenever(status).thenReturn(COMPLETED.value)
+            }
+
+            val successResponses = listOf(
+                BatchOrderApiResponse.OrderResponse.Success(order1),
+                BatchOrderApiResponse.OrderResponse.Success(order2),
+                BatchOrderApiResponse.OrderResponse.Success(order3)
+            )
+
+            whenever(orderRestClient.batchUpdateOrdersStatus(site, orderIds, newStatus))
+                .thenReturn(BulkUpdateOrderStatusResponsePayload(successResponses))
+
+            // When
+            val result = orderStore.batchUpdateOrdersStatus(site, orderIds, newStatus)
+
+            // Then
+            assertThat(result.isError).isFalse()
+            result.model?.let { updateResult ->
+                assertEquals(orderIds, updateResult.updatedOrders)
+                assertTrue(updateResult.failedOrders.isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun `given mixed success and failure response when batch updating status then returns successful and failed orders`() {
+        runBlocking {
+            // Given
+            val site = SiteModel().apply { id = 1 }
+            val orderIds = listOf(1L, 2L, 3L)
+            val newStatus = COMPLETED.value
+
+            // Mock successful orders
+            val order1 = mock<OrderDto>().apply {
+                whenever(id).thenReturn(1L)
+                whenever(status).thenReturn(COMPLETED.value)
+            }
+            val order3 = mock<OrderDto>().apply {
+                whenever(id).thenReturn(3L)
+                whenever(status).thenReturn(COMPLETED.value)
+            }
+
+            val mixedResponses = listOf(
+                BatchOrderApiResponse.OrderResponse.Success(order1),
+                BatchOrderApiResponse.OrderResponse.Error(
+                    id = 2L,
+                    error = BatchOrderApiResponse.ErrorResponse(
+                        code = "woocommerce_rest_shop_order_invalid_id",
+                        message = "Invalid ID.",
+                        data = BatchOrderApiResponse.ErrorData(status = 400)
+                    )
+                ),
+                BatchOrderApiResponse.OrderResponse.Success(order3)
+            )
+
+            whenever(orderRestClient.batchUpdateOrdersStatus(site, orderIds, newStatus))
+                .thenReturn(BulkUpdateOrderStatusResponsePayload(mixedResponses))
+
+            // When
+            val result = orderStore.batchUpdateOrdersStatus(site, orderIds, newStatus)
+
+            // Then
+            assertThat(result.isError).isFalse()
+            result.model?.let { updateResult ->
+                assertEquals(listOf(1L, 3L), updateResult.updatedOrders)
+                assertEquals(1, updateResult.failedOrders.size)
+                with(updateResult.failedOrders[0]) {
+                    assertEquals(2L, id)
+                    assertEquals("woocommerce_rest_shop_order_invalid_id", errorCode)
+                    assertEquals("Invalid ID.", errorMessage)
+                    assertEquals(400, errorStatus)
+                }
+            }
         }
     }
 

--- a/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/example/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -641,7 +641,11 @@ class WCOrderStoreTest {
                 .thenReturn(BulkUpdateOrderStatusResponsePayload(successResponses))
 
             // When
-            val result = orderStore.batchUpdateOrdersStatus(site, orderIds, newStatus)
+            val result = orderStore.batchUpdateOrdersStatus(
+                site,
+                orderIds,
+                WCOrderStatusModel(COMPLETED.value)
+            )
 
             // Then
             assertThat(result.isError).isFalse()
@@ -687,7 +691,11 @@ class WCOrderStoreTest {
                 .thenReturn(BulkUpdateOrderStatusResponsePayload(mixedResponses))
 
             // When
-            val result = orderStore.batchUpdateOrdersStatus(site, orderIds, newStatus)
+            val result = orderStore.batchUpdateOrdersStatus(
+                site,
+                orderIds,
+                WCOrderStatusModel(COMPLETED.value)
+            )
 
             // Then
             assertThat(result.isError).isFalse()

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/BatchOrderApiResponse.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/BatchOrderApiResponse.kt
@@ -7,6 +7,43 @@ import com.google.gson.annotations.JsonAdapter
 import java.lang.reflect.Type
 import org.wordpress.android.fluxc.network.Response
 
+/**
+ * Represents the response from WooCommerce's Batch Order Update API endpoint.
+ * https://woocommerce.github.io/woocommerce-rest-api-docs/?shell#batch-update-orders
+ *
+ * While the WooCommerce REST API orders batch endpoint supports three operations at once
+ * (create, update, delete), this class specifically handles only the "update" operation
+ * responses, because we don't yet support the other operations.
+ *
+ * The response contains a list of order updates, where each update can be
+ * either successful or failed.
+ * 1. Success: Contains the complete updated order data (OrderDto)
+ * 2. Error: Contains the failed order ID and error details
+ *
+ *  Also refer to the orders-batch.json file in test resources.
+ *
+ * Example successful response:
+ * {
+ *   "update": [{
+ *     "id": 1032,
+ *     "status": "completed",
+ *     // ... other order fields
+ *   }]
+ * }
+ *
+ * Example error response:
+ * {
+ *   "update": [{
+ *     "id": "525",
+ *     "error": {
+ *       "code": "woocommerce_rest_shop_order_invalid_id",
+ *       "message": "Invalid ID.",
+ *       "data": { "status": 400 }
+ *     }
+ *   }]
+ * }
+ *
+ */
 data class BatchOrderApiResponse(
     val update: List<OrderResponse>
 ) : Response {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -1261,7 +1261,7 @@ class OrderRestClient @Inject constructor(
             "tracking_provider"
         ).joinToString(separator = ",")
 
-        private val BATCH_UPDATE_LIMIT = 100
+        private const val BATCH_UPDATE_LIMIT = 100
     }
 
     enum class SortOrder(val value: String) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingResponsePayload
+import org.wordpress.android.fluxc.store.WCOrderStore.BulkUpdateOrderStatusPayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload
@@ -1073,6 +1074,52 @@ class OrderRestClient @Inject constructor(
         }
     }
 
+    suspend fun batchUpdateOrdersStatus(
+        site: SiteModel,
+        orderIds: List<Long>,
+        newStatus: String
+    ): BulkUpdateOrderStatusPayload {
+        // Check batch update limit
+        if (orderIds.size > BATCH_UPDATE_LIMIT) {
+            return BulkUpdateOrderStatusPayload(
+                error = OrderError(
+                    type = OrderErrorType.BULK_UPDATE_LIMIT_EXCEEDED,
+                    message = "Cannot update more than 100 orders at once"
+                )
+            )
+        }
+
+        val url = WOOCOMMERCE.orders.batch.pathV3
+        val updateRequests = orderIds.map { orderId ->
+            mapOf(
+                "id" to orderId,
+                "status" to newStatus
+            )
+        }
+
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = BatchOrderApiResponse::class.java,
+            body = mapOf("update" to updateRequests)
+        )
+
+        return when (response) {
+            is WPAPIResponse.Success -> {
+                response.data?.let {
+                    BulkUpdateOrderStatusPayload(it.update)
+                } ?: BulkUpdateOrderStatusPayload(
+                    OrderError(GENERIC_ERROR, "Success response with empty data")
+                )
+            }
+
+            is WPAPIResponse.Error -> {
+                val orderError = wpAPINetworkErrorToOrderError(response.error)
+                BulkUpdateOrderStatusPayload(orderError)
+            }
+        }
+    }
+
     private fun UpdateOrderRequest.toNetworkRequest(): Map<String, Any> {
         return mutableMapOf<String, Any>().apply {
             customerId?.let { put("customer_id", it) }
@@ -1202,6 +1249,8 @@ class OrderRestClient @Inject constructor(
             "tracking_number",
             "tracking_provider"
         ).joinToString(separator = ",")
+
+        private val BATCH_UPDATE_LIMIT = 100
     }
 
     enum class SortOrder(val value: String) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -30,7 +30,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingResponsePayload
-import org.wordpress.android.fluxc.store.WCOrderStore.BulkUpdateOrderStatusPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.BulkUpdateOrderStatusResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.DeleteOrderShipmentTrackingResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchHasOrdersResponsePayload
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListResponsePayload
@@ -1074,14 +1074,25 @@ class OrderRestClient @Inject constructor(
         }
     }
 
+    /**
+    * Performs a batch update of order statuses via the WooCommerce REST API.
+    *
+    * This endpoint enables updating multiple orders to the same status in a single network request.
+    * The WooCommerce API has a limit of 100 orders per batch update.
+    *
+    * @param site The site to perform the update on
+    * @param orderIds List of order IDs to update. Error if exceeds [BATCH_UPDATE_LIMIT]
+    * @param newStatus The new status to set for all specified orders
+    * @return [BulkUpdateOrderStatusResponsePayload] containing either the update results or an error
+    */
     suspend fun batchUpdateOrdersStatus(
         site: SiteModel,
         orderIds: List<Long>,
         newStatus: String
-    ): BulkUpdateOrderStatusPayload {
+    ): BulkUpdateOrderStatusResponsePayload {
         // Check batch update limit
         if (orderIds.size > BATCH_UPDATE_LIMIT) {
-            return BulkUpdateOrderStatusPayload(
+            return BulkUpdateOrderStatusResponsePayload(
                 error = OrderError(
                     type = OrderErrorType.BULK_UPDATE_LIMIT_EXCEEDED,
                     message = "Cannot update more than 100 orders at once"
@@ -1107,15 +1118,15 @@ class OrderRestClient @Inject constructor(
         return when (response) {
             is WPAPIResponse.Success -> {
                 response.data?.let {
-                    BulkUpdateOrderStatusPayload(it.update)
-                } ?: BulkUpdateOrderStatusPayload(
+                    BulkUpdateOrderStatusResponsePayload(it.update)
+                } ?: BulkUpdateOrderStatusResponsePayload(
                     OrderError(GENERIC_ERROR, "Success response with empty data")
                 )
             }
 
             is WPAPIResponse.Error -> {
                 val orderError = wpAPINetworkErrorToOrderError(response.error)
-                BulkUpdateOrderStatusPayload(orderError)
+                BulkUpdateOrderStatusResponsePayload(orderError)
             }
         }
     }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.BatchOrderApiResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.BatchOrderApiResponse.ErrorResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient.OrderBy
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient.SortOrder
@@ -1171,6 +1170,7 @@ class WCOrderStore @Inject constructor(
         }
     }
 
+    @Suppress("NestedBlockDepth")
     suspend fun batchUpdateOrdersStatus(
         site: SiteModel,
         orderIds: List<Long>,

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.BatchOrderApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.BatchOrderApiResponse.ErrorResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient.OrderBy
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient.SortOrder
@@ -44,6 +45,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.PARSE_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.TIMEOUT_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrdersStatusResult.FailedOrder
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.API
@@ -304,6 +306,18 @@ class WCOrderStore @Inject constructor(
         constructor(error: OrderError) : this(emptyList()) {
             this.error = error
         }
+    }
+
+    data class UpdateOrdersStatusResult(
+        val updatedOrders: List<Long> = emptyList(),
+        val failedOrders: List<FailedOrder> = emptyList()
+    ) {
+        data class FailedOrder(
+            val id: Long,
+            val errorCode: String,
+            val errorMessage: String,
+            val errorStatus: Int
+        )
     }
 
     data class OrderError(val type: OrderErrorType = GENERIC_ERROR, val message: String = "") : OnChangedError
@@ -1154,6 +1168,43 @@ class WCOrderStore @Inject constructor(
             @Suppress("SpreadOperator")
             insertOrder(listDescriptor.site.localId(), *result.toTypedArray())
             WooResult(orders)
+        }
+    }
+
+    suspend fun batchUpdateOrdersStatus(
+        site: SiteModel,
+        orderIds: List<Long>,
+        newStatus: String
+    ): WooResult<UpdateOrdersStatusResult> {
+        val result = wcOrderRestClient.batchUpdateOrdersStatus(site, orderIds, newStatus)
+
+        return if (!result.isError) {
+            val orders = result.response
+            val updatedOrders = mutableListOf<Long>()
+            val failedOrders = mutableListOf<FailedOrder>()
+
+            orders.forEach { response ->
+                when (response) {
+                    is BatchOrderApiResponse.OrderResponse.Success -> {
+                        response.order.id?.let { updatedOrders.add(it) }
+                    }
+
+                    is BatchOrderApiResponse.OrderResponse.Error -> {
+                        failedOrders.add(
+                            FailedOrder(
+                                id = response.id,
+                                errorCode = response.error.code,
+                                errorMessage = response.error.message,
+                                errorStatus = response.error.data.status
+                            )
+                        )
+                    }
+                }
+            }
+
+            WooResult(UpdateOrdersStatusResult(updatedOrders, failedOrders))
+        } else {
+            WooResult(WooError(API_ERROR, SERVER_ERROR, result.error.message))
         }
     }
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -298,7 +298,7 @@ class WCOrderStore @Inject constructor(
         }
     }
 
-    class BulkUpdateOrderStatusPayload(
+    class BulkUpdateOrderStatusResponsePayload(
         val response: List<BatchOrderApiResponse.OrderResponse>
     ) : Payload<OrderError>() {
         constructor(error: OrderError) : this(emptyList()) {

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.SERVER_E
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.BatchOrderApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient.OrderBy
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderRestClient.SortOrder
@@ -297,6 +298,14 @@ class WCOrderStore @Inject constructor(
         }
     }
 
+    class BulkUpdateOrderStatusPayload(
+        val response: List<BatchOrderApiResponse.OrderResponse>
+    ) : Payload<OrderError>() {
+        constructor(error: OrderError) : this(emptyList()) {
+            this.error = error
+        }
+    }
+
     data class OrderError(val type: OrderErrorType = GENERIC_ERROR, val message: String = "") : OnChangedError
 
     enum class OrderErrorType {
@@ -308,7 +317,8 @@ class WCOrderStore @Inject constructor(
         GENERIC_ERROR,
         PARSE_ERROR,
         TIMEOUT_ERROR,
-        EMPTY_BILLING_EMAIL;
+        EMPTY_BILLING_EMAIL,
+        BULK_UPDATE_LIMIT_EXCEEDED;
 
         companion object {
             private val reverseMap = values().associateBy(OrderErrorType::name)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -1174,9 +1174,9 @@ class WCOrderStore @Inject constructor(
     suspend fun batchUpdateOrdersStatus(
         site: SiteModel,
         orderIds: List<Long>,
-        newStatus: String
+        newStatus: WCOrderStatusModel
     ): WooResult<UpdateOrdersStatusResult> {
-        val result = wcOrderRestClient.batchUpdateOrdersStatus(site, orderIds, newStatus)
+        val result = wcOrderRestClient.batchUpdateOrdersStatus(site, orderIds, newStatus.statusKey)
 
         return if (!result.isError) {
             val orders = result.response


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-android/issues/13115

Working on adding the endpoint for /wc/v3/orders/batch 
Documentation in pe5sF9-3kb-p2

This PR adds the following:
- REST client functionality to do batch orders status update
- Order store functionality to do batch orders status update
- Unit tests for the store

### Discussion:
- I'm not adding this case to the Example app: so I can save a bit of time and because I feel the unit tests suffice. But let me know if you prefer to have it added, too.
- Still undecided whether the function in order store should save the successfully updated Orders to the database. I need to look at the existing behavior in Woo Android, see if it's easier for it to just do a full reload, etc. I'll make another PR later if that's needed.