### PR TITLE
[Dependency Cache] Remove Restore Cache CI Hook

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Note that as the script is sourced, not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
-
-set -e
-
-restore_gradle_dependency_cache || true


### PR DESCRIPTION
Project Thread: paaHJt-7CE-p2
(Softly) Required By: [a8c-ci-toolkit#135](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/135)

### Description

This PR removes the CI `pre-command` hook that was responsible to trigger `restore_gradle_dependency_cache`.

With this hook present, every build and its within jobs are all restoring the dependency cache, even when this is not really needed, and as such, potentially, unnecessarily delaying some jobs, while also consuming unnecessary resources (downloading from s3, (un)compressing, etc).

FYI: It is better to use `restore_gradle_dependency_cache` only on those jobs that could really benefit from it.

PS: Also, based on the current state of things, with the dependency cache save/restore mechanism being stale, this
`restore_gradle_dependency_cache` command is not working as expected. No cache entry is found for `GRADLE_DEPENDENCY_CACHE` is being output on every build/job that runs on an `android` agent, plus an this `GRADLE_RO_DEP_CACHE: unbound variable` is being output on every build/job that runs on another agent (like the `linter` agent).

----

### Testing information

Just verify that all the CI checks are successful. 