### PR TITLE
[In Person Payments] Capture payment with min amount error handling

### DIFF
--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
@@ -136,14 +136,10 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
         )
 
         assertTrue(result.error!!.type == CAPTURE_ERROR)
-        assertTrue(result.error!!.extraData!!["error_type"] == "amount_too_small")
-        assertTrue(
-            result.error!!.extraData!!["extra_details"] as Map<*, *> ==
-                mapOf(
-                    "minimum_amount" to 50L,
-                    "minimum_amount_currency" to "USD"
-                )
-        )
+        assertEquals("amount_too_small", result.error!!.extraData!!["error_type"])
+        val extraDetails = result.error!!.extraData!!["extra_details"] as Map<*, *>
+        assertEquals(50.0, extraDetails["minimum_amount"])
+        assertEquals("USD", extraDetails["minimum_amount_currency"])
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
@@ -10,6 +10,7 @@ import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.CAPTURE_ERROR
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.MISSING_ORDER
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.PAYMENT_ALREADY_CAPTURED
@@ -121,6 +122,22 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
         )
 
         assertTrue(result.error?.type == SERVER_ERROR)
+    }
+
+    @Test
+    fun whenAmountTooSmallErrorThenAmountTooSmallErrorReturned() = runBlocking {
+        interceptor.respondWithError("wc-pay-capture-terminal-payment-response-amount-too-small.json", 400)
+
+        val result = restClient.capturePayment(
+            WOOCOMMERCE_PAYMENTS,
+            testSite,
+            DUMMY_PAYMENT_ID,
+            -10L
+        )
+
+        val type = result.error?.type as WCCapturePaymentErrorType.AMOUNT_TOO_SMALL
+        assertTrue(type.currency == "USD")
+        assertTrue(type.minAllowedAmountInStripeMinorUnit == 50L)
     }
 
     @Test

--- a/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
+++ b/example/src/androidTest/java/org/wordpress/android/fluxc/mocked/MockedStack_WCInPersonPaymentsTest.kt
@@ -11,8 +11,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType
-import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.CAPTURE_ERROR
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.MISSING_ORDER
+import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.CAPTURE_ERROR
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.PAYMENT_ALREADY_CAPTURED
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.SERVER_ERROR
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus
@@ -135,9 +135,15 @@ class MockedStack_InPersonPaymentsTest : MockedStack_Base() {
             -10L
         )
 
-        val type = result.error?.type as WCCapturePaymentErrorType.AMOUNT_TOO_SMALL
-        assertTrue(type.currency == "USD")
-        assertTrue(type.minAllowedAmountInStripeMinorUnit == 50L)
+        assertTrue(result.error!!.type == CAPTURE_ERROR)
+        assertTrue(result.error!!.extraData!!["error_type"] == "amount_too_small")
+        assertTrue(
+            result.error!!.extraData!!["extra_details"] as Map<*, *> ==
+                mapOf(
+                    "minimum_amount" to 50L,
+                    "minimum_amount_currency" to "USD"
+                )
+        )
     }
 
     @Test

--- a/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-amount-too-small.json
+++ b/example/src/androidTest/resources/wc-pay-capture-terminal-payment-response-amount-too-small.json
@@ -1,0 +1,12 @@
+{
+  "code": "wcpay_capture_error",
+  "message": "Payment capture failed to complete with the following message: Minimum required amount was not reached. The minimum amount to capture is 0.5 USD.",
+  "data": {
+    "status": 400,
+    "extra_details": {
+      "minimum_amount": 50,
+      "minimum_amount_currency": "USD"
+    },
+    "error_type": "amount_too_small"
+  }
+}

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCCapturePaymentResponsePayload.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCCapturePaymentResponsePayload.kt
@@ -26,11 +26,15 @@ class WCCapturePaymentError(
     val message: String = ""
 ) : OnChangedError
 
