### PR TITLE
[Woo POS][Non-Simple Products] Add downloadable filter for POS products

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -102,9 +102,15 @@ class WCProductStore @Inject constructor(
      * Defines the filter options currently supported in the app
      */
     enum class ProductFilterOption {
-        STOCK_STATUS, STATUS, TYPE, CATEGORY;
+        STOCK_STATUS, STATUS, TYPE, CATEGORY, DOWNLOADABLE;
 
-        override fun toString() = name.toLowerCase(Locale.US)
+        override fun toString() = name.lowercase(Locale.US)
+    }
+
+    enum class DownloadableOptions {
+        TRUE, FALSE;
+
+        override fun toString() = name.lowercase(Locale.US)
     }
 
     enum class SkuSearchOptions {


### PR DESCRIPTION
#### NOTE: Please review [this WooCommerce PR](https://github.com/woocommerce/woocommerce-android/pull/13196) after reviewing this PR.

This PR adds downloadable filter to Products API to filter out downloadable products for POS mode. The changes remain unaffected for store management.