### PR TITLE
[Buildkite] Test Android Staging on ami-06a633c14b35c40b9§

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ common_params:
     - "**/build/reports/**/*"
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   ############################


### PR DESCRIPTION
AMI Name: `android-build-image-6.12.0v1.4-rc-1`

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-06a633c14b35c40b9` works as expected.