-enum class WCCapturePaymentErrorType {
-    GENERIC_ERROR,
-    PAYMENT_ALREADY_CAPTURED,
-    MISSING_ORDER,
-    CAPTURE_ERROR,
-    SERVER_ERROR,
-    NETWORK_ERROR
+sealed class WCCapturePaymentErrorType {
+    data object GENERIC_ERROR : WCCapturePaymentErrorType()
+    data object PAYMENT_ALREADY_CAPTURED : WCCapturePaymentErrorType()
+    data object MISSING_ORDER : WCCapturePaymentErrorType()
+    data object CAPTURE_ERROR : WCCapturePaymentErrorType()
+    data object SERVER_ERROR : WCCapturePaymentErrorType()
+    data object NETWORK_ERROR : WCCapturePaymentErrorType()
+    data class AMOUNT_TOO_SMALL(
+        val minAllowedAmountInStripeMinorUnit: Long,
+        val currency: String
+    ) : WCCapturePaymentErrorType()
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCCapturePaymentResponsePayload.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCCapturePaymentResponsePayload.kt
@@ -23,18 +23,15 @@ class WCCapturePaymentResponsePayload(
 
 class WCCapturePaymentError(
     val type: WCCapturePaymentErrorType = GENERIC_ERROR,
-    val message: String = ""
+    val message: String = "",
+    val extraData: Map<String, Any>? = null
 ) : OnChangedError
 
-sealed class WCCapturePaymentErrorType {
-    data object GENERIC_ERROR : WCCapturePaymentErrorType()
-    data object PAYMENT_ALREADY_CAPTURED : WCCapturePaymentErrorType()
-    data object MISSING_ORDER : WCCapturePaymentErrorType()
-    data object CAPTURE_ERROR : WCCapturePaymentErrorType()
-    data object SERVER_ERROR : WCCapturePaymentErrorType()
-    data object NETWORK_ERROR : WCCapturePaymentErrorType()
-    data class AMOUNT_TOO_SMALL(
-        val minAllowedAmountInStripeMinorUnit: Long,
-        val currency: String
-    ) : WCCapturePaymentErrorType()
+enum class WCCapturePaymentErrorType {
+    GENERIC_ERROR,
+    PAYMENT_ALREADY_CAPTURED,
+    MISSING_ORDER,
+    CAPTURE_ERROR,
+    SERVER_ERROR,
+    NETWORK_ERROR
 }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -234,12 +234,13 @@ class InPersonPaymentsRestClient @Inject constructor(
         )
     }
 
-    fun VolleyError.getExtraData(): Map<String, Any>? {
+    @Suppress("TooGenericExceptionCaught")
+    private fun VolleyError.getExtraData(): Map<String, Any>? {
         val jsonString = this.networkResponse?.data?.toString(Charsets.UTF_8)
         return try {
             val mapType = object : TypeToken<Map<String, Any>>() {}.type
             return gson.fromJson<Map<String, Any>>(jsonString, mapType)["data"] as Map<String, Any>?
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             AppLog.e(AppLog.T.API, "Error parsing volley error $jsonString", e)
             null
         }

--- a/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/plugins/woocommerce/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -1,5 +1,8 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.payments.inperson
 
+import com.android.volley.VolleyError
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentError
@@ -26,9 +29,13 @@ import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPayment
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.STRIPE
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
 import org.wordpress.android.fluxc.utils.toWooPayload
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
-class InPersonPaymentsRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
+class InPersonPaymentsRestClient @Inject constructor(
+    private val wooNetwork: WooNetwork,
+    private val gson: Gson,
+) {
     suspend fun fetchConnectionToken(
         activePlugin: InPersonPaymentsPluginType,
         site: SiteModel
@@ -71,15 +78,22 @@ class InPersonPaymentsRestClient @Inject constructor(private val wooNetwork: Woo
                 response.data?.let { data ->
                     WCCapturePaymentResponsePayload(site, paymentId, orderId, data.status)
                 } ?: WCCapturePaymentResponsePayload(
-                    mapToCapturePaymentError(error = null, message = "status field is null, but isError == false"),
+                    mapToCapturePaymentError(
+                        error = null,
+                        message = "status field is null, but isError == false"
+                    ),
                     site,
                     paymentId,
                     orderId
                 )
             }
+
             is WPAPIResponse.Error -> {
                 WCCapturePaymentResponsePayload(
-                    mapToCapturePaymentError(response.error, response.error.message ?: "Unexpected error"),
+                    mapToCapturePaymentError(
+                        response.error,
+                        response.error.message ?: "Unexpected error"
+                    ),
                     site,
                     paymentId,
                     orderId
@@ -146,9 +160,13 @@ class InPersonPaymentsRestClient @Inject constructor(private val wooNetwork: Woo
                     )
                 )
             }
+
             is WPAPIResponse.Error -> {
                 WCTerminalStoreLocationResult(
-                    mapToStoreLocationForSiteError(response.error, response.error.message ?: "Unexpected error")
+                    mapToStoreLocationForSiteError(
+                        response.error,
+                        response.error.message ?: "Unexpected error"
+                    )
                 )
             }
         }
@@ -194,7 +212,10 @@ class InPersonPaymentsRestClient @Inject constructor(private val wooNetwork: Woo
         return response.toWooPayload()
     }
 
-    private fun mapToCapturePaymentError(error: WPAPINetworkError?, message: String): WCCapturePaymentError {
+    private fun mapToCapturePaymentError(
+        error: WPAPINetworkError?,
+        message: String
+    ): WCCapturePaymentError {
         val type = when {
             error == null -> GENERIC_ERROR
             error.errorCode == "wcpay_missing_order" -> MISSING_ORDER
@@ -206,7 +227,22 @@ class InPersonPaymentsRestClient @Inject constructor(private val wooNetwork: Woo
             error.type == GenericErrorType.NETWORK_ERROR -> NETWORK_ERROR
             else -> GENERIC_ERROR
         }
-        return WCCapturePaymentError(type, message)
+        return WCCapturePaymentError(
+            type = type,
+            message = message,
+            extraData = error?.volleyError?.getExtraData()
+        )
+    }
+
+    fun VolleyError.getExtraData(): Map<String, Any>? {
+        val jsonString = this.networkResponse?.data?.toString(Charsets.UTF_8)
+        return try {
+            val mapType = object : TypeToken<Map<String, Any>>() {}.type
+            return gson.fromJson<Map<String, Any>>(jsonString, mapType)["data"] as Map<String, Any>?
+        } catch (e: Exception) {
+            AppLog.e(AppLog.T.API, "Error parsing volley error $jsonString", e)
+            null
+        }
     }
 
     private fun mapToStoreLocationForSiteError(error: WPAPINetworkError?, message: String):


### PR DESCRIPTION
The PR adds handling of the newly added to the woo payments data regarding minimal amount of the payment possible regarding the capture step

More details:

https://github.com/Automattic/woocommerce-payments/pull/10112