### PR TITLE
[Woo POS][Non-Simple Products] Sort variations by menu_order

### DIFF
--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -944,7 +944,7 @@ class ProductRestClient @Inject constructor(
     ): WooPayload<List<WCProductVariationModel>> {
         val params = mutableMapOf(
             "per_page" to pageSize.toString(),
-            "orderby" to "date",
+            "orderby" to "menu_order",
             "order" to "asc",
             "offset" to offset.toString()
         ).putIfNotEmpty("search" to searchQuery)

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -866,13 +866,6 @@ class ProductRestClient @Inject constructor(
      *
      * @param [productId] Unique server id of the product
      *
-     * Variations by default are sorted by `menu_order` with sorting order = desc.
-     * i.e. `orderby` = `menu_order` and `order` = `desc`
-     *
-     * We do not pass `orderby` field in the request here because the API does not support `orderby`
-     * with `menu_order` as value. But we still need to pass `order` field to the API request in order to
-     * preserve the sorting order when fetching multiple pages of variations.
-     *
      */
     suspend fun fetchProductVariations(
         site: SiteModel,
@@ -885,7 +878,7 @@ class ProductRestClient @Inject constructor(
             "per_page" to pageSize.toString(),
             "offset" to offset.toString(),
             "order" to "asc",
-            "orderby" to "date"
+            "orderby" to "menu_order"
         )
 
         val response = wooNetwork.executeGetGsonRequest(


### PR DESCRIPTION
closes https://github.com/woocommerce/woocommerce-android/issues/13373

This PR replaces sort order of Variations from `date` to `menu_order`. This enables merchants to adjust the order of variations in the wp admin, ensuring the same order is reflected in the mobile app.

**Testing instructions:**
Ensure variations in store management and POS behaves as expected and they are ordered as they are seen on the web. Additionally, re-arrange variations on the wp-admin and ensure it is reflected on Android app.