### PR TITLE
Pass in status filter options for variations endpoint

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -939,7 +939,8 @@ class ProductRestClient @Inject constructor(
         offset: Int,
         includedVariationIds: List<Long> = emptyList(),
         searchQuery: String? = null,
-        excludedVariationIds: List<Long> = emptyList()
+        excludedVariationIds: List<Long> = emptyList(),
+        filterOptions: Map<WCProductStore.VariationFilterOption, String>? = null,
     ): WooPayload<List<WCProductVariationModel>> {
         val params = mutableMapOf(
             "per_page" to pageSize.toString(),
@@ -949,6 +950,10 @@ class ProductRestClient @Inject constructor(
         ).putIfNotEmpty("search" to searchQuery)
             .putIfNotEmpty("include" to includedVariationIds.map { it }.joinToString())
             .putIfNotEmpty("exclude" to excludedVariationIds.map { it }.joinToString())
+
+        filterOptions?.let { options ->
+            params.putAll(options.map { it.key.toString() to it.value })
+        }
 
         val url = WOOCOMMERCE.products.id(productId).variations.pathV3
 

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -113,6 +113,12 @@ class WCProductStore @Inject constructor(
         override fun toString() = name.lowercase(Locale.US)
     }
 
+    enum class VariationFilterOption {
+        STATUS;
+
+        override fun toString() = name.lowercase(Locale.US)
+    }
+
     enum class SkuSearchOptions {
         Disabled, ExactSearch, PartialMatch
     }
@@ -1754,7 +1760,8 @@ class WCProductStore @Inject constructor(
         offset: Int = 0,
         pageSize: Int = DEFAULT_PRODUCT_VARIATIONS_PAGE_SIZE,
         includedVariationIds: List<Long> = emptyList(),
-        excludedVariationIds: List<Long> = emptyList()
+        excludedVariationIds: List<Long> = emptyList(),
+        filterOptions: Map<VariationFilterOption, String>? = null,
     ): WooResult<Boolean> {
         return coroutineEngine.withDefaultContext(API, this, "fetchProductVariations") {
             val response = wcProductRestClient.fetchProductVariationsWithSyncRequest(
@@ -1763,7 +1770,8 @@ class WCProductStore @Inject constructor(
                 offset = offset,
                 pageSize = pageSize,
                 includedVariationIds = includedVariationIds,
-                excludedVariationIds = excludedVariationIds
+                excludedVariationIds = excludedVariationIds,
+                filterOptions = filterOptions
             )
             when {
                 response.isError -> WooResult(response.error)


### PR DESCRIPTION
### Please review this corresponding [WooCommerce PR](https://github.com/woocommerce/woocommerce-android/pull/13209) after this PR

This PR passes in `status` filter options for variations endpoint. We use this flag from the POS mode to display only variations that are enabled.